### PR TITLE
fix(homeowner-portal): correct Android TWA keyboard & profile tab regressions from PR #29

### DIFF
--- a/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
@@ -986,16 +986,6 @@ export default function PurchaserChatTab({
   const [isIOSNative, setIsIOSNative] = useState(false);
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
   const [iosTabBarHeight, setIosTabBarHeight] = useState(96); // Dynamic height, fallback 96px
-  // Android TWA detection — the Play Store app is a Trusted Web Activity that wraps this
-  // site in Android Chrome. In TWA the launch happens in standalone display-mode and the
-  // UA contains "Android" + "wv" (WebView) OR the normal Chrome UA plus the standalone
-  // display mode. We use this flag to skip the iOS-style VisualViewport transform on
-  // Android — once layout.tsx sets `interactiveWidget: resizes-content`, Android Chrome
-  // shrinks the layout viewport when the keyboard opens, which means the input bar's
-  // `position: fixed; bottom: …` anchor is already correct; applying the iOS
-  // `translateY(-vv-offset)` on top of that was double-compensating and floating the
-  // bar mid-screen as VisualViewport's offsetTop jittered during scroll (Bug 1).
-  const [isAndroidTWA, setIsAndroidTWA] = useState(false);
 
   // Detect iOS Capacitor native platform - runs once on mount
   // Uses window.Capacitor which is injected by Capacitor runtime in native apps
@@ -1007,35 +997,23 @@ export default function PurchaserChatTab({
     if (cap && typeof cap.isNativePlatform === 'function' && typeof cap.getPlatform === 'function') {
       if (cap.isNativePlatform() && cap.getPlatform() === 'ios') {
         setIsIOSNative(true);
-        return;
       }
     }
-
-    // Detect Android TWA (Trusted Web Activity from Play Store): the Digital Asset Links
-    // handshake launches our URL in a Chrome custom tab running in standalone display
-    // mode. We look for (a) Android UA AND (b) standalone display-mode (or "android-app"
-    // referrer, which the TWA shim injects). Regular Android Chrome tabs don't match
-    // because they're in "browser" display-mode.
-    const ua = navigator.userAgent || '';
-    const isAndroid = /Android/i.test(ua);
-    if (!isAndroid) return;
-    const isStandalone =
-      (typeof window.matchMedia === 'function' &&
-        window.matchMedia('(display-mode: standalone)').matches) ||
-      (typeof document !== 'undefined' &&
-        document.referrer.startsWith('android-app://'));
-    if (isStandalone) {
-      setIsAndroidTWA(true);
-    }
+    // NOTE: Android TWA keyboard handling is delegated entirely to the browser via
+    // `interactiveWidget: 'resizes-content'` in app/layout.tsx. That meta shrinks the
+    // layout viewport when the soft keyboard opens, so the input bar's
+    // `position: fixed; bottom: …` anchor works on its own — no JS repositioning needed.
+    // An earlier attempt (PR #29) to also track keyboard state from JS on Android TWA
+    // caused the input bar to re-render on focus, which stole focus from the input and
+    // dismissed the keyboard (observed as "keyboard appears for a split second and
+    // disappears" when tapping the input bar).
   }, []);
 
-  // Track keyboard state for iOS native AND Android TWA.
-  // We use the same VisualViewport-height-delta heuristic in both cases: when the soft
-  // keyboard opens, VisualViewport.height is significantly smaller than window.innerHeight.
-  // (On Android with `interactiveWidget: resizes-content` the delta is small because the
-  // layout viewport itself shrinks too — we compare against the *outer* height instead.)
+  // Track keyboard state for iOS native only.
+  // VisualViewport-height-delta heuristic: when the soft keyboard opens,
+  // VisualViewport.height is significantly smaller than window.innerHeight.
   useEffect(() => {
-    if (!isIOSNative && !isAndroidTWA) return;
+    if (!isIOSNative) return;
     if (typeof window === 'undefined') return;
 
     const vv = window.visualViewport;
@@ -1043,14 +1021,7 @@ export default function PurchaserChatTab({
 
     const checkKeyboard = () => {
       const keyboardThreshold = 150;
-      // On Android TWA with resizes-content, innerHeight also shrinks, so use the
-      // screen.height as a reference if available; fall back to the documentElement
-      // client height captured at mount. In practice `vv.height < window.innerHeight`
-      // still holds transiently during keyboard animation, which is enough signal.
-      const reference = isAndroidTWA
-        ? Math.max(window.innerHeight, (window.screen && window.screen.height) || 0)
-        : window.innerHeight;
-      const keyboardOpen = (reference - vv.height) > keyboardThreshold;
+      const keyboardOpen = (window.innerHeight - vv.height) > keyboardThreshold;
       setIsKeyboardOpen(keyboardOpen);
     };
 
@@ -1058,7 +1029,7 @@ export default function PurchaserChatTab({
     checkKeyboard();
 
     return () => vv.removeEventListener('resize', checkKeyboard);
-  }, [isIOSNative, isAndroidTWA]);
+  }, [isIOSNative]);
 
   // Measure actual tab bar height from DOM for iOS native
   useEffect(() => {
@@ -1137,16 +1108,7 @@ export default function PurchaserChatTab({
 
     if (vv) {
       const onResize = () => {
-        // On Android TWA, `interactiveWidget: resizes-content` (set in app/layout.tsx)
-        // already shrinks the layout viewport to exclude the keyboard, so the
-        // `position: fixed; bottom: …` anchor on the input bar is correct on its own.
-        // Writing a nonzero `--vv-offset` here would translateY the bar upward a
-        // second time — which is exactly the "input bar floating mid-screen" symptom
-        // reported in the TWA when the user swipes (VisualViewport's `offsetTop`
-        // jitters during scroll on Android). Pin the offset to 0 on Android TWA.
-        const offset = isAndroidTWA
-          ? 0
-          : Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+        const offset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
         document.documentElement.style.setProperty('--vvh', `${vv.height}px`);
         document.documentElement.style.setProperty('--vv-offset', `${offset}px`);
       };
@@ -1168,7 +1130,7 @@ export default function PurchaserChatTab({
       fallback();
       return () => window.removeEventListener('resize', fallback);
     }
-  }, [isAndroidTWA]);
+  }, []);
 
   useEffect(() => {
     // Initialize Web Speech API
@@ -2084,18 +2046,11 @@ export default function PurchaserChatTab({
         style={{
           bottom: isIOSNative
             ? (isKeyboardOpen ? 0 : iosTabBarHeight)
-            : isAndroidTWA
-              // Android TWA: `interactiveWidget: resizes-content` has already shrunk
-              // the layout viewport to exclude the keyboard. When the keyboard is open
-              // we pin the input bar to the bottom of the (now-shrunk) viewport so it
-              // sits flush against the keyboard — matching iOS behavior. When the
-              // keyboard is closed, sit above the tab bar plus safe-area inset.
-              ? (isKeyboardOpen
-                  ? 'env(safe-area-inset-bottom, 0px)'
-                  : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))')
-              : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))',
-          // On Android TWA the VV-offset is pinned to 0 (see the VisualViewport effect
-          // above), so this transform is a no-op there — keeps web/iOS behavior intact.
+            : 'calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tab-bar-h, 80px))',
+          // Web/Android uses `interactiveWidget: 'resizes-content'` in layout.tsx which
+          // handles keyboard-driven viewport shrinking at the browser level. The
+          // --vv-offset is 0 on Android under that setting, so this transform is a no-op
+          // on Android TWA and keeps the iOS-native VisualViewport behavior intact.
           transform: 'translateY(calc(-1 * var(--vv-offset, 0px)))'
         }}
       >

--- a/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserProfilePanel.tsx
@@ -349,7 +349,11 @@ export default function PurchaserProfilePanel({
           animate-in slide-in-from-bottom md:slide-in-from-bottom-0 md:zoom-in-95`}
       >
         {/* Premium Header with Gold Accent */}
-        <div className={`relative bg-gradient-to-br ${headerGradient} overflow-hidden`}>
+        {/* flex-shrink-0 guarantees the header keeps its natural height — without it,
+            the flex-col panel can let the header + tabs + content negotiate space and
+            on narrow Android widths the tabs row loses the negotiation and gets
+            clipped by the panel's max-h-[92vh] + overflow-hidden (Bug 2 round 1). */}
+        <div className={`relative flex-shrink-0 bg-gradient-to-br ${headerGradient} overflow-hidden`}>
           {/* Decorative gold accent line */}
           <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-gold-400 via-gold-500 to-gold-400" />
 
@@ -453,7 +457,12 @@ export default function PurchaserProfilePanel({
             right-edge gradient that reveals there is more content to scroll. The full
             labels still appear on sm: and up (where there is room).
           */}
-          <div className="relative">
+          {/* flex-shrink-0 on the tabs row is essential: when the panel height is
+              constrained (max-h-[92vh] on mobile) and the content cards below want
+              more room than is available, the tabs row is what gets squeezed and
+              clipped by the panel's overflow-hidden. Pinning it keeps the tabs
+              always visible between the header and the scrollable content. */}
+          <div className={`relative flex-shrink-0 ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}>
             <div
               className="px-6 pr-4 flex gap-2 overflow-x-auto scrollbar-hide"
               style={{ WebkitOverflowScrolling: 'touch' }}


### PR DESCRIPTION
Two bugs I shipped in PR #29 regressed things on real Android TWA. This PR reverts the problematic changes while keeping the parts that actually work.

## What went wrong in PR #29

**1. Chat input glitched on tap** — keyboard appeared for a split second then dismissed.

Root cause: the `isAndroidTWA` JS detection added a keyboard-open boolean that flipped the input bar's `bottom:` CSS between `calc(...)` and `env(safe-area-inset-bottom)` on focus. That re-render stole focus from the input, dismissing the keyboard.

Fix: delete the `isAndroidTWA` state and all JS-driven keyboard tracking for Android. Keyboard handling is already fully covered by `interactiveWidget: 'resizes-content'` in `app/layout.tsx` (shipped in PR #29) — the browser shrinks the layout viewport when the keyboard opens, so `position: fixed; bottom: calc(...)` works on its own.

**2. Profile tabs still hidden** — user could just barely touch the top edge to switch tabs.

Root cause: the tabs row had no `flex-shrink-0`, so when the panel's `max-h-[92vh]` couldn't fit header + tabs + content, the tabs row was the one that got squeezed and clipped by the panel's `overflow-hidden`. My PR #29 fade-gradient + shorter-label fix assumed the tabs were horizontally overflowing, but the real problem was vertical.

Fix: `flex-shrink-0` on both the header and the tabs row, plus a solid background on the tabs row so it sits as a distinct band between header and scrollable content.

## Kept from PR #29
- `interactiveWidget: 'resizes-content'` in `layout.tsx` (the actual fix for Bug 1)
- Shorter mobile tab labels + right-edge fade gradient (decorative; harmless)
- Profile API route changes for Bugs 3 & 4 — confirmed working by user

## Test plan
- [ ] Android TWA: tap chat input, keyboard opens and stays open (Bug 1)
- [ ] Android TWA narrow width: all 4 profile tabs are fully visible and tappable (Bug 2)
- [ ] iOS Capacitor: chat input behavior unchanged (regression check — iOS path is untouched)