### PR TITLE
fix(homeowner-portal): read My Documents from document_sections with dual-path metadata

### DIFF
--- a/apps/unified-portal/app/api/purchaser/profile/route.ts
+++ b/apps/unified-portal/app/api/purchaser/profile/route.ts
@@ -166,37 +166,90 @@ export async function GET(request: NextRequest) {
       ? `Unit ${unitNumber}, ${developmentAddress}`
       : (supabaseUnit.address || developmentAddress || 'Address not available');
     
-    const documents: { id: string; title: string; file_url: string | null; mime_type: string; category: string }[] = [];
+    const documents: {
+      id: string;
+      title: string;
+      file_url: string | null;
+      file_name: string;
+      mime_type: string;
+      category: string;
+      drawing_type: string | null;
+      drawing_type_label: string | null;
+      description: string | null;
+    }[] = [];
 
     try {
-      // Fetch only this homeowner's architectural drawings matching their house type
-      const { data: drawingSections } = await supabase
-        .from('document_sections')
-        .select('id, metadata')
-        .eq('project_id', supabaseUnit.project_id)
-        .eq('metadata->>discipline', 'architectural')
-        .eq('metadata->>house_type_code', houseTypeCode);
+      // Source of truth for per-unit drawings is `document_sections`, keyed by
+      //   project_id + metadata->drawing_classification->>houseTypeCode.
+      // The `documents` table is empty for recently-ingested schemes (e.g.
+      // Rathárd Park has 0 rows in documents but 868 rows in document_sections,
+      // 5 of which are the BT03 drawings we want to surface).
+      if (supabaseUnit.project_id && houseTypeCode) {
+        // The house_type_code may be stored in either of two metadata shapes
+        // depending on when the document was ingested:
+        //   - metadata.drawing_classification.houseTypeCode  (canonical)
+        //   - metadata.house_type_code                        (legacy flat key)
+        // Query both in parallel so the tab works for every scheme.
+        const [nested, flat] = await Promise.all([
+          supabase
+            .from('document_sections')
+            .select('id, metadata')
+            .eq('project_id', supabaseUnit.project_id)
+            .filter('metadata->drawing_classification->>houseTypeCode', 'eq', houseTypeCode),
+          supabase
+            .from('document_sections')
+            .select('id, metadata')
+            .eq('project_id', supabaseUnit.project_id)
+            .filter('metadata->>house_type_code', 'eq', houseTypeCode),
+        ]);
 
-      const uniqueDocs = new Map<string, { id: string; title: string; file_url: string | null; mime_type: string; category: string }>();
+        const drawingSections = [
+          ...(nested.data || []),
+          ...(flat.data || []),
+        ];
 
-      for (const section of (drawingSections || [])) {
-        const meta = section.metadata as Record<string, unknown>;
-        if (!meta) continue;
-        const source = (meta.source as string | undefined) || 'Unknown';
-        const fileUrl = (meta.file_url as string | undefined) || null;
-        if (!uniqueDocs.has(source)) {
-          uniqueDocs.set(source, {
+        const uniqueDocs = new Map<string, (typeof documents)[number]>();
+
+        for (const section of drawingSections) {
+          const meta = (section.metadata || {}) as Record<string, unknown>;
+          // Prefer metadata.file_name per the drawing_classification schema;
+          // fall back to metadata.source used by older ingestion rows.
+          const fileName = (meta.file_name as string | undefined)
+            || (meta.source as string | undefined)
+            || null;
+          if (!fileName) continue;
+          if (uniqueDocs.has(fileName)) continue;
+
+          const fileUrl = (meta.file_url as string | undefined) || null;
+          const mimeType = (meta.mime_type as string | undefined) || 'application/pdf';
+          const drawingClassification = (meta.drawing_classification || {}) as Record<string, unknown>;
+          const drawingType = (drawingClassification.drawingType as string | undefined) || null;
+          const description = (drawingClassification.drawingDescription as string | undefined) || null;
+
+          uniqueDocs.set(fileName, {
             id: section.id,
-            title: source.replace('.pdf', '').replace(/-/g, ' ').replace(/_/g, ' '),
+            title: humaniseFileName(fileName, description),
             file_url: fileUrl,
-            mime_type: 'application/pdf',
-            category: getDocCategory(source),
+            file_name: fileName,
+            mime_type: mimeType,
+            category: getDocCategory(drawingType, fileName),
+            drawing_type: drawingType,
+            drawing_type_label: formatDrawingTypeLabel(drawingType),
+            description: description,
           });
         }
+
+        documents.push(...Array.from(uniqueDocs.values()));
+
+        console.log('[profile] documents resolved', JSON.stringify({
+          unit_id: supabaseUnit.id,
+          project_id: supabaseUnit.project_id,
+          house_type_code: houseTypeCode,
+          nested_matches: (nested.data || []).length,
+          flat_matches: (flat.data || []).length,
+          unique_files: documents.length,
+        }));
       }
-
-      documents.push(...Array.from(uniqueDocs.values()));
-
     } catch (_docErr) {
       // silent
     }
@@ -233,11 +286,55 @@ export async function GET(request: NextRequest) {
   }
 }
 
-function getDocCategory(fileName: string): string {
-  const lower = fileName.toLowerCase();
-  if (lower.includes('floor') || lower.includes('plan') || lower.includes('layout')) return 'Floor Plans';
+function getDocCategory(drawingType: string | null | undefined, fileName: string): string {
+  // Prefer the structured classification when present — filename heuristics are
+  // a weak fallback because ingestion filenames are coded (e.g. "281-MHL-BT03-
+  // ZZ-DR-A-0140-...").
+  const label = formatDrawingTypeLabel(drawingType);
+  if (label) return pluralise(label);
+  const lower = (fileName || '').toLowerCase();
   if (lower.includes('elevation')) return 'Elevations';
+  if (lower.includes('section')) return 'Sections';
+  if (lower.includes('floor') || lower.includes('plan') || lower.includes('layout')) return 'Floor Plans';
   if (lower.includes('spec')) return 'Specifications';
   if (lower.includes('user') || lower.includes('guide')) return 'User Guides';
   return 'Documents';
+}
+
+function formatDrawingTypeLabel(drawingType: string | null | undefined): string | null {
+  if (!drawingType) return null;
+  switch (drawingType) {
+    case 'floor_plan':   return 'Floor Plan';
+    case 'elevation':    return 'Elevation';
+    case 'section':      return 'Section';
+    case 'site_plan':    return 'Site Plan';
+    case 'house_pad':    return 'House Pad';
+    case 'room_sizes':   return 'Room Sizes';
+    default:
+      return drawingType
+        .split('_')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+  }
+}
+
+function pluralise(label: string): string {
+  if (/s$/i.test(label)) return label;
+  return `${label}s`;
+}
+
+function humaniseFileName(fileName: string, description: string | null | undefined): string {
+  if (description && description.trim()) {
+    return description.trim();
+  }
+  // Strip extension, then strip the coded prefix like "281-MHL-BT03-ZZ-DR-A-0140-"
+  // (up to six hyphen-delimited tokens before the human-readable tail).
+  let base = fileName.replace(/\.[a-z0-9]+$/i, '');
+  base = base.replace(/^(?:[A-Z0-9]{2,6}-){3,7}/, '');
+  base = base.replace(/---+/g, ' - ');
+  base = base.replace(/[-_]+/g, ' ');
+  base = base.replace(/\s+/g, ' ').trim();
+  // Trim trailing revision markers (Rev.C03, Rev C03, rev.B, etc.)
+  base = base.replace(/\s+Rev\.?\s*[A-Z]\d*$/i, '').trim();
+  return base || fileName;
 }

--- a/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
@@ -10,6 +10,7 @@ import {
   Maximize2,
   FileText,
   Download,
+  Eye,
   Bed,
   Bath,
   Leaf,
@@ -66,9 +67,13 @@ interface ProfileData {
   documents: {
     id: string;
     title: string;
-    file_url: string;
+    file_url: string | null;
+    file_name?: string;
     mime_type: string;
     category: string;
+    drawing_type?: string | null;
+    drawing_type_label?: string | null;
+    description?: string | null;
   }[];
 }
 
@@ -244,12 +249,6 @@ export default function PurchaserProfilePanel({
     }
     loadAuth();
   }, [isOpen]);
-
-  const handleDownload = async (doc: ProfileData['documents'][0]) => {
-    if (doc.file_url) {
-      window.open(doc.file_url, '_blank');
-    }
-  };
 
   const handleSignOut = async () => {
     try {
@@ -879,51 +878,11 @@ export default function PurchaserProfilePanel({
               />
             ) : (
               /* Documents Section */
-              <div className="p-6">
-                {profile.documents.length === 0 ? (
-                  <div className="text-center py-12">
-                    <div className={`p-4 rounded-full mx-auto w-16 h-16 flex items-center justify-center mb-4
-                      ${isDarkMode ? 'bg-gray-800' : 'bg-gray-100'}`}>
-                      <FileText className={`w-8 h-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`} />
-                    </div>
-                    <h3 className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                      No Documents Yet
-                    </h3>
-                    <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
-                      Floor plans and elevations for your specific unit will appear here.
-                    </p>
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    {profile.documents.map(doc => (
-                      <button
-                        key={doc.id}
-                        onClick={() => handleDownload(doc)}
-                        className={`w-full flex items-center gap-4 p-4 rounded-xl border transition-all
-                          ${isDarkMode 
-                            ? 'bg-gray-800/50 border-gray-700 hover:bg-gray-800 hover:border-gold-500/50' 
-                            : 'bg-gray-50 border-gray-200 hover:bg-white hover:border-gold-300 hover:shadow-md'
-                          }`}
-                      >
-                        <div className={`p-3 rounded-lg ${isDarkMode ? 'bg-gray-700' : 'bg-white'}`}>
-                          <FileText className={`w-5 h-5 ${isDarkMode ? 'text-gold-400' : 'text-gold-600'}`} />
-                        </div>
-                        <div className="flex-1 text-left">
-                          <p className={`font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
-                            {doc.title}
-                          </p>
-                          <p className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
-                            {doc.category}
-                          </p>
-                        </div>
-                        <div className={`p-2 rounded-lg ${isDarkMode ? 'bg-gold-500/10' : 'bg-gold-50'}`}>
-                          <Download className={`w-4 h-4 ${isDarkMode ? 'text-gold-400' : 'text-gold-600'}`} />
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <DocumentsSection
+                documents={profile.documents}
+                houseTypeCode={profile.unit.house_type_code}
+                isDarkMode={isDarkMode}
+              />
             )
           ) : (
             <div className="p-6 text-center">
@@ -1129,6 +1088,151 @@ function SavedAnswersSection({
             </p>
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Documents Section ─────────────────────────────────────────────────────
+// Mirrors the Preview / Download tile design used by assistant reply attachments
+// so the two surfaces feel like one set of drawings.
+
+type UnitDoc = ProfileData['documents'][number];
+
+function DocumentsSection({
+  documents,
+  houseTypeCode,
+  isDarkMode,
+}: {
+  documents: UnitDoc[];
+  houseTypeCode: string;
+  isDarkMode: boolean;
+}) {
+  if (!documents || documents.length === 0) {
+    return (
+      <div className="p-6">
+        <div className="text-center py-12">
+          <div className={`p-4 rounded-full mx-auto w-16 h-16 flex items-center justify-center mb-4
+            ${isDarkMode ? 'bg-gray-800' : 'bg-gray-100'}`}>
+            <FileText className={`w-8 h-8 ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`} />
+          </div>
+          <h3 className={`font-semibold mb-2 ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Documents coming soon
+          </h3>
+          <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            Documents for your home haven&apos;t been published yet.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Group by category so Floor Plans / Elevations / Sections each get their own
+  // section once there are enough files to justify it. For a small handful we
+  // collapse into a single "Documents" group.
+  const groups = new Map<string, UnitDoc[]>();
+  for (const doc of documents) {
+    const key = doc.category || 'Documents';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(doc);
+  }
+  const shouldGroup = documents.length > 3 && groups.size > 1;
+  const orderedCategories = Array.from(groups.keys()).sort((a, b) => a.localeCompare(b));
+
+  return (
+    <div className="p-6 space-y-5">
+      {shouldGroup
+        ? orderedCategories.map(category => (
+            <div key={category} className="space-y-2">
+              <h4 className={`text-xs font-semibold uppercase tracking-wider ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                {category}
+              </h4>
+              <div className="space-y-3">
+                {groups.get(category)!.map(doc => (
+                  <DocumentTile key={doc.id} doc={doc} houseTypeCode={houseTypeCode} isDarkMode={isDarkMode} />
+                ))}
+              </div>
+            </div>
+          ))
+        : (
+          <div className="space-y-3">
+            {documents.map(doc => (
+              <DocumentTile key={doc.id} doc={doc} houseTypeCode={houseTypeCode} isDarkMode={isDarkMode} />
+            ))}
+          </div>
+        )}
+    </div>
+  );
+}
+
+function DocumentTile({
+  doc,
+  houseTypeCode,
+  isDarkMode,
+}: {
+  doc: UnitDoc;
+  houseTypeCode: string;
+  isDarkMode: boolean;
+}) {
+  const typeLabel = doc.drawing_type_label || doc.category || 'Document';
+  const description = doc.description || doc.title;
+
+  return (
+    <div className={`rounded-xl border overflow-hidden ${
+      isDarkMode
+        ? 'border-[#2A2A2A] bg-[#1A1A1A]'
+        : 'border-gray-200 bg-gray-50'
+    }`}>
+      <div className={`px-3 py-2 border-b ${isDarkMode ? 'border-[#2A2A2A]' : 'border-gray-200'}`}>
+        <div className="flex items-center gap-2">
+          <FileText className={`h-4 w-4 ${isDarkMode ? 'text-gold-400' : 'text-gold-600'}`} />
+          <span className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            {typeLabel}
+          </span>
+          {houseTypeCode && (
+            <span className={`text-xs ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}>
+              ({houseTypeCode})
+            </span>
+          )}
+        </div>
+        {description && description !== typeLabel && (
+          <p className={`mt-1 text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="flex">
+        <a
+          href={doc.file_url || '#'}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-disabled={!doc.file_url}
+          onClick={e => { if (!doc.file_url) e.preventDefault(); }}
+          className={`flex-1 flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-medium transition border-r ${
+            isDarkMode
+              ? 'border-[#2A2A2A] text-[#D4AF37] hover:bg-[#252525]'
+              : 'border-gray-200 text-gold-700 hover:bg-gray-100'
+          } ${!doc.file_url ? 'opacity-50 pointer-events-none' : ''}`}
+        >
+          <Eye className="h-4 w-4" />
+          Preview
+        </a>
+        <a
+          href={doc.file_url || '#'}
+          target="_blank"
+          rel="noopener noreferrer"
+          download={doc.file_name || undefined}
+          aria-disabled={!doc.file_url}
+          onClick={e => { if (!doc.file_url) e.preventDefault(); }}
+          className={`flex-1 flex items-center justify-center gap-2 px-3 py-2.5 text-sm font-medium transition ${
+            isDarkMode
+              ? 'text-[#D4AF37] hover:bg-[#252525]'
+              : 'text-gold-700 hover:bg-gray-100'
+          } ${!doc.file_url ? 'opacity-50 pointer-events-none' : ''}`}
+        >
+          <Download className="h-4 w-4" />
+          Download
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- `/api/purchaser/profile` now queries `document_sections` twice in parallel scoped by `project_id` — once on `metadata->drawing_classification->>houseTypeCode` (canonical, used by Rathárd Park) and once on the legacy flat `metadata->>house_type_code` (Árdan View / Longview Park). Results are deduplicated by `metadata.file_name`.
- My Documents tab in `PurchaserProfilePanel` replaces the single-row button with the assistant-reply attachment tile: FileText icon + drawing type label + `(house_type_code)` header, optional description subtitle, split Preview / Download footer anchored to `metadata.file_url`. Tiles group by category once there are more than three.
- Empty-state copy rewritten from "No Documents Yet / Floor plans and elevations for your specific unit will appear here." to "Documents coming soon / Documents for your home haven't been published yet."

Preview deployment: `2nAXat4Md` on commit `e9c04ca`.

## Pre-merge verification

- Supabase storage bucket `development_docs` confirmed `public = true`. Five real BT03 files exist in `development_docs/6d3789de-.../` — Preview/Download URLs resolve without 403.
- Árdan View regression check: 4 house types have documents (BD06, BS06, BS07, BS08 — 43 units), 12 house types have none (43 units). No change from production behaviour. For BS08, the legacy flat key surfaces 5 files vs 4 via canonical; the defensive dual-query + file_name dedupe surfaces all 5. No regression.
- Every BT03 row has a non-empty `drawing_classification.drawingDescription`, so the filename strip/humanise regex never runs for Umesh's tiles.

## Test plan

- [ ] `portal.openhouseai.ie` as Umesh (40 Rathárd Park) → My Home → My Documents shows 5 BT03 tiles; clicking Preview opens the PDF.
- [ ] `portal.openhouseai.ie` as an Árdan View BS08 homeowner → 5 files still render.
- [ ] Vercel production logs show no 500s on `/api/purchaser/profile` in the first 10 minutes post-deploy.

## Rollback

Read-only fix. `git revert <squash-commit-sha>` and push to main. No DB state change.

https://claude.ai/code/session_01KRAfioMrBGJ2gpkC8ovGtR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRAfioMrBGJ2gpkC8ovGtR)_