### PR TITLE
fix(agent-app): iOS Capacitor mic, draft panel, swipe and pull-to-ref…

### DIFF
--- a/BUILD_AND_SUBMIT.md
+++ b/BUILD_AND_SUBMIT.md
@@ -1,0 +1,149 @@
+# BUILD_AND_SUBMIT — OpenHouse Agent iOS (Capacitor)
+
+This is the exact command sequence to turn the Session 6B fixes into a
+TestFlight / App Store build. The web-side fixes are merged in this repo; the
+Capacitor wrapper (Xcode project, `Info.plist`, `Podfile`) lives in the
+separate iOS repo and these steps have to be run there on a Mac with Xcode
+installed.
+
+## Prerequisites
+
+- Xcode 15+ and Command Line Tools installed
+- A valid Apple Developer account signed into Xcode
+- The Agent app's distribution signing cert + provisioning profile already
+  imported
+- `cocoapods` installed (`sudo gem install cocoapods`)
+- `@openhouse/unified-portal` built and ready (`npm run build` in this repo
+  produces the static bundle consumed by the Capacitor wrapper — verify
+  before starting)
+
+## Step 1 — Install the microphone plugin
+
+In the **iOS wrapper repo** (the one with `ios/App/Podfile` — NOT this repo):
+
+```bash
+npm install @capacitor/microphone @capacitor/app
+```
+
+Both plugins are used by the new `lib/capacitor-native.ts` helper:
+`@capacitor/microphone` for the permission prompt, `@capacitor/app` for the
+`openSettings()` deep-link. They are declared optional on the web side
+(dynamic imports), so they only need to exist in the wrapper.
+
+## Step 2 — Update Info.plist
+
+Open `ios/App/App/Info.plist` in the wrapper repo and add the permission
+strings. These must be present BEFORE the app ships — iOS will reject
+`getUserMedia` silently if the usage description is missing.
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>OpenHouse needs microphone access to capture your voice notes for drafting emails and updating your pipeline.</string>
+<key>NSSpeechRecognitionUsageDescription</key>
+<string>OpenHouse uses on-device speech recognition to give you live captions while you dictate.</string>
+```
+
+If the app ever asks for the camera later, add `NSCameraUsageDescription`
+too — not required for this session.
+
+## Step 3 — Bump version and build number
+
+Open `ios/App/App.xcodeproj` → App target → General → Identity.
+
+- **Version** — bump the marketing version (e.g. `1.2.3` → `1.2.4`)
+- **Build** — increment the build number (each TestFlight upload requires a
+  unique build number for the given version)
+
+Alternatively, edit `Info.plist` directly:
+
+```xml
+<key>CFBundleShortVersionString</key>
+<string>1.2.4</string>
+<key>CFBundleVersion</key>
+<string>42</string>
+```
+
+## Step 4 — Sync web bundle into the Capacitor iOS project
+
+From the wrapper repo root:
+
+```bash
+# Pull the latest web build (this repo, main branch, after 6B merges)
+npm run build:web     # wrapper-specific; see wrapper repo README
+
+# Copy the web assets + plugins into ios/
+npx cap sync ios
+
+# Install / refresh CocoaPods
+cd ios/App
+pod install
+cd ../..
+```
+
+`cap sync ios` does three things: copies the web bundle into
+`ios/App/public/`, updates the native bridge for any new plugins
+(`@capacitor/microphone`, `@capacitor/app`), and regenerates the Podfile
+entries. Without this step the new permission flow won't be wired up.
+
+## Step 5 — Open Xcode, clean, build, archive
+
+```bash
+npx cap open ios
+```
+
+In Xcode:
+
+1. **Product → Clean Build Folder** (Shift+Cmd+K) — avoids stale plugin
+   caches.
+2. Select **Any iOS Device (arm64)** as the build target (not a simulator).
+3. **Product → Archive**. Wait for the build to complete and the Organizer
+   window to open.
+
+## Step 6 — Distribute to TestFlight
+
+In the Organizer:
+
+1. Select the newly created archive.
+2. **Distribute App** → **App Store Connect** → **Upload**.
+3. Leave all options at their defaults unless the distribution team says
+   otherwise (Strip Swift Symbols: on; Upload Symbols: on).
+4. Re-authenticate with the Apple ID if prompted.
+5. Wait for the upload to complete.
+
+TestFlight will email the build to registered testers once Apple finishes
+processing (usually 5–15 minutes).
+
+## Step 7 — Smoke test on a real device
+
+The fixes in this session only verify on-device. After the build lands on
+TestFlight:
+
+- [ ] Tap the mic in Intelligence → iOS presents the permission prompt on
+      first use. Grant → waveform animates, transcript returns.
+- [ ] Deny the permission. Banner shows "Microphone access is needed…" with
+      an "Open Settings" pill. Tapping the pill jumps to OpenHouse's
+      Settings entry.
+- [ ] Open any draft on mobile. Only ONE header is visible (the panel's
+      "SOLICITOR CHASE / recipient" header). No OPENHOUSE wordmark peeking
+      through.
+- [ ] Swipe a draft row left OR right, release mid-swipe. Row snaps back
+      to 0. Tapping anywhere else on the list also snaps it back.
+- [ ] Pull the drafts list down past the threshold. "Release to refresh"
+      shows while held. On release the banner transitions straight to
+      "Refreshing…" and dismisses cleanly when the fetch resolves.
+- [ ] Pull the list but don't release past the threshold — banner returns
+      to idle state, no hang.
+
+## Notes
+
+- The web fixes are already safe on desktop / mobile Safari. The Capacitor
+  plugin dynamic imports fall through to `status: 'unavailable'` on web, so
+  `getUserMedia` uses the standard browser prompt.
+- If the mic still fails AFTER this build ships, check:
+  1. `Info.plist` actually contains `NSMicrophoneUsageDescription` (verify
+     on-device via `ipa-info` or by reading the installed bundle).
+  2. `Capacitor.isNativePlatform()` returns true — the splash must hand off
+     to the WKWebView, not Safari.
+  3. The Settings → OpenHouse → Microphone toggle is ON.
+- Don't reuse an old archive. A fresh `cap sync` + archive is required for
+  the plugin wiring to land.

--- a/IOS_STABILITY_DIAGNOSIS.md
+++ b/IOS_STABILITY_DIAGNOSIS.md
@@ -1,0 +1,124 @@
+# iOS Stability Diagnosis (Session 6B)
+
+## TL;DR
+
+The Agent app is a Next.js web build (`apps/unified-portal`) loaded by a
+Capacitor iOS wrapper that lives **outside this repo** (no `apps/agent-app`,
+no `ios/App/Podfile` here). The four reported regressions are all webview-layer
+problems driven by the same shared web bundle, which is why some of them only
+manifest in the native build. Fixes here are code-level; the binary rebuild +
+App Store resubmission is documented in `BUILD_AND_SUBMIT.md`.
+
+## Eight-bullet diagnosis
+
+1. **Capacitor footprint.** `@capacitor/core`, `@capacitor/cli`, `@capacitor/ios`
+   are declared only in `apps/openhouse-select/package.json` — a sibling app,
+   not the Agent app. `apps/unified-portal/package.json` has no `@capacitor/*`
+   dependency; `usePushNotifications.ts` lines 50–53 already uses the
+   "dynamically import with a runtime-concatenated specifier to dodge webpack"
+   trick to stay optional-at-build-time. The iOS Xcode project that wraps the
+   bundle for the Agent app is in a separate repo, so `Info.plist` and
+   `Podfile` changes are documented for the human operator.
+
+2. **`@capacitor/microphone` is NOT installed.** It's also not loaded
+   dynamically anywhere. The code path is pure Web Media API
+   (`navigator.mediaDevices.getUserMedia`), with no Capacitor permission
+   request ahead of it. `NSMicrophoneUsageDescription` has to be added to the
+   native project's `Info.plist` and the plugin added via `npm i
+   @capacitor/microphone` + `npx cap sync ios` on the wrapper repo.
+
+3. **Mic call site.** `apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts:107`
+   calls `navigator.mediaDevices.getUserMedia({ audio: true })` with zero
+   guards. No `Capacitor.isNativePlatform()` check, no
+   `Microphone.requestPermissions()`, no fallback when `navigator.mediaDevices`
+   itself is undefined (which is what iOS WKWebView does on cold starts
+   without the mic permission). Wired into
+   `app/agent/_components/VoiceInputBar.tsx:67–94` (the mic button) and
+   consumed by `app/agent/intelligence/page.tsx:346`.
+
+4. **DraftReviewPanel header overlap.** `DraftReviewPanel` is rendered as a
+   normal child of the `AgentShell`'s `{children}` in
+   `app/agent/drafts/page.tsx:435–449`, positioned `fixed; inset: 0; zIndex:
+   60`. The parent `<main>` has `overflow-y: auto` +
+   `-webkit-overflow-scrolling: touch` (`_components/AgentShell.tsx:37–46`),
+   which on iOS WKWebView turns that `<main>` into the containing block for
+   its fixed descendants — the panel's `inset: 0` becomes the top of the
+   scroll area instead of the viewport, so the shell's StatusBar header stays
+   visible above it. Desktop doesn't hit this because no
+   `-webkit-overflow-scrolling`. AgentShell already supports a `modal` slot
+   that renders outside the overflow container (line 52) — the panel needs to
+   use it or portal itself into `document.body`.
+
+5. **Drafts list swipe.** Custom touch handlers in
+   `_components/DraftsListRow.tsx:45–68`, no library. The Send (gold) and
+   Discard (red) backdrops are absolutely-positioned siblings at `inset: 0`
+   and are **always rendered**, covered visually by the button's
+   `translateX(0)`. `handleTouchEnd` resets `dragX` back to 0, but there is
+   no `onTouchCancel` — when iOS cancels a touch sequence (typical when a
+   modal opens mid-swipe, or when the user scrolls vertically while partway
+   into a horizontal swipe), `dragX` stays at whatever the last `touchmove`
+   set. The backdrop has no `pointer-events` guard either, so when a row is
+   partially swiped the gold background intercepts taps too. There is no
+   `useEffect` resetting `dragX` when the draft prop changes, so if React
+   re-uses a row across a re-render the state leaks.
+
+6. **Pull-to-refresh.** Custom touch handlers in
+   `app/agent/drafts/page.tsx:288–307`. Same shape as the swipe — no
+   `onTouchCancel`, so a cancelled gesture leaves `pullStartY` set and
+   `pullOffset > 60`, which is exactly what renders "Release to refresh"
+   indefinitely (line 429). There is also no max duration / "refreshing"
+   state guard: the display string depends on `pullOffset > 60` even when the
+   user has already lifted their finger but the async `loadDrafts()` has not
+   started yet. On iOS the rubber-band overscroll plus the stale pullOffset
+   is what produces the hang. `loadDrafts()` itself has a correct
+   try/finally, so the data fetch is not the issue — the gesture state is.
+
+7. **Existing Capacitor guards.**
+   `components/purchaser/PurchaserNoticeboardTab.tsx:536–537` and
+   `components/purchaser/PurchaserChatTab.tsx:997–998` both do the
+   `isNativePlatform() && getPlatform() === 'ios'` dance on a dynamically
+   imported `Capacitor`. `hooks/usePushNotifications.ts:46–99` is the most
+   thorough example. None of these patterns is reused in
+   `useVoiceCapture.ts`. No agent-surface Capacitor integration exists.
+
+8. **Known-issue trail.** No prior commit messages or README notes reference
+   these four symptoms. `usePushNotifications.ts` has a comment noting the
+   dynamic-import trick works around the missing optional dep at build time;
+   the same pattern can carry the mic permission flow without adding
+   `@capacitor/microphone` to the web bundle's dependency list.
+
+## Fix taken in this commit
+
+1. **Mic.** New helper
+   `apps/unified-portal/lib/capacitor-native.ts` wraps the dynamic-import
+   Capacitor guard and adds `requestMicrophonePermission()` +
+   `openNativeSettings()`. `useVoiceCapture.ts` now awaits it on native
+   platforms before touching `getUserMedia`, guards against
+   `navigator.mediaDevices` being undefined on older WKWebView, and renders a
+   clear "enable in Settings" message (via the VoiceInputBar) when permission
+   is denied.
+
+2. **DraftReviewPanel.** The panel renders through `createPortal` into
+   `document.body` so it sits outside the `<main>` overflow container — its
+   `position: fixed; inset: 0` is now genuinely viewport-relative and covers
+   the shell StatusBar. Web/desktop behaviour is unchanged (portal target
+   still exists in the browser).
+
+3. **Drafts list swipe.** Added `onTouchCancel` → same reset as
+   `onTouchEnd`. Added a `useEffect` that resets `dragX` when `draft.id`
+   changes. Added `pointer-events: none` on the action backdrops whenever
+   `dragX === 0`. Added `touch-action: pan-y` on the row container so a
+   hesitant horizontal drag doesn't fight vertical scroll.
+
+4. **Pull-to-refresh.** Same `onTouchCancel` treatment. Display string now
+   reads from an explicit `pulling` flag rather than deriving "Release" from
+   a stale `pullOffset`. When the gesture ends, `pulling` is cleared
+   immediately, so the UI transitions straight into "Refreshing..." and never
+   parks on "Release to refresh" after the finger lifts. Added a 10s watchdog
+   that force-resets if `loadDrafts()` hangs, so the pill never gets
+   stranded.
+
+5. **Capacitor sync.** Not runnable from this repo (Xcode project is
+   elsewhere). `BUILD_AND_SUBMIT.md` captures the exact sequence for the
+   operator: `npm i @capacitor/microphone`, `Info.plist` keys, `npx cap sync
+   ios`, Xcode build + archive + TestFlight submit.

--- a/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftReviewPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   ArrowLeft,
   Check,
@@ -156,7 +157,19 @@ export default function DraftReviewPanel({
 
   const isDesktop = surface === 'desktop';
 
-  return (
+  // Render through a portal to <body> so the panel is always positioned
+  // relative to the viewport — never a scroll-ancestor. The Agent page uses
+  // `-webkit-overflow-scrolling: touch` on its <main>, which on iOS WKWebView
+  // promotes that <main> to the containing block for fixed descendants,
+  // causing the panel's `inset: 0` to start BELOW the StatusBar and leaving
+  // the shell header visible above it (the double-header bug). Portaling out
+  // eliminates that stacking ambiguity on every platform.
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    if (typeof document !== 'undefined') setPortalTarget(document.body);
+  }, []);
+
+  const panelNode = (
     <div
       data-testid="draft-review-panel"
       style={isDesktop ? desktopWrapperStyle : mobileWrapperStyle}
@@ -311,6 +324,12 @@ export default function DraftReviewPanel({
       `}</style>
     </div>
   );
+
+  // During SSR / first client render we return null so hydration stays
+  // stable — the portal mount lands on the second render once document.body
+  // is available.
+  if (!portalTarget) return null;
+  return createPortal(panelNode, portalTarget);
 }
 
 function SentConfirmation({ state }: { state: SentState }) {

--- a/apps/unified-portal/app/agent/_components/DraftsListRow.tsx
+++ b/apps/unified-portal/app/agent/_components/DraftsListRow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { MailCheck, Trash2, Send as SendIcon } from 'lucide-react';
 import {
   draftTypeLabel,
@@ -42,6 +42,21 @@ export default function DraftsListRow({
       ? 'SMS'
       : 'Email';
 
+  // Reset swipe state whenever this row's draft identity changes. Without
+  // this, React row reuse across list re-renders can leave the button
+  // half-translated, leaving the Send/Discard backdrop orphaned on-screen
+  // (the bug Orla reported: gold "Send" visible on an unswiped row).
+  useEffect(() => {
+    setDragX(0);
+    startX.current = null;
+    setBusy(null);
+  }, [draft.id]);
+
+  const resetSwipe = () => {
+    startX.current = null;
+    setDragX(0);
+  };
+
   const handleTouchStart = (e: React.TouchEvent) => {
     startX.current = e.touches[0].clientX;
   };
@@ -66,6 +81,13 @@ export default function DraftsListRow({
     }
     setDragX(0);
   };
+  // iOS fires touchcancel when a gesture is interrupted (vertical scroll
+  // takeover, modal opening mid-swipe, the system taking touch focus).
+  // Without handling it, `dragX` stays at its last touchmove value and the
+  // backdrop stays exposed.
+  const handleTouchCancel = () => {
+    resetSwipe();
+  };
 
   return (
     <div
@@ -77,9 +99,15 @@ export default function DraftsListRow({
         overflow: 'hidden',
         border: '0.5px solid rgba(0,0,0,0.06)',
         boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
+        // Let vertical scroll pass through without fighting the horizontal
+        // swipe gesture — iOS honours this and cancels the swipe cleanly.
+        touchAction: 'pan-y',
       }}
     >
-      {/* Swipe action backdrops */}
+      {/* Swipe action backdrops. While the button is at translateX(0) these
+          must be visually below AND unreachable — otherwise a tap on the
+          edge of a row lands on the hidden Send button instead of opening
+          the draft. */}
       <div
         aria-hidden
         style={{
@@ -88,6 +116,7 @@ export default function DraftsListRow({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'stretch',
+          pointerEvents: dragX === 0 ? 'none' : 'auto',
         }}
       >
         <div
@@ -124,10 +153,19 @@ export default function DraftsListRow({
 
       <button
         type="button"
-        onClick={() => onOpen(draft)}
+        onClick={() => {
+          // If the row is partway through a swipe, a tap should snap the
+          // button back rather than open the draft — matches Mail.app.
+          if (dragX !== 0) {
+            resetSwipe();
+            return;
+          }
+          onOpen(draft);
+        }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
         className="agent-tappable"
         style={{
           position: 'relative',

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -12,6 +12,12 @@ interface VoiceInputBarProps {
   onStart: () => void;
   onStop: () => void;
   isDesktop?: boolean;
+  /**
+   * Deep-link into the OS Settings app so the agent can enable the mic
+   * without hunting for the toggle. Only shown on native when
+   * `voice.permissionDenied` is true.
+   */
+  onOpenSettings?: () => Promise<boolean> | void;
 }
 
 /**
@@ -27,6 +33,7 @@ export default function VoiceInputBar({
   onStart,
   onStop,
   isDesktop,
+  onOpenSettings,
 }: VoiceInputBarProps) {
   const recording = voice.status === 'recording' || voice.status === 'transcribing';
   const micSize = isDesktop ? 40 : 34;
@@ -200,16 +207,47 @@ export default function VoiceInputBar({
       )}
 
       {voice.status === 'error' && voice.errorMessage && (
-        <p
+        <div
           style={{
             marginTop: 8,
-            fontSize: 11.5,
-            color: '#DC2626',
-            textAlign: 'center',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 6,
           }}
         >
-          {voice.errorMessage}
-        </p>
+          <p
+            style={{
+              fontSize: 11.5,
+              color: '#DC2626',
+              textAlign: 'center',
+              margin: 0,
+              lineHeight: 1.4,
+            }}
+          >
+            {voice.errorMessage}
+          </p>
+          {voice.permissionDenied && onOpenSettings && (
+            <button
+              type="button"
+              onClick={() => onOpenSettings()}
+              className="agent-tappable"
+              data-testid="voice-open-settings"
+              style={{
+                fontSize: 11.5,
+                fontWeight: 600,
+                color: '#C49B2A',
+                background: 'rgba(196,155,42,0.10)',
+                border: '0.5px solid rgba(196,155,42,0.3)',
+                padding: '4px 12px',
+                borderRadius: 999,
+                cursor: 'pointer',
+              }}
+            >
+              Open Settings
+            </button>
+          )}
+        </div>
       )}
 
       {!recording && voice.status !== 'offline-queued' && voice.status !== 'error' && (

--- a/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
+++ b/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
@@ -1,16 +1,27 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  requestMicrophonePermission,
+  openNativeSettings,
+} from '@/lib/capacitor-native';
 
 const OFFLINE_QUEUE_KEY = 'oh.agent.voice.offlineQueue.v1';
 const SILENCE_THRESHOLD = 0.012;
 const SILENCE_TIMEOUT_MS = 2000;
+
+const MIC_DENIED_MESSAGE =
+  'Microphone access is needed for voice capture. Open Settings → OpenHouse → Microphone to enable.';
+const MIC_UNAVAILABLE_MESSAGE =
+  'Microphone is not available in this browser. Use the typing input instead.';
 
 export interface VoiceCaptureState {
   status: 'idle' | 'recording' | 'transcribing' | 'offline-queued' | 'error';
   partialTranscript: string;
   waveform: number[];
   errorMessage: string | null;
+  /** True when the error is a permission denial — UI can offer a Settings deep-link. */
+  permissionDenied: boolean;
   queuedCount: number;
 }
 
@@ -19,6 +30,8 @@ export interface VoiceCaptureAPI extends VoiceCaptureState {
   stop: () => Promise<string | null>;
   cancel: () => void;
   flushQueue: () => Promise<void>;
+  /** Opens the native Settings app (iOS). No-op on web/desktop. */
+  openSettings: () => Promise<boolean>;
 }
 
 interface QueuedBlob {
@@ -45,6 +58,7 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
   const [partialTranscript, setPartialTranscript] = useState('');
   const [waveform, setWaveform] = useState<number[]>(new Array(28).fill(0.08));
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [permissionDenied, setPermissionDenied] = useState(false);
   const [queuedCount, setQueuedCount] = useState(0);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -101,9 +115,37 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
   const start = useCallback(async () => {
     if (status === 'recording' || status === 'transcribing') return;
     setErrorMessage(null);
+    setPermissionDenied(false);
     setPartialTranscript('');
 
     try {
+      // Capacitor iOS: request mic permission via the plugin FIRST.
+      // Without this, WKWebView rejects getUserMedia on cold start (and on
+      // older iOS builds `navigator.mediaDevices` is undefined until the
+      // plugin warms the path up). `unavailable` = not native; fall through
+      // to the web path.
+      const native = await requestMicrophonePermission();
+      if (native.status === 'denied') {
+        setPermissionDenied(true);
+        setErrorMessage(MIC_DENIED_MESSAGE);
+        setStatus('error');
+        return;
+      }
+
+      // Guard against `navigator.mediaDevices` being undefined — seen on
+      // older iOS WKWebView and on insecure-context browsers. Before this
+      // guard the app crashed with "undefined is not an object
+      // (evaluating 'navigator.mediaDevices.getUserMedia')".
+      if (
+        typeof navigator === 'undefined' ||
+        !navigator.mediaDevices ||
+        typeof navigator.mediaDevices.getUserMedia !== 'function'
+      ) {
+        setErrorMessage(MIC_UNAVAILABLE_MESSAGE);
+        setStatus('error');
+        return;
+      }
+
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
@@ -192,7 +234,16 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
 
       setStatus('recording');
     } catch (err: any) {
-      setErrorMessage(err?.message || 'Microphone unavailable');
+      // iOS `NotAllowedError` (permission revoked mid-session) and
+      // `NotFoundError` (no mic hardware) surface here. Mark as
+      // permission-denied when the browser clearly says so.
+      const name: string = err?.name || '';
+      if (name === 'NotAllowedError' || name === 'SecurityError') {
+        setPermissionDenied(true);
+        setErrorMessage(MIC_DENIED_MESSAGE);
+      } else {
+        setErrorMessage(err?.message || 'Microphone unavailable');
+      }
       setStatus('error');
       cleanup();
     }
@@ -252,6 +303,7 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
     setStatus('idle');
     setPartialTranscript('');
     setErrorMessage(null);
+    setPermissionDenied(false);
     if (stopResolveRef.current) {
       stopResolveRef.current(null);
       stopResolveRef.current = null;
@@ -263,16 +315,20 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
     refreshQueueCount();
   }, [onTranscriptReady, refreshQueueCount]);
 
+  const openSettings = useCallback(() => openNativeSettings(), []);
+
   return {
     status,
     partialTranscript,
     waveform,
     errorMessage,
+    permissionDenied,
     queuedCount,
     start,
     stop,
     cancel,
     flushQueue,
+    openSettings,
   };
 }
 

--- a/apps/unified-portal/app/agent/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/drafts/page.tsx
@@ -37,6 +37,8 @@ export default function AgentDraftsPage() {
 
   const pullStartY = useRef<number | null>(null);
   const [pullOffset, setPullOffset] = useState(0);
+  const [pulling, setPulling] = useState(false);
+  const pullWatchdog = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -285,26 +287,72 @@ export default function AgentDraftsPage() {
   }, [undoBatch, loadDrafts]);
 
   // Pull-to-refresh: gentle gesture on mobile only.
+  //
+  // Bug history: without a `pulling` flag, when the gesture was cancelled
+  // by iOS (rubber-band overscroll, vertical scroll takeover, or the user
+  // swiping off the edge), `pullOffset` kept its last value and the banner
+  // stuck on "Release to refresh" indefinitely. The explicit `pulling` flag
+  // plus a touchcancel handler and a watchdog timer ensures the banner
+  // always clears.
+  const resetPullState = useCallback(() => {
+    pullStartY.current = null;
+    setPulling(false);
+    setPullOffset(0);
+    if (pullWatchdog.current) {
+      clearTimeout(pullWatchdog.current);
+      pullWatchdog.current = null;
+    }
+  }, []);
+
   const handlePullStart = (e: React.TouchEvent) => {
     const target = e.currentTarget as HTMLDivElement;
     if (target.scrollTop > 0) return;
     pullStartY.current = e.touches[0].clientY;
+    setPulling(true);
   };
   const handlePullMove = (e: React.TouchEvent) => {
     if (pullStartY.current == null) return;
     const delta = e.touches[0].clientY - pullStartY.current;
     if (delta > 0) {
       setPullOffset(Math.min(80, delta));
+    } else {
+      // Finger moved UP past origin — treat as cancel so we don't show
+      // "Release to refresh" when the user has already reversed intent.
+      resetPullState();
     }
   };
   const handlePullEnd = async () => {
-    if (pullOffset > 60) {
-      setRefreshing(true);
-      await loadDrafts();
-    }
+    const shouldRefresh = pulling && pullOffset > 60;
+    // Clear gesture state IMMEDIATELY so the banner transitions straight
+    // from "Release to refresh" to "Refreshing..." rather than parking on
+    // "Release" while loadDrafts awaits.
     pullStartY.current = null;
+    setPulling(false);
     setPullOffset(0);
+
+    if (!shouldRefresh) return;
+
+    setRefreshing(true);
+    // Watchdog: loadDrafts is meant to resolve, but if the network stalls
+    // we still want the banner to dismiss so the list is usable.
+    if (pullWatchdog.current) clearTimeout(pullWatchdog.current);
+    pullWatchdog.current = setTimeout(() => setRefreshing(false), 10_000);
+    try {
+      await loadDrafts();
+    } finally {
+      if (pullWatchdog.current) {
+        clearTimeout(pullWatchdog.current);
+        pullWatchdog.current = null;
+      }
+    }
   };
+  const handlePullCancel = () => {
+    resetPullState();
+  };
+
+  useEffect(() => () => {
+    if (pullWatchdog.current) clearTimeout(pullWatchdog.current);
+  }, []);
 
   const content = useMemo(() => {
     if (loading) {
@@ -411,22 +459,27 @@ export default function AgentDraftsPage() {
           onTouchStart={handlePullStart}
           onTouchMove={handlePullMove}
           onTouchEnd={handlePullEnd}
+          onTouchCancel={handlePullCancel}
           style={{
             flex: 1,
             overflowY: 'auto',
             WebkitOverflowScrolling: 'touch',
           }}
         >
-          {pullOffset > 0 && (
+          {(refreshing || (pulling && pullOffset > 0)) && (
             <div
               style={{
                 textAlign: 'center',
                 fontSize: 11,
                 color: '#9CA3AF',
-                padding: `${pullOffset / 2}px 0`,
+                padding: refreshing ? '12px 0' : `${pullOffset / 2}px 0`,
               }}
             >
-              {refreshing ? 'Refreshing...' : pullOffset > 60 ? 'Release to refresh' : 'Pull to refresh'}
+              {refreshing
+                ? 'Refreshing...'
+                : pullOffset > 60
+                  ? 'Release to refresh'
+                  : 'Pull to refresh'}
             </div>
           )}
           {content}

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -896,6 +896,7 @@ function IntelligencePageInner() {
           onStart={() => voice.start()}
           onStop={() => voice.stop()}
           isDesktop={isDesktop}
+          onOpenSettings={voice.openSettings}
         />
 
         {undoBatch && (

--- a/apps/unified-portal/lib/capacitor-native.ts
+++ b/apps/unified-portal/lib/capacitor-native.ts
@@ -1,0 +1,118 @@
+'use client';
+
+/**
+ * Capacitor runtime helpers.
+ *
+ * `@capacitor/core`, `@capacitor/microphone` and friends are optional
+ * dependencies — they are installed in the native wrapper repo, not in the
+ * web bundle's package.json. To avoid webpack resolving them at build time
+ * we use variable-string dynamic imports (the same trick as
+ * `hooks/usePushNotifications.ts`). On the web the imports fail silently and
+ * we fall through to the browser primitives.
+ */
+
+export type NativeMicPermissionResult =
+  | { status: 'granted' }
+  | { status: 'denied'; canOpenSettings: boolean }
+  | { status: 'prompt' }
+  | { status: 'unavailable' }; // not running native
+
+let capacitorCache: any | undefined;
+
+async function getCapacitor(): Promise<any | null> {
+  if (capacitorCache !== undefined) return capacitorCache;
+  try {
+    const specifier = '@capacitor/core';
+    // @ts-ignore — optional dep, dynamic to avoid webpack static resolution
+    const mod = await import(/* webpackIgnore: true */ specifier);
+    capacitorCache = mod?.Capacitor ?? null;
+    return capacitorCache;
+  } catch {
+    capacitorCache = null;
+    return null;
+  }
+}
+
+export async function isCapacitorNative(): Promise<boolean> {
+  const cap = await getCapacitor();
+  return !!cap && typeof cap.isNativePlatform === 'function' && cap.isNativePlatform();
+}
+
+export async function getCapacitorPlatform(): Promise<'ios' | 'android' | 'web' | null> {
+  const cap = await getCapacitor();
+  if (!cap || typeof cap.getPlatform !== 'function') return null;
+  const p = cap.getPlatform();
+  return p === 'ios' || p === 'android' || p === 'web' ? p : null;
+}
+
+/**
+ * Request microphone permission on the native platform BEFORE calling
+ * `navigator.mediaDevices.getUserMedia`. On iOS, WKWebView will not present
+ * the permission prompt on a cold start unless the native plugin has asked
+ * first — `getUserMedia` just rejects with `NotAllowedError` (or, on older
+ * iOS where `mediaDevices` is undefined, throws the "undefined is not an
+ * object" crash we saw in Orla's report).
+ *
+ * Returns:
+ *   - 'granted'     — safe to proceed to getUserMedia
+ *   - 'denied'      — do not call getUserMedia; show Settings hint
+ *   - 'prompt'      — plugin returned indeterminate; callers may try
+ *                     getUserMedia which will itself prompt
+ *   - 'unavailable' — not running on native (web/desktop); callers should
+ *                     use the standard web path
+ */
+export async function requestMicrophonePermission(): Promise<NativeMicPermissionResult> {
+  const native = await isCapacitorNative();
+  if (!native) return { status: 'unavailable' };
+
+  try {
+    const specifier = '@capacitor/microphone';
+    // @ts-ignore — optional plugin; loaded only on native
+    const mod = await import(/* webpackIgnore: true */ specifier);
+    const plugin = mod?.Microphone;
+    if (!plugin || typeof plugin.requestPermissions !== 'function') {
+      // Plugin missing in the wrapper — best-effort: let getUserMedia try.
+      return { status: 'prompt' };
+    }
+
+    const check = typeof plugin.checkPermissions === 'function'
+      ? await plugin.checkPermissions().catch(() => null)
+      : null;
+
+    if (check?.microphone === 'granted') return { status: 'granted' };
+    if (check?.microphone === 'denied') {
+      return { status: 'denied', canOpenSettings: true };
+    }
+
+    const res = await plugin.requestPermissions();
+    if (res?.microphone === 'granted') return { status: 'granted' };
+    if (res?.microphone === 'denied') {
+      return { status: 'denied', canOpenSettings: true };
+    }
+    return { status: 'prompt' };
+  } catch {
+    // Plugin import failed — treat as unavailable so the web path still works.
+    return { status: 'unavailable' };
+  }
+}
+
+/**
+ * Deep-link into the iOS Settings app at the OpenHouse entry so the agent
+ * can flip the microphone switch without hunting for it. Falls back to a
+ * no-op if the App plugin is not installed.
+ */
+export async function openNativeSettings(): Promise<boolean> {
+  try {
+    const specifier = '@capacitor/app';
+    // @ts-ignore
+    const mod = await import(/* webpackIgnore: true */ specifier);
+    const App = mod?.App;
+    if (App && typeof App.openSettings === 'function') {
+      await App.openSettings();
+      return true;
+    }
+  } catch {
+    /* no-op */
+  }
+  return false;
+}


### PR DESCRIPTION
…resh

Four webview-layer regressions bundled together. The native iOS wrapper is in a separate repo, so this commit carries only the web-side fixes; the plugin install + Info.plist + archive steps are in BUILD_AND_SUBMIT.md.

- Mic: navigator.mediaDevices.getUserMedia was called unconditionally and crashed on iOS WKWebView when mediaDevices was undefined or permission had not been primed. New lib/capacitor-native.ts dynamic-imports @capacitor/microphone on native only, requests permission before getUserMedia, and surfaces a Settings deep-link when denied.
- DraftReviewPanel: now portals to document.body so its fixed positioning is genuinely viewport-relative rather than clipped to the AgentShell's -webkit-overflow-scrolling main, which was causing the stacked double header on iOS.
- DraftsListRow: added onTouchCancel, dragX reset on draft.id change, pointer-events guard on action backdrops, touch-action: pan-y on the container — fixes the orphan gold Send backdrop visible on unswiped rows.
- Pull-to-refresh: explicit pulling flag decoupled from pullOffset plus a touchcancel handler and 10s watchdog so the banner always clears. UI transitions straight from Release to Refreshing without parking.