### PR TITLE
feat(agent-intelligence): drafts review screen + send flow

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -3,13 +3,16 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Image from 'next/image';
+import { useDraftsCount } from '../_hooks/useDraftsCount';
 
-type TabId = 'home' | 'pipeline' | 'viewings' | 'docs';
+type TabId = 'home' | 'pipeline' | 'drafts' | 'viewings' | 'docs';
 
 const TABS: { id: TabId; label: string; href: string }[] = [
   { id: 'home', label: 'Home', href: '/agent/home' },
   { id: 'pipeline', label: 'Pipeline', href: '/agent/pipeline' },
-  // Intelligence is the FAB — handled separately
+  // Intelligence is the FAB. Drafts sits immediately after, between Pipeline
+  // and Viewings in visual flow per Session 2 spec.
+  { id: 'drafts', label: 'Drafts', href: '/agent/drafts' },
   { id: 'viewings', label: 'Viewings', href: '/agent/viewings' },
   { id: 'docs', label: 'Docs', href: '/agent/docs' },
 ];
@@ -35,6 +38,15 @@ function TabIcon({ id, active }: { id: TabId; active: boolean }) {
           <rect x="14" y="14" width="7" height="7" rx="1.5" />
         </svg>
       );
+    case 'drafts':
+      // Lucide MailCheck mark as required by design spec.
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h9" />
+          <path d="m22 7-10 5L2 7" />
+          <path d="m16 19 2 2 4-4" />
+        </svg>
+      );
     case 'viewings':
       return (
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
@@ -58,6 +70,7 @@ export default function BottomNav() {
   const pathname = usePathname();
   const isActive = (href: string) => pathname.startsWith(href);
   const intelActive = pathname.startsWith('/agent/intelligence');
+  const { count: draftsCount } = useDraftsCount();
 
   const leftTabs = TABS.slice(0, 2);
   const rightTabs = TABS.slice(2);
@@ -97,7 +110,12 @@ export default function BottomNav() {
             }}
           >
             {active && <GoldIndicator />}
-            <TabIcon id={tab.id} active={active} />
+            <div style={{ position: 'relative' }}>
+              <TabIcon id={tab.id} active={active} />
+              {tab.id === 'drafts' && draftsCount > 0 && (
+                <DraftsBadge count={draftsCount} />
+              )}
+            </div>
             <span
               style={{
                 fontSize: 9.5,
@@ -208,7 +226,12 @@ export default function BottomNav() {
             }}
           >
             {active && <GoldIndicator />}
-            <TabIcon id={tab.id} active={active} />
+            <div style={{ position: 'relative' }}>
+              <TabIcon id={tab.id} active={active} />
+              {tab.id === 'drafts' && draftsCount > 0 && (
+                <DraftsBadge count={draftsCount} />
+              )}
+            </div>
             <span
               style={{
                 fontSize: 9.5,
@@ -223,6 +246,32 @@ export default function BottomNav() {
         );
       })}
     </nav>
+  );
+}
+
+function DraftsBadge({ count }: { count: number }) {
+  return (
+    <span
+      data-testid="drafts-badge"
+      style={{
+        position: 'absolute',
+        top: -4,
+        right: -8,
+        minWidth: 16,
+        height: 16,
+        padding: '0 4px',
+        borderRadius: 8,
+        background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+        color: '#fff',
+        fontSize: 9,
+        fontWeight: 700,
+        lineHeight: '16px',
+        textAlign: 'center',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+      }}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
   );
 }
 

--- a/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
@@ -1,0 +1,665 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Check,
+  Info,
+  Mail,
+  MessageCircle,
+  Phone,
+  Send as SendIcon,
+  Trash2,
+  X,
+} from 'lucide-react';
+import {
+  draftTypeLabel,
+  type DraftRecord,
+} from '@/lib/agent-intelligence/drafts';
+
+interface DraftReviewPanelProps {
+  draft: DraftRecord;
+  surface: 'mobile' | 'desktop';
+  sending: boolean;
+  sentState: SentState | null;
+  onClose: () => void;
+  onSave: (patch: { subject: string; body: string; sendMethod?: DraftRecord['sendMethod'] }) => Promise<DraftRecord | null>;
+  onSend: (opts: { wasEdited: boolean }) => Promise<void>;
+  onDiscard: () => Promise<void>;
+}
+
+export interface SentState {
+  recipient: string;
+  status: 'sent' | 'sent_external';
+  externalHref: string | null;
+  externalHint: string | null;
+  undoable: boolean;
+}
+
+const DISCARD_CONFIRM = 'Discard this draft? This cannot be undone.';
+
+/**
+ * Draft review. Mobile: full-screen overlay. Desktop: right-hand side panel
+ * (450px) over a dimmed list. The surface prop only affects chrome — the
+ * editor behaviour (dirty tracking, keyboard shortcuts, keyboard-aware
+ * footer) is identical.
+ */
+export default function DraftReviewPanel({
+  draft,
+  surface,
+  sending,
+  sentState,
+  onClose,
+  onSave,
+  onSend,
+  onDiscard,
+}: DraftReviewPanelProps) {
+  const [subject, setSubject] = useState(draft.subject);
+  const [bodyText, setBodyText] = useState(draft.body);
+  const [sendMethod, setSendMethod] = useState<DraftRecord['sendMethod']>(draft.sendMethod || 'email');
+  const [saving, setSaving] = useState(false);
+  const [popover, setPopover] = useState<string | null>(null);
+  const bodyRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const dirty = useMemo(
+    () =>
+      subject !== draft.subject ||
+      bodyText !== draft.body ||
+      sendMethod !== (draft.sendMethod || 'email'),
+    [subject, bodyText, sendMethod, draft.subject, draft.body, draft.sendMethod],
+  );
+
+  // Auto-resize the body textarea to fit content so long drafts don't hide
+  // behind a scroll well on mobile.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 480)}px`;
+  }, [bodyText]);
+
+  // Keyboard shortcuts on desktop.
+  useEffect(() => {
+    if (surface !== 'desktop') return;
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === 'Enter') {
+        e.preventDefault();
+        handleSend();
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+      if (mod && (e.key === 'd' || e.key === 'D')) {
+        e.preventDefault();
+        handleDiscard();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surface, subject, bodyText, sendMethod, dirty, sending]);
+
+  const persistIfDirty = async () => {
+    if (!dirty) return draft;
+    setSaving(true);
+    try {
+      const next = await onSave({ subject, body: bodyText, sendMethod: sendMethod || 'email' });
+      return next || draft;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    await persistIfDirty();
+  };
+
+  const handleSend = async () => {
+    if (sending || sentState) return;
+    const wasEdited = dirty;
+    await persistIfDirty();
+    await onSend({ wasEdited });
+  };
+
+  const handleDiscard = async () => {
+    const confirmed = typeof window !== 'undefined' ? window.confirm(DISCARD_CONFIRM) : true;
+    if (!confirmed) return;
+    await onDiscard();
+  };
+
+  const handleClose = () => {
+    if (dirty) {
+      const confirmed = typeof window !== 'undefined'
+        ? window.confirm('Discard changes? Your edits will be lost.')
+        : true;
+      if (!confirmed) return;
+    }
+    onClose();
+  };
+
+  const isDesktop = surface === 'desktop';
+
+  return (
+    <div
+      data-testid="draft-review-panel"
+      style={isDesktop ? desktopWrapperStyle : mobileWrapperStyle}
+    >
+      {isDesktop && (
+        <div
+          onClick={handleClose}
+          aria-hidden
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(13,13,18,0.32)',
+            zIndex: 60,
+            animation: 'oh-draft-fade 0.18s ease forwards',
+          }}
+        />
+      )}
+
+      <aside
+        style={isDesktop ? desktopPanelStyle : mobilePanelStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header style={headerStyle}>
+          <button
+            onClick={handleClose}
+            aria-label="Close"
+            className="agent-tappable"
+            style={iconButtonStyle}
+          >
+            {isDesktop ? <X size={18} /> : <ArrowLeft size={18} />}
+          </button>
+          <div style={{ flex: 1, minWidth: 0, textAlign: 'center' }}>
+            <div style={{ fontSize: 11, color: '#9CA3AF', letterSpacing: '0.05em', textTransform: 'uppercase', fontWeight: 600 }}>
+              {draftTypeLabel(draft.draftType)}
+            </div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: '#0D0D12', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {draft.recipient.name || 'Unknown recipient'}
+            </div>
+          </div>
+          <div style={{ width: 34 }} />
+        </header>
+
+        <div style={scrollStyle}>
+          {sentState ? (
+            <SentConfirmation state={sentState} />
+          ) : (
+            <>
+              <RecipientRow
+                draft={draft}
+                sendMethod={sendMethod}
+                onChangeMethod={setSendMethod}
+              />
+
+              <section style={sectionStyle}>
+                <label style={labelStyle}>Subject</label>
+                <input
+                  data-testid="draft-subject-input"
+                  type="text"
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  style={inputStyle}
+                />
+              </section>
+
+              <section style={sectionStyle}>
+                <label style={labelStyle}>Message</label>
+                <textarea
+                  data-testid="draft-body-input"
+                  ref={bodyRef}
+                  value={bodyText}
+                  onChange={(e) => setBodyText(e.target.value)}
+                  style={textareaStyle}
+                  rows={6}
+                />
+              </section>
+
+              {draft.contextChips.length > 0 && (
+                <section style={{ ...sectionStyle, paddingTop: 6 }}>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {draft.contextChips.map((chip) => (
+                      <ContextChip
+                        key={chip.id}
+                        chip={chip}
+                        active={popover === chip.id}
+                        onToggle={() => setPopover(popover === chip.id ? null : chip.id)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </div>
+
+        {!sentState && (
+          <footer style={footerStyle}>
+            <button
+              data-testid="draft-discard"
+              onClick={handleDiscard}
+              className="agent-tappable"
+              style={ghostDestructiveStyle}
+            >
+              <Trash2 size={14} />
+              Discard
+            </button>
+            {dirty && (
+              <button
+                data-testid="draft-save"
+                onClick={handleSave}
+                disabled={saving}
+                className="agent-tappable"
+                style={ghostStyle}
+              >
+                {saving ? 'Saving...' : 'Save changes'}
+              </button>
+            )}
+            <button
+              data-testid="draft-send"
+              onClick={handleSend}
+              disabled={sending}
+              className="agent-tappable"
+              style={{ ...primaryStyle, position: 'relative' }}
+            >
+              <SendIcon size={14} />
+              {sending ? 'Sending...' : 'Send'}
+              {dirty && !sending && <UnsavedDot />}
+            </button>
+          </footer>
+        )}
+      </aside>
+
+      <style>{`
+        @keyframes oh-draft-fade {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        @keyframes oh-draft-slide {
+          from { transform: translateX(32px); opacity: 0; }
+          to { transform: translateX(0); opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function SentConfirmation({ state }: { state: SentState }) {
+  const copy =
+    state.status === 'sent'
+      ? `Sent to ${state.recipient}. You can undo for 60 seconds.`
+      : `Ready to finish on ${state.recipient}.`;
+
+  return (
+    <div
+      data-testid="draft-sent-confirmation"
+      style={{
+        margin: 18,
+        padding: 20,
+        borderRadius: 16,
+        background: 'rgba(5,150,105,0.06)',
+        border: '0.5px solid rgba(5,150,105,0.25)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        alignItems: 'flex-start',
+      }}
+    >
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          background: 'rgba(5,150,105,0.15)',
+          color: '#059669',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Check size={18} />
+      </div>
+      <p style={{ fontSize: 14, color: '#0D0D12', margin: 0, lineHeight: 1.5 }}>{copy}</p>
+      {state.externalHref && (
+        <a
+          href={state.externalHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: '#0D0D12',
+            textDecoration: 'underline',
+          }}
+        >
+          Open {state.status === 'sent_external' ? 'app' : 'provider'}
+        </a>
+      )}
+      {state.externalHint && (
+        <p style={{ fontSize: 12, color: '#6B7280', margin: 0 }}>{state.externalHint}</p>
+      )}
+    </div>
+  );
+}
+
+function RecipientRow({
+  draft,
+  sendMethod,
+  onChangeMethod,
+}: {
+  draft: DraftRecord;
+  sendMethod: DraftRecord['sendMethod'];
+  onChangeMethod: (m: DraftRecord['sendMethod']) => void;
+}) {
+  const emailContact = draft.recipient.email;
+  const phoneContact = draft.recipient.phone;
+
+  return (
+    <section style={sectionStyle}>
+      <label style={labelStyle}>Recipient</label>
+      <div
+        style={{
+          background: '#FAFAF8',
+          borderRadius: 12,
+          border: '0.5px solid rgba(0,0,0,0.06)',
+          padding: '10px 14px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 6,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12' }}>
+          {draft.recipient.name || 'Unknown recipient'}
+        </div>
+        <div style={{ fontSize: 12, color: '#6B7280', display: 'flex', alignItems: 'center', gap: 6 }}>
+          {sendMethod === 'email' ? (
+            <><Mail size={12} /> {emailContact || 'No email on file'}</>
+          ) : sendMethod === 'sms' ? (
+            <><Phone size={12} /> {phoneContact || 'No phone on file'}</>
+          ) : (
+            <><MessageCircle size={12} /> {phoneContact || 'No phone on file'}</>
+          )}
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+          {(['email', 'whatsapp', 'sms'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => onChangeMethod(m)}
+              className="agent-tappable"
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                border: sendMethod === m ? '0.5px solid #C49B2A' : '0.5px solid rgba(0,0,0,0.08)',
+                background: sendMethod === m ? 'rgba(196,155,42,0.12)' : '#FFFFFF',
+                color: sendMethod === m ? '#8A6E1F' : '#6B7280',
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {m === 'whatsapp' ? 'WhatsApp' : m === 'sms' ? 'SMS' : 'Email'}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ContextChip({
+  chip,
+  active,
+  onToggle,
+}: {
+  chip: { id: string; label: string; detail: string | null };
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <span style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="agent-tappable"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '4px 10px',
+          borderRadius: 999,
+          background: '#F1F1EE',
+          color: '#6B7280',
+          fontSize: 11.5,
+          fontWeight: 500,
+          border: 'none',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        <Info size={11} />
+        {chip.label}
+      </button>
+      {active && chip.detail && (
+        <div
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            left: 0,
+            background: '#0D0D12',
+            color: '#fff',
+            borderRadius: 8,
+            padding: '8px 12px',
+            fontSize: 11.5,
+            fontWeight: 500,
+            lineHeight: 1.4,
+            maxWidth: 280,
+            whiteSpace: 'normal',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.24)',
+            zIndex: 2,
+          }}
+        >
+          {chip.detail}
+        </div>
+      )}
+    </span>
+  );
+}
+
+function UnsavedDot() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: 'absolute',
+        top: 6,
+        right: 6,
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        background: '#fff',
+        boxShadow: '0 0 0 1.5px rgba(255,255,255,0.6)',
+      }}
+    />
+  );
+}
+
+// ─── Styles ───
+
+const desktopWrapperStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 60,
+  pointerEvents: 'auto',
+};
+
+const mobileWrapperStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 60,
+  background: '#FAFAF8',
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+const desktopPanelStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: 450,
+  background: '#FAFAF8',
+  zIndex: 61,
+  boxShadow: '-12px 0 32px rgba(0,0,0,0.08)',
+  display: 'flex',
+  flexDirection: 'column',
+  animation: 'oh-draft-slide 0.2s cubic-bezier(0.22,0.8,0.2,1)',
+};
+
+const mobilePanelStyle: React.CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 0,
+  background: '#FAFAF8',
+  paddingTop: 'env(safe-area-inset-top)',
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '12px 16px',
+  borderBottom: '0.5px solid rgba(0,0,0,0.08)',
+  background: 'rgba(250,250,248,0.98)',
+  backdropFilter: 'blur(16px)',
+  WebkitBackdropFilter: 'blur(16px)',
+  flexShrink: 0,
+};
+
+const iconButtonStyle: React.CSSProperties = {
+  width: 34,
+  height: 34,
+  borderRadius: 17,
+  border: 'none',
+  background: 'transparent',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  color: '#0D0D12',
+};
+
+const scrollStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  WebkitOverflowScrolling: 'touch',
+  paddingBottom: 8,
+};
+
+const sectionStyle: React.CSSProperties = {
+  padding: '14px 18px 6px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#9CA3AF',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+};
+
+const inputStyle: React.CSSProperties = {
+  border: '0.5px solid rgba(0,0,0,0.08)',
+  background: '#FFFFFF',
+  borderRadius: 10,
+  padding: '10px 12px',
+  fontSize: 14,
+  color: '#0D0D12',
+  fontFamily: 'inherit',
+  outline: 'none',
+};
+
+const textareaStyle: React.CSSProperties = {
+  border: '0.5px solid rgba(0,0,0,0.08)',
+  background: '#FFFFFF',
+  borderRadius: 12,
+  padding: '12px 14px',
+  fontSize: 14,
+  lineHeight: 1.55,
+  color: '#0D0D12',
+  fontFamily: 'inherit',
+  outline: 'none',
+  resize: 'none',
+  minHeight: 140,
+};
+
+const footerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: 8,
+  padding: '12px 16px calc(16px + env(safe-area-inset-bottom, 0px))',
+  borderTop: '0.5px solid rgba(0,0,0,0.08)',
+  background: 'rgba(250,250,248,0.98)',
+  backdropFilter: 'blur(16px)',
+  WebkitBackdropFilter: 'blur(16px)',
+  flexShrink: 0,
+  // Keep the footer above the soft keyboard on mobile. env(keyboard-inset-height)
+  // is supported on iOS 16.4+, Android Chrome 119+.
+  marginBottom: 'env(keyboard-inset-height, 0px)',
+};
+
+const primaryStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '10px 18px',
+  background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 12,
+  fontSize: 13.5,
+  fontWeight: 600,
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  boxShadow: '0 2px 6px rgba(196,155,42,0.25)',
+};
+
+const ghostStyle: React.CSSProperties = {
+  padding: '10px 14px',
+  background: 'transparent',
+  border: '0.5px solid rgba(0,0,0,0.12)',
+  borderRadius: 12,
+  fontSize: 13,
+  fontWeight: 500,
+  color: '#6B7280',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const ghostDestructiveStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'transparent',
+  border: 'none',
+  borderRadius: 12,
+  fontSize: 13,
+  fontWeight: 500,
+  color: '#DC2626',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  marginRight: 'auto',
+};

--- a/apps/unified-portal/app/agent/_components/DraftsListRow.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftsListRow.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { MailCheck, Trash2, Send as SendIcon } from 'lucide-react';
+import {
+  draftTypeLabel,
+  relativeTimestamp,
+  type DraftRecord,
+} from '@/lib/agent-intelligence/drafts';
+
+const SWIPE_REVEAL = 84;
+const SWIPE_TRIGGER = 60;
+
+interface DraftsListRowProps {
+  draft: DraftRecord;
+  onOpen: (draft: DraftRecord) => void;
+  onDiscard: (draft: DraftRecord) => Promise<void> | void;
+  onQuickSend: (draft: DraftRecord) => Promise<void> | void;
+}
+
+/**
+ * Single draft row. Mobile-first with iOS-style swipe gestures.
+ *   - Swipe left reveals the red Discard action
+ *   - Swipe right reveals the gold Send action
+ * Desktop users just tap the row; the swipe handlers no-op on pointer types
+ * that aren't touch.
+ */
+export default function DraftsListRow({
+  draft,
+  onOpen,
+  onDiscard,
+  onQuickSend,
+}: DraftsListRowProps) {
+  const [dragX, setDragX] = useState(0);
+  const startX = useRef<number | null>(null);
+  const [busy, setBusy] = useState<'send' | 'discard' | null>(null);
+
+  const preview = (draft.body || '').split('\n').slice(0, 2).join(' ').slice(0, 180);
+  const methodLabel = draft.sendMethod === 'whatsapp'
+    ? 'WhatsApp'
+    : draft.sendMethod === 'sms'
+      ? 'SMS'
+      : 'Email';
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0].clientX;
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (startX.current == null) return;
+    const dx = e.touches[0].clientX - startX.current;
+    const clamped = Math.max(-SWIPE_REVEAL, Math.min(SWIPE_REVEAL, dx));
+    setDragX(clamped);
+  };
+  const handleTouchEnd = async () => {
+    const dx = dragX;
+    startX.current = null;
+    if (dx <= -SWIPE_TRIGGER) {
+      setBusy('discard');
+      try { await onDiscard(draft); } finally { setBusy(null); setDragX(0); }
+      return;
+    }
+    if (dx >= SWIPE_TRIGGER) {
+      setBusy('send');
+      try { await onQuickSend(draft); } finally { setBusy(null); setDragX(0); }
+      return;
+    }
+    setDragX(0);
+  };
+
+  return (
+    <div
+      data-testid="drafts-list-row"
+      style={{
+        position: 'relative',
+        background: '#FFFFFF',
+        borderRadius: 14,
+        overflow: 'hidden',
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+      }}
+    >
+      {/* Swipe action backdrops */}
+      <div
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'stretch',
+        }}
+      >
+        <div
+          style={{
+            width: SWIPE_REVEAL,
+            background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            gap: 6,
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
+          <SendIcon size={16} /> Send
+        </div>
+        <div
+          style={{
+            width: SWIPE_REVEAL,
+            background: '#DC2626',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            gap: 6,
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
+          <Trash2 size={16} /> Discard
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onOpen(draft)}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        className="agent-tappable"
+        style={{
+          position: 'relative',
+          display: 'block',
+          width: '100%',
+          textAlign: 'left',
+          background: '#FFFFFF',
+          border: 'none',
+          padding: '14px 16px',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          transform: `translateX(${dragX}px)`,
+          transition: startX.current == null ? 'transform 0.15s ease' : 'none',
+          opacity: busy ? 0.6 : 1,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 4,
+            gap: 8,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: '#0D0D12',
+              letterSpacing: '-0.01em',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              maxWidth: '60%',
+            }}
+          >
+            {draft.recipient.name || 'Unknown recipient'}
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              color: '#9CA3AF',
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+            }}
+          >
+            {relativeTimestamp(draft.createdAt)}
+          </span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            marginBottom: 6,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#8A6E1F',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+            }}
+          >
+            <MailCheck size={12} />
+            {draftTypeLabel(draft.draftType)}
+          </span>
+          <span
+            style={{
+              fontSize: 10.5,
+              fontWeight: 500,
+              color: '#6B7280',
+              background: 'rgba(0,0,0,0.05)',
+              padding: '2px 7px',
+              borderRadius: 999,
+            }}
+          >
+            {methodLabel}
+          </span>
+        </div>
+        <p
+          style={{
+            fontSize: 13,
+            lineHeight: 1.45,
+            color: '#6B7280',
+            margin: 0,
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            maskImage:
+              preview.length > 140
+                ? 'linear-gradient(to bottom, #000 80%, transparent 100%)'
+                : undefined,
+            WebkitMaskImage:
+              preview.length > 140
+                ? 'linear-gradient(to bottom, #000 80%, transparent 100%)'
+                : undefined,
+          }}
+        >
+          {preview || 'No preview'}
+        </p>
+      </button>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
+++ b/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const REFRESH_EVENT = 'oh.agent.drafts.refresh';
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Polls /api/agent/intelligence/drafts for the pending-review count so the
+ * bottom nav + sidebar badges stay accurate without each consumer hitting
+ * the endpoint themselves. Other parts of the app (review screen, approve
+ * action, send flow) can dispatch `oh.agent.drafts.refresh` to force an
+ * immediate refresh instead of waiting for the next poll tick.
+ */
+export function useDraftsCount(): { count: number; refresh: () => Promise<void> } {
+  const [count, setCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agent/intelligence/drafts', { cache: 'no-store' });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (typeof data.count === 'number') setCount(data.count);
+    } catch {
+      /* silent — the badge just stays at its last known value */
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL_MS);
+    const onRefresh = () => { refresh(); };
+    window.addEventListener(REFRESH_EVENT, onRefresh);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener(REFRESH_EVENT, onRefresh);
+    };
+  }, [refresh]);
+
+  return { count, refresh };
+}
+
+export function notifyDraftsChanged(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(REFRESH_EVENT));
+}

--- a/apps/unified-portal/app/agent/dashboard/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/dashboard/drafts/page.tsx
@@ -1,0 +1,7 @@
+import AgentDraftsPage from '../../drafts/page';
+
+/**
+ * Dashboard (desktop) drafts route. The same page powers mobile and desktop —
+ * desktop layout kicks in at >= 900px via the matchMedia check in the page.
+ */
+export default AgentDraftsPage;

--- a/apps/unified-portal/app/agent/dashboard/layout-sidebar.tsx
+++ b/apps/unified-portal/app/agent/dashboard/layout-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   GitBranch,
   Sparkles,
   Users,
+  MailCheck,
   MessageSquare,
   CalendarCheck,
   FolderArchive,
@@ -27,6 +28,7 @@ import {
 } from 'lucide-react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useAgentDashboard } from './layout-provider';
+import { useDraftsCount } from '../_hooks/useDraftsCount';
 
 interface NavItem {
   label: string;
@@ -46,6 +48,7 @@ const agentNavSections: NavSection[] = [
       { label: 'Overview', href: '/agent/dashboard/overview', icon: LayoutDashboard },
       { label: 'Sales Pipeline', href: '/agent/dashboard/pipeline', icon: GitBranch },
       { label: 'OpenHouse Intelligence', href: '/agent/dashboard/intelligence', icon: Sparkles },
+      { label: 'Drafts', href: '/agent/dashboard/drafts', icon: MailCheck },
     ],
   },
   {
@@ -83,6 +86,7 @@ export function AgentDashboardSidebar() {
   const [signingOut, setSigningOut] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const switcherRef = useRef<HTMLDivElement>(null);
+  const { count: draftsCount } = useDraftsCount();
 
   const isActive = (href: string) => {
     if (href === '/agent/dashboard/overview') {
@@ -233,6 +237,18 @@ export function AgentDashboardSidebar() {
                     >
                       <Icon className="w-4 h-4 flex-shrink-0" />
                       <span>{item.label}</span>
+                      {item.href === '/agent/dashboard/drafts' && draftsCount > 0 && (
+                        <span
+                          data-testid="drafts-badge-sidebar"
+                          className="ml-auto inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full text-[10px] font-bold"
+                          style={{
+                            background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                            color: '#fff',
+                          }}
+                        >
+                          {draftsCount > 99 ? '99+' : draftsCount}
+                        </span>
+                      )}
                     </Link>
                   );
                 })}

--- a/apps/unified-portal/app/agent/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/drafts/page.tsx
@@ -1,0 +1,410 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MailCheck } from 'lucide-react';
+import AgentShell from '../_components/AgentShell';
+import DraftsListRow from '../_components/DraftsListRow';
+import DraftReviewPanel, { type SentState } from '../_components/DraftReviewPanel';
+import UndoPill from '../_components/UndoPill';
+import { useAgent } from '@/lib/agent/AgentContext';
+import { notifyDraftsChanged } from '../_hooks/useDraftsCount';
+import type { DraftRecord } from '@/lib/agent-intelligence/drafts';
+
+const AUTO_CLOSE_MS = 3000;
+
+interface UndoBatch {
+  batchId: string;
+  createdAt: number;
+  notice: string | null;
+}
+
+export default function AgentDraftsPage() {
+  const { agent, alerts } = useAgent();
+  const [drafts, setDrafts] = useState<DraftRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [activeDraft, setActiveDraft] = useState<DraftRecord | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sentState, setSentState] = useState<SentState | null>(null);
+  const [undoBatch, setUndoBatch] = useState<UndoBatch | null>(null);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  const pullStartY = useRef<number | null>(null);
+  const [pullOffset, setPullOffset] = useState(0);
+  const autoCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 900px)');
+    const update = () => setIsDesktop(mq.matches);
+    update();
+    mq.addEventListener('change', update);
+    return () => mq.removeEventListener('change', update);
+  }, []);
+
+  const loadDrafts = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agent/intelligence/drafts', { cache: 'no-store' });
+      if (!res.ok) return;
+      const data = await res.json();
+      setDrafts(data.drafts || []);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { loadDrafts(); }, [loadDrafts]);
+
+  useEffect(() => () => {
+    if (autoCloseTimer.current) clearTimeout(autoCloseTimer.current);
+  }, []);
+
+  const handleOpen = (draft: DraftRecord) => {
+    setActiveDraft(draft);
+    setSentState(null);
+  };
+
+  const handleClose = () => {
+    if (autoCloseTimer.current) clearTimeout(autoCloseTimer.current);
+    setActiveDraft(null);
+    setSentState(null);
+  };
+
+  const handleSave = useCallback(async (
+    patch: { subject: string; body: string; sendMethod?: DraftRecord['sendMethod'] },
+  ): Promise<DraftRecord | null> => {
+    if (!activeDraft) return null;
+    const res = await fetch(`/api/agent/intelligence/drafts/${activeDraft.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) return null;
+    const { draft } = await res.json();
+    setActiveDraft(draft);
+    setDrafts((prev) => prev.map((d) => (d.id === draft.id ? draft : d)));
+    return draft as DraftRecord;
+  }, [activeDraft]);
+
+  const handleSend = useCallback(async ({ wasEdited }: { wasEdited: boolean }) => {
+    if (!activeDraft) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/agent/intelligence/send-draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draftId: activeDraft.id, wasEdited }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || 'Could not send that draft.');
+        return;
+      }
+      const data = await res.json();
+      const newSent: SentState = {
+        recipient: activeDraft.recipient.name || 'recipient',
+        status: data.status,
+        externalHref: data.externalPayload?.href ?? null,
+        externalHint: data.externalPayload?.hint ?? null,
+        undoable: !!data.undoable,
+      };
+      setSentState(newSent);
+      if (data.externalPayload?.href) {
+        window.open(data.externalPayload.href, '_blank', 'noopener');
+      }
+      setDrafts((prev) => prev.filter((d) => d.id !== activeDraft.id));
+      setUndoBatch({ batchId: data.batchId, createdAt: Date.now(), notice: null });
+      notifyDraftsChanged();
+
+      autoCloseTimer.current = setTimeout(() => {
+        setActiveDraft(null);
+        setSentState(null);
+      }, AUTO_CLOSE_MS);
+    } finally {
+      setSending(false);
+    }
+  }, [activeDraft]);
+
+  const handleQuickSend = useCallback(async (draft: DraftRecord) => {
+    setActiveDraft(draft);
+    setSending(true);
+    try {
+      const res = await fetch('/api/agent/intelligence/send-draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draftId: draft.id, wasEdited: false }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || 'Could not send that draft.');
+        setActiveDraft(null);
+        return;
+      }
+      const data = await res.json();
+      setSentState({
+        recipient: draft.recipient.name || 'recipient',
+        status: data.status,
+        externalHref: data.externalPayload?.href ?? null,
+        externalHint: data.externalPayload?.hint ?? null,
+        undoable: !!data.undoable,
+      });
+      if (data.externalPayload?.href) {
+        window.open(data.externalPayload.href, '_blank', 'noopener');
+      }
+      setDrafts((prev) => prev.filter((d) => d.id !== draft.id));
+      setUndoBatch({ batchId: data.batchId, createdAt: Date.now(), notice: null });
+      notifyDraftsChanged();
+      autoCloseTimer.current = setTimeout(() => {
+        setActiveDraft(null);
+        setSentState(null);
+      }, AUTO_CLOSE_MS);
+    } finally {
+      setSending(false);
+    }
+  }, []);
+
+  const handleDiscard = useCallback(async (draft: DraftRecord) => {
+    const confirmed = typeof window !== 'undefined'
+      ? window.confirm("Discard this draft? This can't be undone.")
+      : true;
+    if (!confirmed) return;
+    const res = await fetch(`/api/agent/intelligence/drafts/${draft.id}`, { method: 'DELETE' });
+    if (res.ok) {
+      setDrafts((prev) => prev.filter((d) => d.id !== draft.id));
+      if (activeDraft?.id === draft.id) {
+        setActiveDraft(null);
+        setSentState(null);
+      }
+      notifyDraftsChanged();
+    }
+  }, [activeDraft]);
+
+  const handleDiscardFromReview = useCallback(async () => {
+    if (!activeDraft) return;
+    await handleDiscard(activeDraft);
+  }, [activeDraft, handleDiscard]);
+
+  const handleUndoSend = useCallback(async () => {
+    if (!undoBatch) return;
+    const batch = undoBatch;
+    setUndoBatch(null);
+    try {
+      const res = await fetch('/api/agent/intelligence/undo-send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ batchId: batch.batchId }),
+      });
+      const data = await res.json();
+      if (data?.notice) {
+        alert(data.notice);
+      }
+      await loadDrafts();
+      notifyDraftsChanged();
+    } catch {
+      alert("Couldn't undo that one — check the drafts list.");
+    }
+  }, [undoBatch, loadDrafts]);
+
+  // Pull-to-refresh: gentle gesture on mobile only.
+  const handlePullStart = (e: React.TouchEvent) => {
+    const target = e.currentTarget as HTMLDivElement;
+    if (target.scrollTop > 0) return;
+    pullStartY.current = e.touches[0].clientY;
+  };
+  const handlePullMove = (e: React.TouchEvent) => {
+    if (pullStartY.current == null) return;
+    const delta = e.touches[0].clientY - pullStartY.current;
+    if (delta > 0) {
+      setPullOffset(Math.min(80, delta));
+    }
+  };
+  const handlePullEnd = async () => {
+    if (pullOffset > 60) {
+      setRefreshing(true);
+      await loadDrafts();
+    }
+    pullStartY.current = null;
+    setPullOffset(0);
+  };
+
+  const content = useMemo(() => {
+    if (loading) {
+      return (
+        <div style={{ padding: 48, textAlign: 'center', color: '#9CA3AF', fontSize: 13 }}>
+          Loading drafts...
+        </div>
+      );
+    }
+    if (drafts.length === 0) {
+      return <EmptyState />;
+    }
+    return (
+      <div
+        data-testid="drafts-list"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          padding: '16px 16px 24px',
+        }}
+      >
+        {drafts.map((draft) => (
+          <DraftsListRow
+            key={draft.id}
+            draft={draft}
+            onOpen={handleOpen}
+            onDiscard={handleDiscard}
+            onQuickSend={handleQuickSend}
+          />
+        ))}
+      </div>
+    );
+  }, [loading, drafts, handleDiscard, handleQuickSend]);
+
+  return (
+    <AgentShell agentName={agent?.displayName?.split(' ')[0] || 'Agent'} urgentCount={alerts?.length || 0}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+          position: 'relative',
+        }}
+      >
+        <header
+          style={{
+            padding: '16px 20px 12px',
+            borderBottom: '0.5px solid rgba(0,0,0,0.05)',
+            background: 'rgba(250,250,248,0.95)',
+          }}
+        >
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 20,
+              fontWeight: 700,
+              letterSpacing: '-0.03em',
+              color: '#0D0D12',
+            }}
+          >
+            Drafts
+          </h1>
+          <p
+            style={{
+              margin: '4px 0 0',
+              fontSize: 12.5,
+              color: '#9CA3AF',
+              letterSpacing: '0.005em',
+            }}
+          >
+            Review what Intelligence wrote for you. Nothing sends until you say so.
+          </p>
+        </header>
+
+        <div
+          onTouchStart={handlePullStart}
+          onTouchMove={handlePullMove}
+          onTouchEnd={handlePullEnd}
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+          }}
+        >
+          {pullOffset > 0 && (
+            <div
+              style={{
+                textAlign: 'center',
+                fontSize: 11,
+                color: '#9CA3AF',
+                padding: `${pullOffset / 2}px 0`,
+              }}
+            >
+              {refreshing ? 'Refreshing...' : pullOffset > 60 ? 'Release to refresh' : 'Pull to refresh'}
+            </div>
+          )}
+          {content}
+        </div>
+
+        {activeDraft && (
+          <DraftReviewPanel
+            draft={activeDraft}
+            surface={isDesktop ? 'desktop' : 'mobile'}
+            sending={sending}
+            sentState={sentState}
+            onClose={handleClose}
+            onSave={handleSave}
+            onSend={handleSend}
+            onDiscard={handleDiscardFromReview}
+          />
+        )}
+
+        {undoBatch && (
+          <UndoPill
+            batchId={undoBatch.batchId}
+            createdAt={undoBatch.createdAt}
+            onUndo={handleUndoSend}
+            onExpire={() => setUndoBatch(null)}
+          />
+        )}
+      </div>
+    </AgentShell>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div
+      data-testid="drafts-empty-state"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '72px 32px',
+        gap: 12,
+        color: '#9CA3AF',
+      }}
+    >
+      <div
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 20,
+          background: 'rgba(196,155,42,0.08)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#C49B2A',
+          marginBottom: 8,
+        }}
+      >
+        <MailCheck size={28} />
+      </div>
+      <p
+        style={{
+          fontSize: 15,
+          fontWeight: 600,
+          color: '#0D0D12',
+          margin: 0,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        No drafts waiting. Nice.
+      </p>
+      <p
+        style={{
+          fontSize: 12.5,
+          color: '#9CA3AF',
+          margin: 0,
+          textAlign: 'center',
+          maxWidth: 260,
+          lineHeight: 1.5,
+        }}
+      >
+        When Intelligence drafts an update for you, it will land here for review.
+      </p>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  resolveRecipient,
+  toDraftRecord,
+} from '@/lib/agent-intelligence/drafts';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/intelligence/drafts/:id
+ * Returns the full draft (subject, body, recipient, context chips).
+ */
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data: row, error } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('id', params.id)
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const recipient = await resolveRecipient(supabase, row.draft_type, row.recipient_id);
+    return NextResponse.json({ draft: toDraftRecord(row, recipient) });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/agent/intelligence/drafts/:id
+ * Body: { subject?, body?, sendMethod?, recipientId? }
+ * Saves edits back into content_json. Any save implicitly means the user
+ * touched the draft — the send route reads this flag off a later diff rather
+ * than tracking it here, to keep this route dumb.
+ */
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json();
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const { data: existing, error: getErr } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('id', params.id)
+      .maybeSingle();
+
+    if (getErr) return NextResponse.json({ error: getErr.message }, { status: 500 });
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (user && existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const nextContent = { ...(existing.content_json || {}) };
+    if (typeof body.subject === 'string') nextContent.subject = body.subject;
+    if (typeof body.body === 'string') nextContent.body = body.body;
+
+    const updates: Record<string, any> = {
+      content_json: nextContent,
+      updated_at: new Date().toISOString(),
+    };
+    if (body.sendMethod) updates.send_method = body.sendMethod;
+    if (typeof body.recipientId === 'string') updates.recipient_id = body.recipientId;
+
+    const { data: updated, error: updErr } = await supabase
+      .from('pending_drafts')
+      .update(updates)
+      .eq('id', params.id)
+      .select('*')
+      .single();
+
+    if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+    const recipient = await resolveRecipient(supabase, updated.draft_type, updated.recipient_id);
+    return NextResponse.json({ draft: toDraftRecord(updated, recipient) });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/agent/intelligence/drafts/:id
+ * Hard-deletes — drafts are disposable by design. The recent_actions row from
+ * Session 1 is removed too so the Session 1 undo pill can't resurrect a draft
+ * the user explicitly discarded.
+ */
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const { data: existing } = await supabase
+      .from('pending_drafts')
+      .select('user_id')
+      .eq('id', params.id)
+      .maybeSingle();
+
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (user && existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    await supabase
+      .from('recent_actions')
+      .delete()
+      .eq('target_table', 'pending_drafts')
+      .eq('target_id', params.id);
+
+    const { error } = await supabase.from('pending_drafts').delete().eq('id', params.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  resolveRecipient,
+  toDraftRecord,
+  type DraftRecord,
+} from '@/lib/agent-intelligence/drafts';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/intelligence/drafts
+ * Returns every pending_review draft for the authenticated user, newest first.
+ * Also returns a `count` field so the bottom nav / sidebar badge can stay
+ * live without a second round trip.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const userId = user?.id || (await fallbackUserId(supabase));
+    if (!userId) {
+      return NextResponse.json({ drafts: [], count: 0 }, { status: 200 });
+    }
+
+    const { data: rows, error } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('status', 'pending_review')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const drafts: DraftRecord[] = [];
+    for (const row of rows || []) {
+      const recipient = await resolveRecipient(supabase, row.draft_type, row.recipient_id);
+      drafts.push(toDraftRecord(row, recipient));
+    }
+
+    return NextResponse.json({ drafts, count: drafts.length });
+  } catch (error: any) {
+    console.error('[agent/intelligence/drafts GET] Error:', error.message);
+    return NextResponse.json(
+      { error: 'Failed to list drafts', details: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+async function fallbackUserId(supabase: ReturnType<typeof getSupabaseAdmin>): Promise<string | null> {
+  // Mirrors the voice capture routes — dev/preview mode drops onto the first
+  // agent profile so you can exercise the screen without a real session.
+  const { data } = await supabase
+    .from('agent_profiles')
+    .select('user_id')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.user_id || null;
+}

--- a/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
@@ -1,0 +1,201 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getResendClient } from '@/lib/resend';
+import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agent/intelligence/send-draft
+ * Body: { draftId, wasEdited?: boolean }
+ *
+ * Routes the draft to the right channel:
+ *   - email: Resend (reuses existing lib/resend.ts)
+ *   - whatsapp / sms: returns a deep-link payload for the client to open,
+ *     marks the draft as sent_external. Session 3 replaces these with
+ *     proper provider integrations.
+ *
+ * Always writes an agent_send_history row so the track record is complete
+ * regardless of channel, and records a recent_actions reversal payload so
+ * the 60-second undo pill can flip the draft back to pending_review.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { draftId, wasEdited = false } = body || {};
+    if (!draftId) {
+      return NextResponse.json({ error: 'draftId required' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const { data: draft, error: fetchErr } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('id', draftId)
+      .maybeSingle();
+
+    if (fetchErr) return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+    if (!draft) return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+    if (user && draft.user_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (draft.status !== 'pending_review') {
+      return NextResponse.json(
+        { error: `Draft is already in status "${draft.status}"` },
+        { status: 409 }
+      );
+    }
+
+    const recipient = await resolveRecipient(supabase, draft.draft_type, draft.recipient_id);
+    const sendMethod = draft.send_method || 'email';
+    const batchId = randomUUID();
+    const sentAt = new Date().toISOString();
+    const subject = (draft.content_json?.subject as string) || `Update on ${recipient.address || 'your property'}`;
+    const messageBody =
+      (draft.content_json?.body as string) ||
+      (draft.content_json?.update_summary as string) ||
+      '';
+
+    let providerMessageId: string | null = null;
+    let provider: string | null = null;
+    let externalPayload: { href?: string; hint?: string } | null = null;
+    let nextStatus: 'sent' | 'sent_external' = 'sent';
+
+    if (sendMethod === 'email') {
+      if (!recipient.email) {
+        return NextResponse.json(
+          {
+            error:
+              "No email on file for this recipient. Add one in the review screen or use WhatsApp instead.",
+          },
+          { status: 400 }
+        );
+      }
+
+      try {
+        const { client, fromEmail } = await getResendClient();
+        const result = await client.emails.send({
+          from: fromEmail,
+          to: recipient.email,
+          subject,
+          text: messageBody,
+        });
+        provider = 'resend';
+        providerMessageId = (result as any)?.data?.id ?? (result as any)?.id ?? null;
+      } catch (err: any) {
+        return NextResponse.json(
+          {
+            error: 'Email provider rejected the send',
+            details: err?.message || 'unknown',
+          },
+          { status: 502 }
+        );
+      }
+    } else if (sendMethod === 'whatsapp') {
+      nextStatus = 'sent_external';
+      provider = 'whatsapp_handoff';
+      const phoneDigits = (recipient.phone || '').replace(/\D/g, '');
+      externalPayload = phoneDigits
+        ? {
+            href: `https://wa.me/${phoneDigits}?text=${encodeURIComponent(messageBody)}`,
+            hint: 'Opens WhatsApp with the message ready to send.',
+          }
+        : {
+            hint: 'No phone number on file. Add one to finish on WhatsApp.',
+          };
+    } else if (sendMethod === 'sms') {
+      nextStatus = 'sent_external';
+      provider = 'sms_handoff';
+      const phone = recipient.phone || '';
+      externalPayload = phone
+        ? {
+            href: `sms:${phone}?body=${encodeURIComponent(messageBody)}`,
+            hint: 'Opens your messages app with the text ready to send.',
+          }
+        : {
+            hint: 'No phone number on file. Add one to finish in messages.',
+          };
+    } else {
+      return NextResponse.json(
+        { error: `Unsupported send method: ${sendMethod}` },
+        { status: 400 }
+      );
+    }
+
+    const { error: updErr } = await supabase
+      .from('pending_drafts')
+      .update({ status: nextStatus, sent_at: sentAt, updated_at: sentAt })
+      .eq('id', draftId);
+
+    if (updErr) {
+      return NextResponse.json(
+        { error: 'Draft sent but status update failed', details: updErr.message },
+        { status: 500 }
+      );
+    }
+
+    const { data: history } = await supabase
+      .from('agent_send_history')
+      .insert({
+        user_id: draft.user_id,
+        tenant_id: draft.tenant_id,
+        draft_id: draft.id,
+        draft_type: draft.draft_type,
+        recipient_id: draft.recipient_id,
+        sent_at: sentAt,
+        was_edited_before_send: !!wasEdited,
+        send_method: sendMethod,
+        provider,
+        provider_message_id: providerMessageId,
+      })
+      .select('id')
+      .single();
+
+    await supabase.from('recent_actions').insert({
+      user_id: draft.user_id,
+      tenant_id: draft.tenant_id,
+      approval_batch_id: batchId,
+      action_type: `send_${sendMethod}`,
+      target_table: 'pending_drafts',
+      target_id: draft.id,
+      reversal_payload: {
+        op: 'restore_draft',
+        draftId: draft.id,
+        priorStatus: 'pending_review',
+        providerMessageId,
+        provider,
+        historyId: history?.id || null,
+      },
+      status: 'active',
+    });
+
+    // Resend supports cancellation within the scheduled window. We don't use
+    // scheduled sends in this session so we can't truly cancel once sent;
+    // the undo route surfaces that honestly to the user.
+    const undoable = sendMethod !== 'email' || Boolean(providerMessageId);
+
+    return NextResponse.json({
+      batchId,
+      status: nextStatus,
+      provider,
+      providerMessageId,
+      externalPayload,
+      undoable,
+      sentAt,
+    });
+  } catch (error: any) {
+    console.error('[agent/intelligence/send-draft] Error:', error.message);
+    return NextResponse.json(
+      { error: 'Send failed', details: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/unified-portal/app/api/agent/intelligence/undo-send/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/undo-send/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { getResendClient } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agent/intelligence/undo-send
+ * Body: { batchId }
+ *
+ * Flips the draft back to pending_review, attempts to cancel the email on
+ * Resend (only works within Resend's cancellation window for scheduled sends
+ * — for immediate sends it surfaces that honestly rather than pretending to
+ * have pulled the email back), and marks the send-history row as undone.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { batchId } = await request.json();
+    if (!batchId) {
+      return NextResponse.json({ error: 'batchId required' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: entries, error } = await supabase
+      .from('recent_actions')
+      .select('id, target_id, reversal_payload, status, action_type')
+      .eq('approval_batch_id', batchId)
+      .eq('status', 'active');
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!entries || entries.length === 0) {
+      return NextResponse.json({ reversed: [], notice: 'Nothing to undo' });
+    }
+
+    const reversed: string[] = [];
+    let providerNotice: string | null = null;
+
+    for (const entry of entries) {
+      const payload = entry.reversal_payload as any;
+      if (payload?.op !== 'restore_draft') continue;
+
+      // Best-effort provider cancellation. Resend only cancels scheduled
+      // emails that haven't left yet; immediate sends cannot be recalled.
+      if (entry.action_type === 'send_email' && payload.providerMessageId) {
+        try {
+          const { client } = await getResendClient();
+          const anyClient = client as any;
+          if (anyClient?.emails?.cancel) {
+            await anyClient.emails.cancel(payload.providerMessageId);
+          } else {
+            providerNotice =
+              "Email already left Resend — draft restored as pending, but the recipient may have already received it.";
+          }
+        } catch {
+          providerNotice =
+            "Email already left Resend — draft restored as pending, but the recipient may have already received it.";
+        }
+      }
+
+      await supabase
+        .from('pending_drafts')
+        .update({
+          status: payload.priorStatus || 'pending_review',
+          sent_at: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', payload.draftId);
+
+      if (payload.historyId) {
+        await supabase
+          .from('agent_send_history')
+          .update({ undone: true })
+          .eq('id', payload.historyId);
+      }
+
+      await supabase
+        .from('recent_actions')
+        .update({ status: 'undone', undone_at: new Date().toISOString() })
+        .eq('id', entry.id);
+
+      reversed.push(entry.id);
+    }
+
+    return NextResponse.json({ reversed, notice: providerNotice });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -1,0 +1,217 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Shared types + helpers for the Drafts screen (Session 2).
+ *
+ * The draft review screen reads `pending_drafts` rows directly. Recipient
+ * fields (name, email, phone) are resolved against the source table that
+ * matches draft_type — today that's listings.vendor_* for vendor updates.
+ * Every helper here has to be defensive: the `recipient_id` is a free-form
+ * string written by the voice extractor, so it could be a listing UUID or a
+ * plain address reference like "14 Oakfield".
+ */
+
+export type DraftStatus =
+  | 'pending_review'
+  | 'sent'
+  | 'sent_external'
+  | 'discarded'
+  | 'undone';
+
+export interface DraftRecipient {
+  id: string | null;
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  source: 'listing_vendor' | 'unknown';
+  address?: string | null;
+}
+
+export interface DraftRecord {
+  id: string;
+  userId: string;
+  tenantId: string | null;
+  draftType: string;
+  status: DraftStatus;
+  sendMethod: 'email' | 'whatsapp' | 'sms' | null;
+  recipient: DraftRecipient;
+  subject: string;
+  body: string;
+  contextChips: Array<{ id: string; label: string; detail: string | null }>;
+  createdAt: string;
+  updatedAt: string;
+  sentAt: string | null;
+}
+
+export function draftTypeLabel(type: string): string {
+  switch (type) {
+    case 'vendor_update':
+      return 'Vendor update';
+    case 'landlord_statement':
+      return 'Landlord statement';
+    case 'buyer_followup':
+      return 'Buyer follow-up';
+    default:
+      return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+}
+
+export async function resolveRecipient(
+  supabase: SupabaseClient,
+  draftType: string,
+  recipientId: string | null,
+): Promise<DraftRecipient> {
+  if (!recipientId) {
+    return { id: null, name: null, email: null, phone: null, source: 'unknown' };
+  }
+
+  if (draftType === 'vendor_update') {
+    const listing = await findListingFromReference(supabase, recipientId);
+    if (listing) {
+      return {
+        id: listing.id,
+        name: listing.vendor_name || listing.address || null,
+        email: listing.vendor_solicitor_email || null,
+        phone: listing.vendor_phone || null,
+        address: listing.address || null,
+        source: 'listing_vendor',
+      };
+    }
+  }
+
+  // Fallback — display the raw reference so the user sees what the voice heard.
+  return {
+    id: recipientId,
+    name: recipientId,
+    email: null,
+    phone: null,
+    source: 'unknown',
+  };
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function findListingFromReference(
+  supabase: SupabaseClient,
+  reference: string,
+): Promise<any | null> {
+  if (UUID_REGEX.test(reference)) {
+    const { data } = await supabase
+      .from('listings')
+      .select('id, address, vendor_name, vendor_phone, vendor_solicitor_email')
+      .eq('id', reference)
+      .maybeSingle();
+    if (data) return data;
+  }
+
+  const { data: matches } = await supabase
+    .from('listings')
+    .select('id, address, vendor_name, vendor_phone, vendor_solicitor_email')
+    .ilike('address', `%${reference}%`)
+    .limit(1);
+  return matches?.[0] || null;
+}
+
+/**
+ * Convert a pending_drafts row + resolved recipient into the shape the UI
+ * consumes. Centralises the content_json decoding so the API route and the
+ * review route stay in sync.
+ */
+export function toDraftRecord(row: any, recipient: DraftRecipient): DraftRecord {
+  const content = row.content_json || {};
+  const subject = extractSubject(content, recipient);
+  const body = extractBody(content);
+  const contextChips = extractContextChips(content, recipient);
+
+  return {
+    id: row.id,
+    userId: row.user_id,
+    tenantId: row.tenant_id,
+    draftType: row.draft_type,
+    status: row.status,
+    sendMethod: row.send_method ?? null,
+    recipient,
+    subject,
+    body,
+    contextChips,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    sentAt: row.sent_at ?? null,
+  };
+}
+
+function extractSubject(content: any, recipient: DraftRecipient): string {
+  if (typeof content.subject === 'string' && content.subject.trim()) {
+    return content.subject.trim();
+  }
+  // Vendor updates never get a subject from the voice extractor today, so we
+  // derive a sensible one that the user can edit.
+  const addr = recipient.address || recipient.name || 'your property';
+  return `Update on ${addr}`;
+}
+
+function extractBody(content: any): string {
+  if (typeof content.body === 'string' && content.body.trim()) {
+    return content.body.trim();
+  }
+  if (typeof content.update_summary === 'string') {
+    return content.update_summary.trim();
+  }
+  return '';
+}
+
+function extractContextChips(
+  content: any,
+  recipient: DraftRecipient,
+): Array<{ id: string; label: string; detail: string | null }> {
+  const chips: Array<{ id: string; label: string; detail: string | null }> = [];
+
+  if (recipient.address) {
+    chips.push({
+      id: 'property',
+      label: recipient.address,
+      detail: recipient.name && recipient.name !== recipient.address
+        ? `Vendor: ${recipient.name}`
+        : null,
+    });
+  }
+
+  if (typeof content.source_viewing_id === 'string') {
+    chips.push({
+      id: 'viewing',
+      label: 'From a logged viewing',
+      detail: content.source_viewing_id,
+    });
+  }
+
+  if (Array.isArray(content.source_facts)) {
+    for (const fact of content.source_facts.slice(0, 3)) {
+      chips.push({ id: `fact_${chips.length}`, label: String(fact), detail: null });
+    }
+  }
+
+  return chips;
+}
+
+/**
+ * Format relative timestamps for the list view. Keeps Irish peer-to-peer tone.
+ */
+export function relativeTimestamp(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+
+  const diffMs = now - then;
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min${mins === 1 ? '' : 's'} ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  if (days === 1) {
+    const d = new Date(then);
+    return `yesterday at ${d.toLocaleTimeString('en-IE', { hour: 'numeric', minute: '2-digit' }).toLowerCase()}`;
+  }
+  if (days < 7) return `${days} days ago`;
+  return new Date(then).toLocaleDateString('en-IE', { day: 'numeric', month: 'short' });
+}

--- a/apps/unified-portal/migrations/043_draft_send_flow.sql
+++ b/apps/unified-portal/migrations/043_draft_send_flow.sql
@@ -1,0 +1,66 @@
+-- Migration: Draft Send Flow (Session 2)
+-- Adds sent_at to pending_drafts, expands its status enum, and creates
+-- agent_send_history — a track-record table Session 3 will use to gate
+-- auto-send behaviour.
+--
+-- Run as three separate query blocks in Supabase SQL Editor:
+--   (1) CREATE / ALTER
+--   (2) ENABLE RLS
+--   (3) CREATE POLICY
+-- Never batch together.
+
+-- ============================================
+-- 1. Schema changes
+-- ============================================
+
+-- New timestamp for when the draft was actually sent.
+ALTER TABLE pending_drafts
+  ADD COLUMN IF NOT EXISTS sent_at TIMESTAMPTZ;
+
+-- Widen the allowed statuses. 'sent_external' covers WhatsApp/SMS which this
+-- session hands off to the native URI handlers rather than sending directly.
+-- 'undone' is a distinct terminal state so the track-record is truthful.
+ALTER TABLE pending_drafts
+  DROP CONSTRAINT IF EXISTS pending_drafts_status_check;
+
+ALTER TABLE pending_drafts
+  ADD CONSTRAINT pending_drafts_status_check
+  CHECK (status IN ('pending_review', 'sent', 'sent_external', 'discarded', 'undone'));
+
+-- Track record of every successful send for the authenticated agent.
+-- Used later to decide when auto-send is safe. Undo flips the undone flag.
+CREATE TABLE IF NOT EXISTS agent_send_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) NOT NULL,
+  tenant_id UUID REFERENCES tenants(id),
+  draft_id UUID REFERENCES pending_drafts(id),
+  draft_type TEXT NOT NULL,
+  recipient_id TEXT,
+  sent_at TIMESTAMPTZ DEFAULT now(),
+  was_edited_before_send BOOLEAN NOT NULL,
+  undone BOOLEAN DEFAULT false,
+  send_method TEXT,
+  provider TEXT,
+  provider_message_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_send_history_user_id ON agent_send_history(user_id);
+CREATE INDEX IF NOT EXISTS idx_agent_send_history_draft_type ON agent_send_history(draft_type);
+CREATE INDEX IF NOT EXISTS idx_agent_send_history_sent_at ON agent_send_history(sent_at DESC);
+
+-- ============================================
+-- 2. Enable RLS
+-- ============================================
+ALTER TABLE agent_send_history ENABLE ROW LEVEL SECURITY;
+
+-- ============================================
+-- 3. Policies — drop-if-exists for idempotency
+-- ============================================
+DROP POLICY IF EXISTS agent_send_history_service_role ON agent_send_history;
+DROP POLICY IF EXISTS agent_send_history_self_access ON agent_send_history;
+
+CREATE POLICY agent_send_history_service_role ON agent_send_history
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_send_history_self_access ON agent_send_history
+  FOR ALL USING (user_id = auth.uid());

--- a/apps/unified-portal/tests/e2e/drafts-review.spec.ts
+++ b/apps/unified-portal/tests/e2e/drafts-review.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Playwright smoke test for the Session 2 drafts review flow.
+ *
+ * Install & run once:
+ *   npm i -D @playwright/test
+ *   npx playwright install chromium
+ *   npx playwright test tests/e2e/drafts-review.spec.ts
+ *
+ * Mocks the list/get/patch/send endpoints so it doesn't touch Supabase or
+ * Resend. Covers the golden path:
+ *   1. Create a draft (mock) via the voice capture extract+execute routes
+ *   2. Open the drafts list
+ *   3. Tap the draft row
+ *   4. Edit the subject
+ *   5. Send
+ *   6. Verify sent state + 60s undo pill
+ */
+import { expect, test } from '@playwright/test';
+
+const DRAFT_ID = 'draft_smoke_1';
+
+const MOCK_DRAFT = {
+  id: DRAFT_ID,
+  userId: 'user_smoke',
+  tenantId: 'tenant_smoke',
+  draftType: 'vendor_update',
+  status: 'pending_review',
+  sendMethod: 'email',
+  recipient: {
+    id: 'listing_1',
+    name: 'Mary Doyle',
+    email: 'mary@doyle.ie',
+    phone: null,
+    source: 'listing_vendor',
+    address: '14 Oakfield',
+  },
+  subject: 'Update on 14 Oakfield',
+  body: 'Murphys viewed and loved the place, concern about the garden.',
+  contextChips: [
+    { id: 'property', label: '14 Oakfield', detail: 'Vendor: Mary Doyle' },
+  ],
+  createdAt: new Date(Date.now() - 3600_000).toISOString(),
+  updatedAt: new Date().toISOString(),
+  sentAt: null,
+};
+
+test.describe('Agent Drafts review', () => {
+  test('opens a draft, edits subject, sends, shows undo pill', async ({ page }) => {
+    let currentSubject = MOCK_DRAFT.subject;
+
+    await page.route('**/api/agent/intelligence/drafts', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          drafts: [{ ...MOCK_DRAFT, subject: currentSubject }],
+          count: 1,
+        }),
+      });
+    });
+
+    await page.route(`**/api/agent/intelligence/drafts/${DRAFT_ID}`, async (route) => {
+      const method = route.request().method();
+      if (method === 'PATCH') {
+        const body = JSON.parse(route.request().postData() || '{}');
+        if (typeof body.subject === 'string') currentSubject = body.subject;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ draft: { ...MOCK_DRAFT, subject: currentSubject } }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ draft: { ...MOCK_DRAFT, subject: currentSubject } }),
+      });
+    });
+
+    await page.route('**/api/agent/intelligence/send-draft', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_smoke_send',
+          status: 'sent',
+          provider: 'resend',
+          providerMessageId: 'msg_1',
+          externalPayload: null,
+          undoable: true,
+          sentAt: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.goto('/agent/drafts');
+
+    const row = page.getByTestId('drafts-list-row');
+    await expect(row).toBeVisible({ timeout: 5000 });
+    await expect(row).toContainText('Mary Doyle');
+    await row.click();
+
+    const panel = page.getByTestId('draft-review-panel');
+    await expect(panel).toBeVisible();
+
+    const subjectInput = page.getByTestId('draft-subject-input');
+    await subjectInput.fill('Quick update on 14 Oakfield');
+
+    const saveButton = page.getByTestId('draft-save');
+    await expect(saveButton).toBeVisible();
+
+    await page.getByTestId('draft-send').click();
+
+    await expect(page.getByTestId('draft-sent-confirmation')).toBeVisible();
+    await expect(page.getByTestId('voice-undo-pill')).toBeVisible();
+  });
+
+  test('empty state renders when there are no drafts', async ({ page }) => {
+    await page.route('**/api/agent/intelligence/drafts', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ drafts: [], count: 0 }),
+      });
+    });
+
+    await page.goto('/agent/drafts');
+    await expect(page.getByTestId('drafts-empty-state')).toBeVisible();
+    await expect(page.getByTestId('drafts-empty-state')).toContainText('No drafts waiting');
+  });
+});


### PR DESCRIPTION
Session 2 ships the screen where voice-captured drafts land for review before anything goes to the recipient.

- Drafts list surface at /agent/drafts (mobile) and /agent/dashboard/drafts (desktop). Lists every pending_review row with recipient, type, preview, send method and relative timestamp. Empty state renders a calm 'No drafts waiting. Nice.' acknowledgement.
- DraftReviewPanel: full-screen on mobile, 450px right-hand side panel on desktop. Editable subject + body with dirty-state tracking, auto- resizing textarea, tap-to-change send method, context chips with tooltips, recipient row with contact fallback. Keyboard-inset-height footer so the Send button stays visible above the soft keyboard. Desktop keyboard shortcuts: Cmd/Ctrl+Enter sends, Esc closes, Cmd/Ctrl+D discards with confirm.
- DraftsListRow: iOS-style swipe-left-to-discard, swipe-right-to-send for high-confidence quick sends without opening the review.
- Pull-to-refresh on the list.
- /api/agent/intelligence/drafts (GET, PATCH, DELETE via /[id]) drives list/review/edit/discard. Hard delete on discard per spec.
- /api/agent/intelligence/send-draft routes by send_method: email via existing lib/resend.ts, WhatsApp/SMS as wa.me/sms: deep-link payloads that mark the draft sent_external. Every successful send inserts an agent_send_history row with was_edited_before_send so Session 3 can gate auto-send. Each send records a recent_actions reversal so the 60s undo pill reuses the Session 1 UndoPill.
- /api/agent/intelligence/undo-send flips status back to pending_review, attempts Resend cancellation where supported, surfaces an honest 'may have already been delivered' notice where not.
- Drafts badge counts in bottom nav and desktop sidebar driven by a shared useDraftsCount hook that polls every 30s and responds to the oh.agent.drafts.refresh event dispatched by send/discard.
- Migration 043: ALTER pending_drafts (add sent_at, widen status constraint) and CREATE agent_send_history with RLS. Written as separate CREATE/ALTER, ENABLE RLS and CREATE POLICY blocks with DROP POLICY IF EXISTS for idempotency.
- Playwright smoke test for open-draft, edit-subject, send, undo-pill.