### PR TITLE
feat(agent-intelligence): lettings foundation (rental viewing to appl…

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -4,15 +4,18 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
+import { useApplicantsCount } from '../_hooks/useApplicantsCount';
 
-type TabId = 'home' | 'pipeline' | 'drafts' | 'viewings' | 'docs';
+type TabId = 'home' | 'pipeline' | 'drafts' | 'applicants' | 'viewings' | 'docs';
 
 const TABS: { id: TabId; label: string; href: string }[] = [
   { id: 'home', label: 'Home', href: '/agent/home' },
   { id: 'pipeline', label: 'Pipeline', href: '/agent/pipeline' },
-  // Intelligence is the FAB. Drafts sits immediately after, between Pipeline
-  // and Viewings in visual flow per Session 2 spec.
+  // Intelligence is the FAB in the middle. The right cluster is lettings-
+  // heavy by design: letting agents spend most of their day between
+  // Drafts, Applicants, and Viewings.
   { id: 'drafts', label: 'Drafts', href: '/agent/drafts' },
+  { id: 'applicants', label: 'Applicants', href: '/agent/applicants' },
   { id: 'viewings', label: 'Viewings', href: '/agent/viewings' },
   { id: 'docs', label: 'Docs', href: '/agent/docs' },
 ];
@@ -47,6 +50,16 @@ function TabIcon({ id, active }: { id: TabId; active: boolean }) {
           <path d="m16 19 2 2 4-4" />
         </svg>
       );
+    case 'applicants':
+      // Lucide Users glyph.
+      return (
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      );
     case 'viewings':
       return (
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
@@ -71,6 +84,7 @@ export default function BottomNav() {
   const isActive = (href: string) => pathname.startsWith(href);
   const intelActive = pathname.startsWith('/agent/intelligence');
   const { count: draftsCount } = useDraftsCount();
+  const { count: applicantsCount } = useApplicantsCount();
 
   const leftTabs = TABS.slice(0, 2);
   const rightTabs = TABS.slice(2);
@@ -114,6 +128,9 @@ export default function BottomNav() {
               <TabIcon id={tab.id} active={active} />
               {tab.id === 'drafts' && draftsCount > 0 && (
                 <DraftsBadge count={draftsCount} />
+              )}
+              {tab.id === 'applicants' && applicantsCount > 0 && (
+                <DraftsBadge count={applicantsCount} testId="applicants-badge" />
               )}
             </div>
             <span
@@ -231,6 +248,9 @@ export default function BottomNav() {
               {tab.id === 'drafts' && draftsCount > 0 && (
                 <DraftsBadge count={draftsCount} />
               )}
+              {tab.id === 'applicants' && applicantsCount > 0 && (
+                <DraftsBadge count={applicantsCount} testId="applicants-badge" />
+              )}
             </div>
             <span
               style={{
@@ -249,10 +269,10 @@ export default function BottomNav() {
   );
 }
 
-function DraftsBadge({ count }: { count: number }) {
+function DraftsBadge({ count, testId = 'drafts-badge' }: { count: number; testId?: string }) {
   return (
     <span
-      data-testid="drafts-badge"
+      data-testid={testId}
       style={{
         position: 'absolute',
         top: -4,

--- a/apps/unified-portal/app/agent/_components/VoiceConfirmationCard.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceConfirmationCard.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import Image from 'next/image';
-import { Check, HelpCircle, PauseCircle, Pencil, X } from 'lucide-react';
+import { Check, HelpCircle, PauseCircle, Pencil, RefreshCw, X } from 'lucide-react';
 import AutoSendCountdown from './AutoSendCountdown';
 import {
   LOW_CONFIDENCE_THRESHOLD,
@@ -28,11 +28,13 @@ interface VoiceConfirmationCardProps {
   results?: ExecutedAction[];
   autoSendUi?: AutoSendUiState | null;
   globalPaused?: boolean;
+  retryingIds?: string[];
   onChange: (actions: ExtractedAction[]) => void;
   onApprove: () => void;
   onDiscard: () => void;
   onAutoSendElapsed?: () => void;
   onAutoSendCancel?: () => void;
+  onRetryAction?: (actionId: string) => void;
 }
 
 /**
@@ -46,12 +48,15 @@ export default function VoiceConfirmationCard({
   results,
   autoSendUi,
   globalPaused,
+  retryingIds,
   onChange,
   onApprove,
   onDiscard,
   onAutoSendElapsed,
   onAutoSendCancel,
+  onRetryAction,
 }: VoiceConfirmationCardProps) {
+  const retryingSet = useMemo(() => new Set(retryingIds || []), [retryingIds]);
   const resultById = useMemo(() => {
     const map: Record<string, ExecutedAction> = {};
     for (const r of results || []) map[r.id] = r;
@@ -236,8 +241,10 @@ export default function VoiceConfirmationCard({
               action={action}
               status={status}
               result={resultById[action.id]}
+              isRetrying={retryingSet.has(action.id)}
               onRemove={() => removeAction(action.id)}
               onFieldChange={(field, value) => updateField(action.id, field, value)}
+              onRetry={onRetryAction ? () => onRetryAction(action.id) : undefined}
             />
           ))}
         </div>
@@ -313,15 +320,21 @@ function ActionSection({
   action,
   status,
   result,
+  isRetrying,
   onRemove,
   onFieldChange,
+  onRetry,
 }: {
   action: ExtractedAction;
   status: VoiceConfirmationCardProps['status'];
   result?: ExecutedAction;
+  isRetrying?: boolean;
   onRemove: () => void;
   onFieldChange: (field: string, value: any) => void;
+  onRetry?: () => void;
 }) {
+  const failed = status === 'done' && result && !result.success;
+  const canRetry = !!onRetry && failed && !isRetrying;
   return (
     <div
       style={{
@@ -374,19 +387,50 @@ function ActionSection({
           </button>
         )}
         {status === 'done' && result && (
-          <span
-            style={{
-              fontSize: 11,
-              fontWeight: 600,
-              color: result.success ? '#059669' : '#DC2626',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 4,
-            }}
-          >
-            {result.success ? <Check size={13} /> : <X size={13} />}
-            {result.success ? 'Done' : 'Failed'}
-          </span>
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+            <span
+              data-testid={`action-status-${action.id}`}
+              data-success={result.success ? 'true' : 'false'}
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                color: result.success ? '#059669' : '#DC2626',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              {result.success ? <Check size={13} /> : <X size={13} />}
+              {result.success ? 'Done' : 'Failed'}
+            </span>
+            {canRetry && (
+              <button
+                data-testid={`action-retry-${action.id}`}
+                onClick={onRetry}
+                className="agent-tappable"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: '#8A6E1F',
+                  background: 'rgba(196,155,42,0.1)',
+                  border: '0.5px solid rgba(196,155,42,0.3)',
+                  borderRadius: 999,
+                  padding: '3px 10px',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                <RefreshCw size={11} />
+                Retry
+              </button>
+            )}
+            {isRetrying && (
+              <span style={{ fontSize: 11, color: '#9CA3AF' }}>Retrying...</span>
+            )}
+          </div>
         )}
       </div>
 

--- a/apps/unified-portal/app/agent/_hooks/useApplicantsCount.ts
+++ b/apps/unified-portal/app/agent/_hooks/useApplicantsCount.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const REFRESH_EVENT = 'oh.agent.applicants.refresh';
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Polls /api/agent/applicants/badge-count for the action-required count
+ * that drives the bottom nav + sidebar badges for lettings applicants.
+ * Other parts of the app (draft_application_invitation approval, applicant
+ * status changes) can dispatch oh.agent.applicants.refresh to force a
+ * refresh without waiting for the next poll tick.
+ */
+export function useApplicantsCount(): { count: number; refresh: () => Promise<void> } {
+  const [count, setCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/agent/applicants/badge-count', { cache: 'no-store' });
+      if (!res.ok) return;
+      const data = await res.json();
+      if (typeof data.count === 'number') setCount(data.count);
+    } catch {
+      /* silent — badge holds its last known value */
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL_MS);
+    const onRefresh = () => { refresh(); };
+    window.addEventListener(REFRESH_EVENT, onRefresh);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener(REFRESH_EVENT, onRefresh);
+    };
+  }, [refresh]);
+
+  return { count, refresh };
+}
+
+export function notifyApplicantsChanged(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(REFRESH_EVENT));
+}

--- a/apps/unified-portal/app/agent/applicants/[id]/page.tsx
+++ b/apps/unified-portal/app/agent/applicants/[id]/page.tsx
@@ -1,0 +1,485 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  ArrowLeft,
+  Briefcase,
+  CalendarCheck,
+  Cigarette,
+  Dog,
+  Euro,
+  Home as HomeIcon,
+  Mail,
+  Phone,
+  Shield,
+  Send as SendIcon,
+  Sparkles,
+  Users,
+} from 'lucide-react';
+import AgentShell from '../../_components/AgentShell';
+import { useAgent } from '@/lib/agent/AgentContext';
+import {
+  amlLabel,
+  applicationStatusLabel,
+  employmentLabel,
+  formatCurrency,
+  referencesLabel,
+  type ApplicantDetail,
+} from '@/lib/agent-intelligence/applicants';
+import { relativeTimestamp } from '@/lib/agent-intelligence/drafts';
+
+export default function ApplicantDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { agent, alerts } = useAgent();
+  const [applicant, setApplicant] = useState<ApplicantDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/agent/applicants/${params.id}`, { cache: 'no-store' });
+      if (res.status === 404) { setNotFound(true); return; }
+      if (!res.ok) return;
+      const data = await res.json();
+      setApplicant(data.applicant);
+    } finally {
+      setLoading(false);
+    }
+  }, [params.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleInvite = () => {
+    if (!applicant) return;
+    const intent = `draft_application_invitation:${applicant.id}`;
+    router.push(`/agent/intelligence?intent=${encodeURIComponent(intent)}&prompt=${encodeURIComponent(
+      `Invite ${applicant.fullName} to apply.`
+    )}`);
+  };
+
+  return (
+    <AgentShell agentName={agent?.displayName?.split(' ')[0] || 'Agent'} urgentCount={alerts?.length || 0}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+        }}
+      >
+        <header
+          style={{
+            padding: '12px 16px',
+            borderBottom: '0.5px solid rgba(0,0,0,0.05)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+        >
+          <Link
+            href="/agent/applicants"
+            aria-label="Back"
+            className="agent-tappable"
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: 17,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#0D0D12',
+              textDecoration: 'none',
+            }}
+          >
+            <ArrowLeft size={18} />
+          </Link>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 16,
+                fontWeight: 700,
+                color: '#0D0D12',
+                letterSpacing: '-0.02em',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {applicant?.fullName || 'Applicant'}
+            </div>
+            {applicant && (
+              <div style={{ fontSize: 11.5, color: '#9CA3AF', marginTop: 2 }}>
+                Source: {sourceLabel(applicant.source)}
+              </div>
+            )}
+          </div>
+        </header>
+
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+            padding: '16px 16px 32px',
+          }}
+        >
+          {loading && !applicant && (
+            <p style={{ padding: 48, textAlign: 'center', color: '#9CA3AF', fontSize: 13 }}>
+              Loading applicant...
+            </p>
+          )}
+          {notFound && (
+            <p style={{ padding: 48, textAlign: 'center', color: '#9CA3AF', fontSize: 13 }}>
+              Applicant not found. They may have been deleted.
+            </p>
+          )}
+          {applicant && (
+            <>
+              <ContactCard applicant={applicant} />
+              <SignalsSection applicant={applicant} />
+              <ViewingsList applicant={applicant} />
+              <ApplicationsList applicant={applicant} />
+              <CtaRow applicant={applicant} onInvite={handleInvite} />
+            </>
+          )}
+        </div>
+      </div>
+    </AgentShell>
+  );
+}
+
+function ContactCard({ applicant }: { applicant: ApplicantDetail }) {
+  return (
+    <section
+      style={{
+        background: '#FFFFFF',
+        borderRadius: 14,
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        padding: '14px 16px',
+        marginBottom: 14,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <ContactLine icon={<Mail size={13} />} label={applicant.email || 'No email on file'} />
+      <ContactLine icon={<Phone size={13} />} label={applicant.phone || 'No phone on file'} />
+      {applicant.currentAddress && (
+        <ContactLine icon={<HomeIcon size={13} />} label={applicant.currentAddress} />
+      )}
+      {applicant.latestStatus && (
+        <div style={{ fontSize: 11, color: '#6B7280', marginTop: 4 }}>
+          Latest status: <strong style={{ color: '#0D0D12' }}>{applicationStatusLabel(applicant.latestStatus)}</strong>
+          <span style={{ color: '#9CA3AF', marginLeft: 6 }}>
+            {relativeTimestamp(applicant.lastActivityAt)}
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ContactLine({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#374151' }}>
+      <span style={{ color: '#9CA3AF' }}>{icon}</span>
+      <span style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function SignalsSection({ applicant }: { applicant: ApplicantDetail }) {
+  const s = applicant.signals;
+  const incomeCopy =
+    s.annualIncome != null
+      ? `${formatCurrency(s.annualIncome)} per year${
+          s.incomeToRentRatio ? ` · ${s.incomeToRentRatio.toFixed(1)}x annual rent` : ''
+        }`
+      : 'Not captured yet';
+  const householdPieces: string[] = [];
+  if (s.householdSize != null) householdPieces.push(`${s.householdSize} people`);
+  if (s.hasPets === true) householdPieces.push(s.petDetails ? `pets (${s.petDetails})` : 'pets');
+  if (s.hasPets === false) householdPieces.push('no pets');
+  if (s.smoker === true) householdPieces.push('smoker');
+  if (s.smoker === false) householdPieces.push('non-smoker');
+
+  return (
+    <section
+      data-testid="applicant-signals"
+      style={{
+        background: '#FFFFFF',
+        borderRadius: 14,
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        padding: '14px 16px',
+        marginBottom: 14,
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          marginBottom: 12,
+          fontSize: 11,
+          fontWeight: 600,
+          color: '#8A6E1F',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        }}
+      >
+        <Sparkles size={12} />
+        Signals at a glance
+      </div>
+      <SignalRow
+        icon={<Briefcase size={14} />}
+        label="Employment"
+        value={`${employmentLabel(s.employmentStatus)}${s.employer ? ` · ${s.employer}` : ''}`}
+      />
+      <SignalRow icon={<Euro size={14} />} label="Income" value={incomeCopy} />
+      <SignalRow
+        icon={<Users size={14} />}
+        label="Household"
+        value={householdPieces.length ? householdPieces.join(' · ') : 'Not captured yet'}
+      />
+      <SignalRow
+        icon={<Dog size={14} />}
+        label="Pets"
+        value={
+          s.hasPets === true
+            ? (s.petDetails || 'Yes')
+            : s.hasPets === false
+              ? 'None'
+              : 'Not captured'
+        }
+      />
+      <SignalRow
+        icon={<Cigarette size={14} />}
+        label="Smoker"
+        value={s.smoker == null ? 'Not captured' : s.smoker ? 'Yes' : 'No'}
+      />
+      <SignalRow
+        icon={<Shield size={14} />}
+        label="References"
+        value={referencesLabel(s.referencesStatus)}
+      />
+      <SignalRow
+        icon={<Shield size={14} />}
+        label="AML"
+        value={amlLabel(s.amlStatus)}
+      />
+    </section>
+  );
+}
+
+function SignalRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        fontSize: 13,
+        padding: '8px 0',
+        borderBottom: '0.5px solid rgba(0,0,0,0.04)',
+      }}
+    >
+      <span style={{ width: 18, color: '#9CA3AF', display: 'flex' }}>{icon}</span>
+      <span style={{ width: 96, color: '#9CA3AF', fontSize: 11.5 }}>{label}</span>
+      <span style={{ flex: 1, color: '#0D0D12', fontWeight: 500 }}>{value}</span>
+    </div>
+  );
+}
+
+function ViewingsList({ applicant }: { applicant: ApplicantDetail }) {
+  if (applicant.viewings.length === 0) return null;
+  return (
+    <section style={{ marginBottom: 14 }}>
+      <h2 style={sectionHeading}>
+        <CalendarCheck size={12} /> Viewings
+      </h2>
+      <div style={listStyle}>
+        {applicant.viewings.map((v) => (
+          <div key={v.id} style={listRowStyle}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>
+                {v.propertyAddress || 'Unknown property'}
+              </div>
+              <div style={{ fontSize: 11.5, color: '#9CA3AF', marginTop: 2 }}>
+                {relativeTimestamp(v.viewingDate)}
+                {v.interestLevel ? ` · ${v.interestLevel} interest` : ''}
+              </div>
+            </div>
+            {v.wasPreferred && (
+              <span style={preferredPill}>Preferred</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ApplicationsList({ applicant }: { applicant: ApplicantDetail }) {
+  if (applicant.applications.length === 0) return null;
+  return (
+    <section style={{ marginBottom: 14 }}>
+      <h2 style={sectionHeading}>
+        <Shield size={12} /> Applications
+      </h2>
+      <div style={listStyle}>
+        {applicant.applications.map((a) => (
+          <div key={a.id} style={listRowStyle}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>
+                {a.propertyAddress || 'Unknown property'}
+              </div>
+              <div style={{ fontSize: 11.5, color: '#9CA3AF', marginTop: 2 }}>
+                {relativeTimestamp(a.applicationDate)}
+                {a.rentPcm ? ` · ${formatCurrency(a.rentPcm)} pcm` : ''}
+              </div>
+            </div>
+            <span style={applicationStatusPill(a.status)}>
+              {applicationStatusLabel(a.status)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CtaRow({ applicant, onInvite }: { applicant: ApplicantDetail; onInvite: () => void }) {
+  return (
+    <section style={{ display: 'flex', gap: 10 }}>
+      <button
+        data-testid="applicant-invite-cta"
+        onClick={onInvite}
+        className="agent-tappable"
+        style={{
+          flex: 1,
+          padding: '12px 14px',
+          background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+          color: '#fff',
+          border: 'none',
+          borderRadius: 12,
+          fontSize: 13.5,
+          fontWeight: 600,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 6,
+          boxShadow: '0 2px 6px rgba(196,155,42,0.25)',
+        }}
+      >
+        <SendIcon size={14} />
+        Draft application invitation
+      </button>
+      <Link
+        href={`/agent/applicants/${applicant.id}/edit`}
+        className="agent-tappable"
+        style={{
+          padding: '12px 18px',
+          background: 'transparent',
+          border: '0.5px solid rgba(0,0,0,0.12)',
+          borderRadius: 12,
+          fontSize: 13,
+          fontWeight: 500,
+          color: '#6B7280',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          textDecoration: 'none',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Edit
+      </Link>
+    </section>
+  );
+}
+
+const sectionHeading: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: '#9CA3AF',
+  margin: '0 0 8px 4px',
+};
+
+const listStyle: React.CSSProperties = {
+  background: '#FFFFFF',
+  borderRadius: 14,
+  border: '0.5px solid rgba(0,0,0,0.06)',
+  overflow: 'hidden',
+};
+
+const listRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '12px 14px',
+  borderBottom: '0.5px solid rgba(0,0,0,0.04)',
+};
+
+const preferredPill: React.CSSProperties = {
+  fontSize: 9.5,
+  fontWeight: 700,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+  color: '#8A6E1F',
+  background: 'rgba(196,155,42,0.12)',
+  border: '0.5px solid rgba(196,155,42,0.35)',
+  padding: '2px 7px',
+  borderRadius: 999,
+};
+
+function applicationStatusPill(status: string): React.CSSProperties {
+  const palette = {
+    invited: { bg: 'rgba(13,13,18,0.08)', color: '#374151' },
+    received: { bg: 'rgba(196,155,42,0.14)', color: '#8A6E1F' },
+    referencing: { bg: 'rgba(196,155,42,0.14)', color: '#8A6E1F' },
+    approved: { bg: 'rgba(5,150,105,0.12)', color: '#047857' },
+    offer_accepted: { bg: 'rgba(5,150,105,0.12)', color: '#047857' },
+    rejected: { bg: 'rgba(220,38,38,0.08)', color: '#B91C1C' },
+    withdrawn: { bg: 'rgba(220,38,38,0.08)', color: '#B91C1C' },
+  } as const;
+  const c = (palette as any)[status] || { bg: 'rgba(0,0,0,0.04)', color: '#9CA3AF' };
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '2px 10px',
+    borderRadius: 999,
+    background: c.bg,
+    color: c.color,
+    fontSize: 10.5,
+    fontWeight: 600,
+    letterSpacing: '0.02em',
+  };
+}
+
+function sourceLabel(s: string): string {
+  const map: Record<string, string> = {
+    daft: 'Daft',
+    myhome: 'MyHome',
+    rent_ie: 'Rent.ie',
+    facebook: 'Facebook',
+    walk_in: 'Walk-in',
+    word_of_mouth: 'Word of mouth',
+    other: 'Other',
+    unknown: 'Not recorded',
+  };
+  return map[s] || s;
+}

--- a/apps/unified-portal/app/agent/applicants/page.tsx
+++ b/apps/unified-portal/app/agent/applicants/page.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { Users } from 'lucide-react';
+import AgentShell from '../_components/AgentShell';
+import { useAgent } from '@/lib/agent/AgentContext';
+import {
+  applicationStatusLabel,
+  type ApplicantListItem,
+} from '@/lib/agent-intelligence/applicants';
+import { relativeTimestamp } from '@/lib/agent-intelligence/drafts';
+
+type FilterKey = 'all' | 'preferred' | 'invited' | 'applied' | 'approved';
+
+const FILTERS: Array<{ key: FilterKey; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'preferred', label: 'Preferred' },
+  { key: 'invited', label: 'Invited' },
+  { key: 'applied', label: 'Applied' },
+  { key: 'approved', label: 'Approved' },
+];
+
+export default function ApplicantsListPage() {
+  const { agent, alerts } = useAgent();
+  const [items, setItems] = useState<ApplicantListItem[]>([]);
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const [loading, setLoading] = useState(true);
+  const [pullOffset, setPullOffset] = useState(0);
+  const pullStartY = useRef<number | null>(null);
+
+  const load = useCallback(async (next: FilterKey) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/agent/applicants?filter=${next}`, { cache: 'no-store' });
+      if (!res.ok) return;
+      const data = await res.json();
+      setItems(data.applicants || []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(filter); }, [filter, load]);
+
+  const handlePullStart = (e: React.TouchEvent) => {
+    const target = e.currentTarget as HTMLDivElement;
+    if (target.scrollTop > 0) return;
+    pullStartY.current = e.touches[0].clientY;
+  };
+  const handlePullMove = (e: React.TouchEvent) => {
+    if (pullStartY.current == null) return;
+    const delta = e.touches[0].clientY - pullStartY.current;
+    if (delta > 0) setPullOffset(Math.min(80, delta));
+  };
+  const handlePullEnd = async () => {
+    if (pullOffset > 60) await load(filter);
+    pullStartY.current = null;
+    setPullOffset(0);
+  };
+
+  return (
+    <AgentShell agentName={agent?.displayName?.split(' ')[0] || 'Agent'} urgentCount={alerts?.length || 0}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          minHeight: 0,
+        }}
+      >
+        <header
+          style={{
+            padding: '16px 20px 12px',
+            borderBottom: '0.5px solid rgba(0,0,0,0.05)',
+            background: 'rgba(250,250,248,0.95)',
+          }}
+        >
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 20,
+              fontWeight: 700,
+              letterSpacing: '-0.03em',
+              color: '#0D0D12',
+            }}
+          >
+            Applicants
+          </h1>
+          <p
+            style={{
+              margin: '4px 0 0',
+              fontSize: 12.5,
+              color: '#9CA3AF',
+              letterSpacing: '0.005em',
+            }}
+          >
+            Everyone who viewed, enquired, or applied. Flagged ones first.
+          </p>
+
+          {/* Filter tabs */}
+          <div
+            data-testid="applicants-filter-tabs"
+            style={{
+              marginTop: 14,
+              display: 'flex',
+              gap: 6,
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              scrollbarWidth: 'none',
+            }}
+            className="[&::-webkit-scrollbar]:hidden"
+          >
+            {FILTERS.map((f) => (
+              <button
+                key={f.key}
+                data-testid={`applicants-filter-${f.key}`}
+                onClick={() => setFilter(f.key)}
+                className="agent-tappable"
+                style={{
+                  padding: '6px 14px',
+                  borderRadius: 999,
+                  border: filter === f.key ? '0.5px solid #C49B2A' : '0.5px solid rgba(0,0,0,0.08)',
+                  background: filter === f.key ? 'rgba(196,155,42,0.12)' : '#FFFFFF',
+                  color: filter === f.key ? '#8A6E1F' : '#6B7280',
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        <div
+          onTouchStart={handlePullStart}
+          onTouchMove={handlePullMove}
+          onTouchEnd={handlePullEnd}
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            WebkitOverflowScrolling: 'touch',
+          }}
+        >
+          {pullOffset > 0 && (
+            <div
+              style={{
+                textAlign: 'center',
+                fontSize: 11,
+                color: '#9CA3AF',
+                padding: `${pullOffset / 2}px 0`,
+              }}
+            >
+              {pullOffset > 60 ? 'Release to refresh' : 'Pull to refresh'}
+            </div>
+          )}
+
+          {loading && items.length === 0 ? (
+            <p style={{ padding: 48, textAlign: 'center', color: '#9CA3AF', fontSize: 13 }}>
+              Loading applicants...
+            </p>
+          ) : items.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div
+              data-testid="applicants-list"
+              style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '16px 16px 32px' }}
+            >
+              {items.map((item) => (
+                <ApplicantRow key={item.id} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </AgentShell>
+  );
+}
+
+function ApplicantRow({ item }: { item: ApplicantListItem }) {
+  const secondary = item.phone || item.email || 'No contact on file';
+  const statusLabel = applicationStatusLabel(item.latestStatus);
+  const propertyCopy =
+    item.linkedPropertyCount === 0
+      ? 'No properties linked'
+      : item.linkedPropertyCount === 1
+        ? '1 property'
+        : `${item.linkedPropertyCount} properties`;
+
+  return (
+    <Link
+      href={`/agent/applicants/${item.id}`}
+      data-testid={`applicants-row-${item.id}`}
+      className="agent-tappable"
+      style={{
+        display: 'block',
+        background: '#FFFFFF',
+        border: '0.5px solid rgba(0,0,0,0.06)',
+        borderRadius: 14,
+        padding: '14px 16px',
+        textDecoration: 'none',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginBottom: 4,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+          <span
+            style={{
+              fontSize: 15,
+              fontWeight: 600,
+              color: '#0D0D12',
+              letterSpacing: '-0.01em',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {item.fullName}
+          </span>
+          {item.preferredCount > 0 && (
+            <span
+              style={{
+                fontSize: 9.5,
+                fontWeight: 700,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                color: '#8A6E1F',
+                background: 'rgba(196,155,42,0.12)',
+                border: '0.5px solid rgba(196,155,42,0.35)',
+                padding: '2px 7px',
+                borderRadius: 999,
+              }}
+            >
+              Preferred
+            </span>
+          )}
+        </div>
+        <span style={{ fontSize: 11, color: '#9CA3AF', flexShrink: 0 }}>
+          {relativeTimestamp(item.lastActivityAt)}
+        </span>
+      </div>
+      <div style={{ fontSize: 12.5, color: '#6B7280', marginBottom: 6 }}>{secondary}</div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <span style={{ fontSize: 11.5, color: '#9CA3AF' }}>{propertyCopy}</span>
+        <StatusPill status={item.latestStatus} label={statusLabel} />
+      </div>
+    </Link>
+  );
+}
+
+function StatusPill({ status, label }: { status: string | null; label: string }) {
+  const palette = pillPalette(status);
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 10px',
+        borderRadius: 999,
+        background: palette.bg,
+        color: palette.color,
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function pillPalette(status: string | null): { bg: string; color: string } {
+  switch (status) {
+    case 'approved':
+    case 'offer_accepted':
+      return { bg: 'rgba(5,150,105,0.12)', color: '#047857' };
+    case 'received':
+    case 'referencing':
+      return { bg: 'rgba(196,155,42,0.14)', color: '#8A6E1F' };
+    case 'invited':
+      return { bg: 'rgba(13,13,18,0.08)', color: '#374151' };
+    case 'rejected':
+    case 'withdrawn':
+      return { bg: 'rgba(220,38,38,0.08)', color: '#B91C1C' };
+    default:
+      return { bg: 'rgba(0,0,0,0.04)', color: '#9CA3AF' };
+  }
+}
+
+function EmptyState() {
+  return (
+    <div
+      data-testid="applicants-empty-state"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '72px 32px',
+        gap: 10,
+      }}
+    >
+      <div
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 20,
+          background: 'rgba(196,155,42,0.08)',
+          color: '#C49B2A',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <Users size={28} />
+      </div>
+      <p style={{ fontSize: 15, fontWeight: 600, color: '#0D0D12', margin: 0 }}>
+        No applicants yet
+      </p>
+      <p
+        style={{
+          fontSize: 12.5,
+          color: '#9CA3AF',
+          margin: 0,
+          textAlign: 'center',
+          maxWidth: 260,
+          lineHeight: 1.5,
+        }}
+      >
+        Voice-log a viewing and they&apos;ll appear here.
+      </p>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/agent/dashboard/applicants/page.tsx
+++ b/apps/unified-portal/app/agent/dashboard/applicants/page.tsx
@@ -1,0 +1,8 @@
+import ApplicantsListPage from '../../applicants/page';
+
+/**
+ * Dashboard (desktop) applicants route. Same page powers mobile + desktop;
+ * the design is dense-enough to read fine on a 450px side by side with a
+ * detail view, and fills a desktop viewport gracefully as a single column.
+ */
+export default ApplicantsListPage;

--- a/apps/unified-portal/app/agent/dashboard/layout-sidebar.tsx
+++ b/apps/unified-portal/app/agent/dashboard/layout-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   GitBranch,
   Sparkles,
   Users,
+  UserCheck,
   MailCheck,
   MessageSquare,
   CalendarCheck,
@@ -29,6 +30,7 @@ import {
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useAgentDashboard } from './layout-provider';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
+import { useApplicantsCount } from '../_hooks/useApplicantsCount';
 
 interface NavItem {
   label: string;
@@ -49,6 +51,7 @@ const agentNavSections: NavSection[] = [
       { label: 'Sales Pipeline', href: '/agent/dashboard/pipeline', icon: GitBranch },
       { label: 'OpenHouse Intelligence', href: '/agent/dashboard/intelligence', icon: Sparkles },
       { label: 'Drafts', href: '/agent/dashboard/drafts', icon: MailCheck },
+      { label: 'Applicants', href: '/agent/dashboard/applicants', icon: UserCheck },
     ],
   },
   {
@@ -87,6 +90,7 @@ export function AgentDashboardSidebar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const switcherRef = useRef<HTMLDivElement>(null);
   const { count: draftsCount } = useDraftsCount();
+  const { count: applicantsCount } = useApplicantsCount();
 
   const isActive = (href: string) => {
     if (href === '/agent/dashboard/overview') {
@@ -247,6 +251,18 @@ export function AgentDashboardSidebar() {
                           }}
                         >
                           {draftsCount > 99 ? '99+' : draftsCount}
+                        </span>
+                      )}
+                      {item.href === '/agent/dashboard/applicants' && applicantsCount > 0 && (
+                        <span
+                          data-testid="applicants-badge-sidebar"
+                          className="ml-auto inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full text-[10px] font-bold"
+                          style={{
+                            background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                            color: '#fff',
+                          }}
+                        >
+                          {applicantsCount > 99 ? '99+' : applicantsCount}
                         </span>
                       )}
                     </Link>

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -33,6 +33,8 @@ const WRITE_PILLS: Array<{ label: string; intent: string }> = [
   { label: 'Update the tracker', intent: 'update_tracker' },
   { label: 'Follow up with a buyer', intent: 'draft_viewing_followup_buyer' },
   { label: 'Respond to an offer', intent: 'draft_offer_response' },
+  { label: 'Log a rental viewing', intent: 'log_rental_viewing' },
+  { label: 'Invite an applicant', intent: 'draft_application_invitation' },
 ];
 
 interface DraftedEmail {
@@ -48,6 +50,10 @@ interface VoiceActionsPayload {
   transcript?: string;
   autoSendUi?: AutoSendUiState | null;
   globalPaused?: boolean;
+  // Session 4B: retry state for sequentially-failed actions.
+  batchId?: string;
+  sharedContext?: Record<string, unknown>;
+  retryingActionIds?: string[];
 }
 
 interface Message {
@@ -388,6 +394,8 @@ export default function IntelligencePage() {
           results,
           autoSendUi,
           globalPaused,
+          batchId,
+          sharedContext: data.sharedContext,
         }));
 
         // Natural-language confirmation below the card — but only for actions
@@ -428,6 +436,53 @@ export default function IntelligencePage() {
             content: "Couldn't log those just now. Try again in a second?",
           },
         ]);
+      }
+    },
+    [messages, updateVoiceMessage],
+  );
+
+  const handleRetryAction = useCallback(
+    async (msgId: string, actionId: string) => {
+      const msg = messages.find((m) => m.id === msgId);
+      if (!msg?.voice) return;
+      const action = msg.voice.actions.find((a) => a.id === actionId);
+      if (!action) return;
+
+      updateVoiceMessage(msgId, (v) => ({
+        ...v,
+        retryingActionIds: [...(v.retryingActionIds || []), actionId],
+      }));
+
+      try {
+        const res = await fetch('/api/agent/intelligence/execute-actions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            actions: [action],
+            batchId: msg.voice.batchId,
+            sharedContext: msg.voice.sharedContext,
+          }),
+        });
+        if (!res.ok) throw new Error('retry failed');
+        const data = await res.json();
+        const retryResult: ExecutedAction | undefined = (data.results || [])[0];
+        if (!retryResult) throw new Error('no_result');
+
+        updateVoiceMessage(msgId, (v) => ({
+          ...v,
+          results: (v.results || []).map((r) => (r.id === actionId ? retryResult : r)),
+          sharedContext: data.sharedContext || v.sharedContext,
+          retryingActionIds: (v.retryingActionIds || []).filter((id) => id !== actionId),
+        }));
+
+        if (retryResult.success && retryResult.type === 'draft_application_invitation') {
+          notifyDraftsChanged();
+        }
+      } catch {
+        updateVoiceMessage(msgId, (v) => ({
+          ...v,
+          retryingActionIds: (v.retryingActionIds || []).filter((id) => id !== actionId),
+        }));
       }
     },
     [messages, updateVoiceMessage],
@@ -748,11 +803,13 @@ export default function IntelligencePage() {
                     results={msg.voice.results}
                     autoSendUi={msg.voice.autoSendUi}
                     globalPaused={msg.voice.globalPaused}
+                    retryingIds={msg.voice.retryingActionIds}
                     onChange={(next) => handleVoiceActionsChange(msg.id, next)}
                     onApprove={() => handleApprove(msg.id)}
                     onDiscard={() => handleDiscard(msg.id)}
                     onAutoSendElapsed={() => handleAutoSendElapsed(msg.id)}
                     onAutoSendCancel={() => handleAutoSendCancel(msg.id)}
+                    onRetryAction={(actionId) => handleRetryAction(msg.id, actionId)}
                   />
                 );
               }
@@ -847,6 +904,18 @@ function buildConfirmationSummary(
     } else if (a.type === 'draft_chain_update_to_buyer') {
       const name = a.fields.buyer_id || 'the buyer';
       clauses.push(`drafted the chain update for ${name}`);
+    } else if (a.type === 'log_rental_viewing') {
+      const property = a.fields.letting_property_id || 'the property';
+      clauses.push(`logged the rental viewing at ${property}`);
+    } else if (a.type === 'create_applicant') {
+      const name = a.fields.full_name || 'a new applicant';
+      clauses.push(`added ${name} to applicants`);
+    } else if (a.type === 'flag_applicant_preferred') {
+      const name = a.fields.applicant_name || 'the applicant';
+      clauses.push(`flagged ${name} as preferred`);
+    } else if (a.type === 'draft_application_invitation') {
+      const name = a.fields.applicant_name || 'the applicant';
+      clauses.push(`drafted the application invitation for ${name}`);
     } else if (a.type === 'create_reminder') {
       const due = a.fields.due_date ? formatReminder(a.fields.due_date) : '';
       clauses.push(due ? `set a reminder for ${due}` : 'set a reminder');

--- a/apps/unified-portal/app/api/agent/applicants/[id]/route.ts
+++ b/apps/unified-portal/app/api/agent/applicants/[id]/route.ts
@@ -1,0 +1,201 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import {
+  computeIncomeToRentRatio,
+  type ApplicantDetail,
+} from '@/lib/agent-intelligence/applicants';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/applicants/:id
+ * Returns the full applicant detail with the signals section
+ * (employment, income, household, references + AML statuses) and the
+ * linked viewings + applications lists.
+ */
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = getSupabaseAdmin();
+
+    const { data: applicant, error } = await supabase
+      .from('agent_applicants')
+      .select('*')
+      .eq('id', params.id)
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!applicant) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const [
+      { data: attendees },
+      { data: applications },
+    ] = await Promise.all([
+      supabase
+        .from('agent_rental_viewing_attendees')
+        .select('id, rental_viewing_id, was_preferred')
+        .eq('applicant_id', params.id),
+      supabase
+        .from('agent_rental_applications')
+        .select('id, letting_property_id, status, references_status, aml_status, application_date')
+        .eq('applicant_id', params.id)
+        .order('application_date', { ascending: false }),
+    ]);
+
+    const viewingIds = (attendees || []).map((a) => a.rental_viewing_id).filter(Boolean);
+    const propertyIdsFromApps = (applications || []).map((a) => a.letting_property_id).filter(Boolean);
+    const propertyIdsFromViewings: string[] = [];
+
+    let viewingRows: any[] = [];
+    if (viewingIds.length) {
+      const { data } = await supabase
+        .from('agent_rental_viewings')
+        .select('id, letting_property_id, viewing_date, interest_level')
+        .in('id', viewingIds);
+      viewingRows = data || [];
+      for (const v of viewingRows) {
+        if (v.letting_property_id) propertyIdsFromViewings.push(v.letting_property_id);
+      }
+    }
+
+    const propertyIds = Array.from(new Set([...propertyIdsFromApps, ...propertyIdsFromViewings]));
+    let propertyById = new Map<string, { address: string | null; rent_pcm: number | null }>();
+    if (propertyIds.length) {
+      const { data: props } = await supabase
+        .from('agent_letting_properties')
+        .select('id, address, address_line_1, rent_pcm')
+        .in('id', propertyIds);
+      for (const p of props || []) {
+        propertyById.set(p.id, {
+          address: p.address || p.address_line_1 || null,
+          rent_pcm: p.rent_pcm ?? null,
+        });
+      }
+    }
+
+    const latestApp = (applications || [])[0];
+    const latestRent = latestApp
+      ? propertyById.get(latestApp.letting_property_id)?.rent_pcm ?? null
+      : null;
+
+    const detail: ApplicantDetail = {
+      id: applicant.id,
+      fullName: applicant.full_name,
+      email: applicant.email,
+      phone: applicant.phone,
+      source: applicant.source,
+      linkedPropertyCount: new Set(propertyIdsFromApps).size,
+      latestStatus: (latestApp?.status as ApplicantDetail['latestStatus']) ?? null,
+      lastActivityAt: latestApp?.application_date || applicant.updated_at || applicant.created_at,
+      preferredCount: (attendees || []).filter((a) => a.was_preferred).length,
+      currentAddress: applicant.current_address,
+      budgetMonthly: applicant.budget_monthly,
+      requestedMoveInDate: applicant.requested_move_in_date,
+      notes: applicant.notes,
+      signals: {
+        employmentStatus: applicant.employment_status,
+        employer: applicant.employer,
+        annualIncome: applicant.annual_income,
+        incomeToRentRatio: computeIncomeToRentRatio(applicant.annual_income, latestRent),
+        householdSize: applicant.household_size,
+        hasPets: applicant.has_pets,
+        petDetails: applicant.pet_details,
+        smoker: applicant.smoker,
+        referencesStatus: latestApp?.references_status ?? null,
+        amlStatus: latestApp?.aml_status ?? null,
+      },
+      viewings: viewingRows.map((v) => {
+        const preferredMatch = (attendees || []).find((a) => a.rental_viewing_id === v.id);
+        return {
+          id: v.id,
+          propertyAddress: propertyById.get(v.letting_property_id)?.address || null,
+          viewingDate: v.viewing_date,
+          wasPreferred: !!preferredMatch?.was_preferred,
+          interestLevel: v.interest_level,
+        };
+      }),
+      applications: (applications || []).map((a) => ({
+        id: a.id,
+        propertyAddress: propertyById.get(a.letting_property_id)?.address || null,
+        rentPcm: propertyById.get(a.letting_property_id)?.rent_pcm ?? null,
+        status: a.status,
+        referencesStatus: a.references_status,
+        amlStatus: a.aml_status,
+        applicationDate: a.application_date,
+      })),
+    };
+
+    return NextResponse.json({ applicant: detail });
+  } catch (error: any) {
+    console.error('[agent/applicants/:id GET] Error:', error.message);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/agent/applicants/:id
+ * Basic edit form — only the fields the settings screen allows the agent
+ * to change are accepted. Anything else is silently ignored.
+ */
+const EDITABLE_FIELDS = new Set([
+  'full_name',
+  'email',
+  'phone',
+  'current_address',
+  'employment_status',
+  'employer',
+  'annual_income',
+  'household_size',
+  'has_pets',
+  'pet_details',
+  'smoker',
+  'requested_move_in_date',
+  'source',
+  'budget_monthly',
+  'notes',
+]);
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json();
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const updates: Record<string, any> = { updated_at: new Date().toISOString() };
+    for (const [k, v] of Object.entries(body || {})) {
+      if (EDITABLE_FIELDS.has(k)) updates[k] = v;
+    }
+
+    const { data: existing } = await supabase
+      .from('agent_applicants')
+      .select('id, agent_id')
+      .eq('id', params.id)
+      .maybeSingle();
+
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    if (user) {
+      const { data: profile } = await supabase
+        .from('agent_profiles')
+        .select('id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      if (profile && existing.agent_id !== profile.id) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    const { error } = await supabase
+      .from('agent_applicants')
+      .update(updates)
+      .eq('id', params.id);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent/applicants/badge-count/route.ts
+++ b/apps/unified-portal/app/api/agent/applicants/badge-count/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/applicants/badge-count
+ *
+ * Returns the number of applicants with at least one application in an
+ * action-required state (received or referencing) — i.e. things the agent
+ * needs to look at. Drives the nav badge on mobile + sidebar on desktop.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    let agentId: string | null = null;
+    if (user) {
+      const { data } = await supabase
+        .from('agent_profiles')
+        .select('id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      agentId = data?.id || null;
+    }
+    if (!agentId) {
+      const { data } = await supabase
+        .from('agent_profiles')
+        .select('id')
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      agentId = data?.id || null;
+    }
+    if (!agentId) return NextResponse.json({ count: 0 });
+
+    const { data: apps } = await supabase
+      .from('agent_rental_applications')
+      .select('applicant_id')
+      .eq('agent_id', agentId)
+      .in('status', ['received', 'referencing']);
+
+    const unique = new Set((apps || []).map((a) => a.applicant_id));
+    return NextResponse.json({ count: unique.size });
+  } catch (error: any) {
+    return NextResponse.json({ count: 0, error: error.message }, { status: 200 });
+  }
+}

--- a/apps/unified-portal/app/api/agent/applicants/route.ts
+++ b/apps/unified-portal/app/api/agent/applicants/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import type { ApplicantListItem, ApplicationStatus } from '@/lib/agent-intelligence/applicants';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/applicants
+ * Optional ?filter=preferred|invited|received|referencing|approved
+ * Returns every applicant for the authenticated agent with enrichment
+ * fields (linked property count, latest status, last activity) so the
+ * list view renders in a single round trip.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const agentProfile = await resolveAgentProfile(supabase, user?.id);
+    if (!agentProfile) {
+      return NextResponse.json({ applicants: [], count: 0 });
+    }
+
+    const filter = request.nextUrl.searchParams.get('filter') || 'all';
+
+    const { data: applicants, error } = await supabase
+      .from('agent_applicants')
+      .select('id, full_name, email, phone, source, created_at, updated_at')
+      .eq('agent_id', agentProfile.id)
+      .order('created_at', { ascending: false });
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!applicants || applicants.length === 0) {
+      return NextResponse.json({ applicants: [], count: 0 });
+    }
+
+    const applicantIds = applicants.map((a) => a.id);
+
+    const [
+      { data: applications },
+      { data: attendees },
+    ] = await Promise.all([
+      supabase
+        .from('agent_rental_applications')
+        .select('id, applicant_id, letting_property_id, status, application_date, updated_at')
+        .in('applicant_id', applicantIds)
+        .order('application_date', { ascending: false }),
+      supabase
+        .from('agent_rental_viewing_attendees')
+        .select('applicant_id, was_preferred, created_at')
+        .in('applicant_id', applicantIds),
+    ]);
+
+    const appsByApplicant = new Map<string, typeof applications>();
+    for (const app of applications || []) {
+      if (!appsByApplicant.has(app.applicant_id)) appsByApplicant.set(app.applicant_id, [] as any);
+      appsByApplicant.get(app.applicant_id)!.push(app);
+    }
+
+    const preferredCountByApplicant = new Map<string, number>();
+    const lastAttendanceAt = new Map<string, string>();
+    for (const att of attendees || []) {
+      if (!att.applicant_id) continue;
+      if (att.was_preferred) {
+        preferredCountByApplicant.set(att.applicant_id, (preferredCountByApplicant.get(att.applicant_id) || 0) + 1);
+      }
+      const prev = lastAttendanceAt.get(att.applicant_id);
+      if (!prev || att.created_at > prev) {
+        lastAttendanceAt.set(att.applicant_id, att.created_at);
+      }
+    }
+
+    const items: ApplicantListItem[] = applicants.map((a) => {
+      const apps = appsByApplicant.get(a.id) || [];
+      const latest = apps[0];
+      const uniqueProperties = new Set(apps.map((x: any) => x.letting_property_id));
+      const attendanceAt = lastAttendanceAt.get(a.id);
+      const lastActivity =
+        latest?.updated_at || latest?.application_date || attendanceAt || a.updated_at || a.created_at;
+      return {
+        id: a.id,
+        fullName: a.full_name,
+        email: a.email,
+        phone: a.phone,
+        source: a.source,
+        linkedPropertyCount: uniqueProperties.size,
+        latestStatus: (latest?.status as ApplicationStatus | undefined) ?? null,
+        lastActivityAt: lastActivity,
+        preferredCount: preferredCountByApplicant.get(a.id) || 0,
+      };
+    });
+
+    const filtered = applyFilter(items, filter);
+    return NextResponse.json({ applicants: filtered, count: filtered.length });
+  } catch (error: any) {
+    console.error('[agent/applicants GET] Error:', error.message);
+    return NextResponse.json(
+      { error: 'Failed to list applicants', details: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+function applyFilter(items: ApplicantListItem[], filter: string): ApplicantListItem[] {
+  switch (filter) {
+    case 'preferred':
+      return items.filter((i) => i.preferredCount > 0);
+    case 'invited':
+      return items.filter((i) => i.latestStatus === 'invited');
+    case 'applied':
+    case 'received':
+      return items.filter((i) => i.latestStatus === 'received' || i.latestStatus === 'referencing');
+    case 'approved':
+      return items.filter((i) => i.latestStatus === 'approved' || i.latestStatus === 'offer_accepted');
+    default:
+      return items;
+  }
+}
+
+async function resolveAgentProfile(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  userId: string | undefined,
+): Promise<{ id: string; tenant_id: string } | null> {
+  if (userId) {
+    const { data } = await supabase
+      .from('agent_profiles')
+      .select('id, tenant_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (data) return data as any;
+  }
+  const { data } = await supabase
+    .from('agent_profiles')
+    .select('id, tenant_id')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return (data as any) || null;
+}

--- a/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
@@ -23,11 +23,27 @@ type SupabaseAdmin = ReturnType<typeof getSupabaseAdmin>;
 
 /**
  * POST /api/agent/intelligence/execute-actions
- * Body: { actions: ExtractedAction[], transcript?: string }
- * Returns: { batchId, results: ExecutedAction[] }
+ * Body:
+ *   {
+ *     actions: ExtractedAction[],
+ *     transcript?: string,
+ *     // Optional: when retrying a subset of failed actions from a prior
+ *     // batch, the client passes back the shared context so later actions
+ *     // can still reference earlier-created ids.
+ *     sharedContext?: SharedContextShape,
+ *     batchId?: string,
+ *   }
+ * Returns: { batchId, results: ExecutedAction[], sharedContext, globalPaused }
  *
- * Executes every approved action in parallel and records a reversal payload
- * in recent_actions so the 60-second undo pill can roll the batch back.
+ * Session 4B: executes sequentially, not in parallel, so action N can
+ * reference ids produced by action N-1 (e.g. flag_applicant_preferred
+ * matching names against log_rental_viewing's attendees, or
+ * draft_application_invitation resolving an applicant created a moment ago).
+ *
+ * On partial failure we still return every result so the confirmation card
+ * can show ✓/✗ per action. Successful rows keep their reversal payload in
+ * recent_actions so the Session 1 undo pill still works even if a later
+ * action failed.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -68,9 +84,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
     }
 
-    const batchId = randomUUID();
+    const batchId: string = typeof body?.batchId === 'string' ? body.batchId : randomUUID();
     const userId = user?.id || agentProfile.user_id;
     const timezone = agentProfile.timezone || 'Europe/Dublin';
+
+    // Sequential execution needs a shared context so each action can reference
+    // ids produced by earlier actions in the same batch. Client can also pass
+    // a prior shared context back when retrying a failed subset.
+    const sharedContext: SharedContext = {
+      applicantsByName: toCaseMap(body?.sharedContext?.applicantsByName),
+      rentalViewingIds: { ...(body?.sharedContext?.rentalViewingIds || {}) },
+      lettingPropertiesByRef: toCaseMap(body?.sharedContext?.lettingPropertiesByRef),
+    };
 
     // Load autonomy prefs + the last 10 auto-sends per draft_type so the
     // decideAutoSend helper can apply every gate in one go. This is a single
@@ -92,22 +117,51 @@ export async function POST(request: NextRequest) {
       recentByType.get(r.draft_type)!.push(r);
     }
 
-    const results = await Promise.all(
-      actions.map((action) =>
-        executeAction(supabase, {
-          action,
-          batchId,
-          userId,
-          tenantId: agentProfile.tenant_id,
-          agentId: agentProfile.id,
-          timezone,
-          autonomy,
-          recentByType,
-        }),
-      ),
-    );
+    // Sequential loop — each action can read from and write to sharedContext.
+    const results: ExecutedAction[] = [];
+    for (const action of actions) {
+      const result = await executeAction(supabase, {
+        action,
+        batchId,
+        userId,
+        tenantId: agentProfile.tenant_id,
+        agentId: agentProfile.id,
+        timezone,
+        autonomy,
+        recentByType,
+        sharedContext,
+      });
 
-    return NextResponse.json({ batchId, results, globalPaused: autonomy.globalPaused });
+      // Feed outputs back into sharedContext so later actions can resolve.
+      if (result.success && result.meta) {
+        if (result.meta.rentalViewingId) {
+          sharedContext.rentalViewingIds[action.id] = result.meta.rentalViewingId;
+          sharedContext.rentalViewingIds.__latest = result.meta.rentalViewingId;
+        }
+        if (result.meta.applicantsByName) {
+          for (const [name, id] of Object.entries(result.meta.applicantsByName)) {
+            sharedContext.applicantsByName[name.toLowerCase()] = id;
+          }
+        }
+        if (result.meta.lettingPropertyId) {
+          const raw = action.fields?.letting_property_id
+            || action.fields?.property_id
+            || action.fields?.letting_property_ref;
+          if (typeof raw === 'string' && raw.trim()) {
+            sharedContext.lettingPropertiesByRef[raw.toLowerCase().trim()] = result.meta.lettingPropertyId;
+          }
+        }
+      }
+
+      results.push(result);
+    }
+
+    return NextResponse.json({
+      batchId,
+      results,
+      globalPaused: autonomy.globalPaused,
+      sharedContext,
+    });
   } catch (error: any) {
     console.error('[agent/intelligence/execute-actions] Error:', error.message);
     return NextResponse.json(
@@ -115,6 +169,21 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+interface SharedContext {
+  applicantsByName: Record<string, string>;
+  rentalViewingIds: Record<string, string>;
+  lettingPropertiesByRef: Record<string, string>;
+}
+
+function toCaseMap(source: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!source || typeof source !== 'object') return out;
+  for (const [k, v] of Object.entries(source as Record<string, unknown>)) {
+    if (typeof v === 'string' && v.trim()) out[String(k).toLowerCase()] = v;
+  }
+  return out;
 }
 
 interface ExecCtx {
@@ -126,6 +195,7 @@ interface ExecCtx {
   timezone: string;
   autonomy: Awaited<ReturnType<typeof loadAutonomyPreferences>>;
   recentByType: Map<string, SendHistoryRow[]>;
+  sharedContext: SharedContext;
 }
 
 async function executeAction(
@@ -138,6 +208,14 @@ async function executeAction(
     switch (action.type) {
       case 'log_viewing':
         return await execLogViewing(supabase, ctx);
+      case 'log_rental_viewing':
+        return await execLogRentalViewing(supabase, ctx);
+      case 'create_applicant':
+        return await execCreateApplicant(supabase, ctx);
+      case 'flag_applicant_preferred':
+        return await execFlagApplicantPreferred(supabase, ctx);
+      case 'draft_application_invitation':
+        return await execDraftApplicationInvitation(supabase, ctx);
       case 'draft_vendor_update':
         return await execDraftVendorUpdate(supabase, ctx);
       case 'draft_viewing_followup_buyer':
@@ -815,3 +893,546 @@ function nowTimeInDublin(): string {
   const d = new Date();
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
+
+// ────────────────────────────────────────────────────────────────
+// Session 4B — Lettings handlers
+// ────────────────────────────────────────────────────────────────
+
+/**
+ * Find a letting property for the current agent matching a free-form
+ * reference. Tries address_line_1, address, city — returns the highest
+ * confidence match. Results are cached on the shared context so the same
+ * reference in a later action (e.g. draft_application_invitation) does not
+ * re-query.
+ */
+async function resolveLettingProperty(
+  supabase: SupabaseAdmin,
+  agentId: string,
+  reference: string,
+  shared: SharedContext,
+): Promise<{ id: string; address: string | null } | null> {
+  const key = reference.toLowerCase().trim();
+  const cached = shared.lettingPropertiesByRef[key];
+  if (cached) {
+    const { data } = await supabase
+      .from('agent_letting_properties')
+      .select('id, address, address_line_1')
+      .eq('id', cached)
+      .maybeSingle();
+    if (data) return { id: data.id, address: data.address || data.address_line_1 || null };
+  }
+
+  if (/^[0-9a-f-]{36}$/i.test(reference)) {
+    const { data } = await supabase
+      .from('agent_letting_properties')
+      .select('id, address, address_line_1')
+      .eq('id', reference)
+      .eq('agent_id', agentId)
+      .maybeSingle();
+    if (data) {
+      shared.lettingPropertiesByRef[key] = data.id;
+      return { id: data.id, address: data.address || data.address_line_1 || null };
+    }
+  }
+
+  // Fuzzy match on address fields, restricted to the agent's properties.
+  const { data: matches } = await supabase
+    .from('agent_letting_properties')
+    .select('id, address, address_line_1')
+    .eq('agent_id', agentId)
+    .or(`address.ilike.%${reference}%,address_line_1.ilike.%${reference}%`)
+    .limit(2);
+
+  if (matches && matches.length >= 1) {
+    const row = matches[0];
+    shared.lettingPropertiesByRef[key] = row.id;
+    return { id: row.id, address: row.address || row.address_line_1 || null };
+  }
+  return null;
+}
+
+async function execLogRentalViewing(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action, agentId, tenantId, sharedContext } = ctx;
+  const f = action.fields;
+  const rawPropertyRef = f.letting_property_id ? String(f.letting_property_id) : '';
+
+  if (!rawPropertyRef) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Need a rental property reference',
+      error: 'letting_property_id missing',
+    };
+  }
+
+  const property = await resolveLettingProperty(supabase, agentId, rawPropertyRef, sharedContext);
+  if (!property) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: `Could not match a rental property for "${rawPropertyRef}"`,
+      error: 'letting_property_not_found',
+    };
+  }
+
+  const viewingDateIso = typeof f.viewing_date === 'string' && f.viewing_date
+    ? f.viewing_date
+    : new Date().toISOString();
+
+  const { data: viewing, error: viewingErr } = await supabase
+    .from('agent_rental_viewings')
+    .insert({
+      agent_id: agentId,
+      tenant_id: tenantId,
+      letting_property_id: property.id,
+      viewing_date: viewingDateIso,
+      viewing_type: f.viewing_type || 'individual',
+      interest_level: f.interest_level || null,
+      feedback: f.feedback || null,
+      next_action: f.next_action || null,
+      status: 'completed',
+    })
+    .select('id')
+    .single();
+
+  if (viewingErr || !viewing) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Could not log the rental viewing',
+      error: viewingErr?.message || 'unknown',
+    };
+  }
+
+  await recordReversal(supabase, ctx, {
+    targetTable: 'agent_rental_viewings',
+    targetId: viewing.id,
+    reversal: { op: 'delete', table: 'agent_rental_viewings', id: viewing.id },
+  });
+
+  // Create / link applicants for each attendee. Exact-name match against this
+  // agent's existing applicants; otherwise create a bare record.
+  const attendees: any[] = Array.isArray(f.attendees) ? f.attendees : [];
+  const applicantsByName: Record<string, string> = {};
+
+  for (const attendee of attendees) {
+    const name: string = String(attendee?.name || '').trim();
+    if (!name) continue;
+
+    const { data: existing } = await supabase
+      .from('agent_applicants')
+      .select('id')
+      .eq('agent_id', agentId)
+      .ilike('full_name', name)
+      .limit(1)
+      .maybeSingle();
+
+    let applicantId = existing?.id;
+    if (!applicantId) {
+      const { data: created, error: applicantErr } = await supabase
+        .from('agent_applicants')
+        .insert({
+          agent_id: agentId,
+          tenant_id: tenantId,
+          full_name: name,
+          email: extractEmail(attendee?.contact_if_known),
+          phone: extractPhone(attendee?.contact_if_known),
+          employment_status: attendee?.employment_status || 'unknown',
+          employer: attendee?.employer || null,
+          notes: attendee?.notes || null,
+          source: 'walk_in',
+        })
+        .select('id')
+        .single();
+
+      if (applicantErr || !created) continue;
+      applicantId = created.id;
+      await recordReversal(supabase, ctx, {
+        targetTable: 'agent_applicants',
+        targetId: applicantId,
+        reversal: { op: 'delete', table: 'agent_applicants', id: applicantId },
+      });
+    }
+
+    applicantsByName[name.toLowerCase()] = applicantId;
+
+    const { data: attendeeRow } = await supabase
+      .from('agent_rental_viewing_attendees')
+      .insert({
+        rental_viewing_id: viewing.id,
+        applicant_id: applicantId,
+        name_if_unknown: name,
+        contact_if_known: attendee?.contact_if_known || null,
+        was_preferred: !!attendee?.was_preferred,
+        notes: attendee?.notes || null,
+      })
+      .select('id')
+      .single();
+    if (attendeeRow?.id) {
+      await recordReversal(supabase, ctx, {
+        targetTable: 'agent_rental_viewing_attendees',
+        targetId: attendeeRow.id,
+        reversal: { op: 'delete', table: 'agent_rental_viewing_attendees', id: attendeeRow.id },
+      });
+    }
+  }
+
+  return {
+    id: action.id,
+    type: action.type,
+    success: true,
+    targetId: viewing.id,
+    message: `Logged rental viewing at ${property.address || rawPropertyRef} with ${attendees.length} attendee${attendees.length === 1 ? '' : 's'}`,
+    meta: {
+      rentalViewingId: viewing.id,
+      applicantsByName,
+      lettingPropertyId: property.id,
+    },
+  };
+}
+
+async function execCreateApplicant(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action, agentId, tenantId } = ctx;
+  const f = action.fields;
+  const fullName = String(f.full_name || '').trim();
+  if (!fullName) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Applicant needs a name',
+      error: 'full_name missing',
+    };
+  }
+
+  const { data: applicant, error } = await supabase
+    .from('agent_applicants')
+    .insert({
+      agent_id: agentId,
+      tenant_id: tenantId,
+      full_name: fullName,
+      email: f.email || null,
+      phone: f.phone || null,
+      employment_status: f.employment_status || 'unknown',
+      employer: f.employer || null,
+      annual_income: typeof f.annual_income === 'number' ? f.annual_income : null,
+      household_size: typeof f.household_size === 'number' ? f.household_size : null,
+      has_pets: typeof f.has_pets === 'boolean' ? f.has_pets : null,
+      pet_details: f.pet_details || null,
+      smoker: typeof f.smoker === 'boolean' ? f.smoker : null,
+      budget_monthly: typeof f.budget_monthly === 'number' ? f.budget_monthly : null,
+      source: f.source || 'unknown',
+      notes: f.notes || null,
+    })
+    .select('id')
+    .single();
+
+  if (error || !applicant) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Could not create applicant',
+      error: error?.message || 'unknown',
+    };
+  }
+
+  await recordReversal(supabase, ctx, {
+    targetTable: 'agent_applicants',
+    targetId: applicant.id,
+    reversal: { op: 'delete', table: 'agent_applicants', id: applicant.id },
+  });
+
+  return {
+    id: action.id,
+    type: action.type,
+    success: true,
+    targetId: applicant.id,
+    message: `Created applicant ${fullName}`,
+    meta: { applicantsByName: { [fullName.toLowerCase()]: applicant.id } },
+  };
+}
+
+async function resolveApplicantByName(
+  supabase: SupabaseAdmin,
+  agentId: string,
+  shared: SharedContext,
+  name: string,
+): Promise<string | null> {
+  if (!name) return null;
+  const key = name.toLowerCase().trim();
+  if (shared.applicantsByName[key]) return shared.applicantsByName[key];
+
+  // Try partial match on the same-batch map first (e.g. "O'Sheas" vs "O'Shea").
+  for (const [candidate, id] of Object.entries(shared.applicantsByName)) {
+    if (candidate.includes(key) || key.includes(candidate)) return id;
+  }
+
+  // Fall back to the agent's most recent applicant with a fuzzy name match.
+  const { data } = await supabase
+    .from('agent_applicants')
+    .select('id')
+    .eq('agent_id', agentId)
+    .ilike('full_name', `%${name}%`)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data?.id || null;
+}
+
+async function execFlagApplicantPreferred(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action, agentId, sharedContext } = ctx;
+  const f = action.fields;
+  const applicantName = String(f.applicant_name || '').trim();
+  if (!applicantName) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Need an applicant name to flag',
+      error: 'applicant_name missing',
+    };
+  }
+
+  const applicantId = await resolveApplicantByName(supabase, agentId, sharedContext, applicantName);
+  if (!applicantId) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: `Could not find an applicant matching "${applicantName}"`,
+      error: 'applicant_not_found',
+    };
+  }
+
+  // Target viewing: same-batch preferred, then most recent viewing for this
+  // applicant under the current agent.
+  let rentalViewingId: string | null = sharedContext.rentalViewingIds.__latest || null;
+
+  if (!rentalViewingId && typeof f.rental_viewing_ref === 'string') {
+    // Try via the letting property reference on the ref — match most recent
+    // viewing at that property.
+    const property = await resolveLettingProperty(supabase, agentId, String(f.rental_viewing_ref), sharedContext);
+    if (property) {
+      const { data: recent } = await supabase
+        .from('agent_rental_viewings')
+        .select('id')
+        .eq('letting_property_id', property.id)
+        .eq('agent_id', agentId)
+        .order('viewing_date', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      rentalViewingId = recent?.id || null;
+    }
+  }
+
+  if (!rentalViewingId) {
+    // Last resort: the most recent viewing this applicant attended.
+    const { data: attendeeRow } = await supabase
+      .from('agent_rental_viewing_attendees')
+      .select('rental_viewing_id, id')
+      .eq('applicant_id', applicantId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    rentalViewingId = attendeeRow?.rental_viewing_id || null;
+  }
+
+  if (!rentalViewingId) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: `Found ${applicantName}, but could not match them to a recent viewing`,
+      error: 'rental_viewing_not_found',
+    };
+  }
+
+  const { data: attendee, error } = await supabase
+    .from('agent_rental_viewing_attendees')
+    .update({ was_preferred: true })
+    .eq('rental_viewing_id', rentalViewingId)
+    .eq('applicant_id', applicantId)
+    .select('id')
+    .maybeSingle();
+
+  if (error || !attendee) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Could not flag preferred',
+      error: error?.message || 'attendee_row_not_found',
+    };
+  }
+
+  await recordReversal(supabase, ctx, {
+    targetTable: 'agent_rental_viewing_attendees',
+    targetId: attendee.id,
+    reversal: { op: 'update', table: 'agent_rental_viewing_attendees', id: attendee.id, set: { was_preferred: false } },
+  });
+
+  return {
+    id: action.id,
+    type: action.type,
+    success: true,
+    targetId: attendee.id,
+    message: `Flagged ${applicantName} as preferred`,
+  };
+}
+
+async function execDraftApplicationInvitation(
+  supabase: SupabaseAdmin,
+  ctx: ExecCtx,
+): Promise<ExecutedAction> {
+  const { action, agentId, tenantId, sharedContext } = ctx;
+  const f = action.fields;
+  const applicantName = String(f.applicant_name || '').trim();
+  const propertyRef = String(f.letting_property_id || '').trim();
+
+  if (!applicantName || !propertyRef) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: 'Need both applicant and property',
+      error: 'applicant_name_or_property_missing',
+    };
+  }
+
+  const applicantId = await resolveApplicantByName(supabase, agentId, sharedContext, applicantName);
+  if (!applicantId) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: `Could not find an applicant matching "${applicantName}"`,
+      error: 'applicant_not_found',
+    };
+  }
+
+  const property = await resolveLettingProperty(supabase, agentId, propertyRef, sharedContext);
+  if (!property) {
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: `Could not match a rental property for "${propertyRef}"`,
+      error: 'letting_property_not_found',
+    };
+  }
+
+  // Load applicant for recipient display + body personalisation.
+  const { data: applicant } = await supabase
+    .from('agent_applicants')
+    .select('id, full_name, email, phone')
+    .eq('id', applicantId)
+    .maybeSingle();
+
+  // Create the application record first — if the insert hits the unique
+  // partial index (active application already exists) we surface that
+  // honestly and skip the draft.
+  const { data: application, error: appErr } = await supabase
+    .from('agent_rental_applications')
+    .insert({
+      agent_id: agentId,
+      tenant_id: tenantId,
+      applicant_id: applicantId,
+      letting_property_id: property.id,
+      status: 'invited',
+      references_status: 'not_requested',
+      aml_status: 'not_started',
+    })
+    .select('id')
+    .single();
+
+  if (appErr || !application) {
+    const duplicate = appErr?.message?.includes('idx_unique_active_application');
+    return {
+      id: action.id,
+      type: action.type,
+      success: false,
+      message: duplicate
+        ? `${applicantName} already has an active application on that property`
+        : 'Could not create the application',
+      error: appErr?.message || 'unknown',
+    };
+  }
+
+  await recordReversal(supabase, ctx, {
+    targetTable: 'agent_rental_applications',
+    targetId: application.id,
+    reversal: { op: 'delete', table: 'agent_rental_applications', id: application.id },
+  });
+
+  const firstName = (applicant?.full_name || applicantName).split(/\s+/)[0] || 'there';
+  const bodyTemplate: string = typeof f.body === 'string' && f.body.trim()
+    ? f.body
+    : `Hi ${firstName},\n\nLovely to meet you at the viewing of ${property.address || propertyRef}. When you have a moment, could you pop through the application details at this link? {application_link}\n\nAny questions, give me a shout.\n\nThanks,`;
+
+  const body = bodyTemplate.replace(/\{first_name\}/g, firstName);
+
+  const subject = typeof f.subject === 'string' && f.subject.trim()
+    ? f.subject
+    : `Application for ${property.address || propertyRef}`;
+
+  const provenance = [
+    { id: 'property', label: property.address || propertyRef, detail: null },
+    { id: 'application', label: `Application ${application.id.slice(0, 8)}`, detail: `Status: invited` },
+  ];
+
+  const draftResult = await insertDraftAndMaybeAutoSend(supabase, ctx, {
+    draftType: 'application_invitation',
+    recipientId: applicantId,
+    sendMethod: 'email',
+    contentJson: {
+      applicant_id: applicantId,
+      application_id: application.id,
+      letting_property_id: property.id,
+      subject,
+      body,
+      tone: f.tone || 'warm',
+      provenance,
+    },
+    reviewMessage: `Drafted application invitation for ${applicant?.full_name || applicantName}`,
+    autoSendMessage: (name) => `Auto-sending application invitation to ${name}`,
+  });
+
+  if (!draftResult.success) {
+    return draftResult;
+  }
+
+  return {
+    ...draftResult,
+    meta: {
+      ...(draftResult.meta || {}),
+      applicationId: application.id,
+      draftId: draftResult.targetId,
+    },
+  };
+}
+
+function extractEmail(raw?: string | null): string | null {
+  if (!raw) return null;
+  const m = /[\w.+-]+@[\w.-]+\.\w+/.exec(raw);
+  return m ? m[0] : null;
+}
+
+function extractPhone(raw?: string | null): string | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/[^\d+]/g, '');
+  return cleaned.length >= 7 ? cleaned : null;
+}
+

--- a/apps/unified-portal/app/api/agent/intelligence/extract-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/extract-actions/route.ts
@@ -117,6 +117,7 @@ interface VoiceContext {
   activeDevelopmentId: string | null;
   schemeName: string | null;
   recentListings: Array<{ id: string; address: string; vendor: string | null }>;
+  lettingProperties: Array<{ id: string; address: string }>;
 }
 
 async function buildVoiceContext(
@@ -141,6 +142,30 @@ async function buildVoiceContext(
     .order('listed_date', { ascending: false })
     .limit(12);
 
+  // Session 4B: pull the agent's letting properties so the model can match
+  // rental viewing references like "14 Oakfield" to the right row. We scope
+  // by the resolved agent_profile to keep the list relevant.
+  let lettingProperties: Array<{ id: string; address: string }> = [];
+  if (userId) {
+    const { data: profile } = await supabase
+      .from('agent_profiles')
+      .select('id')
+      .eq('user_id', userId)
+      .limit(1)
+      .maybeSingle();
+    if (profile?.id) {
+      const { data: props } = await supabase
+        .from('agent_letting_properties')
+        .select('id, address, address_line_1')
+        .eq('agent_id', profile.id)
+        .limit(20);
+      lettingProperties = (props || []).map((p: any) => ({
+        id: p.id,
+        address: p.address || p.address_line_1 || p.id,
+      }));
+    }
+  }
+
   return {
     activeDevelopmentId: activeDevelopmentId ?? null,
     schemeName,
@@ -149,6 +174,7 @@ async function buildVoiceContext(
       address: l.address,
       vendor: l.vendor_name ?? null,
     })),
+    lettingProperties,
   };
 }
 
@@ -158,6 +184,12 @@ function buildExtractionSystemPrompt(ctx: VoiceContext, intentHint?: string): st
         .map((l) => `- ${l.id}: ${l.address}${l.vendor ? ` (vendor: ${l.vendor})` : ''}`)
         .join('\n')
     : 'No recent listings available.';
+
+  const lettingsBlock = ctx.lettingProperties.length
+    ? ctx.lettingProperties
+        .map((p) => `- ${p.id}: ${p.address}`)
+        .join('\n')
+    : 'No rental properties on file.';
 
   const intentLine = intentHint
     ? `\nThe user tapped a chip hinting the intent is "${intentHint}". Treat it as a prior, not a constraint.`
@@ -171,8 +203,11 @@ function buildExtractionSystemPrompt(ctx: VoiceContext, intentHint?: string): st
 
 ${schemeLine}${intentLine}
 
-Recent listings you can match property references against:
+Recent sales listings you can match property references against:
 ${listingsBlock}
+
+Rental properties on the agent's book (for lettings actions):
+${lettingsBlock}
 
 Given the agent's spoken transcript you must:
 1. Identify every distinct action implied. A single sentence may imply several — for example "Murphys came to 14 Oakfield, loved it, probably offering Monday, tell the vendor" implies log_viewing + draft_vendor_update + create_reminder.
@@ -184,9 +219,17 @@ Given the agent's spoken transcript you must:
 7. Do not emit tool calls for speculative or unrelated actions. If the transcript is purely a question (no action), return zero tool calls.
 
 Choosing between draft tools:
- - draft_viewing_followup_buyer: the agent wants a thank-you / next-step email to the attendees after a viewing. Trigger phrases: "follow up with Murphys", "thank them for coming", "send more info". Reference anything specific they cared about.
- - draft_offer_response: the agent describes how to respond to an offer. Trigger phrases: "accept their offer", "counter at X", "reject the 420", "acknowledge and pass to vendor". Choose the right action enum. For counters the new amount must appear in the body.
- - draft_price_reduction_notice: the agent says the price has dropped and wants to tell active buyers. Trigger phrases: "vendor dropped to 450, tell anyone who viewed", "price reduction on 14 Oakfield". Populate recipient_ids with every buyer referenced. The body_template uses the literal token {first_name} for personalisation — the server fills it in per recipient.
- - draft_chain_update_to_buyer: the agent describes chain progress for a single buyer. Trigger phrases: "survey came back", "solicitor instructed", "contracts issued", "contracts exchanged", "there's a delay on completion". Pick the closest update_type enum; use "custom" only when no enum fits.
- - draft_vendor_update: default sales-side update back to the vendor. Use for "tell the vendor" / "let the vendor know" when none of the more specific tools apply.`;
+ - draft_viewing_followup_buyer: the agent wants a thank-you / next-step email to the attendees after a SALES viewing. Trigger phrases: "follow up with Murphys", "thank them for coming". Reference anything specific they cared about. Note: for a RENTAL viewing follow-up, use draft_application_invitation instead.
+ - draft_offer_response: the agent describes how to respond to an offer. Trigger phrases: "accept their offer", "counter at X", "reject the 420". Choose the right action enum. For counters the new amount must appear in the body.
+ - draft_price_reduction_notice: the agent says the price has dropped and wants to tell active buyers. Trigger phrases: "vendor dropped to 450, tell anyone who viewed". Populate recipient_ids with every buyer referenced. The body_template uses the literal token {first_name} for personalisation — the server fills it in per recipient.
+ - draft_chain_update_to_buyer: the agent describes chain progress for a single sales buyer. Trigger phrases: "survey came back", "solicitor instructed", "contracts issued", "there's a delay on completion".
+ - draft_vendor_update: default sales-side update back to the vendor. Use for "tell the vendor" / "let the vendor know".
+
+Lettings workflows:
+ - log_rental_viewing: the agent just viewed a RENTAL property with prospective tenants. Trigger phrases: "three people came to see", "showed the Rathmines one today". Populate every attendee by name (even surnames like "the O'Sheas"). Set was_preferred=true on any attendee the agent says stood out. Use this BEFORE flag_applicant_preferred so the attendees exist.
+ - flag_applicant_preferred: the agent explicitly says one attendee was their preferred applicant AFTER log_rental_viewing fires. Trigger phrases: "the O'Sheas were miles ahead", "the couple with the baby were the best fit". applicant_name must match the name used in the log_rental_viewing attendees list verbatim.
+ - create_applicant: a standalone applicant capture from a phone enquiry, walk-in or referral that did NOT involve a viewing. Do NOT use this for viewing attendees.
+ - draft_application_invitation: the agent wants to invite a preferred applicant to fill in the application form. Trigger phrases: "ask them to apply", "send them the form", "invite the O'Sheas to apply". Body must include the literal token {application_link} where the form URL will go. Emit this AFTER the log_rental_viewing + flag_applicant_preferred actions when the agent chains them in one sentence.
+
+The canonical multi-action sentence looks like: "Three people came to see 14 Oakfield this afternoon, the O'Sheas were miles ahead, ask them to apply." That should produce log_rental_viewing + flag_applicant_preferred + draft_application_invitation, in that order, in a single response.`;
 }

--- a/apps/unified-portal/app/api/agent/intelligence/undo-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/undo-actions/route.ts
@@ -52,6 +52,18 @@ export async function POST(request: NextRequest) {
           failed.push({ id: entry.id, error: delErr.message });
           continue;
         }
+      } else if (payload?.op === 'update' && payload?.table && payload?.id && payload?.set) {
+        // Session 4B: flag_applicant_preferred records an update reversal so
+        // undoing flips was_preferred back to false without deleting the
+        // attendee row (which log_rental_viewing may also want to keep).
+        const { error: updErr } = await supabase
+          .from(payload.table)
+          .update(payload.set)
+          .eq('id', payload.id);
+        if (updErr) {
+          failed.push({ id: entry.id, error: updErr.message });
+          continue;
+        }
       }
 
       const { error: updErr } = await supabase

--- a/apps/unified-portal/lib/agent-intelligence/applicants.ts
+++ b/apps/unified-portal/lib/agent-intelligence/applicants.ts
@@ -1,0 +1,140 @@
+/**
+ * Applicant types + helpers shared between the list API, detail API and the
+ * UI. Keep the DB -> UI mapping in one place so filter tabs, status pills
+ * and the signals section never drift out of sync.
+ */
+
+export type ApplicationStatus =
+  | 'invited'
+  | 'received'
+  | 'referencing'
+  | 'approved'
+  | 'rejected'
+  | 'withdrawn'
+  | 'offer_accepted';
+
+export type ReferencesStatus = 'not_requested' | 'requested' | 'partial' | 'complete';
+export type AmlStatus = 'not_started' | 'in_progress' | 'complete' | 'flagged';
+
+export interface ApplicantListItem {
+  id: string;
+  fullName: string;
+  email: string | null;
+  phone: string | null;
+  source: string;
+  linkedPropertyCount: number;
+  latestStatus: ApplicationStatus | null;
+  lastActivityAt: string;
+  preferredCount: number;
+}
+
+export interface ApplicantSignals {
+  employmentStatus: string;
+  employer: string | null;
+  annualIncome: number | null;
+  incomeToRentRatio: number | null;
+  householdSize: number | null;
+  hasPets: boolean | null;
+  petDetails: string | null;
+  smoker: boolean | null;
+  referencesStatus: ReferencesStatus | null;
+  amlStatus: AmlStatus | null;
+}
+
+export interface ApplicantDetail extends ApplicantListItem {
+  currentAddress: string | null;
+  budgetMonthly: number | null;
+  requestedMoveInDate: string | null;
+  notes: string | null;
+  signals: ApplicantSignals;
+  viewings: Array<{
+    id: string;
+    propertyAddress: string | null;
+    viewingDate: string;
+    wasPreferred: boolean;
+    interestLevel: string | null;
+  }>;
+  applications: Array<{
+    id: string;
+    propertyAddress: string | null;
+    rentPcm: number | null;
+    status: ApplicationStatus;
+    referencesStatus: ReferencesStatus;
+    amlStatus: AmlStatus;
+    applicationDate: string;
+  }>;
+}
+
+const EMPLOYMENT_LABELS: Record<string, string> = {
+  employed: 'Employed',
+  self_employed: 'Self-employed',
+  student: 'Student',
+  unemployed: 'Unemployed',
+  retired: 'Retired',
+  unknown: 'Not known',
+};
+
+export function employmentLabel(status: string): string {
+  return EMPLOYMENT_LABELS[status] || 'Not known';
+}
+
+const APPLICATION_STATUS_LABELS: Record<string, string> = {
+  invited: 'Invited',
+  received: 'Received',
+  referencing: 'Referencing',
+  approved: 'Approved',
+  rejected: 'Rejected',
+  withdrawn: 'Withdrawn',
+  offer_accepted: 'Offer accepted',
+};
+
+export function applicationStatusLabel(status: string | null): string {
+  if (!status) return 'No application yet';
+  return APPLICATION_STATUS_LABELS[status] || status;
+}
+
+const REFERENCES_LABELS: Record<string, string> = {
+  not_requested: 'Not requested',
+  requested: 'Requested',
+  partial: 'Partial',
+  complete: 'Complete',
+};
+
+export function referencesLabel(status: string | null | undefined): string {
+  if (!status) return 'Not requested';
+  return REFERENCES_LABELS[status] || status;
+}
+
+const AML_LABELS: Record<string, string> = {
+  not_started: 'Not started',
+  in_progress: 'In progress',
+  complete: 'Complete',
+  flagged: 'Flagged',
+};
+
+export function amlLabel(status: string | null | undefined): string {
+  if (!status) return 'Not started';
+  return AML_LABELS[status] || status;
+}
+
+/**
+ * Income-to-rent ratio as a simple multiple (annual income / annual rent).
+ * Letting agents scan this in seconds — 2.5x and up is conventional Irish
+ * affordability, but we surface the raw number and let the agent decide.
+ */
+export function computeIncomeToRentRatio(
+  annualIncome: number | null,
+  rentPcm: number | null,
+): number | null {
+  if (!annualIncome || !rentPcm || rentPcm <= 0) return null;
+  return annualIncome / (rentPcm * 12);
+}
+
+export function formatCurrency(value: number | null | undefined, locale = 'en-IE'): string {
+  if (value == null) return 'Not known';
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+}

--- a/apps/unified-portal/lib/agent-intelligence/autonomy.ts
+++ b/apps/unified-portal/lib/agent-intelligence/autonomy.ts
@@ -394,4 +394,9 @@ export const REQUIRED_FIELDS_BY_DRAFT_TYPE: Record<string, readonly string[]> = 
   draft_price_reduction_notice: ['property_id', 'new_price', 'recipient_ids', 'body_template'],
   chain_update_to_buyer: ['buyer_id', 'property_id', 'update_type', 'body'],
   draft_chain_update_to_buyer: ['buyer_id', 'property_id', 'update_type', 'body'],
+  // Lettings — Session 4B. applicant_name resolution runs against the same-
+  // batch attendees first; auto-send only fires when the agent explicitly
+  // named the applicant and property in the voice capture.
+  application_invitation: ['applicant_name', 'letting_property_id', 'body', 'tone'],
+  draft_application_invitation: ['applicant_name', 'letting_property_id', 'body', 'tone'],
 };

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -23,7 +23,7 @@ export interface DraftRecipient {
   name: string | null;
   email: string | null;
   phone: string | null;
-  source: 'listing_vendor' | 'listing_buyer' | 'unknown';
+  source: 'listing_vendor' | 'listing_buyer' | 'applicant' | 'unknown';
   address?: string | null;
 }
 
@@ -59,6 +59,8 @@ export function draftTypeLabel(type: string): string {
       return 'Landlord statement';
     case 'buyer_followup':
       return 'Buyer follow-up';
+    case 'application_invitation':
+      return 'Application invitation';
     default:
       return type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
   }
@@ -108,6 +110,20 @@ export async function resolveRecipient(
     }
   }
 
+  // Session 4B: lettings draft types resolve against agent_applicants.
+  if (draftType === 'application_invitation') {
+    const applicant = await findApplicantFromReference(supabase, recipientId);
+    if (applicant) {
+      return {
+        id: applicant.id,
+        name: applicant.full_name,
+        email: applicant.email || null,
+        phone: applicant.phone || null,
+        source: 'applicant',
+      };
+    }
+  }
+
   // Fallback — display the raw reference so the user sees what the voice heard.
   return {
     id: recipientId,
@@ -139,6 +155,27 @@ async function findListingFromReference(
     .ilike('address', `%${reference}%`)
     .limit(1);
   return matches?.[0] || null;
+}
+
+async function findApplicantFromReference(
+  supabase: SupabaseClient,
+  reference: string,
+): Promise<any | null> {
+  if (UUID_REGEX.test(reference)) {
+    const { data } = await supabase
+      .from('agent_applicants')
+      .select('id, full_name, email, phone')
+      .eq('id', reference)
+      .maybeSingle();
+    if (data) return data;
+  }
+
+  const { data: byName } = await supabase
+    .from('agent_applicants')
+    .select('id, full_name, email, phone')
+    .ilike('full_name', `%${reference}%`)
+    .limit(1);
+  return byName?.[0] || null;
 }
 
 async function findListingByBuyerReference(
@@ -226,11 +263,15 @@ function extractContextChips(
   const chips: Array<{ id: string; label: string; detail: string | null }> = [];
 
   if (recipient.address) {
+    const roleLabel =
+      recipient.source === 'listing_buyer' ? 'Buyer'
+      : recipient.source === 'applicant' ? 'Applicant'
+      : 'Vendor';
     chips.push({
       id: 'property',
       label: recipient.address,
       detail: recipient.name && recipient.name !== recipient.address
-        ? `${recipient.source === 'listing_buyer' ? 'Buyer' : 'Vendor'}: ${recipient.name}`
+        ? `${roleLabel}: ${recipient.name}`
         : null,
     });
   }

--- a/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
+++ b/apps/unified-portal/lib/agent-intelligence/voice-actions.ts
@@ -13,6 +13,10 @@
 
 export type VoiceActionType =
   | 'log_viewing'
+  | 'log_rental_viewing'
+  | 'create_applicant'
+  | 'flag_applicant_preferred'
+  | 'draft_application_invitation'
   | 'draft_vendor_update'
   | 'draft_viewing_followup_buyer'
   | 'draft_offer_response'
@@ -65,6 +69,20 @@ export interface ExecutedAction {
    * reason shows as a one-liner under the action in the confirmation card.
    */
   autoSendHold?: string | null;
+  /**
+   * Session 4B: sequential execution returns ids that later actions in the
+   * same batch might reference. log_rental_viewing emits created applicant
+   * ids keyed by lowercased name, plus the rental_viewing_id; subsequent
+   * flag_applicant_preferred / draft_application_invitation actions resolve
+   * their applicant_name / letting_property_id against this map.
+   */
+  meta?: {
+    rentalViewingId?: string;
+    applicantsByName?: Record<string, string>;
+    lettingPropertyId?: string;
+    applicationId?: string;
+    draftId?: string;
+  };
 }
 
 const CONFIDENCE_SCHEMA = {
@@ -359,6 +377,159 @@ export const ACTION_TOOLS = [
     },
   },
   {
+    name: 'log_rental_viewing',
+    description:
+      'Log a rental viewing that has just happened (or was recounted) for a letting agent. Trigger phrases: "X people came to see", "showed 14 Oakfield today", "viewing for [rental property]". Always populate attendees with every person or couple mentioned, even if only by surname like "the O\'Sheas".',
+    input_schema: {
+      type: 'object',
+      properties: {
+        letting_property_id: {
+          type: 'string',
+          description:
+            'A letting property id or a short reference like "14 Oakfield" or "the Rathmines one". The server fuzzy-matches against agent_letting_properties, so a human reference is fine — but keep the _confidence for this field below 0.7 if you are not sure which property was meant.',
+        },
+        viewing_date: {
+          type: 'string',
+          description:
+            'ISO 8601 datetime of the viewing. Default to now in Europe/Dublin if the agent is describing a viewing that just happened.',
+        },
+        viewing_type: {
+          type: 'string',
+          enum: ['individual', 'group', 'open_house'],
+        },
+        attendees: {
+          type: 'array',
+          description: 'Every person or couple who attended the viewing.',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              contact_if_known: { type: 'string' },
+              was_preferred: {
+                type: 'boolean',
+                description:
+                  'Set true when the agent clearly says this attendee was their standout (e.g. "the O\'Sheas were miles ahead"). Otherwise false or omit.',
+              },
+              notes: {
+                type: 'string',
+                description:
+                  'Anything specific the agent mentioned about this attendee (jobs, pets, move-in date, etc.). This seeds the bare applicant record.',
+              },
+              employment_status: {
+                type: 'string',
+                enum: ['employed', 'self_employed', 'student', 'unemployed', 'retired', 'unknown'],
+              },
+              employer: { type: 'string' },
+            },
+            required: ['name'],
+          },
+        },
+        interest_level: {
+          type: 'string',
+          enum: ['low', 'medium', 'high'],
+        },
+        feedback: { type: 'string' },
+        next_action: { type: 'string' },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: [
+        'letting_property_id',
+        'viewing_date',
+        'viewing_type',
+        'attendees',
+        'interest_level',
+        'feedback',
+        'next_action',
+        '_confidence',
+      ],
+    },
+  },
+  {
+    name: 'create_applicant',
+    description:
+      'Create an applicant record outside a viewing — phone enquiries, walk-ins, referrals. Do NOT use this for attendees at a viewing (log_rental_viewing creates those automatically).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        full_name: { type: 'string' },
+        email: { type: 'string' },
+        phone: { type: 'string' },
+        employment_status: {
+          type: 'string',
+          enum: ['employed', 'self_employed', 'student', 'unemployed', 'retired', 'unknown'],
+        },
+        employer: { type: 'string' },
+        annual_income: { type: 'number' },
+        household_size: { type: 'number' },
+        has_pets: { type: 'boolean' },
+        pet_details: { type: 'string' },
+        smoker: { type: 'boolean' },
+        budget_monthly: { type: 'number' },
+        source: {
+          type: 'string',
+          enum: ['daft', 'myhome', 'rent_ie', 'facebook', 'walk_in', 'word_of_mouth', 'other', 'unknown'],
+        },
+        notes: { type: 'string' },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: ['full_name', '_confidence'],
+    },
+  },
+  {
+    name: 'flag_applicant_preferred',
+    description:
+      'Mark one attendee of a just-logged rental viewing as the agent\'s preferred applicant. Use this when the agent says things like "the O\'Sheas were miles ahead", "prefer the young couple". Always refer to the applicant by the same name used in the attendees list of the matching log_rental_viewing action.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        applicant_name: {
+          type: 'string',
+          description:
+            'Name or surname exactly as used in the log_rental_viewing attendees list. The server matches against that list, then falls back to recent applicants for the agent.',
+        },
+        rental_viewing_ref: {
+          type: 'string',
+          description:
+            'Optional hint tying this preference to a specific viewing — a property reference like "14 Oakfield" is fine. If omitted, the server uses the most recent log_rental_viewing in the same batch.',
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: ['applicant_name', '_confidence'],
+    },
+  },
+  {
+    name: 'draft_application_invitation',
+    description:
+      'Draft the "please complete the application form" email to a preferred applicant for a specific rental property. Use when the agent says "ask them to apply", "send them the form", "invite them to apply". Creates an application record in status=invited alongside the draft.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        applicant_name: {
+          type: 'string',
+          description:
+            'Name or surname of the applicant to invite. The server matches against same-batch created applicants first, then the agent\'s recent applicants list.',
+        },
+        letting_property_id: {
+          type: 'string',
+          description:
+            'Letting property the application is for. Short reference (e.g. "14 Oakfield") is fine — the server resolves it.',
+        },
+        subject: { type: 'string' },
+        body: {
+          type: 'string',
+          description:
+            'Full email body, Irish peer-to-peer tone, no em dashes, no emoji. Reference the property by address, greet the applicant by first name, and include the placeholder link token {application_link} exactly once where the application URL belongs.',
+        },
+        tone: {
+          type: 'string',
+          enum: ['warm', 'straightforward'],
+        },
+        _confidence: CONFIDENCE_SCHEMA,
+      },
+      required: ['applicant_name', 'letting_property_id', 'body', 'tone', '_confidence'],
+    },
+  },
+  {
     name: 'create_reminder',
     description:
       'Create a reminder / task the agent wants to be nudged on later.',
@@ -394,6 +565,22 @@ export function actionLabel(action: ExtractedAction): string {
   switch (action.type) {
     case 'log_viewing':
       return 'Log viewing';
+    case 'log_rental_viewing': {
+      const property = action.fields?.letting_property_id;
+      return property ? `Log rental viewing at ${property}` : 'Log rental viewing';
+    }
+    case 'create_applicant': {
+      const name = action.fields?.full_name;
+      return name ? `Create applicant: ${name}` : 'Create applicant';
+    }
+    case 'flag_applicant_preferred': {
+      const name = action.fields?.applicant_name;
+      return name ? `Flag ${name} as preferred` : 'Flag preferred applicant';
+    }
+    case 'draft_application_invitation': {
+      const name = action.fields?.applicant_name;
+      return name ? `Invite ${name} to apply` : 'Draft application invitation';
+    }
     case 'draft_vendor_update': {
       const vendor = action.fields?.vendor_id;
       return vendor ? `Draft vendor update for ${vendor}` : 'Draft vendor update';

--- a/apps/unified-portal/migrations/045_lettings_viewings_applicants_applications.sql
+++ b/apps/unified-portal/migrations/045_lettings_viewings_applicants_applications.sql
@@ -1,0 +1,174 @@
+-- Migration: Lettings foundation — rental viewings to applications (Session 4B)
+--
+-- Adds four tables that sit between agent_letting_properties (existing) and
+-- agent_tenancies (existing) to cover the pre-tenancy pipeline: applicants,
+-- rental viewings, viewing attendees, and applications. RTB/HAP/tenancy
+-- creation stack onto this in later sessions.
+--
+-- Convention note: the existing lettings surface keys by agent_id which
+-- references agent_profiles(id). RLS self-access joins via agent_profiles
+-- where user_id = auth.uid(). Matching that pattern so joins and policies
+-- stay consistent across the lettings surface.
+--
+-- Run as three separate query blocks in Supabase SQL Editor:
+--   (1) CREATE / ALTER
+--   (2) ENABLE RLS
+--   (3) CREATE POLICY
+-- Never batch together.
+
+-- ============================================
+-- 1. Schema
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS agent_applicants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agent_profiles(id) ON DELETE CASCADE,
+  tenant_id UUID REFERENCES tenants(id),
+  full_name TEXT NOT NULL,
+  email TEXT,
+  phone TEXT,
+  current_address TEXT,
+  employment_status TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (employment_status IN ('employed', 'self_employed', 'student', 'unemployed', 'retired', 'unknown')),
+  employer TEXT,
+  annual_income NUMERIC,
+  household_size INT,
+  has_pets BOOLEAN,
+  pet_details TEXT,
+  smoker BOOLEAN,
+  requested_move_in_date DATE,
+  source TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (source IN ('daft', 'myhome', 'rent_ie', 'facebook', 'walk_in', 'word_of_mouth', 'other', 'unknown')),
+  budget_monthly NUMERIC,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_applicants_agent_created
+  ON agent_applicants(agent_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_rental_viewings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agent_profiles(id) ON DELETE CASCADE,
+  tenant_id UUID REFERENCES tenants(id),
+  letting_property_id UUID NOT NULL REFERENCES agent_letting_properties(id) ON DELETE CASCADE,
+  viewing_date TIMESTAMPTZ NOT NULL,
+  viewing_type TEXT NOT NULL DEFAULT 'individual'
+    CHECK (viewing_type IN ('individual', 'group', 'open_house')),
+  interest_level TEXT
+    CHECK (interest_level IS NULL OR interest_level IN ('low', 'medium', 'high')),
+  feedback TEXT,
+  next_action TEXT,
+  status TEXT NOT NULL DEFAULT 'completed'
+    CHECK (status IN ('scheduled', 'completed', 'cancelled', 'no_show')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_rental_viewings_agent_date
+  ON agent_rental_viewings(agent_id, viewing_date DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_rental_viewings_letting_property
+  ON agent_rental_viewings(letting_property_id);
+
+CREATE TABLE IF NOT EXISTS agent_rental_viewing_attendees (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  rental_viewing_id UUID NOT NULL REFERENCES agent_rental_viewings(id) ON DELETE CASCADE,
+  applicant_id UUID REFERENCES agent_applicants(id) ON DELETE SET NULL,
+  name_if_unknown TEXT,
+  contact_if_known TEXT,
+  was_preferred BOOLEAN DEFAULT false,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT attendee_has_identity CHECK ((applicant_id IS NOT NULL) OR (name_if_unknown IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_rental_viewing_attendees_viewing
+  ON agent_rental_viewing_attendees(rental_viewing_id);
+CREATE INDEX IF NOT EXISTS idx_rental_viewing_attendees_applicant
+  ON agent_rental_viewing_attendees(applicant_id);
+
+CREATE TABLE IF NOT EXISTS agent_rental_applications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agent_profiles(id) ON DELETE CASCADE,
+  tenant_id UUID REFERENCES tenants(id),
+  applicant_id UUID NOT NULL REFERENCES agent_applicants(id) ON DELETE CASCADE,
+  letting_property_id UUID NOT NULL REFERENCES agent_letting_properties(id) ON DELETE CASCADE,
+  application_date TIMESTAMPTZ DEFAULT now(),
+  status TEXT NOT NULL DEFAULT 'invited'
+    CHECK (status IN ('invited', 'received', 'referencing', 'approved', 'rejected', 'withdrawn', 'offer_accepted')),
+  references_status TEXT NOT NULL DEFAULT 'not_requested'
+    CHECK (references_status IN ('not_requested', 'requested', 'partial', 'complete')),
+  aml_status TEXT NOT NULL DEFAULT 'not_started'
+    CHECK (aml_status IN ('not_started', 'in_progress', 'complete', 'flagged')),
+  decision_notes TEXT,
+  decided_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_rental_applications_agent_date
+  ON agent_rental_applications(agent_id, application_date DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_rental_applications_applicant
+  ON agent_rental_applications(applicant_id);
+CREATE INDEX IF NOT EXISTS idx_agent_rental_applications_property
+  ON agent_rental_applications(letting_property_id);
+
+-- Partial unique index — a single applicant cannot have two active
+-- applications on the same property. Rejected / withdrawn are fair game.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_application
+  ON agent_rental_applications (applicant_id, letting_property_id)
+  WHERE status NOT IN ('rejected', 'withdrawn');
+
+-- ============================================
+-- 2. Enable RLS
+-- ============================================
+ALTER TABLE agent_applicants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_rental_viewings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_rental_viewing_attendees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE agent_rental_applications ENABLE ROW LEVEL SECURITY;
+
+-- ============================================
+-- 3. Policies — drop-if-exists for idempotency
+-- ============================================
+DROP POLICY IF EXISTS agent_applicants_service_role ON agent_applicants;
+DROP POLICY IF EXISTS agent_applicants_self_access ON agent_applicants;
+DROP POLICY IF EXISTS agent_rental_viewings_service_role ON agent_rental_viewings;
+DROP POLICY IF EXISTS agent_rental_viewings_self_access ON agent_rental_viewings;
+DROP POLICY IF EXISTS agent_rental_viewing_attendees_service_role ON agent_rental_viewing_attendees;
+DROP POLICY IF EXISTS agent_rental_viewing_attendees_self_access ON agent_rental_viewing_attendees;
+DROP POLICY IF EXISTS agent_rental_applications_service_role ON agent_rental_applications;
+DROP POLICY IF EXISTS agent_rental_applications_self_access ON agent_rental_applications;
+
+CREATE POLICY agent_applicants_service_role ON agent_applicants
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_applicants_self_access ON agent_applicants
+  FOR ALL USING (agent_id IN (SELECT id FROM agent_profiles WHERE user_id = auth.uid()));
+
+CREATE POLICY agent_rental_viewings_service_role ON agent_rental_viewings
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_rental_viewings_self_access ON agent_rental_viewings
+  FOR ALL USING (agent_id IN (SELECT id FROM agent_profiles WHERE user_id = auth.uid()));
+
+-- Attendees join via the viewing's agent_id. Write policy uses EXISTS so a
+-- row cannot be inserted for a viewing the caller does not own.
+CREATE POLICY agent_rental_viewing_attendees_service_role ON agent_rental_viewing_attendees
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_rental_viewing_attendees_self_access ON agent_rental_viewing_attendees
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM agent_rental_viewings v
+      JOIN agent_profiles p ON p.id = v.agent_id
+      WHERE v.id = agent_rental_viewing_attendees.rental_viewing_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY agent_rental_applications_service_role ON agent_rental_applications
+  FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY agent_rental_applications_self_access ON agent_rental_applications
+  FOR ALL USING (agent_id IN (SELECT id FROM agent_profiles WHERE user_id = auth.uid()));

--- a/apps/unified-portal/tests/e2e/lettings-foundation.spec.ts
+++ b/apps/unified-portal/tests/e2e/lettings-foundation.spec.ts
@@ -1,0 +1,382 @@
+/**
+ * Playwright smoke tests for Session 4B lettings foundation.
+ *
+ * Install & run once:
+ *   npm i -D @playwright/test
+ *   npx playwright install chromium
+ *   npx playwright test tests/e2e/lettings-foundation.spec.ts
+ *
+ * Mocks transcribe/extract/execute + applicants APIs so the tests don't hit
+ * Supabase, Claude or Resend. Covers:
+ *   1. The canonical chain: voice -> log_rental_viewing +
+ *      flag_applicant_preferred + draft_application_invitation, all three
+ *      approved in one go. Confirmation summary mentions all three.
+ *   2. Applicants list renders, filter pills switch, row opens detail view
+ *      with the signals section.
+ *   3. Partial failure: the draft step fails, the card shows ✓/✓/✗ per
+ *      action with a Retry button that re-executes just the failed one.
+ */
+import { expect, test } from '@playwright/test';
+
+const CANONICAL_TRANSCRIPT =
+  "Three people came to see 14 Oakfield this afternoon, the O'Sheas were miles ahead, she's a teacher he's in the guards, ask them to apply.";
+
+const LOG_VIEWING_ACTION = {
+  id: 'act_log_1',
+  type: 'log_rental_viewing',
+  fields: {
+    letting_property_id: '14 Oakfield',
+    viewing_date: new Date().toISOString(),
+    viewing_type: 'individual',
+    attendees: [
+      { name: "O'Shea", was_preferred: true, notes: 'Teacher + guard', employment_status: 'employed' },
+      { name: 'Murphy' },
+      { name: 'Kelly' },
+    ],
+    interest_level: 'high',
+    feedback: 'Three parties viewed, one clear standout',
+    next_action: 'Invite O\'Sheas to apply',
+  },
+  confidence: {
+    letting_property_id: 0.85,
+    viewing_date: 0.8,
+    viewing_type: 0.8,
+    attendees: 0.9,
+    interest_level: 0.9,
+    feedback: 0.85,
+    next_action: 0.8,
+  },
+};
+
+const FLAG_PREFERRED_ACTION = {
+  id: 'act_flag_1',
+  type: 'flag_applicant_preferred',
+  fields: { applicant_name: "O'Shea" },
+  confidence: { applicant_name: 0.95 },
+};
+
+const DRAFT_INVITE_ACTION = {
+  id: 'act_invite_1',
+  type: 'draft_application_invitation',
+  fields: {
+    applicant_name: "O'Shea",
+    letting_property_id: '14 Oakfield',
+    subject: 'Application for 14 Oakfield',
+    body: "Hi {first_name}, lovely to meet you at 14 Oakfield today. When you have a moment, could you pop through the details at {application_link}?\n\nThanks,",
+    tone: 'warm',
+  },
+  confidence: {
+    applicant_name: 0.9,
+    letting_property_id: 0.85,
+    body: 0.8,
+    tone: 0.8,
+  },
+};
+
+async function patchMediaRecorder(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    (navigator.mediaDevices as any).getUserMedia = async () => ({
+      getTracks: () => [{ stop: () => {} }],
+    });
+    class FakeRecorder {
+      state = 'inactive';
+      ondataavailable: ((e: any) => void) | null = null;
+      onstop: (() => void) | null = null;
+      mimeType = 'audio/webm';
+      start() { this.state = 'recording'; }
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({ data: new Blob(['mock'], { type: this.mimeType }) });
+        this.onstop?.();
+      }
+      static isTypeSupported() { return true; }
+    }
+    (window as any).MediaRecorder = FakeRecorder;
+  });
+}
+
+async function stubTranscribe(page: import('@playwright/test').Page) {
+  await page.route('**/api/agent/intelligence/transcribe', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ transcript: CANONICAL_TRANSCRIPT, provider: 'mock' }),
+    });
+  });
+}
+
+async function stubExtract(page: import('@playwright/test').Page) {
+  await page.route('**/api/agent/intelligence/extract-actions', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        actions: [LOG_VIEWING_ACTION, FLAG_PREFERRED_ACTION, DRAFT_INVITE_ACTION],
+        transcript: CANONICAL_TRANSCRIPT,
+      }),
+    });
+  });
+}
+
+test.describe('Lettings foundation — canonical chain', () => {
+  test('voice capture produces viewing + preference + draft actions in one card', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubTranscribe(page);
+    await stubExtract(page);
+
+    await page.route('**/api/agent/intelligence/execute-actions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_canonical',
+          globalPaused: false,
+          sharedContext: {
+            applicantsByName: { "o'shea": 'applicant_oshea', murphy: 'applicant_murphy', kelly: 'applicant_kelly' },
+            rentalViewingIds: { __latest: 'rv_1' },
+            lettingPropertiesByRef: { '14 oakfield': 'prop_1' },
+          },
+          results: [
+            {
+              id: LOG_VIEWING_ACTION.id,
+              type: LOG_VIEWING_ACTION.type,
+              success: true,
+              targetId: 'rv_1',
+              message: 'Logged rental viewing at 14 Oakfield with 3 attendees',
+              meta: { rentalViewingId: 'rv_1', applicantsByName: { "o'shea": 'applicant_oshea' } },
+            },
+            {
+              id: FLAG_PREFERRED_ACTION.id,
+              type: FLAG_PREFERRED_ACTION.type,
+              success: true,
+              targetId: 'attendee_1',
+              message: "Flagged O'Shea as preferred",
+            },
+            {
+              id: DRAFT_INVITE_ACTION.id,
+              type: DRAFT_INVITE_ACTION.type,
+              success: true,
+              targetId: 'draft_1',
+              message: "Drafted application invitation for O'Shea",
+              meta: { applicationId: 'app_1', draftId: 'draft_1' },
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/agent/intelligence');
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-mic-button').click();
+
+    const card = page.getByTestId('voice-confirmation-card');
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await expect(card).toContainText('Log rental viewing');
+    await expect(card).toContainText("Flag O'Shea as preferred");
+    await expect(card).toContainText("Invite O'Shea to apply");
+
+    await page.getByTestId('voice-approve-all').click();
+
+    await expect(page.getByText(/logged the rental viewing/i)).toBeVisible();
+    await expect(page.getByText(/flagged O'Shea as preferred/i)).toBeVisible();
+    await expect(page.getByText(/drafted the application invitation/i)).toBeVisible();
+  });
+
+  test('partial failure surfaces per-action status and retries the failed one', async ({ page, context }) => {
+    await context.grantPermissions(['microphone']);
+    await patchMediaRecorder(page);
+    await stubTranscribe(page);
+    await stubExtract(page);
+
+    let executeHits = 0;
+    await page.route('**/api/agent/intelligence/execute-actions', async (route) => {
+      executeHits += 1;
+      const body = JSON.parse(route.request().postData() || '{}');
+      const actionIds = (body.actions || []).map((a: any) => a.id);
+
+      if (executeHits === 1) {
+        // Initial approval — draft step fails.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            batchId: 'batch_partial',
+            globalPaused: false,
+            sharedContext: {
+              applicantsByName: { "o'shea": 'applicant_oshea' },
+              rentalViewingIds: { __latest: 'rv_1' },
+              lettingPropertiesByRef: { '14 oakfield': 'prop_1' },
+            },
+            results: [
+              { id: LOG_VIEWING_ACTION.id, type: LOG_VIEWING_ACTION.type, success: true, targetId: 'rv_1', message: 'Logged' },
+              { id: FLAG_PREFERRED_ACTION.id, type: FLAG_PREFERRED_ACTION.type, success: true, targetId: 'att_1', message: 'Flagged' },
+              { id: DRAFT_INVITE_ACTION.id, type: DRAFT_INVITE_ACTION.type, success: false, message: 'Could not save draft', error: 'resend_down' },
+            ],
+          }),
+        });
+        return;
+      }
+
+      // Retry — only the draft action was resent, include sharedContext echo.
+      expect(actionIds).toEqual([DRAFT_INVITE_ACTION.id]);
+      expect(body.sharedContext?.applicantsByName?.["o'shea"]).toBe('applicant_oshea');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          batchId: 'batch_partial',
+          globalPaused: false,
+          sharedContext: body.sharedContext,
+          results: [
+            { id: DRAFT_INVITE_ACTION.id, type: DRAFT_INVITE_ACTION.type, success: true, targetId: 'draft_retried', message: 'Drafted on retry' },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/agent/intelligence');
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-mic-button').click();
+    await page.getByTestId('voice-confirmation-card').waitFor();
+    await page.getByTestId('voice-approve-all').click();
+
+    // After initial approve: first two succeed, last one failed, Retry visible.
+    await expect(page.getByTestId(`action-status-${LOG_VIEWING_ACTION.id}`)).toHaveAttribute('data-success', 'true');
+    await expect(page.getByTestId(`action-status-${FLAG_PREFERRED_ACTION.id}`)).toHaveAttribute('data-success', 'true');
+    await expect(page.getByTestId(`action-status-${DRAFT_INVITE_ACTION.id}`)).toHaveAttribute('data-success', 'false');
+
+    const retry = page.getByTestId(`action-retry-${DRAFT_INVITE_ACTION.id}`);
+    await expect(retry).toBeVisible();
+    await retry.click();
+
+    // After retry the draft flips to success.
+    await expect(page.getByTestId(`action-status-${DRAFT_INVITE_ACTION.id}`)).toHaveAttribute('data-success', 'true');
+    expect(executeHits).toBe(2);
+  });
+});
+
+test.describe('Applicants page', () => {
+  test('list renders and filter pills switch', async ({ page }) => {
+    const allApplicants = [
+      {
+        id: 'a1',
+        fullName: "Siobhan O'Shea",
+        email: 'siobhan@example.ie',
+        phone: null,
+        source: 'walk_in',
+        linkedPropertyCount: 1,
+        latestStatus: 'invited',
+        lastActivityAt: new Date().toISOString(),
+        preferredCount: 1,
+      },
+      {
+        id: 'a2',
+        fullName: 'Peter Murphy',
+        email: null,
+        phone: '+35385111',
+        source: 'daft',
+        linkedPropertyCount: 0,
+        latestStatus: null,
+        lastActivityAt: new Date().toISOString(),
+        preferredCount: 0,
+      },
+    ];
+
+    await page.route('**/api/agent/applicants**', async (route) => {
+      const url = new URL(route.request().url());
+      const filter = url.searchParams.get('filter') || 'all';
+      const filtered = filter === 'preferred' ? allApplicants.filter((a) => a.preferredCount > 0) : allApplicants;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ applicants: filtered, count: filtered.length }),
+      });
+    });
+
+    await page.goto('/agent/applicants');
+    await expect(page.getByTestId('applicants-list')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Siobhan O'Shea")).toBeVisible();
+    await expect(page.getByText('Peter Murphy')).toBeVisible();
+
+    await page.getByTestId('applicants-filter-preferred').click();
+    await expect(page.getByText("Siobhan O'Shea")).toBeVisible();
+    await expect(page.getByText('Peter Murphy')).not.toBeVisible();
+  });
+
+  test('detail view shows signals section', async ({ page }) => {
+    await page.route('**/api/agent/applicants**', async (route) => {
+      if (route.request().url().includes('badge-count')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ count: 0 }) });
+        return;
+      }
+      if (route.request().url().endsWith('/api/agent/applicants') || route.request().url().includes('?filter')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ applicants: [], count: 0 }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          applicant: {
+            id: 'a1',
+            fullName: "Siobhan O'Shea",
+            email: 'siobhan@example.ie',
+            phone: '+35385222333',
+            source: 'walk_in',
+            linkedPropertyCount: 1,
+            latestStatus: 'invited',
+            lastActivityAt: new Date().toISOString(),
+            preferredCount: 1,
+            currentAddress: null,
+            budgetMonthly: 1800,
+            requestedMoveInDate: null,
+            notes: null,
+            signals: {
+              employmentStatus: 'employed',
+              employer: 'Dublin City Council',
+              annualIncome: 48000,
+              incomeToRentRatio: 2.2,
+              householdSize: 2,
+              hasPets: false,
+              petDetails: null,
+              smoker: false,
+              referencesStatus: 'not_requested',
+              amlStatus: 'not_started',
+            },
+            viewings: [
+              {
+                id: 'rv1',
+                propertyAddress: '14 Oakfield',
+                viewingDate: new Date().toISOString(),
+                wasPreferred: true,
+                interestLevel: 'high',
+              },
+            ],
+            applications: [
+              {
+                id: 'app1',
+                propertyAddress: '14 Oakfield',
+                rentPcm: 1800,
+                status: 'invited',
+                referencesStatus: 'not_requested',
+                amlStatus: 'not_started',
+                applicationDate: new Date().toISOString(),
+              },
+            ],
+          },
+        }),
+      });
+    });
+
+    await page.goto('/agent/applicants/a1');
+    await expect(page.getByTestId('applicant-signals')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('applicant-signals')).toContainText('Dublin City Council');
+    await expect(page.getByTestId('applicant-signals')).toContainText('2.2x annual rent');
+    await expect(page.getByTestId('applicant-invite-cta')).toBeVisible();
+  });
+});


### PR DESCRIPTION
…ication)

Opens the lettings side of the product with one workflow end-to-end: voice-capture a rental viewing, log who attended, flag the preferred applicant, draft the application invitation. This is the foundation that RTB, HAP, pre-let walkthroughs, tenancy lifecycle, and landlord statements stack onto in future sessions.

- Migration 045: four new tables — agent_applicants, agent_rental_viewings, agent_rental_viewing_attendees, agent_rental_applications. Indexes, CHECK constraints and a partial unique index on (applicant_id, letting_property_id) WHERE status NOT IN ('rejected','withdrawn'). RLS self-access via agent_profiles.user_id to match the existing lettings surface.
- Four new voice actions with tool schemas: log_rental_viewing, create_applicant, flag_applicant_preferred, draft_application_invitation.
- execute-actions refactored from parallel to SEQUENTIAL execution with a shared context object, so later actions can reference ids produced by earlier ones. log_rental_viewing emits applicantsByName + rentalViewingId; flag + draft resolve 'O\'Sheas' against the same-batch map first, then fall back to the agent's recent applicants.
- Partial failure is surfaced per-action in the confirmation card: ✓/✓/✗ with an inline Retry button that re-executes just the failed subset, passing the sharedContext back so name -> id resolution still works. undo-actions gains an 'update' reversal op for flag_preferred.
- Applicants surface at /agent/applicants (mobile) and /agent/dashboard/applicants (desktop). Filter tabs (All / Preferred / Invited / Applied / Approved), list rows with name, contact, property count, status pill, relative timestamp. Detail view: contact card, 'signals at a glance' section (employment, income with income-to-rent ratio, household, pets, smoker, references status, AML status), linked viewings + applications lists, draft-invitation CTA.
- Applicants added to mobile bottom nav (Lucide Users) with live badge count of applicants with status=received|referencing; desktop sidebar under Intelligence / Drafts. useApplicantsCount hook polls every 60s plus oh.agent.applicants.refresh event.
- Two new write-action chips on the Intelligence landing state: 'Log a rental viewing', 'Invite an applicant'.
- Drafts inbox inherits application_invitation automatically via the 4A insertDraftAndMaybeAutoSend helper. Drafts lib label map gains 'Application invitation'; recipient resolver gains an applicant path against agent_applicants.
- /api/agent/applicants (list + filter + enrichment), /:id (detail + signals), /badge-count.
- extract-actions prompt expanded: new 'Lettings workflows' section with the canonical sentence ("Three people came to see 14 Oakfield, the O'Sheas were miles ahead, ask them to apply") called out as the archetypal three-action chain. Rental property list injected into the system prompt so references resolve.
- Playwright smoke tests: canonical chain, partial-failure retry, applicants list with filter, detail view signals section.