### PR TITLE
feat(agent-intelligence): auto-send track record + workflow autonomy

### DIFF
--- a/apps/unified-portal/app/agent/_components/AutoSendCountdown.tsx
+++ b/apps/unified-portal/app/agent/_components/AutoSendCountdown.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+
+interface AutoSendCountdownProps {
+  label: string;
+  countdownSeconds: number;
+  onElapsed: () => void;
+  onCancel: () => void;
+  active: boolean;
+}
+
+/**
+ * Thin banner that sits at the top of the confirmation card while an
+ * auto-send is pending. Ticks down once per second from the server-supplied
+ * countdown, fires onElapsed at zero, or onCancel when the user taps the
+ * X. `active` stops the countdown externally (e.g. after success/failure).
+ */
+export default function AutoSendCountdown({
+  label,
+  countdownSeconds,
+  onElapsed,
+  onCancel,
+  active,
+}: AutoSendCountdownProps) {
+  const [remaining, setRemaining] = useState(countdownSeconds);
+  const elapsedFired = useRef(false);
+
+  useEffect(() => {
+    if (!active) return;
+    if (remaining <= 0) {
+      if (!elapsedFired.current) {
+        elapsedFired.current = true;
+        onElapsed();
+      }
+      return;
+    }
+    const id = setTimeout(() => setRemaining((r) => r - 1), 1000);
+    return () => clearTimeout(id);
+  }, [remaining, active, onElapsed]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      data-testid="auto-send-countdown"
+      data-remaining={remaining}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '10px 14px',
+        background: 'linear-gradient(135deg, rgba(196,155,42,0.08), rgba(232,200,74,0.12))',
+        border: '0.5px solid rgba(196,155,42,0.35)',
+        borderRadius: 12,
+        marginBottom: 12,
+      }}
+    >
+      <div
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 14,
+          background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+          color: '#fff',
+          fontSize: 12,
+          fontWeight: 700,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        {remaining}
+      </div>
+      <span
+        style={{
+          flex: 1,
+          fontSize: 13,
+          fontWeight: 500,
+          color: '#0D0D12',
+          lineHeight: 1.4,
+        }}
+      >
+        {label} in {remaining}s
+      </span>
+      <button
+        data-testid="auto-send-cancel"
+        onClick={onCancel}
+        aria-label="Cancel auto-send"
+        className="agent-tappable"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '6px 10px',
+          background: 'transparent',
+          color: '#DC2626',
+          border: '0.5px solid rgba(220,38,38,0.25)',
+          borderRadius: 999,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        <X size={12} />
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/agent/_components/AutoSendOfferCard.tsx
+++ b/apps/unified-portal/app/agent/_components/AutoSendOfferCard.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { draftTypeLabel } from '@/lib/agent-intelligence/drafts';
+
+interface AutoSendOfferCardProps {
+  draftType: string;
+  totalSent: number;
+  sentEdited: number;
+  onEnable: () => Promise<void>;
+  onDismiss: () => Promise<void>;
+}
+
+/**
+ * Shown in the Drafts review "Sent" confirmation state the first time the
+ * user crosses eligibility for auto-send on a given draft_type. Copy is
+ * pulled straight from the Session 3 spec — understated, no pressure, no
+ * dark pattern. Dismissal is as easy as acceptance.
+ */
+export default function AutoSendOfferCard({
+  draftType,
+  totalSent,
+  sentEdited,
+  onEnable,
+  onDismiss,
+}: AutoSendOfferCardProps) {
+  const [busy, setBusy] = useState<'enable' | 'dismiss' | null>(null);
+
+  const typeLabel = draftTypeLabel(draftType).toLowerCase();
+  const typeLabelPlural = typeLabel.endsWith('s') ? typeLabel : `${typeLabel}s`;
+
+  return (
+    <div
+      data-testid="auto-send-offer-card"
+      style={{
+        margin: '0 18px 18px',
+        padding: '14px 16px',
+        borderRadius: 14,
+        background: '#FFFFFF',
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        borderLeft: '3px solid #D4AF37',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          marginBottom: 6,
+          color: '#8A6E1F',
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        <Sparkles size={12} />
+        Offer
+      </div>
+      <p
+        style={{
+          margin: '0 0 10px',
+          fontSize: 13.5,
+          lineHeight: 1.55,
+          color: '#0D0D12',
+        }}
+      >
+        You&apos;ve sent {totalSent} {typeLabelPlural} with Intelligence, and only
+        edited {sentEdited} of them before sending. Want me to start sending
+        these automatically? You&apos;ll still have 10 seconds to pull each
+        one back before it goes.
+      </p>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button
+          data-testid="auto-send-offer-enable"
+          onClick={async () => {
+            setBusy('enable');
+            try { await onEnable(); } finally { setBusy(null); }
+          }}
+          disabled={busy !== null}
+          className="agent-tappable"
+          style={{
+            padding: '8px 14px',
+            background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 10,
+            fontSize: 12.5,
+            fontWeight: 600,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+        >
+          {busy === 'enable' ? 'Turning on...' : 'Turn on auto-send'}
+        </button>
+        <button
+          data-testid="auto-send-offer-dismiss"
+          onClick={async () => {
+            setBusy('dismiss');
+            try { await onDismiss(); } finally { setBusy(null); }
+          }}
+          disabled={busy !== null}
+          className="agent-tappable"
+          style={{
+            padding: '8px 12px',
+            background: 'transparent',
+            color: '#6B7280',
+            border: '0.5px solid rgba(0,0,0,0.12)',
+            borderRadius: 10,
+            fontSize: 12.5,
+            fontWeight: 500,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+        >
+          Not yet
+        </button>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          fontSize: 11,
+          color: '#9CA3AF',
+          letterSpacing: '0.005em',
+        }}
+      >
+        You can change this anytime in settings.
+      </p>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
@@ -16,16 +16,20 @@ import {
   draftTypeLabel,
   type DraftRecord,
 } from '@/lib/agent-intelligence/drafts';
+import AutoSendOfferCard from './AutoSendOfferCard';
 
 interface DraftReviewPanelProps {
   draft: DraftRecord;
   surface: 'mobile' | 'desktop';
   sending: boolean;
   sentState: SentState | null;
+  autoSendOffer?: AutoSendOffer | null;
   onClose: () => void;
   onSave: (patch: { subject: string; body: string; sendMethod?: DraftRecord['sendMethod'] }) => Promise<DraftRecord | null>;
   onSend: (opts: { wasEdited: boolean }) => Promise<void>;
   onDiscard: () => Promise<void>;
+  onEnableAutoSend?: (draftType: string) => Promise<void>;
+  onDismissAutoSendOffer?: (draftType: string) => Promise<void>;
 }
 
 export interface SentState {
@@ -34,6 +38,12 @@ export interface SentState {
   externalHref: string | null;
   externalHint: string | null;
   undoable: boolean;
+}
+
+export interface AutoSendOffer {
+  draftType: string;
+  totalSent: number;
+  sentEdited: number;
 }
 
 const DISCARD_CONFIRM = 'Discard this draft? This cannot be undone.';
@@ -49,10 +59,13 @@ export default function DraftReviewPanel({
   surface,
   sending,
   sentState,
+  autoSendOffer,
   onClose,
   onSave,
   onSend,
   onDiscard,
+  onEnableAutoSend,
+  onDismissAutoSendOffer,
 }: DraftReviewPanelProps) {
   const [subject, setSubject] = useState(draft.subject);
   const [bodyText, setBodyText] = useState(draft.body);
@@ -188,7 +201,18 @@ export default function DraftReviewPanel({
 
         <div style={scrollStyle}>
           {sentState ? (
-            <SentConfirmation state={sentState} />
+            <>
+              <SentConfirmation state={sentState} />
+              {autoSendOffer && onEnableAutoSend && onDismissAutoSendOffer && (
+                <AutoSendOfferCard
+                  draftType={autoSendOffer.draftType}
+                  totalSent={autoSendOffer.totalSent}
+                  sentEdited={autoSendOffer.sentEdited}
+                  onEnable={() => onEnableAutoSend(autoSendOffer.draftType)}
+                  onDismiss={() => onDismissAutoSendOffer(autoSendOffer.draftType)}
+                />
+              )}
+            </>
           ) : (
             <>
               <RecipientRow

--- a/apps/unified-portal/app/agent/_components/VoiceConfirmationCard.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceConfirmationCard.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import Image from 'next/image';
-import { Check, HelpCircle, Pencil, X } from 'lucide-react';
+import { Check, HelpCircle, PauseCircle, Pencil, X } from 'lucide-react';
+import AutoSendCountdown from './AutoSendCountdown';
 import {
   LOW_CONFIDENCE_THRESHOLD,
   actionLabel,
@@ -10,13 +11,28 @@ import {
   type ExtractedAction,
 } from '@/lib/agent-intelligence/voice-actions';
 
+export interface AutoSendUiState {
+  actionId: string;
+  draftId: string;
+  draftType: string;
+  recipientName: string;
+  countdownSeconds: number;
+  active: boolean;
+  status: 'counting' | 'sending' | 'sent' | 'cancelled' | 'failed';
+  failMessage?: string;
+}
+
 interface VoiceConfirmationCardProps {
   actions: ExtractedAction[];
   status: 'review' | 'executing' | 'done';
   results?: ExecutedAction[];
+  autoSendUi?: AutoSendUiState | null;
+  globalPaused?: boolean;
   onChange: (actions: ExtractedAction[]) => void;
   onApprove: () => void;
   onDiscard: () => void;
+  onAutoSendElapsed?: () => void;
+  onAutoSendCancel?: () => void;
 }
 
 /**
@@ -28,9 +44,13 @@ export default function VoiceConfirmationCard({
   actions,
   status,
   results,
+  autoSendUi,
+  globalPaused,
   onChange,
   onApprove,
   onDiscard,
+  onAutoSendElapsed,
+  onAutoSendCancel,
 }: VoiceConfirmationCardProps) {
   const resultById = useMemo(() => {
     const map: Record<string, ExecutedAction> = {};
@@ -104,6 +124,110 @@ export default function VoiceConfirmationCard({
                 : "Here's what I'll do. Approve to send"}
           </span>
         </div>
+
+        {globalPaused && status === 'review' && (
+          <div
+            data-testid="voice-global-pause-banner"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 12px',
+              marginBottom: 12,
+              background: 'rgba(0,0,0,0.04)',
+              border: '0.5px dashed rgba(0,0,0,0.12)',
+              borderRadius: 10,
+              color: '#6B7280',
+              fontSize: 12,
+              fontWeight: 500,
+            }}
+          >
+            <PauseCircle size={14} />
+            Auto-send paused. Everything will go to drafts for review.
+          </div>
+        )}
+
+        {autoSendUi?.active && autoSendUi.status === 'counting' && onAutoSendElapsed && onAutoSendCancel && (
+          <AutoSendCountdown
+            label={`Sending vendor update to ${autoSendUi.recipientName}`}
+            countdownSeconds={autoSendUi.countdownSeconds}
+            active={autoSendUi.status === 'counting'}
+            onElapsed={onAutoSendElapsed}
+            onCancel={onAutoSendCancel}
+          />
+        )}
+
+        {autoSendUi?.status === 'sending' && (
+          <div
+            data-testid="auto-send-sending-banner"
+            style={{
+              padding: '10px 14px',
+              marginBottom: 12,
+              background: 'rgba(196,155,42,0.08)',
+              border: '0.5px solid rgba(196,155,42,0.3)',
+              borderRadius: 12,
+              fontSize: 13,
+              color: '#0D0D12',
+              fontWeight: 500,
+            }}
+          >
+            Sending vendor update to {autoSendUi.recipientName}...
+          </div>
+        )}
+
+        {autoSendUi?.status === 'sent' && (
+          <div
+            data-testid="auto-send-success-banner"
+            style={{
+              padding: '10px 14px',
+              marginBottom: 12,
+              background: 'rgba(5,150,105,0.08)',
+              border: '0.5px solid rgba(5,150,105,0.25)',
+              borderRadius: 12,
+              fontSize: 13,
+              color: '#047857',
+              fontWeight: 500,
+            }}
+          >
+            Sent to {autoSendUi.recipientName}. Undo available for 60 seconds.
+          </div>
+        )}
+
+        {autoSendUi?.status === 'cancelled' && (
+          <div
+            data-testid="auto-send-cancelled-banner"
+            style={{
+              padding: '10px 14px',
+              marginBottom: 12,
+              background: 'rgba(0,0,0,0.03)',
+              border: '0.5px solid rgba(0,0,0,0.1)',
+              borderRadius: 12,
+              fontSize: 13,
+              color: '#6B7280',
+              fontWeight: 500,
+            }}
+          >
+            Held for review. Find it in Drafts.
+          </div>
+        )}
+
+        {autoSendUi?.status === 'failed' && (
+          <div
+            data-testid="auto-send-failed-banner"
+            style={{
+              padding: '10px 14px',
+              marginBottom: 12,
+              background: 'rgba(220,38,38,0.06)',
+              border: '0.5px solid rgba(220,38,38,0.25)',
+              borderRadius: 12,
+              fontSize: 13,
+              color: '#B91C1C',
+              fontWeight: 500,
+            }}
+          >
+            {autoSendUi.failMessage || "Couldn't auto-send — the draft is in review."}
+          </div>
+        )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {actions.map((action) => (
@@ -288,6 +412,19 @@ function ActionSection({
           }}
         >
           {result.message}
+        </div>
+      )}
+      {status === 'done' && result?.autoSendHold && (
+        <div
+          data-testid="auto-send-hold-message"
+          style={{
+            marginTop: 6,
+            fontSize: 11.5,
+            color: '#92400E',
+            fontStyle: 'italic',
+          }}
+        >
+          {result.autoSendHold}
         </div>
       )}
     </div>

--- a/apps/unified-portal/app/agent/dashboard/settings/autonomy/page.tsx
+++ b/apps/unified-portal/app/agent/dashboard/settings/autonomy/page.tsx
@@ -1,0 +1,3 @@
+import AutonomySettingsPage from '../../../settings/autonomy/page';
+
+export default AutonomySettingsPage;

--- a/apps/unified-portal/app/agent/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/drafts/page.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { MailCheck } from 'lucide-react';
+import Link from 'next/link';
+import { MailCheck, Settings2 } from 'lucide-react';
 import AgentShell from '../_components/AgentShell';
 import DraftsListRow from '../_components/DraftsListRow';
-import DraftReviewPanel, { type SentState } from '../_components/DraftReviewPanel';
+import DraftReviewPanel, { type AutoSendOffer, type SentState } from '../_components/DraftReviewPanel';
+import {
+  canOfferAutoSend,
+  type DraftTypeStats,
+} from '@/lib/agent-intelligence/autonomy';
 import UndoPill from '../_components/UndoPill';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { notifyDraftsChanged } from '../_hooks/useDraftsCount';
@@ -26,6 +31,7 @@ export default function AgentDraftsPage() {
   const [activeDraft, setActiveDraft] = useState<DraftRecord | null>(null);
   const [sending, setSending] = useState(false);
   const [sentState, setSentState] = useState<SentState | null>(null);
+  const [autoSendOffer, setAutoSendOffer] = useState<AutoSendOffer | null>(null);
   const [undoBatch, setUndoBatch] = useState<UndoBatch | null>(null);
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -68,7 +74,44 @@ export default function AgentDraftsPage() {
     if (autoCloseTimer.current) clearTimeout(autoCloseTimer.current);
     setActiveDraft(null);
     setSentState(null);
+    setAutoSendOffer(null);
   };
+
+  const closeAfterOffer = useCallback(() => {
+    if (autoCloseTimer.current) clearTimeout(autoCloseTimer.current);
+    autoCloseTimer.current = setTimeout(() => {
+      setActiveDraft(null);
+      setSentState(null);
+      setAutoSendOffer(null);
+    }, 1200);
+  }, []);
+
+  const handleEnableAutoSend = useCallback(async (draftType: string) => {
+    try {
+      await fetch('/api/agent/intelligence/autonomy', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draftType, autoSendEnabled: true }),
+      });
+      setAutoSendOffer(null);
+      closeAfterOffer();
+    } catch {
+      alert("Couldn't turn that on. Try from settings.");
+    }
+  }, [closeAfterOffer]);
+
+  const handleDismissAutoSendOffer = useCallback(async (draftType: string) => {
+    try {
+      await fetch('/api/agent/intelligence/autonomy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'dismiss_offer', draftType }),
+      });
+    } finally {
+      setAutoSendOffer(null);
+      closeAfterOffer();
+    }
+  }, [closeAfterOffer]);
 
   const handleSave = useCallback(async (
     patch: { subject: string; body: string; sendMethod?: DraftRecord['sendMethod'] },
@@ -116,10 +159,46 @@ export default function AgentDraftsPage() {
       setUndoBatch({ batchId: data.batchId, createdAt: Date.now(), notice: null });
       notifyDraftsChanged();
 
-      autoCloseTimer.current = setTimeout(() => {
-        setActiveDraft(null);
-        setSentState(null);
-      }, AUTO_CLOSE_MS);
+      // Evaluate the auto-send offer before setting the auto-close timer —
+      // if the offer will show, we hold the panel open until the user
+      // decides.
+      const draftType = activeDraft.draftType;
+      let offered = false;
+      try {
+        const statsRes = await fetch('/api/agent/intelligence/track-record', { cache: 'no-store' });
+        if (statsRes.ok) {
+          const statsData = await statsRes.json();
+          const stats: DraftTypeStats | undefined = (statsData.draftTypes || []).find(
+            (d: DraftTypeStats) => d.draftType === draftType,
+          );
+          if (
+            stats &&
+            canOfferAutoSend(stats, {
+              autoSendEnabled: stats.autoSendEnabled,
+              offerDismissedCount: stats.offerDismissedCount,
+              offeredAt: stats.offeredAt,
+              sendsSinceOffer: 0,
+            })
+          ) {
+            setAutoSendOffer({
+              draftType: stats.draftType,
+              totalSent: stats.totalSent,
+              sentEdited: stats.sentEdited,
+            });
+            offered = true;
+          }
+        }
+      } catch {
+        /* non-fatal */
+      }
+
+      if (!offered) {
+        autoCloseTimer.current = setTimeout(() => {
+          setActiveDraft(null);
+          setSentState(null);
+          setAutoSendOffer(null);
+        }, AUTO_CLOSE_MS);
+      }
     } finally {
       setSending(false);
     }
@@ -277,29 +356,55 @@ export default function AgentDraftsPage() {
             padding: '16px 20px 12px',
             borderBottom: '0.5px solid rgba(0,0,0,0.05)',
             background: 'rgba(250,250,248,0.95)',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 8,
           }}
         >
-          <h1
+          <div>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 20,
+                fontWeight: 700,
+                letterSpacing: '-0.03em',
+                color: '#0D0D12',
+              }}
+            >
+              Drafts
+            </h1>
+            <p
+              style={{
+                margin: '4px 0 0',
+                fontSize: 12.5,
+                color: '#9CA3AF',
+                letterSpacing: '0.005em',
+              }}
+            >
+              Review what Intelligence wrote for you. Nothing sends until you say so.
+            </p>
+          </div>
+          <Link
+            href="/agent/settings/autonomy"
+            aria-label="Autonomy settings"
+            data-testid="drafts-autonomy-link"
+            className="agent-tappable"
             style={{
-              margin: 0,
-              fontSize: 20,
-              fontWeight: 700,
-              letterSpacing: '-0.03em',
-              color: '#0D0D12',
+              width: 36,
+              height: 36,
+              borderRadius: 18,
+              background: 'rgba(0,0,0,0.04)',
+              border: '0.5px solid rgba(0,0,0,0.06)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#6B7280',
+              flexShrink: 0,
             }}
           >
-            Drafts
-          </h1>
-          <p
-            style={{
-              margin: '4px 0 0',
-              fontSize: 12.5,
-              color: '#9CA3AF',
-              letterSpacing: '0.005em',
-            }}
-          >
-            Review what Intelligence wrote for you. Nothing sends until you say so.
-          </p>
+            <Settings2 size={16} />
+          </Link>
         </header>
 
         <div
@@ -333,10 +438,13 @@ export default function AgentDraftsPage() {
             surface={isDesktop ? 'desktop' : 'mobile'}
             sending={sending}
             sentState={sentState}
+            autoSendOffer={autoSendOffer}
             onClose={handleClose}
             onSave={handleSave}
             onSend={handleSend}
             onDiscard={handleDiscardFromReview}
+            onEnableAutoSend={handleEnableAutoSend}
+            onDismissAutoSendOffer={handleDismissAutoSendOffer}
           />
         )}
 

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -11,6 +11,8 @@ import { useVoiceCapture } from '../_hooks/useVoiceCapture';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { Mail, Copy, Check, ExternalLink } from 'lucide-react';
 import type { ExecutedAction, ExtractedAction } from '@/lib/agent-intelligence/voice-actions';
+import type { AutoSendUiState } from '../_components/VoiceConfirmationCard';
+import { notifyDraftsChanged } from '../_hooks/useDraftsCount';
 
 const SCHEME_PILLS = [
   "What's outstanding on contracts?",
@@ -42,6 +44,8 @@ interface VoiceActionsPayload {
   actions: ExtractedAction[];
   results?: ExecutedAction[];
   transcript?: string;
+  autoSendUi?: AutoSendUiState | null;
+  globalPaused?: boolean;
 }
 
 interface Message {
@@ -356,22 +360,61 @@ export default function IntelligencePage() {
         const data = await res.json();
         const results: ExecutedAction[] = data.results || [];
         const batchId: string = data.batchId;
+        const globalPaused: boolean = !!data.globalPaused;
 
-        updateVoiceMessage(msgId, (v) => ({ ...v, status: 'done', results }));
+        // If any action came back with an auto-send plan, set up the countdown
+        // state. Only one auto-send plan at a time is supported — the spec
+        // narrows Session 3 to draft_vendor_update, and a transcript produces
+        // at most one of those.
+        const autoSendAction = results.find((r) => r.autoSendPlan);
+        let autoSendUi: AutoSendUiState | null = null;
+        if (autoSendAction?.autoSendPlan) {
+          autoSendUi = {
+            actionId: autoSendAction.id,
+            draftId: autoSendAction.autoSendPlan.draftId,
+            draftType: autoSendAction.autoSendPlan.draftType,
+            recipientName: autoSendAction.autoSendPlan.recipientName,
+            countdownSeconds: autoSendAction.autoSendPlan.countdownSeconds,
+            active: true,
+            status: 'counting',
+          };
+        }
 
-        // Natural-language confirmation below the card.
-        const summary = buildConfirmationSummary(actions, results);
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `asst_confirm_${Date.now()}`,
-            role: 'assistant',
-            content: summary,
-          },
-        ]);
+        updateVoiceMessage(msgId, (v) => ({
+          ...v,
+          status: 'done',
+          results,
+          autoSendUi,
+          globalPaused,
+        }));
 
-        if (results.some((r) => r.success)) {
+        // Natural-language confirmation below the card — but only for actions
+        // that actually completed. Auto-send actions haven't finished yet.
+        const summary = buildConfirmationSummary(actions, results, autoSendUi);
+        if (summary) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `asst_confirm_${Date.now()}`,
+              role: 'assistant',
+              content: summary,
+            },
+          ]);
+        }
+
+        if (autoSendUi) {
+          // Track the approval batch so the Session 1 undo also covers the
+          // draft insertion. The auto-send itself gets a separate undo batch
+          // once the send actually fires.
+          if (results.filter((r) => !r.autoSendPlan).some((r) => r.success)) {
+            setUndoBatch({ batchId, createdAt: Date.now() });
+          }
+        } else if (results.some((r) => r.success)) {
           setUndoBatch({ batchId, createdAt: Date.now() });
+        }
+
+        if (results.some((r) => r.type === 'draft_vendor_update')) {
+          notifyDraftsChanged();
         }
       } catch {
         updateVoiceMessage(msgId, (v) => ({ ...v, status: 'review' }));
@@ -383,6 +426,86 @@ export default function IntelligencePage() {
             content: "Couldn't log those just now. Try again in a second?",
           },
         ]);
+      }
+    },
+    [messages, updateVoiceMessage],
+  );
+
+  const handleAutoSendElapsed = useCallback(
+    async (msgId: string) => {
+      const msg = messages.find((m) => m.id === msgId);
+      const ui = msg?.voice?.autoSendUi;
+      if (!ui || ui.status !== 'counting') return;
+      updateVoiceMessage(msgId, (v) => ({
+        ...v,
+        autoSendUi: v.autoSendUi ? { ...v.autoSendUi, status: 'sending' } : v.autoSendUi,
+      }));
+      try {
+        const res = await fetch('/api/agent/intelligence/send-draft', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            draftId: ui.draftId,
+            wasEdited: false,
+            mode: 'auto_sent',
+          }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          updateVoiceMessage(msgId, (v) => ({
+            ...v,
+            autoSendUi: v.autoSendUi
+              ? {
+                  ...v.autoSendUi,
+                  status: 'failed',
+                  active: false,
+                  failMessage: err.holdCopy || err.error || "Couldn't auto-send — the draft is in review.",
+                }
+              : v.autoSendUi,
+          }));
+          notifyDraftsChanged();
+          return;
+        }
+        const data = await res.json();
+        updateVoiceMessage(msgId, (v) => ({
+          ...v,
+          autoSendUi: v.autoSendUi ? { ...v.autoSendUi, status: 'sent', active: false } : v.autoSendUi,
+        }));
+        if (data.batchId) {
+          setUndoBatch({ batchId: data.batchId, createdAt: Date.now() });
+        }
+        notifyDraftsChanged();
+      } catch {
+        updateVoiceMessage(msgId, (v) => ({
+          ...v,
+          autoSendUi: v.autoSendUi
+            ? { ...v.autoSendUi, status: 'failed', active: false, failMessage: "Couldn't auto-send — the draft is in review." }
+            : v.autoSendUi,
+        }));
+        notifyDraftsChanged();
+      }
+    },
+    [messages, updateVoiceMessage],
+  );
+
+  const handleAutoSendCancel = useCallback(
+    async (msgId: string) => {
+      const msg = messages.find((m) => m.id === msgId);
+      const ui = msg?.voice?.autoSendUi;
+      if (!ui || ui.status !== 'counting') return;
+      updateVoiceMessage(msgId, (v) => ({
+        ...v,
+        autoSendUi: v.autoSendUi ? { ...v.autoSendUi, status: 'cancelled', active: false } : v.autoSendUi,
+      }));
+      try {
+        await fetch('/api/agent/intelligence/cancel-auto-send', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ draftId: ui.draftId }),
+        });
+        notifyDraftsChanged();
+      } catch {
+        /* best-effort — the UI already shows cancelled */
       }
     },
     [messages, updateVoiceMessage],
@@ -619,9 +742,13 @@ export default function IntelligencePage() {
                     actions={msg.voice.actions}
                     status={msg.voice.status}
                     results={msg.voice.results}
+                    autoSendUi={msg.voice.autoSendUi}
+                    globalPaused={msg.voice.globalPaused}
                     onChange={(next) => handleVoiceActionsChange(msg.id, next)}
                     onApprove={() => handleApprove(msg.id)}
                     onDiscard={() => handleDiscard(msg.id)}
+                    onAutoSendElapsed={() => handleAutoSendElapsed(msg.id)}
+                    onAutoSendCancel={() => handleAutoSendCancel(msg.id)}
                   />
                 );
               }
@@ -666,13 +793,22 @@ export default function IntelligencePage() {
 function buildConfirmationSummary(
   actions: ExtractedAction[],
   results: ExecutedAction[],
-): string {
+  autoSendUi: AutoSendUiState | null,
+): string | null {
   const okById: Record<string, boolean> = {};
-  results.forEach((r) => { okById[r.id] = r.success; });
+  const resultById: Record<string, ExecutedAction> = {};
+  results.forEach((r) => {
+    okById[r.id] = r.success;
+    resultById[r.id] = r;
+  });
 
   const clauses: string[] = [];
   for (const a of actions) {
     if (!okById[a.id]) continue;
+    // Skip auto-send actions — their confirmation sentence fires from the
+    // countdown banner, not this summary line.
+    if (autoSendUi && autoSendUi.actionId === a.id) continue;
+
     if (a.type === 'log_viewing') {
       clauses.push(`logged the viewing for ${a.fields.property_id || 'the property'}`);
     } else if (a.type === 'draft_vendor_update') {
@@ -684,10 +820,13 @@ function buildConfirmationSummary(
   }
 
   const failures = results.filter((r) => !r.success);
-  const core = clauses.length
-    ? `Done. I've ${joinClauses(clauses)}.`
-    : "Done.";
+  if (clauses.length === 0 && failures.length === 0) {
+    // Auto-send is the only action. Summary is redundant — the countdown
+    // banner speaks for itself.
+    return null;
+  }
 
+  const core = clauses.length ? `Done. I've ${joinClauses(clauses)}.` : 'Done.';
   if (failures.length > 0) {
     return `${core} One or two items didn't save, have a look above.`;
   }

--- a/apps/unified-portal/app/agent/settings/autonomy/page.tsx
+++ b/apps/unified-portal/app/agent/settings/autonomy/page.tsx
@@ -1,0 +1,420 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, PauseCircle } from 'lucide-react';
+import AgentShell from '../../_components/AgentShell';
+import { useAgent } from '@/lib/agent/AgentContext';
+import { draftTypeLabel } from '@/lib/agent-intelligence/drafts';
+import { ELIGIBILITY_RULES, type DraftTypeStats } from '@/lib/agent-intelligence/autonomy';
+
+interface Payload {
+  draftTypes: DraftTypeStats[];
+  globalPaused: boolean;
+}
+
+export default function AutonomySettingsPage() {
+  const { agent, alerts } = useAgent();
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agent/intelligence/track-record', { cache: 'no-store' });
+      if (!res.ok) return;
+      setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const toggleType = async (draftType: string, nextEnabled: boolean) => {
+    setSaving(draftType);
+    try {
+      await fetch('/api/agent/intelligence/autonomy', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draftType, autoSendEnabled: nextEnabled }),
+      });
+      await load();
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const toggleGlobalPause = async (paused: boolean) => {
+    setSaving('_global_pause');
+    try {
+      await fetch('/api/agent/intelligence/autonomy', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ globalPaused: paused }),
+      });
+      await load();
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  return (
+    <AgentShell agentName={agent?.displayName?.split(' ')[0] || 'Agent'} urgentCount={alerts?.length || 0}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+        }}
+      >
+        <header
+          style={{
+            padding: '14px 16px 12px',
+            borderBottom: '0.5px solid rgba(0,0,0,0.05)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+        >
+          <Link
+            href="/agent/drafts"
+            aria-label="Back"
+            className="agent-tappable"
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: 17,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#0D0D12',
+              background: 'transparent',
+              border: 'none',
+              textDecoration: 'none',
+            }}
+          >
+            <ArrowLeft size={18} />
+          </Link>
+          <div>
+            <h1
+              style={{
+                margin: 0,
+                fontSize: 18,
+                fontWeight: 700,
+                letterSpacing: '-0.03em',
+                color: '#0D0D12',
+              }}
+            >
+              Auto-send
+            </h1>
+            <p
+              style={{
+                margin: '2px 0 0',
+                fontSize: 11.5,
+                color: '#9CA3AF',
+                letterSpacing: '0.005em',
+              }}
+            >
+              Your autonomy settings. Change at any time.
+            </p>
+          </div>
+        </header>
+
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            padding: '16px 16px 32px',
+          }}
+        >
+          <p
+            style={{
+              margin: '0 0 18px',
+              fontSize: 13.5,
+              lineHeight: 1.55,
+              color: '#374151',
+              letterSpacing: '0.005em',
+            }}
+          >
+            Some things are worth doing by hand. Some things aren&apos;t. You decide
+            which is which. Every auto-sent message still gives you 10 seconds to
+            stop it, and 60 more to pull it back after it goes.
+          </p>
+
+          {data && (
+            <GlobalPauseRow
+              paused={data.globalPaused}
+              saving={saving === '_global_pause'}
+              onChange={toggleGlobalPause}
+            />
+          )}
+
+          {loading && (
+            <p style={{ color: '#9CA3AF', fontSize: 13, textAlign: 'center', padding: 32 }}>
+              Loading...
+            </p>
+          )}
+
+          {data && data.draftTypes.length === 0 && !loading && (
+            <div
+              data-testid="autonomy-empty-state"
+              style={{
+                padding: '40px 20px',
+                textAlign: 'center',
+                color: '#9CA3AF',
+                fontSize: 13,
+                lineHeight: 1.5,
+              }}
+            >
+              Nothing to configure yet. Auto-send rows appear once you&apos;ve sent a
+              draft of a given type.
+            </div>
+          )}
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {(data?.draftTypes || []).map((stats) => (
+              <AutonomyRow
+                key={stats.draftType}
+                stats={stats}
+                saving={saving === stats.draftType}
+                onChange={toggleType}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </AgentShell>
+  );
+}
+
+function GlobalPauseRow({
+  paused,
+  saving,
+  onChange,
+}: {
+  paused: boolean;
+  saving: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div
+      data-testid="autonomy-global-pause-row"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '14px 16px',
+        marginBottom: 16,
+        borderRadius: 14,
+        background: paused ? 'rgba(220,38,38,0.05)' : '#FFFFFF',
+        border: paused ? '0.5px solid rgba(220,38,38,0.2)' : '0.5px solid rgba(0,0,0,0.06)',
+      }}
+    >
+      <div
+        style={{
+          width: 34,
+          height: 34,
+          borderRadius: 17,
+          background: paused ? 'rgba(220,38,38,0.1)' : 'rgba(0,0,0,0.04)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: paused ? '#DC2626' : '#6B7280',
+          flexShrink: 0,
+        }}
+      >
+        <PauseCircle size={18} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12' }}>Pause all auto-send</div>
+        <div style={{ fontSize: 12, color: '#6B7280', marginTop: 2 }}>
+          {paused
+            ? 'Auto-send is paused. Everything drops to drafts for review.'
+            : 'Kill switch. Flip on to hold every message for review.'}
+        </div>
+      </div>
+      <Toggle
+        checked={paused}
+        disabled={saving}
+        onChange={onChange}
+        testId="autonomy-global-pause-toggle"
+      />
+    </div>
+  );
+}
+
+function AutonomyRow({
+  stats,
+  saving,
+  onChange,
+}: {
+  stats: DraftTypeStats;
+  saving: boolean;
+  onChange: (draftType: string, next: boolean) => void;
+}) {
+  const enabled = stats.autoSendEnabled;
+  const canToggle = !stats.statutory && (stats.eligibleForAutoSend || enabled);
+  const trackSummary = `${stats.totalSent} sent, ${stats.sentAsGenerated} without edits, ${stats.undoneCount} undone`;
+
+  let pill: { label: string; tone: 'gold' | 'neutral' | 'muted' };
+  if (stats.statutory) {
+    pill = { label: 'Review only', tone: 'muted' };
+  } else if (enabled) {
+    pill = { label: 'On', tone: 'gold' };
+  } else if (stats.eligibleForAutoSend) {
+    pill = { label: 'Eligible', tone: 'neutral' };
+  } else {
+    pill = { label: 'Building up', tone: 'muted' };
+  }
+
+  const remaining = Math.max(0, ELIGIBILITY_RULES.minTotalSent - stats.sentAsGenerated);
+  const buildingUpCopy =
+    !stats.statutory && !stats.eligibleForAutoSend && !enabled && remaining > 0
+      ? `Need ${remaining} more send${remaining === 1 ? '' : 's'} without edits to unlock.`
+      : stats.eligibilityMessage;
+
+  return (
+    <div
+      data-testid={`autonomy-row-${stats.draftType}`}
+      style={{
+        background: '#FFFFFF',
+        borderRadius: 14,
+        padding: '14px 16px',
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: '#0D0D12',
+              letterSpacing: '-0.01em',
+              marginBottom: 2,
+            }}
+          >
+            {draftTypeLabel(stats.draftType)}s
+          </div>
+          <div style={{ fontSize: 12, color: '#6B7280' }}>{trackSummary}</div>
+        </div>
+        <StatusPill pill={pill} statutory={stats.statutory} />
+      </div>
+
+      {buildingUpCopy && (
+        <div style={{ fontSize: 11.5, color: '#9CA3AF', lineHeight: 1.5 }}>
+          {buildingUpCopy}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Toggle
+          checked={enabled}
+          disabled={!canToggle || saving}
+          onChange={(next) => onChange(stats.draftType, next)}
+          testId={`autonomy-toggle-${stats.draftType}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StatusPill({
+  pill,
+  statutory,
+}: {
+  pill: { label: string; tone: 'gold' | 'neutral' | 'muted' };
+  statutory: boolean;
+}) {
+  const tone = pill.tone;
+  const palette =
+    tone === 'gold'
+      ? { bg: 'linear-gradient(135deg, #C49B2A, #E8C84A)', color: '#fff' }
+      : tone === 'neutral'
+        ? { bg: 'rgba(13,13,18,0.06)', color: '#0D0D12' }
+        : { bg: 'rgba(0,0,0,0.04)', color: '#9CA3AF' };
+
+  return (
+    <span
+      title={statutory ? 'Statutory documents always require your review' : undefined}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '4px 10px',
+        borderRadius: 999,
+        background: palette.bg,
+        color: palette.color,
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+      }}
+    >
+      {pill.label}
+    </span>
+  );
+}
+
+function Toggle({
+  checked,
+  disabled,
+  onChange,
+  testId,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      data-testid={testId}
+      onClick={() => onChange(!checked)}
+      style={{
+        position: 'relative',
+        width: 46,
+        height: 28,
+        borderRadius: 14,
+        border: 'none',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        background: checked
+          ? 'linear-gradient(135deg, #C49B2A, #E8C84A)'
+          : 'rgba(0,0,0,0.1)',
+        opacity: disabled ? 0.45 : 1,
+        transition: 'background 0.15s ease',
+        padding: 0,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: 3,
+          left: checked ? 21 : 3,
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          background: '#FFFFFF',
+          boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+          transition: 'left 0.15s cubic-bezier(0.22,0.8,0.2,1)',
+        }}
+      />
+    </button>
+  );
+}

--- a/apps/unified-portal/app/api/agent/intelligence/autonomy/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/autonomy/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  GLOBAL_PAUSE_DRAFT_TYPE,
+  isStatutoryDraftType,
+  loadAutonomyPreferences,
+} from '@/lib/agent-intelligence/autonomy';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function resolveUserId(): Promise<string | null> {
+  const cookieStore = cookies();
+  const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+  const { data: { user } } = await supabaseAuth.auth.getUser();
+  if (user?.id) return user.id;
+
+  // Dev/preview fallback, mirrors drafts route behaviour.
+  const admin = getSupabaseAdmin();
+  const { data } = await admin
+    .from('agent_profiles')
+    .select('user_id')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.user_id || null;
+}
+
+/**
+ * GET /api/agent/intelligence/autonomy
+ * Returns the full preferences map + global pause flag.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const userId = await resolveUserId();
+    if (!userId) return NextResponse.json({ preferences: {}, globalPaused: false });
+
+    const supabase = getSupabaseAdmin();
+    const { byDraftType, globalPaused } = await loadAutonomyPreferences(supabase, userId);
+    return NextResponse.json({ preferences: byDraftType, globalPaused });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/agent/intelligence/autonomy
+ * Body: { draftType: string, autoSendEnabled: boolean }
+ *       or { globalPaused: boolean }
+ *
+ * Toggling on a statutory type is silently refused at the API layer — UI
+ * should render the row as non-interactive but we defend the same rule here.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const userId = await resolveUserId();
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json();
+    const supabase = getSupabaseAdmin();
+    const now = new Date().toISOString();
+
+    if (typeof body?.globalPaused === 'boolean') {
+      await supabase
+        .from('agent_autonomy_preferences')
+        .upsert(
+          {
+            user_id: userId,
+            draft_type: GLOBAL_PAUSE_DRAFT_TYPE,
+            auto_send_enabled: body.globalPaused,
+            enabled_at: body.globalPaused ? now : null,
+            disabled_at: body.globalPaused ? null : now,
+            updated_at: now,
+          },
+          { onConflict: 'user_id,draft_type' },
+        );
+      return NextResponse.json({ globalPaused: body.globalPaused });
+    }
+
+    const draftType: string | undefined = body?.draftType;
+    const autoSendEnabled: boolean | undefined = body?.autoSendEnabled;
+    if (!draftType || typeof autoSendEnabled !== 'boolean') {
+      return NextResponse.json({ error: 'draftType + autoSendEnabled required' }, { status: 400 });
+    }
+
+    if (autoSendEnabled && isStatutoryDraftType(draftType)) {
+      return NextResponse.json(
+        { error: 'Statutory draft types cannot be auto-sent' },
+        { status: 403 },
+      );
+    }
+
+    await supabase
+      .from('agent_autonomy_preferences')
+      .upsert(
+        {
+          user_id: userId,
+          draft_type: draftType,
+          auto_send_enabled: autoSendEnabled,
+          enabled_at: autoSendEnabled ? now : null,
+          disabled_at: autoSendEnabled ? null : now,
+          updated_at: now,
+        },
+        { onConflict: 'user_id,draft_type' },
+      );
+
+    return NextResponse.json({ draftType, autoSendEnabled });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/agent/intelligence/autonomy
+ * Body: { action: 'dismiss_offer', draftType }
+ * Records the dismissal so the offer respects the 30-day / +10-sends cooldown.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await resolveUserId();
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json();
+    const supabase = getSupabaseAdmin();
+
+    if (body?.action !== 'dismiss_offer' || !body?.draftType) {
+      return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+    }
+
+    const now = new Date().toISOString();
+    const { data: existing } = await supabase
+      .from('agent_autonomy_preferences')
+      .select('offer_dismissed_count')
+      .eq('user_id', userId)
+      .eq('draft_type', body.draftType)
+      .maybeSingle();
+
+    const nextCount = (existing?.offer_dismissed_count || 0) + 1;
+
+    await supabase
+      .from('agent_autonomy_preferences')
+      .upsert(
+        {
+          user_id: userId,
+          draft_type: body.draftType,
+          auto_send_enabled: false,
+          offered_at: now,
+          offer_dismissed_count: nextCount,
+          updated_at: now,
+        },
+        { onConflict: 'user_id,draft_type' },
+      );
+
+    return NextResponse.json({ dismissed: true, dismissCount: nextCount });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent/intelligence/cancel-auto-send/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/cancel-auto-send/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agent/intelligence/cancel-auto-send
+ * Body: { draftId }
+ *
+ * Called when the user hits Cancel during the 10-second auto-send window.
+ * Flips the draft from auto_sending back to pending_review so it drops
+ * into the Drafts inbox. Also records a lightweight send-history row with
+ * send_mode = 'auto_cancelled_pre_send' so Session 3's telemetry reflects
+ * the cancellation (it is not an undo — nothing was ever sent).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const { draftId } = await request.json();
+    if (!draftId) return NextResponse.json({ error: 'draftId required' }, { status: 400 });
+
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const { data: draft } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('id', draftId)
+      .maybeSingle();
+
+    if (!draft) return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+    if (user && draft.user_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (draft.status !== 'auto_sending') {
+      return NextResponse.json({ error: `Draft is in status "${draft.status}"` }, { status: 409 });
+    }
+
+    await supabase
+      .from('pending_drafts')
+      .update({ status: 'pending_review', updated_at: new Date().toISOString() })
+      .eq('id', draftId);
+
+    // Telemetry: this is a cancelled auto-send, not a sent row. Recorded so
+    // the autonomy analytics can distinguish "held by user" from "held by
+    // confidence / active hours / trust floor".
+    await supabase.from('agent_send_history').insert({
+      user_id: draft.user_id,
+      tenant_id: draft.tenant_id,
+      draft_id: draft.id,
+      draft_type: draft.draft_type,
+      recipient_id: draft.recipient_id,
+      sent_at: new Date().toISOString(),
+      was_edited_before_send: false,
+      undone: false,
+      send_method: draft.send_method,
+      send_mode: 'auto_cancelled_pre_send',
+    });
+
+    return NextResponse.json({ cancelled: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
@@ -3,6 +3,14 @@ import { randomUUID } from 'crypto';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  decideAutoSend,
+  ELIGIBILITY_RULES,
+  loadAutonomyPreferences,
+  REQUIRED_FIELDS_BY_DRAFT_TYPE,
+  type SendHistoryRow,
+} from '@/lib/agent-intelligence/autonomy';
+import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
 import type {
   ExtractedAction,
   ExecutedAction,
@@ -40,7 +48,7 @@ export async function POST(request: NextRequest) {
     if (user) {
       const { data } = await supabase
         .from('agent_profiles')
-        .select('id, user_id, tenant_id')
+        .select('id, user_id, tenant_id, timezone')
         .eq('user_id', user.id)
         .limit(1)
         .maybeSingle();
@@ -49,7 +57,7 @@ export async function POST(request: NextRequest) {
     if (!agentProfile) {
       const { data } = await supabase
         .from('agent_profiles')
-        .select('id, user_id, tenant_id')
+        .select('id, user_id, tenant_id, timezone')
         .order('created_at', { ascending: true })
         .limit(1)
         .maybeSingle();
@@ -62,6 +70,27 @@ export async function POST(request: NextRequest) {
 
     const batchId = randomUUID();
     const userId = user?.id || agentProfile.user_id;
+    const timezone = agentProfile.timezone || 'Europe/Dublin';
+
+    // Load autonomy prefs + the last 10 auto-sends per draft_type so the
+    // decideAutoSend helper can apply every gate in one go. This is a single
+    // batch of queries per approval, not per-action.
+    const [autonomy, { data: recentAutoSendRows }] = await Promise.all([
+      loadAutonomyPreferences(supabase, userId),
+      supabase
+        .from('agent_send_history')
+        .select('id, user_id, draft_type, was_edited_before_send, undone, sent_at, send_mode')
+        .eq('user_id', userId)
+        .eq('send_mode', 'auto_sent')
+        .order('sent_at', { ascending: false })
+        .limit(ELIGIBILITY_RULES.trustFloorWindow * 4),
+    ]);
+
+    const recentByType = new Map<string, SendHistoryRow[]>();
+    for (const r of (recentAutoSendRows || []) as SendHistoryRow[]) {
+      if (!recentByType.has(r.draft_type)) recentByType.set(r.draft_type, []);
+      recentByType.get(r.draft_type)!.push(r);
+    }
 
     const results = await Promise.all(
       actions.map((action) =>
@@ -71,11 +100,14 @@ export async function POST(request: NextRequest) {
           userId,
           tenantId: agentProfile.tenant_id,
           agentId: agentProfile.id,
+          timezone,
+          autonomy,
+          recentByType,
         }),
       ),
     );
 
-    return NextResponse.json({ batchId, results });
+    return NextResponse.json({ batchId, results, globalPaused: autonomy.globalPaused });
   } catch (error: any) {
     console.error('[agent/intelligence/execute-actions] Error:', error.message);
     return NextResponse.json(
@@ -91,6 +123,9 @@ interface ExecCtx {
   userId: string;
   tenantId: string;
   agentId: string;
+  timezone: string;
+  autonomy: Awaited<ReturnType<typeof loadAutonomyPreferences>>;
+  recentByType: Map<string, SendHistoryRow[]>;
 }
 
 async function executeAction(
@@ -220,8 +255,24 @@ async function execDraftVendorUpdate(
   supabase: SupabaseAdmin,
   ctx: ExecCtx,
 ): Promise<ExecutedAction> {
-  const { action, userId, tenantId } = ctx;
+  const { action, userId, tenantId, timezone, autonomy, recentByType } = ctx;
   const f = action.fields;
+  const draftType = 'vendor_update';
+
+  // Decide auto-send vs review BEFORE inserting, so we can set the right
+  // initial status on the draft row.
+  const pref = autonomy.byDraftType[draftType] || { autoSendEnabled: false };
+  const decision = decideAutoSend({
+    draftType,
+    autoSendEnabled: pref.autoSendEnabled,
+    globalPaused: autonomy.globalPaused,
+    confidence: action.confidence,
+    requiredFields: REQUIRED_FIELDS_BY_DRAFT_TYPE[draftType] || [],
+    timezone,
+    recentAutoSends: recentByType.get(draftType) || [],
+  });
+
+  const initialStatus = decision.autoSend ? 'auto_sending' : 'pending_review';
 
   const { data: draft, error } = await supabase
     .from('pending_drafts')
@@ -229,7 +280,7 @@ async function execDraftVendorUpdate(
       user_id: userId,
       tenant_id: tenantId,
       skin: 'agent',
-      draft_type: 'vendor_update',
+      draft_type: draftType,
       recipient_id: f.vendor_id ? String(f.vendor_id) : null,
       content_json: {
         vendor_id: f.vendor_id,
@@ -237,7 +288,7 @@ async function execDraftVendorUpdate(
         tone: f.tone || 'casual',
       },
       send_method: f.send_method || 'email',
-      status: 'pending_review',
+      status: initialStatus,
     })
     .select('id')
     .single();
@@ -258,12 +309,30 @@ async function execDraftVendorUpdate(
     reversal: { op: 'delete', table: 'pending_drafts', id: draft.id },
   });
 
+  if (decision.autoSend) {
+    const recipient = await resolveRecipient(supabase, draftType, f.vendor_id ? String(f.vendor_id) : null);
+    return {
+      id: action.id,
+      type: action.type,
+      success: true,
+      targetId: draft.id,
+      message: `Auto-sending vendor update to ${recipient.name || 'vendor'}`,
+      autoSendPlan: {
+        draftId: draft.id,
+        draftType,
+        countdownSeconds: ELIGIBILITY_RULES.autoSendCountdownSeconds,
+        recipientName: recipient.name || 'vendor',
+      },
+    };
+  }
+
   return {
     id: action.id,
     type: action.type,
     success: true,
     targetId: draft.id,
     message: `Drafted vendor update for ${f.vendor_id || 'vendor'}`,
+    autoSendHold: decision.holdCopy || null,
   };
 }
 

--- a/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getResendClient } from '@/lib/resend';
 import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
+import { isStatutoryDraftType } from '@/lib/agent-intelligence/autonomy';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -26,10 +27,19 @@ export const dynamic = 'force-dynamic';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { draftId, wasEdited = false } = body || {};
+    const {
+      draftId,
+      wasEdited = false,
+      // 'reviewed' (default, human pressed Send), 'auto_sent' (autonomy
+      // countdown elapsed without Cancel), 'auto_cancelled_pre_send'
+      // (countdown cancelled). The server is the authority on which it is —
+      // UI should pass an honest value but we defend the statutory rule here.
+      mode = 'reviewed',
+    } = body || {};
     if (!draftId) {
       return NextResponse.json({ error: 'draftId required' }, { status: 400 });
     }
+    const sendMode: 'reviewed' | 'auto_sent' = mode === 'auto_sent' ? 'auto_sent' : 'reviewed';
 
     const supabase = getSupabaseAdmin();
     const cookieStore = cookies();
@@ -47,10 +57,26 @@ export async function POST(request: NextRequest) {
     if (user && draft.user_id !== user.id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
-    if (draft.status !== 'pending_review') {
+    if (draft.status !== 'pending_review' && draft.status !== 'auto_sending') {
       return NextResponse.json(
         { error: `Draft is already in status "${draft.status}"` },
         { status: 409 }
+      );
+    }
+
+    // Statutory guard: auto-sends are refused even if the UI somehow asked.
+    if (sendMode === 'auto_sent' && isStatutoryDraftType(draft.draft_type)) {
+      await supabase
+        .from('pending_drafts')
+        .update({ status: 'pending_review', updated_at: new Date().toISOString() })
+        .eq('id', draft.id);
+      return NextResponse.json(
+        {
+          error: 'Statutory drafts cannot be auto-sent',
+          held: true,
+          holdCopy: 'Statutory documents always require your review.',
+        },
+        { status: 403 },
       );
     }
 
@@ -155,6 +181,7 @@ export async function POST(request: NextRequest) {
         send_method: sendMethod,
         provider,
         provider_message_id: providerMessageId,
+        send_mode: sendMode,
       })
       .select('id')
       .single();

--- a/apps/unified-portal/app/api/agent/intelligence/track-record/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/track-record/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  computeEligibility,
+  loadAutonomyPreferences,
+  GLOBAL_PAUSE_DRAFT_TYPE,
+  type DraftTypeStats,
+  type SendHistoryRow,
+} from '@/lib/agent-intelligence/autonomy';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/intelligence/track-record
+ * Returns per-draft-type stats for the authenticated user, including
+ * eligibility flags + current auto_send_enabled state. The autonomy
+ * settings screen + the voice confirmation card both consume this.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const userId = user?.id || (await fallbackUserId(supabase));
+    if (!userId) {
+      return NextResponse.json({ draftTypes: [], globalPaused: false });
+    }
+
+    const [{ data: historyRows }, prefs] = await Promise.all([
+      supabase
+        .from('agent_send_history')
+        .select('id, user_id, draft_type, was_edited_before_send, undone, sent_at, send_mode')
+        .eq('user_id', userId),
+      loadAutonomyPreferences(supabase, userId),
+    ]);
+
+    const byType = new Map<string, SendHistoryRow[]>();
+    for (const r of (historyRows || []) as SendHistoryRow[]) {
+      if (!byType.has(r.draft_type)) byType.set(r.draft_type, []);
+      byType.get(r.draft_type)!.push(r);
+    }
+
+    // Surface any preference rows the user has even if they haven't sent
+    // anything of that type yet, so the settings screen stays honest.
+    for (const draftType of Object.keys(prefs.byDraftType)) {
+      if (draftType === GLOBAL_PAUSE_DRAFT_TYPE) continue;
+      if (!byType.has(draftType)) byType.set(draftType, []);
+    }
+
+    const draftTypes: DraftTypeStats[] = [];
+    for (const [draftType, rows] of byType) {
+      const base = computeEligibility(draftType, rows);
+      const pref = prefs.byDraftType[draftType] || {
+        autoSendEnabled: false,
+        offeredAt: null,
+        offerDismissedCount: 0,
+      };
+      draftTypes.push({
+        ...base,
+        autoSendEnabled: pref.autoSendEnabled,
+        offeredAt: pref.offeredAt,
+        offerDismissedCount: pref.offerDismissedCount,
+      });
+    }
+
+    draftTypes.sort((a, b) => b.totalSent - a.totalSent);
+
+    return NextResponse.json({
+      draftTypes,
+      globalPaused: prefs.globalPaused,
+    });
+  } catch (error: any) {
+    console.error('[agent/intelligence/track-record] Error:', error.message);
+    return NextResponse.json(
+      { error: 'Failed to compute track record', details: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+async function fallbackUserId(supabase: ReturnType<typeof getSupabaseAdmin>): Promise<string | null> {
+  const { data } = await supabase
+    .from('agent_profiles')
+    .select('user_id')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.user_id || null;
+}

--- a/apps/unified-portal/app/api/agent/intelligence/undo-send/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/undo-send/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getResendClient } from '@/lib/resend';
+import { enforceTrustFloor } from '@/lib/agent-intelligence/autonomy';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -36,6 +37,7 @@ export async function POST(request: NextRequest) {
 
     const reversed: string[] = [];
     let providerNotice: string | null = null;
+    const trustFloorReverts: Array<{ userId: string; draftType: string }> = [];
 
     for (const entry of entries) {
       const payload = entry.reversal_payload as any;
@@ -68,11 +70,15 @@ export async function POST(request: NextRequest) {
         })
         .eq('id', payload.draftId);
 
+      let undoneHistory: { user_id: string; draft_type: string; send_mode: string } | null = null;
       if (payload.historyId) {
-        await supabase
+        const { data } = await supabase
           .from('agent_send_history')
           .update({ undone: true })
-          .eq('id', payload.historyId);
+          .eq('id', payload.historyId)
+          .select('user_id, draft_type, send_mode')
+          .single();
+        undoneHistory = data as any;
       }
 
       await supabase
@@ -81,9 +87,26 @@ export async function POST(request: NextRequest) {
         .eq('id', entry.id);
 
       reversed.push(entry.id);
+
+      // Trust-floor check: if this was an auto-send and the recent window
+      // now exceeds the undo threshold, flip the preference off so the next
+      // voice capture drops back to review mode.
+      if (undoneHistory?.send_mode === 'auto_sent') {
+        const result = await enforceTrustFloor(
+          supabase,
+          undoneHistory.user_id,
+          undoneHistory.draft_type,
+        );
+        if (result.reverted) {
+          trustFloorReverts.push({
+            userId: undoneHistory.user_id,
+            draftType: undoneHistory.draft_type,
+          });
+        }
+      }
     }
 
-    return NextResponse.json({ reversed, notice: providerNotice });
+    return NextResponse.json({ reversed, notice: providerNotice, trustFloorReverts });
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/apps/unified-portal/lib/agent-intelligence/autonomy.ts
+++ b/apps/unified-portal/lib/agent-intelligence/autonomy.ts
@@ -1,0 +1,386 @@
+/**
+ * Autonomy policy — Session 3.
+ *
+ * Centralises the rules that govern whether a given draft can be auto-sent:
+ *   - statutory exclusion list (hard-coded, never auto-send)
+ *   - eligibility thresholds (total_sent >= 20, as_generated_rate >= 0.8, etc.)
+ *   - active-hours check in the user's local timezone
+ *   - confidence-floor check (< 0.7 on any required field = review mode)
+ *   - trust-floor self-correction (2+ undone in last 10 auto-sends => revert)
+ *
+ * Both the track-record API and the send-draft route import from here so
+ * autonomy decisions stay consistent across the stack.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const GLOBAL_PAUSE_DRAFT_TYPE = '_global_pause';
+
+export const STATUTORY_DRAFT_TYPES: readonly string[] = [
+  'draft_notice_of_termination',
+  'draft_rpz_notice',
+  'draft_rtb_dispute_response',
+  'draft_hap_landlord_undertaking',
+  'draft_arrears_letter',
+  'draft_deposit_dispute_response',
+] as const;
+
+/**
+ * Normalises draft-type identifiers so the statutory check works whether the
+ * caller passes the tool-use name (draft_vendor_update) or the persisted
+ * pending_drafts.draft_type value (vendor_update).
+ */
+function normaliseDraftType(draftType: string): string {
+  return draftType.startsWith('draft_') ? draftType : `draft_${draftType}`;
+}
+
+export const ELIGIBILITY_RULES = {
+  minTotalSent: 20,
+  minAsGeneratedRate: 0.8,
+  maxUndoneRate: 0.05,
+  maxDaysSinceLastSend: 14,
+  offerDismissalCooldownDays: 30,
+  offerDismissalCooldownSends: 10,
+  maxOfferDismissals: 3,
+  autoSendCountdownSeconds: 10,
+  activeHoursStart: 8,
+  activeHoursEnd: 21,
+  trustFloorWindow: 10,
+  trustFloorUndoneThreshold: 2,
+} as const;
+
+export interface DraftTypeStats {
+  draftType: string;
+  totalSent: number;
+  sentAsGenerated: number;
+  sentEdited: number;
+  undoneCount: number;
+  asGeneratedRate: number;
+  undoneRate: number;
+  lastSentAt: string | null;
+  eligibleForAutoSend: boolean;
+  autoSendEnabled: boolean;
+  statutory: boolean;
+  eligibilityMessage: string;
+  offerDismissedCount: number;
+  offeredAt: string | null;
+}
+
+export interface SendHistoryRow {
+  id: string;
+  user_id: string;
+  draft_type: string;
+  was_edited_before_send: boolean;
+  undone: boolean;
+  sent_at: string;
+  send_mode?: string;
+}
+
+export function isStatutoryDraftType(draftType: string): boolean {
+  const normalised = normaliseDraftType(draftType);
+  return STATUTORY_DRAFT_TYPES.includes(normalised);
+}
+
+/**
+ * Evaluate eligibility for a given draft_type given that user's send history.
+ * Statutory types short-circuit: never eligible regardless of history.
+ */
+export function computeEligibility(
+  draftType: string,
+  rows: SendHistoryRow[],
+  now: Date = new Date(),
+): Omit<DraftTypeStats, 'autoSendEnabled' | 'offerDismissedCount' | 'offeredAt'> {
+  const statutory = isStatutoryDraftType(draftType);
+  const totalSent = rows.length;
+  const sentAsGenerated = rows.filter((r) => !r.was_edited_before_send).length;
+  const sentEdited = totalSent - sentAsGenerated;
+  const undoneCount = rows.filter((r) => r.undone).length;
+  const asGeneratedRate = totalSent > 0 ? sentAsGenerated / totalSent : 0;
+  const undoneRate = totalSent > 0 ? undoneCount / totalSent : 0;
+  const lastSentAt =
+    rows.length > 0
+      ? rows.reduce((acc, r) => (r.sent_at > acc ? r.sent_at : acc), rows[0].sent_at)
+      : null;
+
+  const daysSinceLastSend = lastSentAt
+    ? (now.getTime() - new Date(lastSentAt).getTime()) / (1000 * 60 * 60 * 24)
+    : Infinity;
+
+  let eligible = false;
+  let message = '';
+
+  if (statutory) {
+    message = 'Statutory documents always require your review.';
+  } else if (totalSent < ELIGIBILITY_RULES.minTotalSent) {
+    const remaining = ELIGIBILITY_RULES.minTotalSent - totalSent;
+    message = `Need ${remaining} more send${remaining === 1 ? '' : 's'} to unlock.`;
+  } else if (asGeneratedRate < ELIGIBILITY_RULES.minAsGeneratedRate) {
+    message = 'Still editing these often. Auto-send unlocks at 80% sent without edits.';
+  } else if (undoneRate > ELIGIBILITY_RULES.maxUndoneRate) {
+    message = 'A few recent sends were pulled back. Build the streak up and we will offer auto-send again.';
+  } else if (daysSinceLastSend > ELIGIBILITY_RULES.maxDaysSinceLastSend) {
+    message = 'No recent sends. Send one in the next 14 days to reactivate auto-send.';
+  } else {
+    eligible = true;
+    message = 'You can turn on auto-send for this type.';
+  }
+
+  return {
+    draftType,
+    totalSent,
+    sentAsGenerated,
+    sentEdited,
+    undoneCount,
+    asGeneratedRate,
+    undoneRate,
+    lastSentAt,
+    eligibleForAutoSend: eligible,
+    statutory,
+    eligibilityMessage: message,
+  };
+}
+
+/**
+ * Can the offer be shown right now?
+ * True only if: eligible, not already enabled, under the dismissal cap, and
+ * past the cooldown since the last dismissal.
+ */
+export function canOfferAutoSend(
+  stats: Omit<DraftTypeStats, 'autoSendEnabled' | 'offerDismissedCount' | 'offeredAt'>,
+  pref: {
+    autoSendEnabled: boolean;
+    offerDismissedCount: number;
+    offeredAt: string | null;
+    sendsSinceOffer: number;
+  },
+  now: Date = new Date(),
+): boolean {
+  if (!stats.eligibleForAutoSend) return false;
+  if (pref.autoSendEnabled) return false;
+  if (pref.offerDismissedCount >= ELIGIBILITY_RULES.maxOfferDismissals) return false;
+
+  if (pref.offeredAt) {
+    const days = (now.getTime() - new Date(pref.offeredAt).getTime()) / (1000 * 60 * 60 * 24);
+    if (
+      days < ELIGIBILITY_RULES.offerDismissalCooldownDays &&
+      pref.sendsSinceOffer < ELIGIBILITY_RULES.offerDismissalCooldownSends
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * 8am–9pm local time. IANA timezone names are parsed via Intl.DateTimeFormat,
+ * which Node 18+ supports without extra data.
+ */
+export function isWithinActiveHours(timezone: string, now: Date = new Date()): boolean {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone || 'Europe/Dublin',
+      hour: 'numeric',
+      hour12: false,
+    });
+    const hour = parseInt(fmt.format(now), 10);
+    return (
+      hour >= ELIGIBILITY_RULES.activeHoursStart &&
+      hour < ELIGIBILITY_RULES.activeHoursEnd
+    );
+  } catch {
+    return true; // Fail open — better to send late than to silently hold.
+  }
+}
+
+/**
+ * Auto-send is blocked when any required field on the extracted action
+ * scored below the confidence threshold. This mirrors the amber-underline
+ * treatment in the Session 1 confirmation card.
+ */
+export function hasLowConfidenceField(
+  confidence: Record<string, number> | null | undefined,
+  requiredFields: readonly string[],
+): boolean {
+  if (!confidence) return false;
+  for (const field of requiredFields) {
+    const score = confidence[field];
+    if (typeof score === 'number' && score < 0.7) return true;
+  }
+  return false;
+}
+
+export type AutoSendBlockReason =
+  | 'statutory'
+  | 'paused'
+  | 'low_confidence'
+  | 'outside_active_hours'
+  | 'not_enabled'
+  | 'trust_floor_recent_undos';
+
+export interface AutoSendDecision {
+  autoSend: boolean;
+  reason?: AutoSendBlockReason;
+  holdCopy?: string;
+}
+
+interface DecisionInputs {
+  draftType: string;
+  autoSendEnabled: boolean;
+  globalPaused: boolean;
+  confidence?: Record<string, number> | null;
+  requiredFields: readonly string[];
+  timezone: string;
+  recentAutoSends: SendHistoryRow[]; // newest first, last N=10
+  now?: Date;
+}
+
+/**
+ * Single decision point the approve flow calls before firing an auto-send.
+ * Returns autoSend=false with a machine-readable reason + user-facing copy
+ * whenever any gate trips.
+ */
+export function decideAutoSend(input: DecisionInputs): AutoSendDecision {
+  const now = input.now || new Date();
+
+  if (isStatutoryDraftType(input.draftType)) {
+    return {
+      autoSend: false,
+      reason: 'statutory',
+      holdCopy: 'Statutory documents always require your review.',
+    };
+  }
+
+  if (input.globalPaused) {
+    return {
+      autoSend: false,
+      reason: 'paused',
+      holdCopy: 'Auto-send is paused. This went to Drafts for review.',
+    };
+  }
+
+  if (!input.autoSendEnabled) {
+    return { autoSend: false, reason: 'not_enabled' };
+  }
+
+  if (hasLowConfidenceField(input.confidence, input.requiredFields)) {
+    return {
+      autoSend: false,
+      reason: 'low_confidence',
+      holdCopy: 'Held for review. Some details looked uncertain.',
+    };
+  }
+
+  if (!isWithinActiveHours(input.timezone, now)) {
+    return {
+      autoSend: false,
+      reason: 'outside_active_hours',
+      holdCopy: 'Held for morning. Outside your active hours.',
+    };
+  }
+
+  const recent = input.recentAutoSends.slice(0, ELIGIBILITY_RULES.trustFloorWindow);
+  const undone = recent.filter((r) => r.undone).length;
+  if (undone >= ELIGIBILITY_RULES.trustFloorUndoneThreshold) {
+    return {
+      autoSend: false,
+      reason: 'trust_floor_recent_undos',
+      holdCopy: 'Switched back to review. A couple of recent auto-sends needed pulling back.',
+    };
+  }
+
+  return { autoSend: true };
+}
+
+/**
+ * Server-side helper to pull the user's preference rows in one go.
+ * Always returns a map so consumers can do `map[draftType]` safely.
+ */
+export async function loadAutonomyPreferences(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<{
+  byDraftType: Record<string, {
+    autoSendEnabled: boolean;
+    enabledAt: string | null;
+    offeredAt: string | null;
+    offerDismissedCount: number;
+  }>;
+  globalPaused: boolean;
+}> {
+  const { data } = await supabase
+    .from('agent_autonomy_preferences')
+    .select('draft_type, auto_send_enabled, enabled_at, offered_at, offer_dismissed_count')
+    .eq('user_id', userId);
+
+  const byDraftType: Record<string, any> = {};
+  let globalPaused = false;
+
+  for (const row of data || []) {
+    if (row.draft_type === GLOBAL_PAUSE_DRAFT_TYPE) {
+      globalPaused = !!row.auto_send_enabled;
+      continue;
+    }
+    byDraftType[row.draft_type] = {
+      autoSendEnabled: !!row.auto_send_enabled,
+      enabledAt: row.enabled_at,
+      offeredAt: row.offered_at,
+      offerDismissedCount: row.offer_dismissed_count || 0,
+    };
+  }
+
+  return { byDraftType, globalPaused };
+}
+
+/**
+ * The trust-floor auto-revert: when >= 2 of the last 10 auto-sends on a
+ * draft_type were undone, we flip the preference off and return true so the
+ * caller can surface a soft notification.
+ */
+export async function enforceTrustFloor(
+  supabase: SupabaseClient,
+  userId: string,
+  draftType: string,
+): Promise<{ reverted: boolean }> {
+  if (isStatutoryDraftType(draftType)) return { reverted: false };
+
+  const { data: recent } = await supabase
+    .from('agent_send_history')
+    .select('undone, send_mode, sent_at')
+    .eq('user_id', userId)
+    .eq('draft_type', draftType)
+    .eq('send_mode', 'auto_sent')
+    .order('sent_at', { ascending: false })
+    .limit(ELIGIBILITY_RULES.trustFloorWindow);
+
+  const undone = (recent || []).filter((r) => r.undone).length;
+  if (undone < ELIGIBILITY_RULES.trustFloorUndoneThreshold) {
+    return { reverted: false };
+  }
+
+  await supabase
+    .from('agent_autonomy_preferences')
+    .upsert(
+      {
+        user_id: userId,
+        draft_type: draftType,
+        auto_send_enabled: false,
+        disabled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,draft_type' },
+    );
+
+  return { reverted: true };
+}
+
+/**
+ * Per-draft-type required-field lists mirror the tool schemas in
+ * lib/agent-intelligence/voice-actions.ts. We can't import the const there
+ * without pulling in a bunch of unrelated schema data, so we keep the
+ * authoritative list here and it's trivially audit-able.
+ */
+export const REQUIRED_FIELDS_BY_DRAFT_TYPE: Record<string, readonly string[]> = {
+  vendor_update: ['vendor_id', 'update_summary', 'tone', 'send_method'],
+  draft_vendor_update: ['vendor_id', 'update_summary', 'tone', 'send_method'],
+};

--- a/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
+++ b/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
@@ -32,6 +32,24 @@ export interface ExecutedAction {
   targetId?: string;
   message: string;
   error?: string;
+  /**
+   * Session 3: when the user has turned on auto-send for the draft_type and
+   * every gate passes (confidence, active hours, trust floor, global kill
+   * switch), the server returns a plan here. The client renders a countdown
+   * and either fires send-draft when it elapses or cancels and flips the
+   * draft back to pending_review.
+   */
+  autoSendPlan?: {
+    draftId: string;
+    draftType: string;
+    countdownSeconds: number;
+    recipientName: string;
+  } | null;
+  /**
+   * When auto-send was considered but blocked by a gate, the human-friendly
+   * reason shows as a one-liner under the action in the confirmation card.
+   */
+  autoSendHold?: string | null;
 }
 
 const CONFIDENCE_SCHEMA = {

--- a/apps/unified-portal/migrations/044_agent_autonomy_preferences.sql
+++ b/apps/unified-portal/migrations/044_agent_autonomy_preferences.sql
@@ -1,0 +1,63 @@
+-- Migration: Autonomy preferences + send_mode telemetry (Session 3)
+--
+-- Creates agent_autonomy_preferences (per-user, per-draft-type auto-send
+-- switches + a `_global_pause` pseudo-row that acts as the kill switch),
+-- extends agent_send_history with send_mode, and adds a timezone column
+-- to agent_profiles so active-hours gating can use the user's local clock.
+--
+-- Run as three separate query blocks in Supabase SQL Editor:
+--   (1) CREATE / ALTER
+--   (2) ENABLE RLS
+--   (3) CREATE POLICY
+-- Never batch together.
+
+-- ============================================
+-- 1. Schema changes
+-- ============================================
+
+-- Per-user, per-draft-type autonomy switch.
+-- The pseudo draft_type '_global_pause' flags the kill switch.
+CREATE TABLE IF NOT EXISTS agent_autonomy_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) NOT NULL,
+  draft_type TEXT NOT NULL,
+  auto_send_enabled BOOLEAN NOT NULL DEFAULT false,
+  enabled_at TIMESTAMPTZ,
+  disabled_at TIMESTAMPTZ,
+  offered_at TIMESTAMPTZ,
+  offer_dismissed_count INT DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(user_id, draft_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_autonomy_preferences_user_id
+  ON agent_autonomy_preferences(user_id);
+
+-- send_mode distinguishes reviewed sends from auto-sends + cancelled autos.
+-- Default keeps historical rows truthful (they were all reviewed pre-session 3).
+ALTER TABLE agent_send_history
+  ADD COLUMN IF NOT EXISTS send_mode TEXT NOT NULL DEFAULT 'reviewed';
+
+-- Timezone defaults to Europe/Dublin, the product's target market. Users who
+-- travel or live elsewhere can update via profile; the active-hours gate
+-- reads this column via the send pipeline.
+ALTER TABLE agent_profiles
+  ADD COLUMN IF NOT EXISTS timezone TEXT DEFAULT 'Europe/Dublin';
+
+-- ============================================
+-- 2. Enable RLS
+-- ============================================
+ALTER TABLE agent_autonomy_preferences ENABLE ROW LEVEL SECURITY;
+
+-- ============================================
+-- 3. Policies — drop-if-exists for idempotency
+-- ============================================
+DROP POLICY IF EXISTS agent_autonomy_preferences_service_role ON agent_autonomy_preferences;
+DROP POLICY IF EXISTS agent_autonomy_preferences_self_access ON agent_autonomy_preferences;
+
+CREATE POLICY agent_autonomy_preferences_service_role ON agent_autonomy_preferences
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_autonomy_preferences_self_access ON agent_autonomy_preferences
+  FOR ALL USING (user_id = auth.uid());

--- a/apps/unified-portal/tests/e2e/auto-send.spec.ts
+++ b/apps/unified-portal/tests/e2e/auto-send.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Playwright smoke tests for the Session 3 auto-send flow.
+ *
+ * Install & run once:
+ *   npm i -D @playwright/test
+ *   npx playwright install chromium
+ *   npx playwright test tests/e2e/auto-send.spec.ts
+ *
+ * Mocks transcribe/extract/execute/send/cancel endpoints so the test doesn't
+ * touch Supabase, Deepgram, Claude or Resend. Covers:
+ *   1. Countdown -> auto-send succeeds -> undo pill visible
+ *   2. Countdown -> Cancel clicked -> "Held for review" banner + cancel API
+ *      hit
+ */
+import { expect, test } from '@playwright/test';
+
+const TRANSCRIPT = 'Tell the vendor of 14 Oakfield we had a great viewing today.';
+
+const ACTION = {
+  id: 'act_auto_1',
+  type: 'draft_vendor_update',
+  fields: {
+    vendor_id: '14 Oakfield',
+    update_summary: 'Great viewing today, strong interest.',
+    tone: 'casual',
+    send_method: 'email',
+  },
+  confidence: {
+    vendor_id: 0.9,
+    update_summary: 0.85,
+    tone: 0.9,
+    send_method: 0.9,
+  },
+};
+
+const AUTO_SEND_EXECUTE_RESPONSE = {
+  batchId: 'batch_auto',
+  globalPaused: false,
+  results: [
+    {
+      id: ACTION.id,
+      type: ACTION.type,
+      success: true,
+      targetId: 'draft_auto_1',
+      message: 'Auto-sending vendor update to Mary Doyle',
+      autoSendPlan: {
+        draftId: 'draft_auto_1',
+        draftType: 'vendor_update',
+        countdownSeconds: 2, // short so the test doesn't wait 10 real seconds
+        recipientName: 'Mary Doyle',
+      },
+    },
+  ],
+};
+
+async function stubCommonRoutes(page: import('@playwright/test').Page) {
+  await page.route('**/api/agent/intelligence/transcribe', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ transcript: TRANSCRIPT, provider: 'mock' }),
+    });
+  });
+
+  await page.route('**/api/agent/intelligence/extract-actions', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ actions: [ACTION], transcript: TRANSCRIPT }),
+    });
+  });
+
+  await page.route('**/api/agent/intelligence/execute-actions', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AUTO_SEND_EXECUTE_RESPONSE),
+    });
+  });
+}
+
+async function patchMediaRecorder(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    (navigator.mediaDevices as any).getUserMedia = async () => ({
+      getTracks: () => [{ stop: () => {} }],
+    });
+    class FakeRecorder {
+      state = 'inactive';
+      ondataavailable: ((e: any) => void) | null = null;
+      onstop: (() => void) | null = null;
+      mimeType = 'audio/webm';
+      start() { this.state = 'recording'; }
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({ data: new Blob(['mock'], { type: this.mimeType }) });
+        this.onstop?.();
+      }
+      static isTypeSupported() { return true; }
+    }
+    (window as any).MediaRecorder = FakeRecorder;
+  });
+}
+
+test.describe('Auto-send countdown', () => {
+  test('elapses and auto-sends, showing success banner + undo pill', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubCommonRoutes(page);
+
+    await page.route('**/api/agent/intelligence/send-draft', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_sent',
+          status: 'sent',
+          provider: 'resend',
+          providerMessageId: 'msg_auto_1',
+          externalPayload: null,
+          undoable: true,
+          sentAt: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.goto('/agent/intelligence');
+
+    const mic = page.getByTestId('voice-mic-button');
+    await mic.click();
+    await mic.click(); // stop immediately — mocked transcript fires
+
+    const card = page.getByTestId('voice-confirmation-card');
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await page.getByTestId('voice-approve-all').click();
+
+    const countdown = page.getByTestId('auto-send-countdown');
+    await expect(countdown).toBeVisible();
+
+    // Wait for countdown to elapse; the send should fire automatically.
+    await expect(page.getByTestId('auto-send-success-banner')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('voice-undo-pill')).toBeVisible();
+  });
+
+  test('cancel click holds the draft and calls cancel-auto-send', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubCommonRoutes(page);
+
+    let cancelled = false;
+    await page.route('**/api/agent/intelligence/cancel-auto-send', async (route) => {
+      cancelled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ cancelled: true }),
+      });
+    });
+    // Should never be hit once Cancel wins.
+    await page.route('**/api/agent/intelligence/send-draft', async (route) => {
+      await route.fulfill({ status: 500, body: 'should not fire' });
+    });
+
+    await page.goto('/agent/intelligence');
+
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-approve-all').click();
+
+    await expect(page.getByTestId('auto-send-countdown')).toBeVisible();
+    await page.getByTestId('auto-send-cancel').click();
+
+    await expect(page.getByTestId('auto-send-cancelled-banner')).toBeVisible();
+    expect(cancelled).toBe(true);
+  });
+});


### PR DESCRIPTION
Session 3 turns the 'review every draft' bar into an earned 'send without reviewing' experience, per-user, per-draft-type, based on the Session 2 track record telemetry.

Core principle: autonomy is earned, opt-in, and reversible. The system never silently starts auto-sending — it offers, the user chooses, and the user can pull it back at any moment (manually or via the self- correcting trust floor).

- lib/agent-intelligence/autonomy.ts — single source of truth for the eligibility rules (>= 20 sent, >= 80% as-generated, <= 5% undone, sent in last 14 days), statutory exclusion list (notice_of_termination, RPZ, RTB dispute, HAP undertaking, arrears stage 2+, deposit dispute), active-hours gate (8am-9pm in the user's local timezone), low-confidence gate (any required field < 0.7 = review mode), trust-floor auto-revert (2+ undone in last 10 auto-sends => flip off), and the offer cooldown (30 days OR +10 sends, capped at 3 dismissals).
- /api/agent/intelligence/track-record — per-draft-type stats + eligibility flags for the settings screen and the offer decision.
- /api/agent/intelligence/autonomy — GET preferences, PATCH per-type or global pause, POST dismiss_offer. Defends the statutory rule at the API layer as well as in the UI.
- /api/agent/intelligence/cancel-auto-send — flips auto_sending back to pending_review on user cancel and logs an auto_cancelled_pre_send row for analytics.
- execute-actions: loads autonomy + recent auto-send history in one batch and runs decideAutoSend() per draft action. Returns autoSendPlan with countdown metadata when all gates pass, or a holdCopy one-liner when they don't (surfaced under the action in the confirmation card).
- send-draft: accepts mode ('reviewed' | 'auto_sent'), populates send_mode in agent_send_history, rejects auto_sent attempts on statutory draft types and safely flips the draft back to review.
- undo-send: when an auto-sent row is pulled back, re-evaluates the trust floor and disables auto-send on that type if recent auto-sends crossed the 2/10 undo threshold.
- VoiceConfirmationCard renders the 10s countdown with Cancel button, sending/sent/cancelled/failed banners, and a kill-switch banner when the user has globally paused auto-send.
- DraftReviewPanel shows the AutoSendOfferCard in the sent-confirmation state when the user just crossed eligibility (respecting dismissal cooldown). Copy matches the spec, Not yet is as easy as Turn on.
- /agent/settings/autonomy + /agent/dashboard/settings/autonomy — one row per draft_type the user has ever sent, with status pill (On, Eligible, Building up, Review only), track record summary, and a toggle that's only interactive when eligible or currently enabled. Kill switch at the top pauses everything without touching per-type settings. Linked from a gear icon in the Drafts header.
- Migration 044: creates agent_autonomy_preferences (with a special _global_pause pseudo-row for the kill switch), adds send_mode to agent_send_history and timezone to agent_profiles. Structured as separate CREATE/ALTER, ENABLE RLS, CREATE POLICY blocks with DROP POLICY IF EXISTS for idempotency.
- Playwright smoke tests cover countdown -> auto-send success + undo pill, and countdown -> Cancel -> held-for-review banner + cancel API hit.