### PR TITLE
fix(agent-nav): drop Drafts tab, badge the Intelligence FAB instead

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -5,14 +5,12 @@ import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
 
-type TabId = 'home' | 'pipeline' | 'drafts' | 'viewings' | 'docs';
+type TabId = 'home' | 'pipeline' | 'viewings' | 'docs';
 
 const TABS: { id: TabId; label: string; href: string }[] = [
   { id: 'home', label: 'Home', href: '/agent/home' },
   { id: 'pipeline', label: 'Pipeline', href: '/agent/pipeline' },
-  // Intelligence is the FAB. Drafts sits immediately after, between Pipeline
-  // and Viewings in visual flow per Session 2 spec.
-  { id: 'drafts', label: 'Drafts', href: '/agent/drafts' },
+  // Intelligence FAB sits between the two clusters.
   { id: 'viewings', label: 'Viewings', href: '/agent/viewings' },
   { id: 'docs', label: 'Docs', href: '/agent/docs' },
 ];
@@ -36,15 +34,6 @@ function TabIcon({ id, active }: { id: TabId; active: boolean }) {
           <rect x="14" y="3" width="7" height="7" rx="1.5" />
           <rect x="3" y="14" width="7" height="7" rx="1.5" />
           <rect x="14" y="14" width="7" height="7" rx="1.5" />
-        </svg>
-      );
-    case 'drafts':
-      // Lucide MailCheck mark as required by design spec.
-      return (
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
-          <path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h9" />
-          <path d="m22 7-10 5L2 7" />
-          <path d="m16 19 2 2 4-4" />
         </svg>
       );
     case 'viewings':
@@ -112,9 +101,6 @@ export default function BottomNav() {
             {active && <GoldIndicator />}
             <div style={{ position: 'relative' }}>
               <TabIcon id={tab.id} active={active} />
-              {tab.id === 'drafts' && draftsCount > 0 && (
-                <DraftsBadge count={draftsCount} />
-              )}
             </div>
             <span
               style={{
@@ -166,7 +152,7 @@ export default function BottomNav() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            overflow: 'hidden',
+            overflow: 'visible',
             boxShadow: intelActive
               ? `0 0 0 1px rgba(255,255,255,0.10) inset,
                  0 0 0 2.5px #C49B2A,
@@ -182,14 +168,17 @@ export default function BottomNav() {
             textDecoration: 'none',
           }}
         >
-          <Image
-            src="/oh-logo-icon.png"
-            alt="OpenHouse Intelligence"
-            width={80}
-            height={80}
-            style={{ objectFit: 'contain' }}
-            priority
-          />
+          <div style={{ width: 80, height: 80, borderRadius: 40, overflow: 'hidden', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Image
+              src="/oh-logo-icon.png"
+              alt="OpenHouse Intelligence"
+              width={80}
+              height={80}
+              style={{ objectFit: 'contain' }}
+              priority
+            />
+          </div>
+          {draftsCount > 0 && <FabDraftsBadge count={draftsCount} />}
         </Link>
 
         {/* Intelligence nav label */}
@@ -228,9 +217,6 @@ export default function BottomNav() {
             {active && <GoldIndicator />}
             <div style={{ position: 'relative' }}>
               <TabIcon id={tab.id} active={active} />
-              {tab.id === 'drafts' && draftsCount > 0 && (
-                <DraftsBadge count={draftsCount} />
-              )}
             </div>
             <span
               style={{
@@ -249,28 +235,28 @@ export default function BottomNav() {
   );
 }
 
-function DraftsBadge({ count }: { count: number }) {
+function FabDraftsBadge({ count }: { count: number }) {
   return (
     <span
-      data-testid="drafts-badge"
+      data-testid="fab-drafts-badge"
       style={{
         position: 'absolute',
-        top: -4,
-        right: -8,
-        minWidth: 16,
-        height: 16,
-        padding: '0 4px',
-        borderRadius: 8,
-        background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
-        color: '#fff',
-        fontSize: 9,
+        top: 2,
+        right: 2,
+        minWidth: 18,
+        height: 18,
+        padding: '0 5px',
+        borderRadius: 9,
+        background: '#D4AF37',
+        color: '#0b0c0f',
+        fontSize: 10,
         fontWeight: 700,
-        lineHeight: '16px',
+        lineHeight: '18px',
         textAlign: 'center',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+        boxShadow: '0 1px 4px rgba(0,0,0,0.35), 0 0 0 1.5px #0D0D12',
       }}
     >
-      {count > 99 ? '99+' : count}
+      {count > 9 ? '9+' : count}
     </span>
   );
 }

--- a/apps/unified-portal/app/agent/_components/DraftsHomeTile.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftsHomeTile.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, MailCheck } from 'lucide-react';
+import { useDraftsCount } from '../_hooks/useDraftsCount';
+
+/**
+ * Session 5B — Drafts entry point on the agent Home screen.
+ * Replaces the bottom-nav Drafts tab. Tap navigates to /agent/drafts.
+ */
+export default function DraftsHomeTile() {
+  const { count } = useDraftsCount();
+  const subtitle = count > 0
+    ? `${count} waiting for review`
+    : 'No drafts waiting. Nice.';
+
+  return (
+    <Link
+      href="/agent/drafts"
+      data-testid="home-drafts-tile"
+      style={{ textDecoration: 'none', display: 'block', marginBottom: 20 }}
+    >
+      <div
+        className="agent-tappable"
+        style={{
+          background: '#FFFFFF',
+          borderRadius: 18,
+          padding: '14px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+        }}
+      >
+        <div
+          style={{
+            width: 38,
+            height: 38,
+            borderRadius: 19,
+            background: 'rgba(196,155,42,0.10)',
+            border: '1px solid rgba(196,155,42,0.22)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <MailCheck size={18} color="#B8960C" strokeWidth={1.8} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14.5, fontWeight: 600, color: '#0D0D12', letterSpacing: '-0.01em', lineHeight: 1.25 }}>
+            Drafts
+          </div>
+          <div style={{ fontSize: 12, color: count > 0 ? '#8A6E1F' : '#A0A8B0', marginTop: 2 }}>
+            {subtitle}
+          </div>
+        </div>
+        {count > 0 && (
+          <span
+            data-testid="home-drafts-tile-count"
+            style={{
+              minWidth: 22,
+              height: 22,
+              padding: '0 7px',
+              borderRadius: 11,
+              background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+              color: '#FFFFFF',
+              fontSize: 11,
+              fontWeight: 700,
+              lineHeight: '22px',
+              textAlign: 'center',
+              flexShrink: 0,
+            }}
+          >
+            {count > 99 ? '99+' : count}
+          </span>
+        )}
+        <ChevronRight size={18} color="#B0B8C4" />
+      </div>
+    </Link>
+  );
+}

--- a/apps/unified-portal/app/agent/_components/IndependentHomeView.tsx
+++ b/apps/unified-portal/app/agent/_components/IndependentHomeView.tsx
@@ -10,6 +10,7 @@ import {
   getRecentEnquiries,
   getListings,
 } from '@/lib/agent/independentAgentService';
+import DraftsHomeTile from './DraftsHomeTile';
 
 interface IndependentHomeViewProps {
   agent: AgentProfile;
@@ -78,6 +79,9 @@ export default function IndependentHomeView({ agent }: IndependentHomeViewProps)
           <StatRow icon="clock" label="Follow-ups due" value={stats?.followUpsDue ?? 0} color="#EF4444" urgent={(stats?.followUpsDue ?? 0) > 0} />
         </Link>
       </div>
+
+      {/* Drafts tile — replaces the bottom-nav Drafts tab. */}
+      <DraftsHomeTile />
 
       {/* Price review alerts */}
       {priceReviews.length > 0 && (

--- a/apps/unified-portal/app/agent/home/page.tsx
+++ b/apps/unified-portal/app/agent/home/page.tsx
@@ -10,6 +10,7 @@ import { type Alert, type DevelopmentSummary, type PipelineUnit, getInitials } f
 import AgentShell from '../_components/AgentShell';
 import StatModal from '../_components/StatModal';
 import IndependentHomeView from '../_components/IndependentHomeView';
+import DraftsHomeTile from '../_components/DraftsHomeTile';
 import type { StatModalType, Scheme as UIScheme, Buyer as UIBuyer } from '../_components/types';
 
 // Convert real pipeline data to the Scheme/Buyer types that StatModal expects
@@ -187,6 +188,9 @@ export default function AgentHomePage() {
           <StatRow icon="users" label="Active pipeline" value={stats.active} color="#3B82F6" onClick={() => setModalType('active')} />
           <StatRow icon="clock" label="Need attention" value={stats.urgent} color="#EF4444" urgent onClick={() => setModalType('urgent')} />
         </div>
+
+        {/* Drafts tile — replaces the bottom-nav Drafts tab from Session 1. */}
+        <DraftsHomeTile />
 
         {/* Requires action section */}
         <SectionLabel>Requires action</SectionLabel>

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import AgentShell from '../_components/AgentShell';
 import VoiceInputBar from '../_components/VoiceInputBar';
@@ -12,7 +13,7 @@ import { useAgent } from '@/lib/agent/AgentContext';
 import { Mail, Copy, Check, ExternalLink } from 'lucide-react';
 import type { ExecutedAction, ExtractedAction } from '@/lib/agent-intelligence/voice-actions';
 import type { AutoSendUiState } from '../_components/VoiceConfirmationCard';
-import { notifyDraftsChanged } from '../_hooks/useDraftsCount';
+import { notifyDraftsChanged, useDraftsCount } from '../_hooks/useDraftsCount';
 import { ApprovalDrawerProvider, useApprovalDrawer } from '@/lib/agent-intelligence/drawer-store';
 import { isAgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import ApprovalDrawer from '@/components/agent/intelligence/ApprovalDrawer';
@@ -115,6 +116,7 @@ export default function IntelligencePage() {
 function IntelligencePageInner() {
   const { agent, alerts, developmentIds } = useAgent();
   const { openApprovalDrawer } = useApprovalDrawer();
+  const { count: pendingDraftsCount } = useDraftsCount();
   const searchParams = useSearchParams();
   const prefillPrompt = searchParams.get('prompt');
   const isIndependent = agent?.agentType !== 'scheme';
@@ -658,6 +660,46 @@ function IntelligencePageInner() {
               Chase contracts, draft reports, follow up buyers. You approve
               every action before it sends.
             </p>
+
+            {pendingDraftsCount > 0 && (
+              <div
+                data-testid="intelligence-drafts-greeting"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 10,
+                  padding: '12px 16px',
+                  background: 'rgba(196,155,42,0.08)',
+                  border: '0.5px solid rgba(196,155,42,0.30)',
+                  borderRadius: 14,
+                  marginBottom: 22,
+                  maxWidth: 320,
+                  width: '100%',
+                }}
+              >
+                <p style={{ margin: 0, color: '#8A6E1F', fontSize: 13, lineHeight: 1.45, textAlign: 'center' }}>
+                  You&rsquo;ve got {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} from earlier.
+                  Tap &lsquo;Review drafts&rsquo; below, or ask me anything.
+                </p>
+                <Link
+                  href="/agent/drafts"
+                  data-testid="intelligence-review-drafts-chip"
+                  style={{
+                    background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                    color: '#FFFFFF',
+                    fontSize: 12,
+                    fontWeight: 600,
+                    padding: '7px 14px',
+                    borderRadius: 999,
+                    textDecoration: 'none',
+                    boxShadow: '0 2px 6px rgba(196,155,42,0.30)',
+                  }}
+                >
+                  Review drafts
+                </Link>
+              </div>
+            )}
 
             {/* Prompt pills */}
             {/* Write-action chips — voice capture entry points. Kept above


### PR DESCRIPTION
Session 5B — restore the original four-tab + centred-FAB symmetry.

- BottomNav: removed the Drafts tab entirely. Layout returns to Home / Pipeline on the left, Viewings / Docs on the right, Intelligence FAB centred. The pending-draft count now sits as a small gold badge on the FAB itself so the signal stays visible from every screen.
- New DraftsHomeTile: warm card with MailCheck icon, live count, chevron, navigates to /agent/drafts on tap. Slots into the scheme home page above Requires action and into the independent home below the stat rows.
- Intelligence landing surfaces a calm one-liner plus a Review drafts chip when pending_drafts > 0; otherwise the standard greeting only.
- Desktop sidebar Drafts entry untouched (already prominent).