### PR TITLE
fix(care): use correct SE Systems logo throughout homeowner portal

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/page.tsx
+++ b/apps/unified-portal/app/care/[installationId]/page.tsx
@@ -114,7 +114,7 @@ export default function CareInstallationPage() {
       >
         <div className="flex items-center max-w-4xl mx-auto">
           <Image
-            src="/branding/se-systems-logo.png"
+            src="/branding/se-systems-logo.svg"
             alt="SE Systems"
             width={120}
             height={36}

--- a/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
+++ b/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
@@ -360,7 +360,7 @@ export default function AssistantScreen({ installationId }: { installationId: st
             }}
           >
             <Image
-              src="/branding/se-systems-logo.png"
+              src="/branding/se-systems-logo.svg"
               alt="SE Systems"
               width={140}
               height={42}


### PR DESCRIPTION
Switch the homeowner portal toolbar and assistant welcome card from the PNG variant to se-systems-logo.svg, matching the care-dashboard sidebar. The existing brightness(0) filter keeps the logo visible on the light toolbar and #FAFAF8 welcome-card backgrounds.