### PR TITLE
feat(agent-intelligence): four new sales draft types

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -31,6 +31,8 @@ const INDEPENDENT_PILLS = [
 const WRITE_PILLS: Array<{ label: string; intent: string }> = [
   { label: 'Log a viewing', intent: 'log_viewing' },
   { label: 'Update the tracker', intent: 'update_tracker' },
+  { label: 'Follow up with a buyer', intent: 'draft_viewing_followup_buyer' },
+  { label: 'Respond to an offer', intent: 'draft_offer_response' },
 ];
 
 interface DraftedEmail {
@@ -640,47 +642,12 @@ export default function IntelligencePage() {
             </p>
 
             {/* Prompt pills */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 10,
-                width: '100%',
-                maxWidth: 320,
-              }}
-            >
-              {PROMPT_PILLS.map((pill, i) => (
-                <button
-                  key={i}
-                  onClick={() => handleSend(pill)}
-                  className="agent-tappable"
-                  style={{
-                    padding: '13px 14px',
-                    minHeight: 54,
-                    background: '#FFFFFF',
-                    border: '0.5px solid rgba(0,0,0,0.10)',
-                    borderRadius: 16,
-                    color: '#374151',
-                    fontSize: 13,
-                    fontWeight: 500,
-                    lineHeight: 1.4,
-                    whiteSpace: 'normal',
-                    textAlign: 'center',
-                    cursor: 'pointer',
-                    fontFamily: 'inherit',
-                    boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
-                  }}
-                >
-                  {pill}
-                </button>
-              ))}
-            </div>
-
-            {/* Write-action chips — voice capture entry points */}
+            {/* Write-action chips — voice capture entry points. Kept above
+                the read chips so the voice-first workflow is the first thing
+                an agent sees on the landing state. */}
             <div
               data-testid="voice-write-chips"
               style={{
-                marginTop: 14,
                 display: 'grid',
                 gridTemplateColumns: '1fr 1fr',
                 gap: 10,
@@ -711,6 +678,43 @@ export default function IntelligencePage() {
                   }}
                 >
                   {pill.label}
+                </button>
+              ))}
+            </div>
+
+            <div
+              style={{
+                marginTop: 14,
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 10,
+                width: '100%',
+                maxWidth: 320,
+              }}
+            >
+              {PROMPT_PILLS.map((pill, i) => (
+                <button
+                  key={i}
+                  onClick={() => handleSend(pill)}
+                  className="agent-tappable"
+                  style={{
+                    padding: '13px 14px',
+                    minHeight: 54,
+                    background: '#FFFFFF',
+                    border: '0.5px solid rgba(0,0,0,0.10)',
+                    borderRadius: 16,
+                    color: '#374151',
+                    fontSize: 13,
+                    fontWeight: 500,
+                    lineHeight: 1.4,
+                    whiteSpace: 'normal',
+                    textAlign: 'center',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+                  }}
+                >
+                  {pill}
                 </button>
               ))}
             </div>
@@ -809,10 +813,40 @@ function buildConfirmationSummary(
     // countdown banner, not this summary line.
     if (autoSendUi && autoSendUi.actionId === a.id) continue;
 
+    const result = resultById[a.id];
+
     if (a.type === 'log_viewing') {
       clauses.push(`logged the viewing for ${a.fields.property_id || 'the property'}`);
     } else if (a.type === 'draft_vendor_update') {
-      clauses.push(`drafted the vendor update for you to review`);
+      clauses.push('drafted the vendor update for you to review');
+    } else if (a.type === 'draft_viewing_followup_buyer') {
+      const name = a.fields.recipient_id || 'the buyer';
+      clauses.push(`drafted the viewing follow-up for ${name}`);
+    } else if (a.type === 'draft_offer_response') {
+      const kind: string = a.fields.action || 'acknowledge';
+      const name = a.fields.recipient_id || 'the buyer';
+      if (kind === 'counter') {
+        const amount = typeof a.fields.counter_amount === 'number'
+          ? ` at €${Math.round(a.fields.counter_amount).toLocaleString('en-IE')}`
+          : '';
+        clauses.push(`drafted the counter-offer${amount} for ${name}`);
+      } else if (kind === 'accept') {
+        clauses.push(`drafted the offer acceptance for ${name}`);
+      } else if (kind === 'reject') {
+        clauses.push(`drafted the offer decline for ${name}`);
+      } else {
+        clauses.push(`drafted the offer acknowledgement for ${name}`);
+      }
+    } else if (a.type === 'draft_price_reduction_notice') {
+      const count = result?.recipientCount ?? (Array.isArray(a.fields.recipient_ids) ? a.fields.recipient_ids.length : 0);
+      clauses.push(
+        count === 1
+          ? 'drafted the price reduction notice for 1 buyer'
+          : `drafted the price reduction notice for ${count} buyers`,
+      );
+    } else if (a.type === 'draft_chain_update_to_buyer') {
+      const name = a.fields.buyer_id || 'the buyer';
+      clauses.push(`drafted the chain update for ${name}`);
     } else if (a.type === 'create_reminder') {
       const due = a.fields.due_date ? formatReminder(a.fields.due_date) : '';
       clauses.push(due ? `set a reminder for ${due}` : 'set a reminder');

--- a/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
@@ -140,6 +140,14 @@ async function executeAction(
         return await execLogViewing(supabase, ctx);
       case 'draft_vendor_update':
         return await execDraftVendorUpdate(supabase, ctx);
+      case 'draft_viewing_followup_buyer':
+        return await execDraftViewingFollowup(supabase, ctx);
+      case 'draft_offer_response':
+        return await execDraftOfferResponse(supabase, ctx);
+      case 'draft_price_reduction_notice':
+        return await execDraftPriceReductionNotice(supabase, ctx);
+      case 'draft_chain_update_to_buyer':
+        return await execDraftChainUpdate(supabase, ctx);
       case 'create_reminder':
         return await execCreateReminder(supabase, ctx);
       default:
@@ -334,6 +342,391 @@ async function execDraftVendorUpdate(
     message: `Drafted vendor update for ${f.vendor_id || 'vendor'}`,
     autoSendHold: decision.holdCopy || null,
   };
+}
+
+/**
+ * Shared draft-insertion path for Session 4A's new sales types. Encapsulates:
+ *   - decideAutoSend() gating per Session 3
+ *   - initial status (auto_sending vs pending_review)
+ *   - row insert + reversal payload for the Session 1 undo pill
+ *   - autoSendPlan return for the client countdown
+ *
+ * Caller provides draft_type + recipient hint + content_json shape.
+ */
+async function insertDraftAndMaybeAutoSend(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+  opts: {
+    draftType: string;
+    recipientId: string | null;
+    sendMethod: string;
+    contentJson: Record<string, any>;
+    reviewMessage: string;
+    autoSendMessage: (recipientName: string) => string;
+    allowAutoSend?: boolean; // false for multi-recipient fanouts
+  },
+): Promise<ExecutedAction> {
+  const { action, userId, tenantId, timezone, autonomy, recentByType } = ctx;
+
+  const pref = autonomy.byDraftType[opts.draftType] || { autoSendEnabled: false };
+  const decision = opts.allowAutoSend === false
+    ? { autoSend: false, holdCopy: null }
+    : decideAutoSend({
+        draftType: opts.draftType,
+        autoSendEnabled: pref.autoSendEnabled,
+        globalPaused: autonomy.globalPaused,
+        confidence: action.confidence,
+        requiredFields: REQUIRED_FIELDS_BY_DRAFT_TYPE[opts.draftType] || [],
+        timezone,
+        recentAutoSends: recentByType.get(opts.draftType) || [],
+      });
+
+  const initialStatus = decision.autoSend ? 'auto_sending' : 'pending_review';
+
+  const { data: draft, error } = await supabase
+    .from('pending_drafts')
+    .insert({
+      user_id: userId,
+      tenant_id: tenantId,
+      skin: 'agent',
+      draft_type: opts.draftType,
+      recipient_id: opts.recipientId,
+      content_json: opts.contentJson,
+      send_method: opts.sendMethod,
+      status: initialStatus,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Could not save draft',
+      error: error.message,
+    };
+  }
+
+  await recordReversal(supabase, ctx, {
+    targetTable: 'pending_drafts',
+    targetId: draft.id,
+    reversal: { op: 'delete', table: 'pending_drafts', id: draft.id },
+  });
+
+  if (decision.autoSend) {
+    const recipient = await resolveRecipient(supabase, opts.draftType, opts.recipientId);
+    return {
+      id: action.id,
+      type: action.type,
+      success: true,
+      targetId: draft.id,
+      message: opts.autoSendMessage(recipient.name || 'recipient'),
+      autoSendPlan: {
+        draftId: draft.id,
+        draftType: opts.draftType,
+        countdownSeconds: ELIGIBILITY_RULES.autoSendCountdownSeconds,
+        recipientName: recipient.name || 'recipient',
+      },
+    };
+  }
+
+  return {
+    id: action.id,
+    type: action.type,
+    success: true,
+    targetId: draft.id,
+    message: opts.reviewMessage,
+    autoSendHold: ('holdCopy' in decision ? decision.holdCopy : null) || null,
+  };
+}
+
+async function execDraftViewingFollowup(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action } = ctx;
+  const f = action.fields;
+  const recipientId = f.recipient_id ? String(f.recipient_id) : null;
+  const recipient = await resolveRecipient(supabase, 'viewing_followup', recipientId);
+
+  const provenance: Array<{ id: string; label: string; detail: string | null }> = [];
+  if (f.viewing_id) {
+    provenance.push({
+      id: 'viewing',
+      label: `From viewing ${String(f.viewing_id)}`,
+      detail: null,
+    });
+  }
+  if (f.include_similar_properties) {
+    provenance.push({
+      id: 'similar',
+      label: 'Will include similar properties',
+      detail: 'Buyer said the property was not quite right.',
+    });
+  }
+
+  return insertDraftAndMaybeAutoSend(supabase, ctx, {
+    draftType: 'viewing_followup',
+    recipientId,
+    sendMethod: 'email',
+    contentJson: {
+      recipient_id: recipientId,
+      viewing_id: f.viewing_id ?? null,
+      subject: f.subject || `Following up on ${recipient.address || 'your viewing'}`,
+      body: f.body || '',
+      tone: f.tone || 'warm',
+      include_similar_properties: !!f.include_similar_properties,
+      provenance,
+    },
+    reviewMessage: `Drafted viewing follow-up for ${recipient.name || recipientId || 'buyer'}`,
+    autoSendMessage: (name) => `Auto-sending viewing follow-up to ${name}`,
+  });
+}
+
+async function execDraftOfferResponse(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action } = ctx;
+  const f = action.fields;
+  const recipientId = f.recipient_id ? String(f.recipient_id) : null;
+  const recipient = await resolveRecipient(supabase, 'offer_response', recipientId);
+  const actionKind: string = f.action || 'acknowledge';
+
+  const provenance: Array<{ id: string; label: string; detail: string | null }> = [];
+  if (f.offer_id) {
+    provenance.push({
+      id: 'offer',
+      label: `Offer ${String(f.offer_id)}`,
+      detail: null,
+    });
+  }
+  if (actionKind === 'counter' && typeof f.counter_amount === 'number') {
+    provenance.push({
+      id: 'counter',
+      label: `Counter at €${Math.round(f.counter_amount).toLocaleString('en-IE')}`,
+      detail: f.counter_conditions ? String(f.counter_conditions) : null,
+    });
+  } else {
+    provenance.push({
+      id: 'action',
+      label: `Action: ${actionKind}`,
+      detail: null,
+    });
+  }
+
+  return insertDraftAndMaybeAutoSend(supabase, ctx, {
+    draftType: 'offer_response',
+    recipientId,
+    sendMethod: 'email',
+    contentJson: {
+      recipient_id: recipientId,
+      offer_id: f.offer_id ?? null,
+      action: actionKind,
+      counter_amount: typeof f.counter_amount === 'number' ? f.counter_amount : null,
+      counter_conditions: f.counter_conditions || '',
+      subject: f.subject || subjectForOfferResponse(actionKind, recipient.address),
+      body: f.body || '',
+      tone: f.tone || (actionKind === 'reject' ? 'firm' : 'warm'),
+      provenance,
+    },
+    reviewMessage: `Drafted offer ${actionKind === 'acknowledge' ? 'acknowledgement' : actionKind} for ${recipient.name || recipientId || 'buyer'}`,
+    autoSendMessage: (name) => `Auto-sending offer ${actionKind} to ${name}`,
+  });
+}
+
+function subjectForOfferResponse(kind: string, address?: string | null): string {
+  const prop = address ? ` on ${address}` : '';
+  switch (kind) {
+    case 'accept':
+      return `Good news about your offer${prop}`;
+    case 'counter':
+      return `On your offer${prop}`;
+    case 'reject':
+      return `Update on your offer${prop}`;
+    default:
+      return `Thanks for your offer${prop}`;
+  }
+}
+
+async function execDraftPriceReductionNotice(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action, userId, tenantId } = ctx;
+  const f = action.fields;
+  const recipients: string[] = Array.isArray(f.recipient_ids)
+    ? f.recipient_ids.map((r: any) => String(r)).filter(Boolean)
+    : [];
+
+  if (recipients.length === 0) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'No recipients specified',
+      error: 'recipient_ids must contain at least one buyer',
+    };
+  }
+
+  const propertyId = f.property_id ? String(f.property_id) : null;
+  const propertyRef = await resolveRecipient(supabase, 'vendor_update', propertyId);
+  const oldPrice = typeof f.old_price === 'number' ? f.old_price : null;
+  const newPrice = typeof f.new_price === 'number' ? f.new_price : null;
+  const template: string = typeof f.body_template === 'string' ? f.body_template : '';
+  const subject = typeof f.subject === 'string' && f.subject.trim()
+    ? f.subject
+    : `Price update on ${propertyRef.address || propertyId || 'a property'}`;
+
+  // Fan out: one pending_draft per recipient. Multi-recipient never auto-sends
+  // on approval (too high-stakes); each row is auto-sendable individually
+  // from the Drafts inbox via the standard gate.
+  const targetIds: string[] = [];
+  const failures: string[] = [];
+
+  for (const recipientId of recipients) {
+    const recipient = await resolveRecipient(supabase, 'price_reduction_notice', recipientId);
+    const firstName = firstNameOf(recipient.name) || firstNameOf(recipientId) || 'there';
+    const body = template ? template.replace(/\{first_name\}/g, firstName) : '';
+
+    const provenance: Array<{ id: string; label: string; detail: string | null }> = [];
+    if (propertyRef.address) {
+      provenance.push({
+        id: 'property',
+        label: propertyRef.address,
+        detail: propertyId ? `Listing ${propertyId}` : null,
+      });
+    }
+    if (oldPrice != null && newPrice != null) {
+      provenance.push({
+        id: 'price',
+        label: `€${Math.round(oldPrice).toLocaleString('en-IE')} -> €${Math.round(newPrice).toLocaleString('en-IE')}`,
+        detail: `Reduction of €${Math.round(oldPrice - newPrice).toLocaleString('en-IE')}`,
+      });
+    }
+
+    const { data: row, error } = await supabase
+      .from('pending_drafts')
+      .insert({
+        user_id: userId,
+        tenant_id: tenantId,
+        skin: 'agent',
+        draft_type: 'price_reduction_notice',
+        recipient_id: recipientId,
+        content_json: {
+          recipient_id: recipientId,
+          property_id: propertyId,
+          old_price: oldPrice,
+          new_price: newPrice,
+          subject,
+          body,
+          body_template: template,
+          provenance,
+        },
+        send_method: 'email',
+        status: 'pending_review',
+      })
+      .select('id')
+      .single();
+
+    if (error || !row) {
+      failures.push(recipientId);
+      continue;
+    }
+
+    targetIds.push(row.id);
+    await recordReversal(supabase, ctx, {
+      targetTable: 'pending_drafts',
+      targetId: row.id,
+      reversal: { op: 'delete', table: 'pending_drafts', id: row.id },
+    });
+  }
+
+  if (targetIds.length === 0) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Could not save any price reduction drafts',
+      error: `Failed for: ${failures.join(', ')}`,
+    };
+  }
+
+  return {
+    id: action.id,
+    type: action.type,
+    success: true,
+    targetId: targetIds[0],
+    targetIds,
+    recipientCount: targetIds.length,
+    message:
+      targetIds.length === 1
+        ? `Drafted price reduction notice for 1 buyer`
+        : `Drafted price reduction notice for ${targetIds.length} buyers`,
+    autoSendHold:
+      failures.length > 0
+        ? `${failures.length} recipient${failures.length === 1 ? '' : 's'} could not be drafted — check the list.`
+        : null,
+  };
+}
+
+function firstNameOf(full: string | null | undefined): string | null {
+  if (!full) return null;
+  const trimmed = String(full).trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0];
+}
+
+async function execDraftChainUpdate(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action } = ctx;
+  const f = action.fields;
+  const buyerId = f.buyer_id ? String(f.buyer_id) : null;
+  const propertyId = f.property_id ? String(f.property_id) : null;
+  const updateType: string = f.update_type || 'custom';
+  const recipient = await resolveRecipient(supabase, 'chain_update_to_buyer', buyerId || propertyId);
+
+  const provenance: Array<{ id: string; label: string; detail: string | null }> = [];
+  provenance.push({
+    id: 'update_type',
+    label: chainUpdateLabel(updateType),
+    detail: updateType === 'custom' && f.custom_detail ? String(f.custom_detail) : null,
+  });
+  if (propertyId && recipient.address) {
+    provenance.push({ id: 'property', label: recipient.address, detail: null });
+  }
+
+  return insertDraftAndMaybeAutoSend(supabase, ctx, {
+    draftType: 'chain_update_to_buyer',
+    recipientId: buyerId,
+    sendMethod: 'email',
+    contentJson: {
+      buyer_id: buyerId,
+      property_id: propertyId,
+      update_type: updateType,
+      custom_detail: f.custom_detail || '',
+      subject: f.subject || `Quick chain update${recipient.address ? ` on ${recipient.address}` : ''}`,
+      body: f.body || '',
+      tone: f.tone || 'reassuring',
+      provenance,
+    },
+    reviewMessage: `Drafted chain update for ${recipient.name || buyerId || 'buyer'}`,
+    autoSendMessage: (name) => `Auto-sending chain update to ${name}`,
+  });
+}
+
+function chainUpdateLabel(type: string): string {
+  switch (type) {
+    case 'survey_completed': return 'Survey completed';
+    case 'solicitor_instructed': return 'Solicitor instructed';
+    case 'contracts_issued': return 'Contracts issued';
+    case 'contracts_exchanged': return 'Contracts exchanged';
+    case 'delay_expected': return 'Delay expected';
+    default: return 'Chain update';
+  }
 }
 
 async function execCreateReminder(

--- a/apps/unified-portal/app/api/agent/intelligence/extract-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/extract-actions/route.ts
@@ -180,6 +180,13 @@ Given the agent's spoken transcript you must:
 3. Include a _confidence object on every tool call mapping each field name to a number between 0 and 1 reflecting how sure you are of that specific value. Fields inferred or guessed should score below 0.7.
 4. Use ISO 8601 for dates and times. If the transcript says "Monday" resolve to the next Monday in Europe/Dublin and set confidence <= 0.75.
 5. Never invent contact details. If a name has no phone or email, leave contact_if_known empty.
-6. Keep Irish peer-to-peer tone for any drafted update summaries — casual, no em dashes, no emoji.
-7. Do not emit tool calls for speculative or unrelated actions. If the transcript is purely a question (no action), return zero tool calls.`;
+6. Keep Irish peer-to-peer tone for any drafted body — casual, grounded, no em dashes, no emoji.
+7. Do not emit tool calls for speculative or unrelated actions. If the transcript is purely a question (no action), return zero tool calls.
+
+Choosing between draft tools:
+ - draft_viewing_followup_buyer: the agent wants a thank-you / next-step email to the attendees after a viewing. Trigger phrases: "follow up with Murphys", "thank them for coming", "send more info". Reference anything specific they cared about.
+ - draft_offer_response: the agent describes how to respond to an offer. Trigger phrases: "accept their offer", "counter at X", "reject the 420", "acknowledge and pass to vendor". Choose the right action enum. For counters the new amount must appear in the body.
+ - draft_price_reduction_notice: the agent says the price has dropped and wants to tell active buyers. Trigger phrases: "vendor dropped to 450, tell anyone who viewed", "price reduction on 14 Oakfield". Populate recipient_ids with every buyer referenced. The body_template uses the literal token {first_name} for personalisation — the server fills it in per recipient.
+ - draft_chain_update_to_buyer: the agent describes chain progress for a single buyer. Trigger phrases: "survey came back", "solicitor instructed", "contracts issued", "contracts exchanged", "there's a delay on completion". Pick the closest update_type enum; use "custom" only when no enum fits.
+ - draft_vendor_update: default sales-side update back to the vendor. Use for "tell the vendor" / "let the vendor know" when none of the more specific tools apply.`;
 }

--- a/apps/unified-portal/lib/agent-intelligence/autonomy.ts
+++ b/apps/unified-portal/lib/agent-intelligence/autonomy.ts
@@ -383,4 +383,15 @@ export async function enforceTrustFloor(
 export const REQUIRED_FIELDS_BY_DRAFT_TYPE: Record<string, readonly string[]> = {
   vendor_update: ['vendor_id', 'update_summary', 'tone', 'send_method'],
   draft_vendor_update: ['vendor_id', 'update_summary', 'tone', 'send_method'],
+  viewing_followup: ['recipient_id', 'body', 'tone'],
+  draft_viewing_followup_buyer: ['recipient_id', 'body', 'tone'],
+  offer_response: ['offer_id', 'recipient_id', 'action', 'body'],
+  draft_offer_response: ['offer_id', 'recipient_id', 'action', 'body'],
+  // Price reduction writes to every recipient — auto-send is high-stakes here.
+  // Required fields include recipient_ids so a low-confidence match list
+  // forces review.
+  price_reduction_notice: ['property_id', 'new_price', 'recipient_ids', 'body_template'],
+  draft_price_reduction_notice: ['property_id', 'new_price', 'recipient_ids', 'body_template'],
+  chain_update_to_buyer: ['buyer_id', 'property_id', 'update_type', 'body'],
+  draft_chain_update_to_buyer: ['buyer_id', 'property_id', 'update_type', 'body'],
 };

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -23,7 +23,7 @@ export interface DraftRecipient {
   name: string | null;
   email: string | null;
   phone: string | null;
-  source: 'listing_vendor' | 'unknown';
+  source: 'listing_vendor' | 'listing_buyer' | 'unknown';
   address?: string | null;
 }
 
@@ -47,6 +47,14 @@ export function draftTypeLabel(type: string): string {
   switch (type) {
     case 'vendor_update':
       return 'Vendor update';
+    case 'viewing_followup':
+      return 'Viewing follow-up';
+    case 'offer_response':
+      return 'Offer response';
+    case 'price_reduction_notice':
+      return 'Price reduction notice';
+    case 'chain_update_to_buyer':
+      return 'Chain update';
     case 'landlord_statement':
       return 'Landlord statement';
     case 'buyer_followup':
@@ -55,6 +63,13 @@ export function draftTypeLabel(type: string): string {
       return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
   }
 }
+
+const BUYER_DRAFT_TYPES: readonly string[] = [
+  'viewing_followup',
+  'offer_response',
+  'price_reduction_notice',
+  'chain_update_to_buyer',
+];
 
 export async function resolveRecipient(
   supabase: SupabaseClient,
@@ -75,6 +90,20 @@ export async function resolveRecipient(
         phone: listing.vendor_phone || null,
         address: listing.address || null,
         source: 'listing_vendor',
+      };
+    }
+  }
+
+  if (BUYER_DRAFT_TYPES.includes(draftType)) {
+    const listing = await findListingByBuyerReference(supabase, recipientId);
+    if (listing) {
+      return {
+        id: listing.id,
+        name: listing.buyer_name || recipientId,
+        email: listing.buyer_solicitor_email || null,
+        phone: listing.buyer_phone || null,
+        address: listing.address || null,
+        source: 'listing_buyer',
       };
     }
   }
@@ -110,6 +139,36 @@ async function findListingFromReference(
     .ilike('address', `%${reference}%`)
     .limit(1);
   return matches?.[0] || null;
+}
+
+async function findListingByBuyerReference(
+  supabase: SupabaseClient,
+  reference: string,
+): Promise<any | null> {
+  if (UUID_REGEX.test(reference)) {
+    const { data } = await supabase
+      .from('listings')
+      .select('id, address, buyer_name, buyer_phone, buyer_solicitor_email, vendor_name')
+      .eq('id', reference)
+      .maybeSingle();
+    if (data) return data;
+  }
+
+  // Match on buyer name or address — voice capture often references the
+  // property the buyer is interested in rather than the buyer's identifier.
+  const { data: byName } = await supabase
+    .from('listings')
+    .select('id, address, buyer_name, buyer_phone, buyer_solicitor_email, vendor_name')
+    .ilike('buyer_name', `%${reference}%`)
+    .limit(1);
+  if (byName && byName[0]) return byName[0];
+
+  const { data: byAddress } = await supabase
+    .from('listings')
+    .select('id, address, buyer_name, buyer_phone, buyer_solicitor_email, vendor_name')
+    .ilike('address', `%${reference}%`)
+    .limit(1);
+  return byAddress?.[0] || null;
 }
 
 /**
@@ -171,9 +230,24 @@ function extractContextChips(
       id: 'property',
       label: recipient.address,
       detail: recipient.name && recipient.name !== recipient.address
-        ? `Vendor: ${recipient.name}`
+        ? `${recipient.source === 'listing_buyer' ? 'Buyer' : 'Vendor'}: ${recipient.name}`
         : null,
     });
+  }
+
+  // Session 4A: execute-actions writes a structured `provenance` array per
+  // draft — list of {id, label, detail} objects — so each draft type can
+  // surface its own context (viewing references, offer amount, update_type,
+  // old/new price, etc.) without every consumer re-deriving it.
+  if (Array.isArray(content.provenance)) {
+    for (const item of content.provenance) {
+      if (!item || typeof item !== 'object') continue;
+      chips.push({
+        id: typeof item.id === 'string' ? item.id : `prov_${chips.length}`,
+        label: String(item.label || ''),
+        detail: item.detail ? String(item.detail) : null,
+      });
+    }
   }
 
   if (typeof content.source_viewing_id === 'string') {
@@ -190,7 +264,7 @@ function extractContextChips(
     }
   }
 
-  return chips;
+  return chips.filter((c) => c.label.trim().length > 0);
 }
 
 /**

--- a/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
+++ b/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
@@ -14,6 +14,10 @@
 export type VoiceActionType =
   | 'log_viewing'
   | 'draft_vendor_update'
+  | 'draft_viewing_followup_buyer'
+  | 'draft_offer_response'
+  | 'draft_price_reduction_notice'
+  | 'draft_chain_update_to_buyer'
   | 'create_reminder';
 
 export type ConfidenceMap = Record<string, number>;
@@ -30,6 +34,17 @@ export interface ExecutedAction {
   type: VoiceActionType | string;
   success: boolean;
   targetId?: string;
+  /**
+   * Populated when a single extracted action fans out to multiple draft rows
+   * (today only draft_price_reduction_notice). targetId is the first row so
+   * existing consumers keep working; targetIds is the full list.
+   */
+  targetIds?: string[];
+  /**
+   * Count of recipients — used by the natural-language summary
+   * ("drafted the notice for 3 buyers").
+   */
+  recipientCount?: number;
   message: string;
   error?: string;
   /**
@@ -163,6 +178,187 @@ export const ACTION_TOOLS = [
     },
   },
   {
+    name: 'draft_viewing_followup_buyer',
+    description:
+      'Draft a follow-up email to a buyer (or pair of attendees) after a viewing. Choose this when the agent describes a viewing they want to follow up on, or when a log_viewing action is also firing and the agent mentions thanking the attendees / sending more info. Reference anything specific the buyer cared about (e.g. garden, commute, schools) directly in the body so it does not read like a template.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        viewing_id: {
+          type: 'string',
+          description:
+            'The logged viewing id if known, otherwise a short human reference like "14 Oakfield viewing this morning". Leave empty if the voice capture does not reference a viewing.',
+        },
+        recipient_id: {
+          type: 'string',
+          description:
+            'Buyer identifier. A contact id, a listing id whose buyer_name matches, or a name like "Murphys" if nothing stronger is available.',
+        },
+        subject: {
+          type: 'string',
+          description:
+            'Short natural subject line, e.g. "Great to meet you at 14 Oakfield".',
+        },
+        body: {
+          type: 'string',
+          description:
+            'Full email body in Irish peer-to-peer tone. Reference specific things the agent mentioned during the viewing. No em dashes, no emoji.',
+        },
+        tone: {
+          type: 'string',
+          enum: ['warm', 'straightforward'],
+        },
+        include_similar_properties: {
+          type: 'boolean',
+          description:
+            'True when the buyer said the property was not quite right but they are still looking.',
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: ['recipient_id', 'body', 'tone', 'include_similar_properties', '_confidence'],
+    },
+  },
+  {
+    name: 'draft_offer_response',
+    description:
+      'Draft a reply to a buyer who has put in an offer. Use for accept, counter, reject, or acknowledge-and-pass-to-vendor. For a counter the new amount must be clearly in the body. For a reject the tone stays professional and leaves the door open without being mealy-mouthed. For acknowledge the body is a short "thanks, I will come back once I have spoken to the vendor".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        offer_id: {
+          type: 'string',
+          description:
+            'The offer record id if known, otherwise a human reference like "Murphys offer on 14 Oakfield".',
+        },
+        recipient_id: {
+          type: 'string',
+          description: 'Buyer or buyer-solicitor identifier.',
+        },
+        action: {
+          type: 'string',
+          enum: ['accept', 'counter', 'reject', 'acknowledge'],
+        },
+        counter_amount: {
+          type: 'number',
+          description: 'Only when action=counter. EUR. Omit for other actions.',
+        },
+        counter_conditions: {
+          type: 'string',
+          description:
+            'Optional extra conditions attached to a counter (e.g. "subject to contract by end of month"). Empty string otherwise.',
+        },
+        subject: {
+          type: 'string',
+          description: 'Short subject line that makes the action clear.',
+        },
+        body: {
+          type: 'string',
+          description:
+            'Email body. Irish peer-to-peer tone, no em dashes, no emoji. For counters include the amount and any conditions explicitly. For acknowledge the body is short.',
+        },
+        tone: {
+          type: 'string',
+          enum: ['warm', 'firm'],
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: ['offer_id', 'recipient_id', 'action', 'body', 'tone', '_confidence'],
+    },
+  },
+  {
+    name: 'draft_price_reduction_notice',
+    description:
+      'Draft a price reduction notice to active buyers who have viewed or enquired about a specific property. One email per recipient, each read personally (e.g. "Hi Mary,"). Use when the agent says something like "the vendor dropped to 450, tell anyone who viewed".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        property_id: {
+          type: 'string',
+          description: 'Listing id or short reference like "14 Oakfield".',
+        },
+        old_price: {
+          type: 'number',
+          description: 'Previous asking price in EUR.',
+        },
+        new_price: {
+          type: 'number',
+          description: 'Updated asking price in EUR.',
+        },
+        recipient_ids: {
+          type: 'array',
+          description:
+            'Array of buyer identifiers (ids or names) who should receive the notice. Each row becomes its own independently-sendable draft.',
+          items: { type: 'string' },
+        },
+        subject: {
+          type: 'string',
+          description: 'Short subject line, e.g. "Price update on 14 Oakfield".',
+        },
+        body_template: {
+          type: 'string',
+          description:
+            'Body template, personalised per recipient. Use the literal token {first_name} where the buyer greeting should go; the server swaps it in. Irish peer-to-peer tone, no em dashes.',
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: [
+        'property_id',
+        'old_price',
+        'new_price',
+        'recipient_ids',
+        'body_template',
+        '_confidence',
+      ],
+    },
+  },
+  {
+    name: 'draft_chain_update_to_buyer',
+    description:
+      'Proactive update to a buyer whose chain is moving (or not moving). Triggered by the agent mentioning survey, solicitor instructed, contracts issued, contracts exchanged, completion, or a delay. Tone is reassuring by default and straightforward if the update is factual.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        buyer_id: { type: 'string' },
+        property_id: { type: 'string' },
+        update_type: {
+          type: 'string',
+          enum: [
+            'survey_completed',
+            'solicitor_instructed',
+            'contracts_issued',
+            'delay_expected',
+            'contracts_exchanged',
+            'custom',
+          ],
+        },
+        custom_detail: {
+          type: 'string',
+          description:
+            'Only when update_type=custom. Empty string otherwise.',
+        },
+        subject: { type: 'string' },
+        body: {
+          type: 'string',
+          description:
+            'Email body. Irish peer-to-peer tone. State what just happened and what the next step is. No em dashes.',
+        },
+        tone: {
+          type: 'string',
+          enum: ['reassuring', 'straightforward'],
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: [
+        'buyer_id',
+        'property_id',
+        'update_type',
+        'body',
+        'tone',
+        '_confidence',
+      ],
+    },
+  },
+  {
     name: 'create_reminder',
     description:
       'Create a reminder / task the agent wants to be nudged on later.',
@@ -201,6 +397,33 @@ export function actionLabel(action: ExtractedAction): string {
     case 'draft_vendor_update': {
       const vendor = action.fields?.vendor_id;
       return vendor ? `Draft vendor update for ${vendor}` : 'Draft vendor update';
+    }
+    case 'draft_viewing_followup_buyer': {
+      const recipient = action.fields?.recipient_id;
+      return recipient ? `Draft viewing follow-up for ${recipient}` : 'Draft viewing follow-up';
+    }
+    case 'draft_offer_response': {
+      const actionKind = action.fields?.action;
+      const recipient = action.fields?.recipient_id;
+      const suffix = recipient ? ` for ${recipient}` : '';
+      if (actionKind === 'accept') return `Draft offer acceptance${suffix}`;
+      if (actionKind === 'counter') return `Draft counter-offer${suffix}`;
+      if (actionKind === 'reject') return `Draft offer decline${suffix}`;
+      return `Draft offer acknowledgement${suffix}`;
+    }
+    case 'draft_price_reduction_notice': {
+      const count = Array.isArray(action.fields?.recipient_ids)
+        ? action.fields.recipient_ids.length
+        : 0;
+      const property = action.fields?.property_id;
+      const scope = count > 0 ? ` for ${count} buyer${count === 1 ? '' : 's'}` : '';
+      return property
+        ? `Draft price reduction notice on ${property}${scope}`
+        : `Draft price reduction notice${scope}`;
+    }
+    case 'draft_chain_update_to_buyer': {
+      const buyer = action.fields?.buyer_id;
+      return buyer ? `Draft chain update for ${buyer}` : 'Draft chain update';
     }
     case 'create_reminder':
       return 'Set reminder';

--- a/apps/unified-portal/tests/e2e/sales-draft-expansion.spec.ts
+++ b/apps/unified-portal/tests/e2e/sales-draft-expansion.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Playwright smoke tests for Session 4A sales draft expansion.
+ *
+ * Install & run once:
+ *   npm i -D @playwright/test
+ *   npx playwright install chromium
+ *   npx playwright test tests/e2e/sales-draft-expansion.spec.ts
+ *
+ * Mocks transcribe/extract/execute so the test doesn't hit Supabase, Claude
+ * or Resend. Covers:
+ *   1. Voice capture -> draft_offer_response -> card renders with the
+ *      counter amount, approve -> confirmation text + undo pill
+ *   2. Voice capture -> draft_price_reduction_notice on 3 buyers -> card
+ *      reports the fanout, approve -> "drafted for 3 buyers" summary
+ */
+import { expect, test } from '@playwright/test';
+
+const TRANSCRIPT = 'Counter the Murphys at 450 on 14 Oakfield, firm tone.';
+
+const OFFER_RESPONSE_ACTION = {
+  id: 'act_offer_1',
+  type: 'draft_offer_response',
+  fields: {
+    offer_id: 'Murphys offer on 14 Oakfield',
+    recipient_id: 'Murphys',
+    action: 'counter',
+    counter_amount: 450000,
+    counter_conditions: '',
+    subject: 'On your offer on 14 Oakfield',
+    body: 'Thanks for the offer. The vendor would like to counter at 450,000.',
+    tone: 'firm',
+  },
+  confidence: {
+    offer_id: 0.8,
+    recipient_id: 0.85,
+    action: 0.95,
+    counter_amount: 0.9,
+    subject: 0.85,
+    body: 0.8,
+    tone: 0.8,
+  },
+};
+
+const PRICE_REDUCTION_ACTION = {
+  id: 'act_price_1',
+  type: 'draft_price_reduction_notice',
+  fields: {
+    property_id: '14 Oakfield',
+    old_price: 475000,
+    new_price: 450000,
+    recipient_ids: ['Mary Doyle', 'John Kelly', 'Sinead Ryan'],
+    subject: 'Price update on 14 Oakfield',
+    body_template: 'Hi {first_name}, quick heads up — 14 Oakfield is now 450,000.',
+  },
+  confidence: {
+    property_id: 0.9,
+    old_price: 0.85,
+    new_price: 0.9,
+    recipient_ids: 0.75,
+    body_template: 0.8,
+  },
+};
+
+async function patchMediaRecorder(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    (navigator.mediaDevices as any).getUserMedia = async () => ({
+      getTracks: () => [{ stop: () => {} }],
+    });
+    class FakeRecorder {
+      state = 'inactive';
+      ondataavailable: ((e: any) => void) | null = null;
+      onstop: (() => void) | null = null;
+      mimeType = 'audio/webm';
+      start() { this.state = 'recording'; }
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({ data: new Blob(['mock'], { type: this.mimeType }) });
+        this.onstop?.();
+      }
+      static isTypeSupported() { return true; }
+    }
+    (window as any).MediaRecorder = FakeRecorder;
+  });
+}
+
+async function stubTranscription(page: import('@playwright/test').Page) {
+  await page.route('**/api/agent/intelligence/transcribe', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ transcript: TRANSCRIPT, provider: 'mock' }),
+    });
+  });
+}
+
+test.describe('Sales draft expansion', () => {
+  test('draft_offer_response counter surfaces amount + lands draft', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubTranscription(page);
+
+    await page.route('**/api/agent/intelligence/extract-actions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ actions: [OFFER_RESPONSE_ACTION], transcript: TRANSCRIPT }),
+      });
+    });
+
+    let executeHits = 0;
+    await page.route('**/api/agent/intelligence/execute-actions', async (route) => {
+      executeHits += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_offer',
+          globalPaused: false,
+          results: [
+            {
+              id: OFFER_RESPONSE_ACTION.id,
+              type: OFFER_RESPONSE_ACTION.type,
+              success: true,
+              targetId: 'draft_offer_1',
+              message: 'Drafted offer counter for Murphys',
+              autoSendPlan: null,
+              autoSendHold: null,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/agent/intelligence');
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-mic-button').click();
+
+    const card = page.getByTestId('voice-confirmation-card');
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await expect(card).toContainText('Draft counter-offer');
+    await expect(card).toContainText('450000'); // counter_amount present in field row
+
+    await page.getByTestId('voice-approve-all').click();
+
+    // Natural-language summary + undo pill.
+    await expect(page.getByText(/counter-offer at €450,000/i)).toBeVisible();
+    await expect(page.getByTestId('voice-undo-pill')).toBeVisible();
+    expect(executeHits).toBe(1);
+  });
+
+  test('draft_price_reduction_notice fans out to 3 buyers', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubTranscription(page);
+
+    await page.route('**/api/agent/intelligence/extract-actions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ actions: [PRICE_REDUCTION_ACTION], transcript: TRANSCRIPT }),
+      });
+    });
+
+    await page.route('**/api/agent/intelligence/execute-actions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_price',
+          globalPaused: false,
+          results: [
+            {
+              id: PRICE_REDUCTION_ACTION.id,
+              type: PRICE_REDUCTION_ACTION.type,
+              success: true,
+              targetId: 'draft_price_1',
+              targetIds: ['draft_price_1', 'draft_price_2', 'draft_price_3'],
+              recipientCount: 3,
+              message: 'Drafted price reduction notice for 3 buyers',
+              autoSendPlan: null,
+              autoSendHold: null,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/agent/intelligence');
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-mic-button').click();
+
+    const card = page.getByTestId('voice-confirmation-card');
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await expect(card).toContainText('Draft price reduction notice');
+    await expect(card).toContainText('3 buyers');
+
+    await page.getByTestId('voice-approve-all').click();
+
+    await expect(page.getByText(/drafted the price reduction notice for 3 buyers/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Session 4A stamps the voice-capture -> draft -> review -> auto-send pattern onto four new sales workflows so the agent has broader coverage from day one and can build parallel track record across types.

New draft types, each with its own Anthropic tool schema, execute handler and confirmation-summary copy:

- draft_viewing_followup_buyer — email to attendees after a viewing, referencing specifics (garden concerns, school run) the agent mentioned during capture.
- draft_offer_response — accept / counter / reject / acknowledge, with the counter amount and any conditions explicit in the body.
- draft_price_reduction_notice — fans out to one pending_drafts row per recipient with personalised greeting via {first_name} template. Never auto-sends on approval (multi-recipient too high-stakes); each row remains independently auto-sendable via the normal gate from the Drafts inbox.
- draft_chain_update_to_buyer — survey, solicitor, contracts issued, contracts exchanged, delay, or custom. Tone defaults to reassuring.

Plumbing:

- voice-actions.ts: tool schemas with example trigger phrases baked into each description so Claude reliably disambiguates. Labels + confidence schemas match the Session 1 pattern. ExecutedAction gains optional targetIds + recipientCount for the fanout case.
- autonomy.ts: REQUIRED_FIELDS_BY_DRAFT_TYPE extended with the four new types. All are eligible to earn auto-send; none statutory.
- drafts.ts: buyer-side recipient resolution (listings.buyer_*), natural-language labels for the new types, structured provenance chips fed from execute-actions so every draft's context row is accurate regardless of type.
- extract-actions: system prompt adds a 'Choosing between draft tools' section with one-line disambiguation hints per type.
- execute-actions: insertDraftAndMaybeAutoSend() shared helper wraps the Session 3 decideAutoSend gating + insert + reversal payload so every new handler is concise. Fanout handler loops per recipient, personalises the template, records one reversal per row.
- intelligence page: buildConfirmationSummary reads recipientCount to print 'drafted the price reduction notice for 3 buyers' correctly, and renders counter-offer amounts as '€450,000'. Two new write-action chips (Follow up with a buyer, Respond to an offer) join the existing two, and the write-chip grid now sits above the read-chip grid on the landing state.
- Playwright smoke tests for draft_offer_response counter amount and draft_price_reduction_notice three-recipient fanout.