### PR TITLE
fix(homeowner-portal): four Android TWA + data bugs for BS01 home

### DIFF
--- a/apps/unified-portal/app/api/purchaser/profile/route.ts
+++ b/apps/unified-portal/app/api/purchaser/profile/route.ts
@@ -84,12 +84,28 @@ export async function GET(request: NextRequest) {
 
     const supabase = getSupabaseClient();
 
-    // Source of truth: the units row. We intentionally do NOT read unit_types.specification_json
-    // — that is a type-level default, and for Rathárd Park it contains known-wrong values
-    // (4/3 bed/bath instead of 2/2, floor area in sqft under an sqm key).
+    // Source of truth: the units row. Historically we avoided reading
+    // `unit_types.specification_json` entirely because for Rathárd Park it contains
+    // known-wrong values (4/3 bed/bath instead of 2/2, floor area in sqft stored under
+    // an sqm key). But for Longview Park (Árdan View / BS01) the units row has NULL
+    // bathrooms AND NULL floor_area_m2 across every row, and the type-level
+    // specification_json is the only source of per-home dimensions. Bug 3 was caused
+    // by only reading the units row, which rendered "—" for both values.
+    //
+    // Fix: always read the units row first; if bathrooms or floor area are missing,
+    // fall back to `unit_types.specification_json` (via `units.unit_type_id`) with
+    // these safety rails:
+    //   - bathrooms: use the spec value as-is (it's a count)
+    //   - floor_area_sqm: treat values > 300 as sqft and divide by 10.7639. Any
+    //     realistic residential unit is ≤ 300 m²; Longview's spec value of 1188.33
+    //     under a "sqm" key is definitely the sqft (110.4 m²) mislabeled.
+    //   - bedrooms: only use the spec value when the units row bedrooms is NULL
+    //     (units.bedrooms is trusted when present)
+    // We do NOT use unit_types spec for property_type — that's what caused the
+    // Rathárd Park bug and is still unreliable.
     const { data: supabaseUnit, error } = await supabase
       .from('units')
-      .select('id, address, purchaser_name, project_id, development_id, house_type_code, bedrooms, bathrooms, floor_area_m2, property_type')
+      .select('id, address, purchaser_name, project_id, development_id, house_type_code, bedrooms, bathrooms, floor_area_m2, property_type, unit_type_id')
       .eq('id', unitUid)
       .single();
 
@@ -154,9 +170,62 @@ export async function GET(request: NextRequest) {
 
     const houseTypeCode = ((supabaseUnit as any).house_type_code as string | null) || '';
     const houseTypeName = ((supabaseUnit as any).property_type as string | null) || houseTypeCode;
-    const bedrooms = toNumberOrNull((supabaseUnit as any).bedrooms);
-    const bathrooms = toNumberOrNull((supabaseUnit as any).bathrooms);
-    const floorAreaM2 = toNumberOrNull((supabaseUnit as any).floor_area_m2);
+    let bedrooms = toNumberOrNull((supabaseUnit as any).bedrooms);
+    let bathrooms = toNumberOrNull((supabaseUnit as any).bathrooms);
+    let floorAreaM2 = toNumberOrNull((supabaseUnit as any).floor_area_m2);
+
+    // Fallback to unit_types.specification_json when the units row is missing
+    // bathrooms or floor area. See the note on the units SELECT above for why this
+    // is necessary (Longview Park units have NULL for both columns) and the safety
+    // rails we apply to spec_json values.
+    const unitTypeId = (supabaseUnit as any).unit_type_id as string | null | undefined;
+    const needBathrooms = bathrooms === null;
+    const needFloorArea = floorAreaM2 === null;
+    const needBedrooms = bedrooms === null;
+    if (unitTypeId && (needBathrooms || needFloorArea || needBedrooms)) {
+      try {
+        const { data: unitTypeRow } = await supabase
+          .from('unit_types')
+          .select('specification_json')
+          .eq('id', unitTypeId)
+          .single();
+        const spec = ((unitTypeRow as any)?.specification_json || {}) as Record<string, unknown>;
+
+        if (needBathrooms) {
+          const specBathrooms = toNumberOrNull(spec.bathrooms);
+          if (specBathrooms !== null) bathrooms = specBathrooms;
+        }
+
+        if (needBedrooms) {
+          const specBedrooms = toNumberOrNull(spec.bedrooms);
+          if (specBedrooms !== null) bedrooms = specBedrooms;
+        }
+
+        if (needFloorArea) {
+          // `specification_json.floor_area_sqm` is the documented key, but for
+          // Árdan View (BS01) the value is actually the sqft figure mislabeled as
+          // sqm (e.g. 1188.33 — which is 110.4 m², the real number). Any value
+          // >300 is treated as sqft and converted; anything ≤300 is used as-is.
+          const rawArea = toNumberOrNull(spec.floor_area_sqm);
+          if (rawArea !== null && rawArea > 0) {
+            const SQM_THRESHOLD = 300; // realistic residential ceiling
+            const SQFT_TO_SQM = 10.7639;
+            const resolved = rawArea > SQM_THRESHOLD ? (rawArea / SQFT_TO_SQM) : rawArea;
+            // Round to 1 decimal place — the UI will further round/display as it wishes.
+            floorAreaM2 = Math.round(resolved * 10) / 10;
+          }
+        }
+
+        console.log('[profile] unit-type fallback applied', JSON.stringify({
+          unit_id: supabaseUnit.id,
+          unit_type_id: unitTypeId,
+          needed: { bathrooms: needBathrooms, floorArea: needFloorArea, bedrooms: needBedrooms },
+          resolved: { bathrooms, floorAreaM2, bedrooms },
+        }));
+      } catch (_utErr) {
+        // Leave values null — UI will render "—"
+      }
+    }
     
     const purchaserName = supabaseUnit.purchaser_name || 'Homeowner';
     
@@ -223,8 +292,22 @@ export async function GET(request: NextRequest) {
           const fileUrl = (meta.file_url as string | undefined) || null;
           const mimeType = (meta.mime_type as string | undefined) || 'application/pdf';
           const drawingClassification = (meta.drawing_classification || {}) as Record<string, unknown>;
-          const drawingType = (drawingClassification.drawingType as string | undefined) || null;
-          const description = (drawingClassification.drawingDescription as string | undefined) || null;
+          // `drawingType` lives in two metadata shapes depending on when the document
+          // was ingested:
+          //   - metadata.drawing_classification.drawingType  (nested — newer shape)
+          //   - metadata.drawing_type                        (flat — older shape, used
+          //                                                   by the Árdan View BS01
+          //                                                   ingestion for Bug 4)
+          // Read the nested path first (it carries richer sibling data) and fall back
+          // to the flat key. Same pattern for drawingDescription / description.
+          const drawingType =
+            (drawingClassification.drawingType as string | undefined)
+            || (meta.drawing_type as string | undefined)
+            || null;
+          const description =
+            (drawingClassification.drawingDescription as string | undefined)
+            || (meta.description as string | undefined)
+            || null;
 
           uniqueDocs.set(fileName, {
             id: section.id,

--- a/apps/unified-portal/app/layout.tsx
+++ b/apps/unified-portal/app/layout.tsx
@@ -23,6 +23,16 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover',
+  // `interactiveWidget: 'resizes-content'` tells Android Chrome (and the TWA wrapper
+  // that ships this site as a Play Store app) to shrink the layout viewport when the
+  // soft keyboard appears instead of overlaying the page. Without it, the default
+  // `overlays-content` behavior is what caused the chat input bar to float mid-screen
+  // in the Android TWA when the user swiped — the bar's `bottom: calc(env(safe-area-inset-bottom)
+  // + tab-bar-height)` was resolved against a viewport that didn't shorten for the keyboard.
+  // iOS Safari / iOS Capacitor ignore this meta (they use VisualViewport + safe-area
+  // insets), so the existing isIOSNative code path in PurchaserChatTab is unaffected.
+  // Supported by Next Viewport type since 14.1; we're on ^14.2.18.
+  interactiveWidget: 'resizes-content',
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#ffffff' },
     { media: '(prefers-color-scheme: dark)', color: '#1A1A1A' },

--- a/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
@@ -986,40 +986,79 @@ export default function PurchaserChatTab({
   const [isIOSNative, setIsIOSNative] = useState(false);
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
   const [iosTabBarHeight, setIosTabBarHeight] = useState(96); // Dynamic height, fallback 96px
+  // Android TWA detection — the Play Store app is a Trusted Web Activity that wraps this
+  // site in Android Chrome. In TWA the launch happens in standalone display-mode and the
+  // UA contains "Android" + "wv" (WebView) OR the normal Chrome UA plus the standalone
+  // display mode. We use this flag to skip the iOS-style VisualViewport transform on
+  // Android — once layout.tsx sets `interactiveWidget: resizes-content`, Android Chrome
+  // shrinks the layout viewport when the keyboard opens, which means the input bar's
+  // `position: fixed; bottom: …` anchor is already correct; applying the iOS
+  // `translateY(-vv-offset)` on top of that was double-compensating and floating the
+  // bar mid-screen as VisualViewport's offsetTop jittered during scroll (Bug 1).
+  const [isAndroidTWA, setIsAndroidTWA] = useState(false);
 
   // Detect iOS Capacitor native platform - runs once on mount
   // Uses window.Capacitor which is injected by Capacitor runtime in native apps
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    
+
     // Check for Capacitor on window object (injected by native runtime)
     const cap = (window as any).Capacitor;
     if (cap && typeof cap.isNativePlatform === 'function' && typeof cap.getPlatform === 'function') {
       if (cap.isNativePlatform() && cap.getPlatform() === 'ios') {
         setIsIOSNative(true);
+        return;
       }
+    }
+
+    // Detect Android TWA (Trusted Web Activity from Play Store): the Digital Asset Links
+    // handshake launches our URL in a Chrome custom tab running in standalone display
+    // mode. We look for (a) Android UA AND (b) standalone display-mode (or "android-app"
+    // referrer, which the TWA shim injects). Regular Android Chrome tabs don't match
+    // because they're in "browser" display-mode.
+    const ua = navigator.userAgent || '';
+    const isAndroid = /Android/i.test(ua);
+    if (!isAndroid) return;
+    const isStandalone =
+      (typeof window.matchMedia === 'function' &&
+        window.matchMedia('(display-mode: standalone)').matches) ||
+      (typeof document !== 'undefined' &&
+        document.referrer.startsWith('android-app://'));
+    if (isStandalone) {
+      setIsAndroidTWA(true);
     }
   }, []);
 
-  // Track keyboard state for iOS native ONLY
+  // Track keyboard state for iOS native AND Android TWA.
+  // We use the same VisualViewport-height-delta heuristic in both cases: when the soft
+  // keyboard opens, VisualViewport.height is significantly smaller than window.innerHeight.
+  // (On Android with `interactiveWidget: resizes-content` the delta is small because the
+  // layout viewport itself shrinks too — we compare against the *outer* height instead.)
   useEffect(() => {
-    if (!isIOSNative || typeof window === 'undefined') return;
-    
+    if (!isIOSNative && !isAndroidTWA) return;
+    if (typeof window === 'undefined') return;
+
     const vv = window.visualViewport;
     if (!vv) return;
-    
+
     const checkKeyboard = () => {
-      // Keyboard is open if visual viewport is significantly smaller than window
       const keyboardThreshold = 150;
-      const keyboardOpen = (window.innerHeight - vv.height) > keyboardThreshold;
+      // On Android TWA with resizes-content, innerHeight also shrinks, so use the
+      // screen.height as a reference if available; fall back to the documentElement
+      // client height captured at mount. In practice `vv.height < window.innerHeight`
+      // still holds transiently during keyboard animation, which is enough signal.
+      const reference = isAndroidTWA
+        ? Math.max(window.innerHeight, (window.screen && window.screen.height) || 0)
+        : window.innerHeight;
+      const keyboardOpen = (reference - vv.height) > keyboardThreshold;
       setIsKeyboardOpen(keyboardOpen);
     };
-    
+
     vv.addEventListener('resize', checkKeyboard);
     checkKeyboard();
-    
+
     return () => vv.removeEventListener('resize', checkKeyboard);
-  }, [isIOSNative]);
+  }, [isIOSNative, isAndroidTWA]);
 
   // Measure actual tab bar height from DOM for iOS native
   useEffect(() => {
@@ -1095,18 +1134,27 @@ export default function PurchaserChatTab({
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const vv = window.visualViewport;
-    
+
     if (vv) {
       const onResize = () => {
-        const offset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+        // On Android TWA, `interactiveWidget: resizes-content` (set in app/layout.tsx)
+        // already shrinks the layout viewport to exclude the keyboard, so the
+        // `position: fixed; bottom: …` anchor on the input bar is correct on its own.
+        // Writing a nonzero `--vv-offset` here would translateY the bar upward a
+        // second time — which is exactly the "input bar floating mid-screen" symptom
+        // reported in the TWA when the user swipes (VisualViewport's `offsetTop`
+        // jitters during scroll on Android). Pin the offset to 0 on Android TWA.
+        const offset = isAndroidTWA
+          ? 0
+          : Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
         document.documentElement.style.setProperty('--vvh', `${vv.height}px`);
         document.documentElement.style.setProperty('--vv-offset', `${offset}px`);
       };
-      
+
       vv.addEventListener('resize', onResize);
       vv.addEventListener('scroll', onResize);
       onResize();
-      
+
       return () => {
         vv.removeEventListener('resize', onResize);
         vv.removeEventListener('scroll', onResize);
@@ -1120,7 +1168,7 @@ export default function PurchaserChatTab({
       fallback();
       return () => window.removeEventListener('resize', fallback);
     }
-  }, []);
+  }, [isAndroidTWA]);
 
   useEffect(() => {
     // Initialize Web Speech API
@@ -2033,10 +2081,21 @@ export default function PurchaserChatTab({
             ? 'bg-[#0F0F0F]/97 backdrop-blur-xl border-t border-[#2A2A2A]/50'
             : 'bg-white/95 backdrop-blur-xl border-t border-black/5'
         }`}
-        style={{ 
-          bottom: isIOSNative 
-            ? (isKeyboardOpen ? 0 : iosTabBarHeight) 
-            : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))',
+        style={{
+          bottom: isIOSNative
+            ? (isKeyboardOpen ? 0 : iosTabBarHeight)
+            : isAndroidTWA
+              // Android TWA: `interactiveWidget: resizes-content` has already shrunk
+              // the layout viewport to exclude the keyboard. When the keyboard is open
+              // we pin the input bar to the bottom of the (now-shrunk) viewport so it
+              // sits flush against the keyboard — matching iOS behavior. When the
+              // keyboard is closed, sit above the tab bar plus safe-area inset.
+              ? (isKeyboardOpen
+                  ? 'env(safe-area-inset-bottom, 0px)'
+                  : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))')
+              : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))',
+          // On Android TWA the VV-offset is pinned to 0 (see the VisualViewport effect
+          // above), so this transform is a no-op there — keeps web/iOS behavior intact.
           transform: 'translateY(calc(-1 * var(--vv-offset, 0px)))'
         }}
       >

--- a/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
@@ -438,86 +438,121 @@ export default function PurchaserProfilePanel({
             )}
           </div>
 
-          {/* Section Tabs */}
-          <div className="px-6 flex gap-2 overflow-x-auto scrollbar-hide" style={{ WebkitOverflowScrolling: 'touch' }}>
-            <button
-              onClick={() => setActiveSection('home')}
-              className={`flex-shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
-                ${activeSection === 'home'
-                  ? (isDarkMode 
-                      ? 'bg-gray-900 text-gold-400 shadow-lg' 
-                      : 'bg-white text-gold-600 shadow-lg')
-                  : (isDarkMode 
-                      ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300' 
-                      : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
-                }`}
+          {/*
+            Section Tabs
+
+            Bug 2: On small Android widths (≤~400px) the four tabs with full labels
+            ("Property Details", "My Documents", "Saved", "Account") + icons + the
+            `px-6` outer padding + `px-4` inner padding + count badges overflow the
+            container, and the `overflow-x-auto scrollbar-hide` masks any hint that
+            the row is scrollable — users perceive the tabs as "missing".
+
+            Fix: shorter mobile-first labels ("Property"/"Documents"/"Saved"/"Account"),
+            tighter inner padding on mobile (px-3 instead of px-4), `pr-4` end padding
+            inside the scroller so the last tab isn't flush with the fade, and a
+            right-edge gradient that reveals there is more content to scroll. The full
+            labels still appear on sm: and up (where there is room).
+          */}
+          <div className="relative">
+            <div
+              className="px-6 pr-4 flex gap-2 overflow-x-auto scrollbar-hide"
+              style={{ WebkitOverflowScrolling: 'touch' }}
             >
-              <Home className="w-4 h-4" />
-              <span>Property Details</span>
-            </button>
-            <button
-              onClick={() => setActiveSection('documents')}
-              className={`flex-shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
-                ${activeSection === 'documents'
-                  ? (isDarkMode 
-                      ? 'bg-gray-900 text-gold-400 shadow-lg' 
-                      : 'bg-white text-gold-600 shadow-lg')
-                  : (isDarkMode 
-                      ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300' 
-                      : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
-                }`}
-            >
-              <FileText className="w-4 h-4" />
-              <span>My Documents</span>
-              {profile && profile.documents.length > 0 && (
-                <span className={`ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold
+              <button
+                onClick={() => setActiveSection('home')}
+                className={`flex-shrink-0 flex items-center gap-2 px-3 sm:px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
+                  ${activeSection === 'home'
+                    ? (isDarkMode
+                        ? 'bg-gray-900 text-gold-400 shadow-lg'
+                        : 'bg-white text-gold-600 shadow-lg')
+                    : (isDarkMode
+                        ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300'
+                        : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
+                  }`}
+              >
+                <Home className="w-4 h-4" />
+                {/* Shorter label on mobile so all 4 tabs fit on narrow Android widths */}
+                <span className="sm:hidden">Property</span>
+                <span className="hidden sm:inline">Property Details</span>
+              </button>
+              <button
+                onClick={() => setActiveSection('documents')}
+                className={`flex-shrink-0 flex items-center gap-2 px-3 sm:px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
                   ${activeSection === 'documents'
-                    ? (isDarkMode ? 'bg-gold-500/20 text-gold-400' : 'bg-gold-100 text-gold-700')
-                    : (isDarkMode ? 'bg-gray-700 text-gray-400' : 'bg-gray-200 text-gray-600')
-                  }`}>
-                  {profile.documents.length}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => setActiveSection('saved')}
-              className={`flex-shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
-                ${activeSection === 'saved'
-                  ? (isDarkMode 
-                      ? 'bg-gray-900 text-gold-400 shadow-lg' 
-                      : 'bg-white text-gold-600 shadow-lg')
-                  : (isDarkMode 
-                      ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300' 
-                      : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
-                }`}
-            >
-              <Bookmark className="w-4 h-4" />
-              <span>Saved</span>
-              {savedNotes.length > 0 && (
-                <span className={`ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold
+                    ? (isDarkMode
+                        ? 'bg-gray-900 text-gold-400 shadow-lg'
+                        : 'bg-white text-gold-600 shadow-lg')
+                    : (isDarkMode
+                        ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300'
+                        : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
+                  }`}
+              >
+                <FileText className="w-4 h-4" />
+                <span className="sm:hidden">Documents</span>
+                <span className="hidden sm:inline">My Documents</span>
+                {profile && profile.documents.length > 0 && (
+                  <span className={`ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold
+                    ${activeSection === 'documents'
+                      ? (isDarkMode ? 'bg-gold-500/20 text-gold-400' : 'bg-gold-100 text-gold-700')
+                      : (isDarkMode ? 'bg-gray-700 text-gray-400' : 'bg-gray-200 text-gray-600')
+                    }`}>
+                    {profile.documents.length}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setActiveSection('saved')}
+                className={`flex-shrink-0 flex items-center gap-2 px-3 sm:px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
                   ${activeSection === 'saved'
-                    ? (isDarkMode ? 'bg-gold-500/20 text-gold-400' : 'bg-gold-100 text-gold-700')
-                    : (isDarkMode ? 'bg-gray-700 text-gray-400' : 'bg-gray-200 text-gray-600')
-                  }`}>
-                  {savedNotes.length}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => setActiveSection('account')}
-              className={`flex-shrink-0 flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
-                ${activeSection === 'account'
-                  ? (isDarkMode
-                      ? 'bg-gray-900 text-gold-400 shadow-lg'
-                      : 'bg-white text-gold-600 shadow-lg')
-                  : (isDarkMode
-                      ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300'
-                      : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
-                }`}
-            >
-              <ArrowRightLeft className="w-4 h-4" />
-              <span>Account</span>
-            </button>
+                    ? (isDarkMode
+                        ? 'bg-gray-900 text-gold-400 shadow-lg'
+                        : 'bg-white text-gold-600 shadow-lg')
+                    : (isDarkMode
+                        ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300'
+                        : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
+                  }`}
+              >
+                <Bookmark className="w-4 h-4" />
+                <span>Saved</span>
+                {savedNotes.length > 0 && (
+                  <span className={`ml-1 px-1.5 py-0.5 rounded-full text-xs font-bold
+                    ${activeSection === 'saved'
+                      ? (isDarkMode ? 'bg-gold-500/20 text-gold-400' : 'bg-gold-100 text-gold-700')
+                      : (isDarkMode ? 'bg-gray-700 text-gray-400' : 'bg-gray-200 text-gray-600')
+                    }`}>
+                    {savedNotes.length}
+                  </span>
+                )}
+              </button>
+              <button
+                onClick={() => setActiveSection('account')}
+                className={`flex-shrink-0 flex items-center gap-2 px-3 sm:px-4 py-2.5 rounded-t-xl text-sm font-medium transition-all
+                  ${activeSection === 'account'
+                    ? (isDarkMode
+                        ? 'bg-gray-900 text-gold-400 shadow-lg'
+                        : 'bg-white text-gold-600 shadow-lg')
+                    : (isDarkMode
+                        ? 'bg-gray-800/50 text-gray-400 hover:text-gray-300'
+                        : 'bg-gray-100/50 text-gray-500 hover:text-gray-700')
+                  }`}
+              >
+                <ArrowRightLeft className="w-4 h-4" />
+                <span>Account</span>
+              </button>
+            </div>
+            {/*
+              Right-edge fade hint — purely decorative, so `pointer-events-none` keeps it
+              from intercepting taps on the underlying scroller. Width matches the outer
+              pr-4 spacing so the last tab is still fully legible behind the fade.
+            */}
+            <div
+              aria-hidden="true"
+              className={`pointer-events-none absolute top-0 right-0 h-full w-6 sm:hidden ${
+                isDarkMode
+                  ? 'bg-gradient-to-l from-gray-900 to-transparent'
+                  : 'bg-gradient-to-l from-white to-transparent'
+              }`}
+            />
           </div>
         </div>
 


### PR DESCRIPTION
Fixes 4 bugs reported in the Android TWA wrapping portal.openhouseai.ie, test case: BS01 showhouse at 8 Longview Park (Ballinahinch / Árdan View).

## Bugs fixed

**1. Chat input bar detaches from Android soft keyboard**
- Added `interactiveWidget: 'resizes-content'` to viewport export so Android Chrome shrinks layout viewport when the keyboard opens.
- Added `isAndroidTWA` detection (UA + standalone display-mode + `android-app://` referrer).
- Pinned `--vv-offset` to 0 on Android TWA and dropped the tab-bar offset when the keyboard is open.
- iOS Capacitor path is untouched — `interactiveWidget` is a no-op on iOS.

**2. Profile tabs not visible on narrow Android width**
- Wrapped tab row in `relative` container with right-edge fade gradient.
- Shortened tab labels on mobile ("Property" vs "Property Details").
- Added `pr-4` end padding + reduced horizontal tab padding on small widths.

**3. House Type card shows empty dashes for BATHROOMS and M²**
- Added `unit_types.specification_json` type-level fallback in the profile API route.
- Safety rails: bathrooms as-is; bedrooms only if null at unit level; floor_area_sqm > 300 treated as sqft and divided by 10.7639.

**4. BS01 drawings render as generic "Documents" stubs**
- Dual-path metadata read in profile API: `metadata.drawing_classification.drawingType` with fallback to top-level `metadata.drawing_type`.

## Test plan
- [ ] Android TWA: chat input stays pinned to keyboard on swipe (Bug 1)
- [ ] Android narrow width: all 4 profile tabs visible with scroll hint (Bug 2)
- [ ] BS01 house type card shows real bathrooms + m² values (Bug 3)
- [ ] BS01 drawings show real labels, not generic "Documents" (Bug 4)
- [ ] iPhone / iOS Capacitor chat input behavior unchanged (regression check)