### PR TITLE
fix(agent-intelligence): drafts pipeline, anti-hallucination guard

### DIFF
--- a/DRAFTS_PIPELINE_HOTFIX_DIAGNOSIS.md
+++ b/DRAFTS_PIPELINE_HOTFIX_DIAGNOSIS.md
@@ -1,0 +1,68 @@
+# Drafts Pipeline Hotfix Diagnosis (Session 6D Hotfix)
+
+## Root cause
+
+The new `draft_buyer_followups` tool added in commit `8332a82` declares
+`targets` as `type: 'array'` with no `items` schema. OpenAI's function-calling
+JSON Schema validator rejects this with a 400 before any tool is invoked, so
+the entire chat completion fails.
+
+## Six-bullet diagnosis
+
+1. **OpenAI 400 signature.** The chat route hits
+   `openai.chat.completions.create({ tools, tool_choice: 'auto', ... })` on
+   `route.ts:199`. When any tool in the passed-in array has an invalid
+   JSON Schema, OpenAI returns 400 with a body like
+   `"Invalid schema for function 'draft_buyer_followups': In context=()... 'items' is a required property"`.
+   Our route catches the exception and returns a generic 500 — so the
+   surface-level symptom hides the schema error.
+
+2. **Malformed tool — `draft_buyer_followups`.**
+   `lib/agent-intelligence/tools/registry.ts:247-250`:
+   ```ts
+   targets: {
+     type: 'array',
+     description: 'Units to draft emails for. Each item must reference a unit (and optionally the scheme / recipient name).',
+   }
+   ```
+   OpenAI's schema (JSON Schema draft-07) requires any `array` type to
+   declare an `items` sub-schema. Without `items` the validator 400s.
+   Every other tool in the registry only uses `string`, `number`, or
+   `object` leaf types, so this is the only offender.
+
+3. **Type system hid the bug at compile time.** The `ToolDefinition`
+   type in `lib/agent-intelligence/types.ts:49-53` typed
+   `properties: Record<string, { type: string; description: string; enum?: string[] }>`
+   — no `items`, no nested `properties`. Adding an `items` schema
+   inline would have been rejected by `tsc`, which is why I shipped the
+   array without one. The type was too narrow from the start; tightening
+   it now without the full shape only pushes the bug to runtime.
+
+4. **No duplicate `draft_message`.** Grepping the registry turns up
+   exactly one `name: 'draft_message'` (line 223). The old
+   `write-tools.draftMessage` was removed in the same commit. Not the
+   cause.
+
+5. **System prompt length unchanged.** The new drafting-behaviour section
+   replaces the old one rather than appending. Prompt token count is
+   roughly flat. Not the cause.
+
+6. **All other tools pass validation.** Every other tool in
+   `AGENT_TOOL_DEFINITIONS` has either primitive leaves or an `object`
+   with explicit `properties`. `chase_aged_contracts`, `draft_message`
+   (agentic), `schedule_viewing_draft`, etc. — all fine.
+
+## Fix
+
+- Widen `ToolDefinition.parameters.properties` to allow `items` (with a
+  recursive sub-schema) and nested `properties` for object-typed fields.
+- Add the missing `items` schema to `targets`: each item is an object
+  with `unit_identifier` (required string), `scheme_name` (optional),
+  `recipient_name` (optional).
+- Keep every other part of Session 6D — anti-hallucination guard,
+  envelope merging, `override` SSE frame, new skills — untouched.
+
+Regression guard: the 6D test file already exercises `draftBuyerFollowups`
+at runtime. A new assertion verifies every registered tool with
+`type: 'array'` fields declares `items`, so this exact shape can't ship
+again.

--- a/DRAFTS_PIPELINE_REGRESSION_DIAGNOSIS.md
+++ b/DRAFTS_PIPELINE_REGRESSION_DIAGNOSIS.md
@@ -1,0 +1,184 @@
+# Drafts Pipeline Regression Diagnosis (Session 6D)
+
+## TL;DR
+
+Root cause is **hypothesis 2**: the user's phrasing ("draft an email to
+those 3 units") does not match any envelope-producing skill. The closest
+tool the model reaches for — `draft_message` — is *not* an agentic skill.
+It's a template helper that returns an `instruction` string telling the
+model to "Generate the COMPLETE email now" inline. It produces no envelope,
+no `pending_drafts` row, and no drawer signal, yet the model takes the
+successful tool response as evidence the work is done and confidently
+writes "drafts are ready for your review".
+
+No amount of prompt tuning fixes a missing tool. The fix is to convert
+`draft_message` into a real envelope-producing agentic skill and add a
+hallucination guard as the last line of defence.
+
+## Six-point diagnosis
+
+### 1. Tool registry inventory
+
+From `lib/agent-intelligence/tools/registry.ts`. Every tool marked "Ⓔ"
+returns an `AgenticSkillEnvelope`, routes through
+`runAgenticSkill()` → `persistSkillEnvelope()` → `persistDraftsForEnvelope()`,
+and therefore writes rows into `pending_drafts`.
+
+| Tool | Produces drafts? | Writes pending_drafts? | Emits envelope? |
+|---|---|---|---|
+| `get_unit_status` | no | no | no |
+| `get_buyer_details` | no | no | no |
+| `get_scheme_overview` | no | no | no |
+| `get_scheme_summary` | no | no | no |
+| `get_outstanding_items` | no | no | no |
+| `get_communication_history` | no | no | no |
+| `get_viewings` | no | no | no |
+| `search_knowledge_base` | no | no | no |
+| `create_task` | no (writes agent_tasks) | no | no |
+| `log_communication` | no (writes communication_events) | no | no |
+| **`draft_message`** | **claims to** | **NO** — returns `instruction` for inline LLM generation | **NO** |
+| `generate_developer_report` | no (returns report data) | no | no |
+| `chase_aged_contracts` Ⓔ | yes | yes | yes |
+| `draft_viewing_followup` Ⓔ | yes | yes | yes |
+| `weekly_monday_briefing` Ⓔ | yes (single report draft) | yes | yes |
+| `draft_lease_renewal` Ⓔ | yes | yes | yes |
+| `natural_query` Ⓔ | yes (single answer-as-draft) | yes | yes |
+| `schedule_viewing_draft` Ⓔ | yes | yes | yes |
+
+**`draft_message` is the odd one out.** It was written as a "give the model
+rich context so it writes the email inline in its streamed response"
+helper. Every other draft-producing tool returns an envelope. `draft_message`
+does not. This is the regression.
+
+### 2. Trace of "can you draft an email to those 3 units…"
+
+The model's tool-choice is governed by the descriptions in the registry.
+When the user just saw a `get_outstanding_items` result listing 3 units and
+then asks "draft an email to those 3 units", the model has these options:
+
+- `chase_aged_contracts` — description says "Find contracts issued over 6
+  weeks ago and draft solicitor chase emails for each". Inputs:
+  `threshold_days`, `scheme_filter`. No way to target a specific subset of
+  units — if the model picks this it drafts for ALL 21 overdue contracts.
+  The user wouldn't have seen "only 3 drafts" so this wasn't what fired.
+
+- `draft_message` — description says "Draft an email or message for the
+  agent to review and send." Inputs: `recipient_type`, `recipient_name`,
+  `context`, `tone`, `related_unit`, `related_scheme`. Single recipient per
+  call, but parallel tool-calls are supported by gpt-4o-mini. The model
+  picks this for "draft an email to X" queries.
+
+gpt-4o-mini called `draft_message` three times in parallel (once per unit).
+Each call hit `draftMessage()` in `lib/agent-intelligence/tools/write-tools.ts:216`
+which:
+1. Resolves the unit / scheme context (lookup on `developments` + `units`).
+2. Returns `{ data: { draft_ready: true, recipient_first_name, recipient_email,
+   unit_context, instruction: "Generate the COMPLETE email now..." }, summary: "..." }`.
+
+That `data` is **not an `AgenticSkillEnvelope`** (fails the
+`isAgenticSkillEnvelope` shape check in `chat/route.ts:390`), so
+`extractEnvelope()` returns `null` and no envelope is collected. The tool
+call succeeds, the model reads `draft_ready: true` + the `instruction`, and
+dutifully writes out the full email body inline in its streamed response.
+
+But zero rows are written to `pending_drafts`. Zero envelopes reach the
+client. The drawer never opens. The inbox is unchanged.
+
+And the model, quite reasonably, summarises the successful tool calls as
+"Drafted follow-up emails for the three units are ready for your review."
+From the model's POV every tool call returned `draft_ready: true`. It has
+no way to know the tool is a template that doesn't actually persist.
+
+### 3. Is there a "follow-up emails to specific units" skill?
+
+**No.** `chase_aged_contracts` is bulk-over-the-overdue-list, fixed
+threshold-based. There is no "draft emails for units X, Y, Z" skill that
+returns an envelope. This is the gap.
+
+### 4. Multi-tool envelope emission
+
+The chat route (`app/api/agent-intelligence/chat/route.ts:216–249`) loops
+over every tool call in every round and pushes every envelope into
+`envelopes[]`. The final SSE emission (line 273–278) iterates that array
+and emits one `envelope` frame per populated envelope. So multi-tool
+rounds are handled correctly in terms of emission.
+
+**However** — the drawer store (`drawer-store.tsx:74–86`) REPLACES state
+on each `openApprovalDrawer()` call. If the server emitted 3 envelopes in
+sequence for 3 `draft_message` calls (had they been envelope-producing),
+only the last would end up visible. So there is a latent bug here that
+would surface the moment `draft_message` starts producing envelopes. This
+session's fix needs to either merge envelopes server-side into one, or
+teach the drawer store to append.
+
+Server-side merge is simpler and closer to how the user thinks about a
+turn — "I asked for 3 drafts, I see 3 drafts in one drawer". Fix goes in
+the chat route.
+
+### 5. `persistDraftsForEnvelope` idempotency
+
+Each draft is a separate `INSERT` — no deduplication. If the model re-runs
+a skill within a turn (rare), rows double up. The envelope rewrite replaces
+the in-memory draft id with the DB id, so the drawer talks to real rows.
+If a single insert fails (line 102), the draft keeps its in-memory UUID
+and the drawer Approve button will 404 against `/send-draft`, but the
+drawer still opens. Partial failures do not silently swallow drafts — they
+leave them visible but un-sendable.
+
+The regression symptom ("0 drafts written") is NOT a persistence failure.
+It's a "we never tried to persist" failure — `draft_message` never reaches
+`persistDraftsForEnvelope` at all.
+
+### 6. Vercel runtime logs
+
+No runtime errors on `/api/agent-intelligence/chat` over the last hour
+that would indicate a crash or rejected insert. Logs show successful 200
+responses on the affected turns, consistent with the "tools called, no
+envelope emitted" path described above. This rules out hypothesis 3
+(envelope emission broken) definitively.
+
+## Fix taken in this commit
+
+1. **Convert `draft_message` into a real agentic skill.** New
+   `draftMessageSkill()` in `lib/agent-intelligence/tools/agentic-skills.ts`
+   returns an `AgenticSkillEnvelope` with one draft. Registered via
+   `runAgenticSkill()` so it funnels through `persistDraftsForEnvelope()`
+   and writes a `pending_drafts` row. Template-based body generation
+   server-side (tone-aware, Irish conversational English) — no more
+   "instruct the model to inline the email" dance.
+
+2. **New `draft_buyer_followups` skill** for explicit multi-recipient
+   requests. Takes `targets[]` (`{ unit_identifier, scheme_name, topic }`)
+   and produces one draft per target, all in one envelope. Matches the
+   "draft emails to those 3 units" pattern directly.
+
+3. **Merge envelopes server-side.** The chat route now concatenates all
+   envelopes produced in a turn into one combined envelope before emitting
+   the SSE frame. Drawer sees one envelope with N drafts, state is
+   consistent.
+
+4. **Anti-hallucination guard.** In the chat route:
+   - Pre-stream: if a draft-producing tool was called but no envelope
+     with drafts was collected, inject a system message telling the model
+     not to claim drafts exist.
+   - Post-stream: if the streamed content claims drafts were created and
+     no envelope was emitted, emit an `override` SSE frame with an honest
+     failure message. Client replaces the assistant content on receipt.
+   - Telemetry: every override is logged via
+     `logInteraction` with `response_type = 'hallucinated_drafts'`, and
+     `console.error` for Vercel log surfacing.
+
+5. **Drawer wiring audit.** Both `/agent/intelligence/page.tsx` and
+   `/agent/dashboard/intelligence/page.tsx` already wrap in
+   `ApprovalDrawerProvider` and call `openApprovalDrawer(data.envelope)`
+   on `envelope` frames. Both now also handle the new `override` frame.
+   The rAF-defer pattern in the drawer store survives unchanged.
+
+## What NOT to change
+
+- The working agentic skills (`chase_aged_contracts`,
+  `draft_viewing_followup`, `draft_lease_renewal`,
+  `weekly_monday_briefing`, `natural_query`, `schedule_viewing_draft`)
+  already go through the correct path and need no edits.
+- `persistDraftsForEnvelope` is correct — not the bug.
+- The SSE frame encoding (`type: 'envelope'`) is correct on both pages.

--- a/apps/unified-portal/app/agent/dashboard/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/dashboard/intelligence/page.tsx
@@ -126,6 +126,14 @@ function AgentDashboardIntelligencePageInner() {
                 try { window.dispatchEvent(new CustomEvent('oh:drafts:changed')); } catch { /* noop */ }
               }
             }
+            else if (data.type === 'override') {
+              // Server detected a hallucinated "drafts ready" — replace
+              // the streamed content so the agent is not misled.
+              if (typeof data.content === 'string') {
+                fullContent = data.content;
+                setMessages(ms => ms.map(m => m.id === assistantMsg.id ? { ...m, content: fullContent } : m));
+              }
+            }
           } catch {}
         }
       }

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -237,6 +237,23 @@ function IntelligencePageInner() {
                 openApprovalDrawer(data.envelope);
                 notifyDraftsChanged();
               }
+            } else if (data.type === 'override') {
+              // Server detected the model hallucinated drafts. Replace
+              // whatever tokens have streamed so far with the honest
+              // failure message.
+              fullContent = typeof data.content === 'string' ? data.content : fullContent;
+              if (streamingStarted) {
+                setMessages(prev => prev.map(m =>
+                  m.id === streamingMsgId ? { ...m, content: fullContent } : m
+                ));
+              } else {
+                streamingStarted = true;
+                setMessages(prev => [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: fullContent,
+                }]);
+              }
             } else if (data.type === 'done') {
               newSessionId = data.sessionId || sessionId;
             }

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -182,6 +182,19 @@ export async function POST(request: NextRequest) {
     const tools = getToolDefinitionsForOpenAI();
     const toolsCalled: Array<{ tool_name: string; params: any; result_summary: string }> = [];
 
+    // Tool names that MUST land a real draft. If any of these fire but no
+    // envelope with drafts comes back, the anti-hallucination guard kicks
+    // in and overrides the model's response.
+    const DRAFT_PRODUCING_TOOLS = new Set<string>([
+      'draft_message',
+      'draft_buyer_followups',
+      'chase_aged_contracts',
+      'draft_viewing_followup',
+      'draft_lease_renewal',
+      'weekly_monday_briefing',
+      'schedule_viewing_draft',
+    ]);
+
     // Run tool-calling rounds (non-streaming so we can parse tool calls)
     let needsFinalStream = true;
     let rounds = 0;
@@ -248,6 +261,36 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // 5b. Anti-hallucination pre-stream guard.
+    //
+    // Collect signals before streaming the final response:
+    //   - Was any draft-producing tool called?
+    //   - Did any envelope come back with drafts?
+    // If a draft tool fired and nothing persisted, inject a system note so
+    // the streaming model is told explicitly NOT to claim drafts exist.
+    // Post-stream we still check the final text and emit a hard override
+    // if the model lies anyway.
+    const draftToolCalled = toolsCalled.some((t) => DRAFT_PRODUCING_TOOLS.has(t.tool_name));
+    const envelopesWithDrafts = envelopes.filter((e) => e.drafts.length > 0);
+    const totalDraftsPersisted = envelopesWithDrafts.reduce((n, e) => n + e.drafts.length, 0);
+
+    if (draftToolCalled && totalDraftsPersisted === 0) {
+      messages.push({
+        role: 'system',
+        content:
+          'IMPORTANT: The draft tool(s) you just called returned zero drafts. Do NOT tell the user their drafts are ready, or that anything is in the drafts inbox, or that you prepared anything to review. Tell them the action did not go through, and ask them to rephrase or try a more specific request.',
+      });
+    }
+
+    // Merge all envelopes produced in this turn into one combined envelope.
+    // The drawer store replaces state on every `openApprovalDrawer()` call,
+    // so multiple sequential envelopes from parallel tool calls would show
+    // only the last. One envelope with N drafts matches the user's mental
+    // model ("I asked for 3 drafts; I see 3 drafts").
+    const combinedEnvelope: AgenticSkillEnvelope | null = envelopesWithDrafts.length
+      ? mergeEnvelopes(envelopesWithDrafts)
+      : null;
+
     // 6. Stream the final response token-by-token
     const currentSessionId = sessionId || `session_${Date.now()}`;
     const encoder = new TextEncoder();
@@ -265,15 +308,13 @@ export async function POST(request: NextRequest) {
             );
           }
 
-          // Emit every agentic-skill envelope. The client listens for this
-          // frame to open the approval drawer. Drafts referenced here are
-          // already persisted in `pending_drafts` (via persistSkillEnvelope
-          // inside the registry adapter) so the drawer's Approve / Edit /
-          // Discard calls hit real rows.
-          for (const envelope of envelopes) {
-            if (!envelope.drafts.length) continue;
+          // One combined envelope per turn. The client's drawer store opens
+          // with the full set — approve / edit / discard targets real
+          // `pending_drafts.id`s that were rewritten by
+          // persistSkillEnvelope inside the registry adapter.
+          if (combinedEnvelope) {
             controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'envelope', envelope }) + '\n')
+              encoder.encode(JSON.stringify({ type: 'envelope', envelope: combinedEnvelope }) + '\n')
             );
           }
 
@@ -305,9 +346,41 @@ export async function POST(request: NextRequest) {
             );
           }
 
+          // Anti-hallucination post-stream guard.
+          //
+          // If the streamed response claims drafts were created but no
+          // envelope landed in this turn, emit an `override` frame. The
+          // client listens for it and replaces the assistant's message
+          // text with an honest failure string. Better to apologise than
+          // to lie politely.
+          const HALLUCINATION_REGEX =
+            /drafted|drafts?\s+(?:are|is)\s+ready|ready\s+for\s+your\s+review|in\s+the\s+drafts?\s+inbox|prepared\s+\d+\s+draft|i['’]ll\s+draft|i\s+(?:have\s+)?drafted/i;
+          const claimsDrafts = HALLUCINATION_REGEX.test(fullContent);
+          if (claimsDrafts && totalDraftsPersisted === 0) {
+            const honestMessage = "I tried to draft those emails but the action didn’t actually go through — nothing landed in your inbox. Could you try asking again, or rephrase with the specific unit numbers / buyer names?";
+            controller.enqueue(
+              encoder.encode(JSON.stringify({ type: 'override', content: honestMessage }) + '\n')
+            );
+            // Replace the recorded response so memory + analytics store the
+            // honest text, not the lie.
+            fullContent = honestMessage;
+            console.error('[hallucinated_drafts] overrode assistant response', {
+              kind: 'hallucinated_drafts',
+              user: agentContext.displayName,
+              userId: agentContext.userId,
+              originalMessage: message,
+              assistantClaimed: fullContent,
+              toolsCalled: toolsCalled.map((t) => t.tool_name),
+              draftToolCalled,
+              totalDraftsPersisted,
+            });
+          }
+
           // Store memory and log interaction (async, non-blocking)
           storeConversationMemory(supabase, agentContext, currentSessionId, message, fullContent, toolsCalled).catch(() => {});
-          logInteraction(supabase, tenantId, authUserId, message, fullContent, toolsCalled, startTime).catch(() => {});
+          logInteraction(supabase, tenantId, authUserId, message, fullContent, toolsCalled, startTime, {
+            hallucinatedDrafts: claimsDrafts && totalDraftsPersisted === 0,
+          }).catch(() => {});
 
           // Generate follow-up suggestions (non-blocking, appended after main response)
           try {
@@ -393,6 +466,30 @@ function extractEnvelope(result: any): AgenticSkillEnvelope | null {
 }
 
 /**
+ * Merge several non-empty envelopes produced in one turn into one. Drafts
+ * are concatenated preserving insert order; skill is the first skill seen
+ * (or `combined` when skills differ). The drawer store replaces state on
+ * every open call, so the client needs one envelope per turn, not many.
+ */
+function mergeEnvelopes(envelopes: AgenticSkillEnvelope[]): AgenticSkillEnvelope {
+  if (envelopes.length === 1) return envelopes[0];
+  const drafts = envelopes.flatMap((e) => e.drafts);
+  const skillSet = new Set(envelopes.map((e) => e.skill));
+  const skill = skillSet.size === 1 ? envelopes[0].skill : 'combined';
+  return {
+    skill,
+    status: 'awaiting_approval',
+    summary: `Drafted ${drafts.length} item${drafts.length === 1 ? '' : 's'}.`,
+    drafts,
+    meta: {
+      record_count: drafts.length,
+      generated_at: new Date().toISOString(),
+      query: envelopes.map((e) => e.meta.query).join(' | '),
+    },
+  };
+}
+
+/**
  * Store user and assistant messages in conversation memory for cross-session context.
  */
 async function storeConversationMemory(
@@ -446,7 +543,8 @@ async function logInteraction(
   queryText: string,
   responseText: string,
   toolsCalled: Array<{ tool_name: string; params: any; result_summary: string }>,
-  startTime: number
+  startTime: number,
+  flags: { hallucinatedDrafts?: boolean } = {}
 ) {
   const latencyMs = Date.now() - startTime;
 
@@ -454,6 +552,14 @@ async function logInteraction(
   const isKnowledgeGap = responseText.toLowerCase().includes('i don\'t have that data') ||
     responseText.toLowerCase().includes('not in the system') ||
     responseText.toLowerCase().includes('no data available');
+
+  const responseType = flags.hallucinatedDrafts
+    ? 'hallucinated_drafts'
+    : toolsCalled.some(t => t.tool_name === 'draft_message' || t.tool_name === 'draft_buyer_followups')
+      ? 'draft'
+      : toolsCalled.some(t => t.tool_name === 'generate_developer_report') ? 'report'
+        : toolsCalled.some(t => t.tool_name === 'create_task') ? 'task_created'
+          : 'answer';
 
   await supabase.from('intelligence_interactions').insert({
     tenant_id: tenantId,
@@ -463,10 +569,7 @@ async function logInteraction(
     query_text: queryText,
     tools_called: toolsCalled,
     response_text: responseText.slice(0, 10000),
-    response_type: toolsCalled.some(t => t.tool_name === 'draft_message') ? 'draft'
-      : toolsCalled.some(t => t.tool_name === 'generate_developer_report') ? 'report'
-      : toolsCalled.some(t => t.tool_name === 'create_task') ? 'task_created'
-      : 'answer',
+    response_type: responseType,
     model_used: 'gpt-4o-mini',
     latency_ms: latencyMs,
   });

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -24,6 +24,8 @@ const AGENTIC_DRAFT_TYPE_BY_SKILL: Record<string, string> = {
   weekly_monday_briefing: 'weekly_briefing',
   natural_query: 'intelligence_answer',
   schedule_viewing_draft: 'schedule_viewing',
+  draft_message: 'buyer_followup',
+  draft_buyer_followups: 'buyer_followup',
 };
 
 function resolveDraftType(skill: string, draft: AgenticSkillDraft): string {

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -226,11 +226,30 @@ agent explicitly approves a draft via the approval drawer.
 
 CRITICAL — DRAFTING BEHAVIOUR:
 When the user asks you to draft, write, send, follow up with, chase, or mail
-ANYONE — ALWAYS call the appropriate draft-producing tool (chase_aged_contracts,
-draft_viewing_followup, draft_lease_renewal, schedule_viewing_draft,
-weekly_monday_briefing). NEVER reply with a numbered list describing drafts you
-would write. The tool call IS the draft; the drafts it produces land in the
-Drafts inbox and open the approval drawer for the agent to review.
+ANYONE — ALWAYS call the appropriate draft-producing tool. Pick the tightest fit:
+
+  - "draft emails to those 3 units" / "follow up with those buyers" / "send those
+    three a chase" → call draft_buyer_followups with a targets array (one entry
+    per unit) and a shared topic.
+  - "draft an email to [one person]" → call draft_message with that single
+    recipient.
+  - "chase all overdue contracts" → call chase_aged_contracts.
+  - "follow up on viewings yesterday" → call draft_viewing_followup.
+  - Lease renewals → draft_lease_renewal. Weekly briefing → weekly_monday_briefing.
+  - New viewing appointment → schedule_viewing_draft.
+
+NEVER reply with a numbered list describing drafts you would write. NEVER write
+email text inline in your response. The tool call IS the draft; the drafts it
+produces land in the Drafts inbox and open the approval drawer for the agent to
+review.
+
+If the user names a specific subset of records you just showed them (e.g. "those
+3 units" right after get_outstanding_items), ALWAYS use draft_buyer_followups
+with that exact subset's unit identifiers — never the bulk chase skill.
+
+If you claim drafts are ready but did not actually call a draft-producing tool,
+the system will OVERRIDE your response with an honest failure message. So: only
+say drafts are ready when you actually called a draft tool in THIS turn.
 
 Your text reply after a draft tool fires is a ONE-SENTENCE summary only. Do NOT
 list recipient names in the text. Do NOT paste subject lines or bodies. The

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -1005,3 +1005,294 @@ export async function scheduleViewingDraft(
     return errorEnvelope(skill, query, err);
   }
 }
+
+// =====================================================================
+// Skill 7 — draft_message (rewritten as envelope-producing)
+// =====================================================================
+//
+// Session 6D fix. The pre-6D `draftMessage` returned a template plus an
+// `instruction` string telling the model to "Generate the COMPLETE email
+// now" inline. That meant the model wrote a convincing email in its
+// streamed response, said "drafts are ready for your review", and
+// persisted NOTHING. This version produces a real draft every time the
+// tool is called. Multi-recipient requests naturally resolve as multiple
+// parallel tool calls (gpt-4o-mini supports these) — each call adds one
+// draft to the turn's envelope.
+
+interface DraftMessageSkillInput {
+  recipient_type: 'buyer' | 'solicitor' | 'developer' | string;
+  recipient_name: string;
+  context: string;
+  tone?: string;
+  related_unit?: string;
+  related_scheme?: string;
+  recipient_email?: string;
+}
+
+function toneGreeting(firstNameValue: string): string {
+  return `Hi ${firstNameValue},`;
+}
+
+function toneSignOff(tone: string): string {
+  if (tone === 'formal') return 'Kind regards,';
+  if (tone === 'urgent') return 'Thanks,';
+  if (tone === 'gentle_chase') return 'Thanks,';
+  return 'Thanks,';
+}
+
+export async function draftMessageSkill(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: DraftMessageSkillInput,
+): Promise<AgenticSkillEnvelope> {
+  const skill = 'draft_message';
+  const recipientName = (inputs.recipient_name || '').trim();
+  const context = (inputs.context || '').trim();
+  const tone = (inputs.tone || (inputs.recipient_type === 'solicitor' ? 'formal' : 'warm')).trim();
+  const query = `draft_message recipient="${recipientName}" unit="${inputs.related_unit || ''}" scheme="${inputs.related_scheme || ''}"`;
+
+  if (!recipientName) {
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: 'Recipient name is required to draft an email.',
+      drafts: [],
+      meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+    };
+  }
+
+  try {
+    // Resolve the unit / scheme / buyer if the model gave us references.
+    // This lets us stamp the real unit number + purchaser email into the
+    // draft rather than whatever placeholder the model chose.
+    let resolvedEmail: string | null = inputs.recipient_email || null;
+    let resolvedUnitNumber: string | null = null;
+    let resolvedSchemeName: string | null = null;
+    let affectedUnitId: string | null = null;
+
+    if (inputs.related_scheme && inputs.related_unit) {
+      const { data: dev } = await supabase
+        .from('developments')
+        .select('id, name')
+        .ilike('name', `%${inputs.related_scheme}%`)
+        .limit(1)
+        .maybeSingle();
+      if (dev) {
+        resolvedSchemeName = dev.name;
+        const { data: units } = await supabase
+          .from('units')
+          .select('id, unit_number, unit_uid, purchaser_email, purchaser_name')
+          .eq('development_id', dev.id)
+          .or(`unit_number.ilike.%${inputs.related_unit}%,unit_uid.ilike.%${inputs.related_unit}%,purchaser_name.ilike.%${recipientName}%`)
+          .limit(1);
+        const unit = units?.[0];
+        if (unit) {
+          resolvedUnitNumber = unit.unit_number || unit.unit_uid || inputs.related_unit;
+          if (!resolvedEmail && unit.purchaser_email) resolvedEmail = unit.purchaser_email;
+          affectedUnitId = unit.id;
+        }
+      }
+    }
+
+    const unitLabel = resolvedUnitNumber && resolvedSchemeName
+      ? `Unit ${resolvedUnitNumber}, ${resolvedSchemeName}`
+      : resolvedUnitNumber
+        ? `Unit ${resolvedUnitNumber}`
+        : resolvedSchemeName || '';
+
+    const subject = unitLabel
+      ? `Following up — ${unitLabel}`
+      : `Following up — ${context.slice(0, 60)}`;
+
+    const body = [
+      toneGreeting(firstName(recipientName)),
+      '',
+      context,
+      unitLabel ? `\nRegarding ${unitLabel}.` : '',
+      '',
+      toneSignOff(tone),
+      signature(agentContext),
+    ].filter((line) => line !== undefined).join('\n');
+
+    const draft = {
+      id: randomUUID(),
+      type: 'email' as const,
+      recipient: {
+        name: recipientName,
+        email: resolvedEmail || 'recipient@tbc.invalid',
+        role: inputs.recipient_type || 'recipient',
+      },
+      subject,
+      body,
+      affected_record: affectedUnitId
+        ? { kind: 'sales_unit', id: affectedUnitId, label: unitLabel || recipientName }
+        : { kind: 'contact', id: recipientName, label: recipientName },
+      reasoning: `Drafted per agent request (${tone} tone). ${resolvedEmail ? '' : 'Recipient email was not on file; placeholder used — please fill in before approving.'}`.trim(),
+    };
+
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: `Drafted email to ${recipientName}${unitLabel ? ` — ${unitLabel}` : ''}.`,
+      drafts: [draft],
+      meta: { record_count: 1, generated_at: new Date().toISOString(), query },
+    };
+  } catch (err) {
+    return errorEnvelope(skill, query, err);
+  }
+}
+
+// =====================================================================
+// Skill 8 — draft_buyer_followups (explicit multi-recipient)
+// =====================================================================
+//
+// Session 6D fix. Gives the model a direct path for "draft emails to
+// those 3 units" without needing three parallel tool calls. Input is a
+// list of unit/scheme references plus a shared topic. Returns one draft
+// per resolved unit.
+
+interface DraftBuyerFollowupsInput {
+  targets: Array<{
+    unit_identifier: string;
+    scheme_name?: string;
+    recipient_name?: string;
+  }>;
+  topic: string;
+  tone?: string;
+}
+
+export async function draftBuyerFollowups(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: DraftBuyerFollowupsInput,
+): Promise<AgenticSkillEnvelope> {
+  const skill = 'draft_buyer_followups';
+  const tone = (inputs.tone || 'gentle_chase').trim();
+  const topic = (inputs.topic || '').trim();
+  const targets = Array.isArray(inputs.targets) ? inputs.targets : [];
+  const query = `draft_buyer_followups targets=${targets.length} topic="${topic.slice(0, 80)}"`;
+
+  if (!targets.length) {
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: 'No targets provided — nothing to draft.',
+      drafts: [],
+      meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+    };
+  }
+  if (!topic) {
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: 'A topic is required so the follow-up makes sense to the recipient.',
+      drafts: [],
+      meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+    };
+  }
+
+  try {
+    const drafts: AgenticSkillEnvelope['drafts'] = [];
+
+    // Pre-resolve the agent's assigned developments so scheme-less targets
+    // can still be matched. Same chain as resolveAgentContext uses.
+    const { data: asgs } = await supabase
+      .from('agent_scheme_assignments')
+      .select('development_id')
+      .eq('agent_id', agentContext.agentId)
+      .eq('is_active', true);
+    const devIds = Array.from(new Set((asgs || []).map((a: any) => a.development_id).filter(Boolean)));
+    const { data: devs } = devIds.length
+      ? await supabase.from('developments').select('id, name').in('id', devIds)
+      : { data: [] };
+    const devList = (devs || []) as Array<{ id: string; name: string }>;
+    const devIdByName = new Map<string, string>(devList.map((d) => [d.name.toLowerCase(), d.id]));
+
+    for (const target of targets) {
+      const unitRef = (target.unit_identifier || '').trim();
+      if (!unitRef) continue;
+
+      let targetDevId: string | null = null;
+      let targetDevName: string | null = null;
+      if (target.scheme_name) {
+        const key = target.scheme_name.trim().toLowerCase();
+        // Fuzzy match against assigned scheme names.
+        for (const d of devList) {
+          if (d.name.toLowerCase().includes(key) || key.includes(d.name.toLowerCase())) {
+            targetDevId = d.id;
+            targetDevName = d.name;
+            break;
+          }
+        }
+        if (!targetDevId) {
+          targetDevId = devIdByName.get(key) || null;
+          targetDevName = target.scheme_name;
+        }
+      }
+      const searchDevIds = targetDevId ? [targetDevId] : devIds;
+      if (!searchDevIds.length) continue;
+
+      const { data: units } = await supabase
+        .from('units')
+        .select('id, unit_number, unit_uid, development_id, purchaser_name, purchaser_email')
+        .in('development_id', searchDevIds)
+        .or(`unit_number.ilike.%${unitRef}%,unit_uid.ilike.%${unitRef}%,purchaser_name.ilike.%${target.recipient_name || unitRef}%`)
+        .limit(1);
+      const unit = units?.[0];
+      if (!unit) continue;
+
+      const resolvedDevName = targetDevName
+        || devList.find((d) => d.id === unit.development_id)?.name
+        || 'Unknown scheme';
+      const resolvedUnitNumber = unit.unit_number || unit.unit_uid || unitRef;
+      const recipientName = target.recipient_name || unit.purchaser_name || 'Buyer';
+
+      const unitLabel = `Unit ${resolvedUnitNumber}, ${resolvedDevName}`;
+      const body = [
+        toneGreeting(firstName(recipientName)),
+        '',
+        topic,
+        '',
+        'Could you let me know where things stand on your end? Happy to help work through anything that\'s holding things up.',
+        '',
+        toneSignOff(tone),
+        signature(agentContext),
+      ].join('\n');
+
+      drafts.push({
+        id: randomUUID(),
+        type: 'email' as const,
+        recipient: {
+          name: recipientName,
+          email: unit.purchaser_email || 'buyer@tbc.invalid',
+          role: 'buyer',
+        },
+        subject: `Following up — ${unitLabel}`,
+        body,
+        affected_record: { kind: 'sales_unit', id: unit.id, label: unitLabel },
+        reasoning: `Requested follow-up to ${recipientName} at ${unitLabel}. Tone: ${tone}.${unit.purchaser_email ? '' : ' Recipient email missing — placeholder used, please fill in before approving.'}`,
+      });
+    }
+
+    if (!drafts.length) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: 'Could not resolve any of the requested units to real buyers. Try naming them more specifically.',
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: `Drafted ${drafts.length} follow-up email${drafts.length === 1 ? '' : 's'}.`,
+      drafts,
+      meta: { record_count: drafts.length, generated_at: new Date().toISOString(), query },
+    };
+  } catch (err) {
+    return errorEnvelope(skill, query, err);
+  }
+}
+

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -247,6 +247,15 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
         targets: {
           type: 'array',
           description: 'Units to draft emails for. Each item must reference a unit (and optionally the scheme / recipient name).',
+          items: {
+            type: 'object',
+            properties: {
+              unit_identifier: { type: 'string', description: 'Unit number or unit reference (e.g. "19", "Unit 37", "AV-36").' },
+              scheme_name: { type: 'string', description: 'Name of the scheme the unit lives in. Optional when the agent only has one assigned scheme.' },
+              recipient_name: { type: 'string', description: 'Override the purchaser name on the unit if the agent named someone specifically.' },
+            },
+            required: ['unit_identifier'],
+          },
         },
         topic: { type: 'string', description: 'Shared topic / reason for the follow-up (e.g. "asking when they expect to sign the contracts"). Becomes the lead of each email body.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -14,13 +14,17 @@ import {
 import {
   createTask,
   logCommunication,
-  draftMessage,
   generateDeveloperReport,
 } from './write-tools';
 // schedule_viewing is intentionally NOT imported here: its immediate-write
 // behaviour has been replaced by schedule_viewing_draft. The underlying
 // scheduleViewing function remains exported from './write-tools' for any
 // internal code path that still needs a direct insert.
+//
+// draft_message is also NOT imported from write-tools any more — it was a
+// non-envelope "template helper" that let the model claim drafts were
+// ready without anything landing in pending_drafts. Session 6D replaced
+// it with draftMessageSkill() in agentic-skills.ts.
 import {
   chaseAgedContracts,
   draftViewingFollowup,
@@ -28,6 +32,8 @@ import {
   draftLeaseRenewal,
   naturalQuery,
   scheduleViewingDraft,
+  draftMessageSkill,
+  draftBuyerFollowups,
   SkillAgentContext,
 } from './agentic-skills';
 import type { AgenticSkillEnvelope } from '../envelope';
@@ -215,20 +221,40 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: 'draft_message',
-    description: 'Draft an email or message for the agent to review and send. NEVER sends anything automatically — returns a draft for review.',
+    description: 'Draft a single email or message to ONE named recipient. Writes a draft to the agent\'s inbox and opens the approval drawer; the drawer controls whether it actually sends. Use this for "draft an email to X about Y" style requests. For multiple recipients in one go, prefer `draft_buyer_followups`.',
     parameters: {
       type: 'object',
       properties: {
         recipient_type: { type: 'string', description: 'Type of recipient', enum: ['buyer', 'developer', 'solicitor'] },
         recipient_name: { type: 'string', description: 'Name of the recipient' },
-        context: { type: 'string', description: 'What the message should cover' },
+        context: { type: 'string', description: 'What the message should cover, in the agent\'s own words — this becomes the body.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         related_unit: { type: 'string', description: 'Related unit number' },
         related_scheme: { type: 'string', description: 'Related scheme name' },
+        recipient_email: { type: 'string', description: 'Recipient email if known; otherwise leave empty and the drawer will show a placeholder for the agent to fill in.' },
       },
       required: ['recipient_type', 'recipient_name', 'context'],
     },
-    execute: draftMessage as ToolFunction,
+    execute: ((supabase, _tenantId, agentContext, params) =>
+      runAgenticSkill(draftMessageSkill, supabase, agentContext, params as any)) as ToolFunction,
+  },
+  {
+    name: 'draft_buyer_followups',
+    description: 'Draft follow-up emails to a SPECIFIC list of units / buyers in one call. Use when the agent says "draft emails to those 3 units", "follow up with those buyers", "send those three a chase", etc. Each target produces one draft in the approval drawer.',
+    parameters: {
+      type: 'object',
+      properties: {
+        targets: {
+          type: 'array',
+          description: 'Units to draft emails for. Each item must reference a unit (and optionally the scheme / recipient name).',
+        },
+        topic: { type: 'string', description: 'Shared topic / reason for the follow-up (e.g. "asking when they expect to sign the contracts"). Becomes the lead of each email body.' },
+        tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
+      },
+      required: ['targets', 'topic'],
+    },
+    execute: ((supabase, _tenantId, agentContext, params) =>
+      runAgenticSkill(draftBuyerFollowups, supabase, agentContext, params as any)) as ToolFunction,
   },
   {
     name: 'generate_developer_report',

--- a/apps/unified-portal/lib/agent-intelligence/tools/write-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/write-tools.ts
@@ -215,80 +215,11 @@ export async function scheduleViewing(
   };
 }
 
-export async function draftMessage(
-  supabase: SupabaseClient,
-  tenantId: string,
-  agentContext: AgentContext,
-  params: {
-    recipient_type: string;
-    recipient_name: string;
-    context: string;
-    tone?: string;
-    related_unit?: string;
-    related_scheme?: string;
-  }
-): Promise<ToolResult> {
-  // Gather context data for the draft
-  let recipientEmail: string | null = null;
-  let unitContext = '';
-  let schemeName = '';
-  let unitNumber = '';
-
-  if (params.related_scheme && params.related_unit) {
-    const { data: dev } = await supabase
-      .from('developments')
-      .select('id, name')
-      .eq('tenant_id', tenantId)
-      .ilike('name', `%${params.related_scheme}%`)
-      .limit(1)
-      .maybeSingle();
-
-    if (dev) {
-      schemeName = dev.name;
-      const { data: units } = await supabase
-        .from('units')
-        .select('id, unit_number, unit_uid, purchaser_email')
-        .eq('development_id', dev.id)
-        .or(`unit_number.ilike.%${params.related_unit}%,unit_uid.ilike.%${params.related_unit}%`)
-        .limit(1);
-
-      if (units?.[0]) {
-        recipientEmail = units[0].purchaser_email;
-        unitNumber = units[0].unit_number || units[0].unit_uid || params.related_unit;
-        unitContext = `Unit ${unitNumber} in ${dev.name}`;
-      }
-    }
-  }
-
-  // Determine tone
-  const tone = params.tone || (
-    params.recipient_type === 'buyer' ? 'warm' :
-    params.recipient_type === 'solicitor' ? 'formal' :
-    'professional'
-  );
-
-  // Extract first name from recipient
-  const firstName = params.recipient_name.split(' ')[0];
-
-  // Return rich context so the LLM generates the COMPLETE email in its response
-  return {
-    data: {
-      draft_ready: true,
-      recipient_type: params.recipient_type,
-      recipient_name: params.recipient_name,
-      recipient_first_name: firstName,
-      recipient_email: recipientEmail,
-      context: params.context,
-      tone,
-      unit_context: unitContext,
-      unit_number: unitNumber,
-      scheme_name: schemeName,
-      agent_name: agentContext.displayName,
-      instruction: `Generate the COMPLETE email now. Include: Subject line, greeting using "${firstName}", full body text, sign-off, and signature placeholder ([Agent Name] / [Agent Phone] / [Agency Name]). The email must sound like a real person wrote it in natural Irish conversational English. Do NOT describe what the email would say — write the actual email text ready to copy and send.`,
-    },
-    summary: `Drafting email to ${firstName} ${params.recipient_name !== firstName ? `(${params.recipient_name})` : ''} — ${unitContext || params.context.slice(0, 60)}.`,
-  };
-}
+// Session 6D: the pre-6D `draftMessage()` template helper was removed.
+// It claimed success without writing to `pending_drafts`, which caused the
+// model to confidently announce drafts that didn't exist. The envelope-
+// producing replacement lives in `./agentic-skills.ts` as
+// `draftMessageSkill()` and is wired into the registry there.
 
 export async function generateDeveloperReport(
   supabase: SupabaseClient,

--- a/apps/unified-portal/lib/agent-intelligence/types.ts
+++ b/apps/unified-portal/lib/agent-intelligence/types.ts
@@ -41,16 +41,28 @@ export type ToolFunction = (
   params: Record<string, any>
 ) => Promise<ToolResult>;
 
+/**
+ * A JSON Schema parameter as accepted by OpenAI function-calling. Shaped
+ * recursively: `array` types MUST carry an `items` sub-schema, `object`
+ * types MUST carry a `properties` map — OpenAI 400s otherwise.
+ */
+export interface ToolParameterSchema {
+  type: string;
+  description?: string;
+  enum?: string[];
+  /** Required when `type === 'array'`. */
+  items?: ToolParameterSchema;
+  /** Required when `type === 'object'`. */
+  properties?: Record<string, ToolParameterSchema>;
+  required?: string[];
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
   parameters: {
     type: 'object';
-    properties: Record<string, {
-      type: string;
-      description: string;
-      enum?: string[];
-    }>;
+    properties: Record<string, ToolParameterSchema>;
     required: string[];
   };
   execute: ToolFunction;

--- a/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
@@ -208,4 +208,28 @@ describe('Tool registry invariant (Session 6D)', () => {
       expect(tool.execute.name).toBe('');
     }
   });
+
+  // Session 6D hotfix: any `type: 'array'` parameter MUST carry an `items`
+  // sub-schema, otherwise OpenAI rejects the whole completion with a 400.
+  // Any `type: 'object'` parameter MUST carry `properties`. Walk every tool
+  // and assert both.
+  it('every array parameter declares items, every object declares properties', () => {
+    function walk(node: any, path: string): void {
+      if (!node || typeof node !== 'object') return;
+      if (node.type === 'array') {
+        expect(node.items).toBeDefined();
+        expect(typeof node.items?.type).toBe('string');
+        walk(node.items, `${path}.items`);
+      }
+      if (node.type === 'object' && node !== undefined) {
+        expect(node.properties).toBeDefined();
+        for (const [key, child] of Object.entries(node.properties || {})) {
+          walk(child, `${path}.${key}`);
+        }
+      }
+    }
+    for (const tool of AGENT_TOOL_DEFINITIONS) {
+      walk(tool.parameters, tool.name);
+    }
+  });
 });

--- a/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Session 6D regression guards.
+ *
+ * Protect two specific invariants that broke in production:
+ *   1. Every draft-producing tool funnels through persistDraftsForEnvelope
+ *      (no skill may claim success without writing to pending_drafts).
+ *   2. The new draft_message / draft_buyer_followups skills produce real
+ *      envelopes with drafts[] populated.
+ *
+ * Hermetic — stubbed Supabase, no network.
+ */
+
+import {
+  draftMessageSkill,
+  draftBuyerFollowups,
+} from '../../lib/agent-intelligence/tools/agentic-skills';
+import { AGENT_TOOL_DEFINITIONS } from '../../lib/agent-intelligence/tools/registry';
+import { persistDraftsForEnvelope } from '../../lib/agent-intelligence/draft-store';
+import { isAgenticSkillEnvelope } from '../../lib/agent-intelligence/envelope';
+
+const SKILL_CTX = {
+  agentId: 'profile-1',
+  userId: 'user-1',
+  displayName: 'Orla Hennessy',
+  agencyName: 'Hennessy Property',
+};
+
+type Row = Record<string, any>;
+
+function mockSupabase(state: {
+  developments?: Row[];
+  units?: Row[];
+  agent_scheme_assignments?: Row[];
+  pending_drafts?: Row[];
+}) {
+  const data = {
+    developments: state.developments ?? [],
+    units: state.units ?? [],
+    agent_scheme_assignments: state.agent_scheme_assignments ?? [],
+    pending_drafts: state.pending_drafts ?? [],
+  };
+
+  function qb(table: keyof typeof data) {
+    const filters: Row = {};
+    const ins: Row[] = [];
+    const builder: any = {
+      eq(col: string, val: any) { filters[col] = val; return builder; },
+      in(col: string, vals: any[]) { filters[`__in_${col}`] = vals; return builder; },
+      ilike() { return builder; },
+      order() { return builder; },
+      limit() { return builder; },
+      not() { return builder; },
+      is() { return builder; },
+      or() { return builder; },
+      select() { return builder; },
+      insert(row: Row) {
+        const withId = { id: `row-${data[table].length + 1}`, ...row };
+        data[table].push(withId);
+        ins.push(withId);
+        return {
+          select() { return { single: async () => ({ data: withId, error: null }) }; },
+        };
+      },
+      async single() { return { data: (data[table] as Row[])[0] ?? null, error: null }; },
+      async maybeSingle() {
+        const rows = data[table] as Row[];
+        const match = rows.find((r) =>
+          Object.entries(filters).every(([k, v]) =>
+            k.startsWith('__in_') ? (v as any[]).includes(r[k.slice(5)]) : r[k] === v,
+          ),
+        ) ?? null;
+        return { data: match, error: null };
+      },
+      then(resolve: any) {
+        const rows = (data[table] as Row[]).filter((r) =>
+          Object.entries(filters).every(([k, v]) =>
+            k.startsWith('__in_') ? (v as any[]).includes(r[k.slice(5)]) : r[k] === v,
+          ),
+        );
+        return Promise.resolve({ data: rows, error: null }).then(resolve);
+      },
+    };
+    return builder;
+  }
+
+  return { from: (table: string) => qb(table as any) } as any;
+}
+
+describe('draftMessageSkill (Session 6D)', () => {
+  it('returns a valid envelope with one draft persisted through the helper', async () => {
+    const supabase = mockSupabase({
+      developments: [{ id: 'dev-1', name: 'Árdan View' }],
+      units: [
+        {
+          id: 'unit-50',
+          development_id: 'dev-1',
+          unit_number: '50',
+          unit_uid: 'AV-50',
+          purchaser_email: 'laura@example.com',
+          purchaser_name: 'Laura Hayes',
+        },
+      ],
+    });
+
+    const envelope = await draftMessageSkill(supabase, SKILL_CTX, {
+      recipient_type: 'buyer',
+      recipient_name: 'Laura Hayes',
+      context: "Checking when you expect to have the contracts signed.",
+      tone: 'gentle_chase',
+      related_unit: '50',
+      related_scheme: 'Árdan View',
+    });
+
+    expect(isAgenticSkillEnvelope(envelope)).toBe(true);
+    expect(envelope.drafts).toHaveLength(1);
+    expect(envelope.drafts[0].recipient?.email).toBe('laura@example.com');
+    expect(envelope.drafts[0].body).toContain('Laura');
+    expect(envelope.drafts[0].subject).toContain('Unit 50');
+    expect(envelope.summary.toLowerCase()).toContain('drafted email to laura');
+
+    // End-to-end: envelope flows through persistDraftsForEnvelope without
+    // errors, rows land in pending_drafts, ids are rewritten.
+    const persisted = await persistDraftsForEnvelope(supabase, envelope, {
+      userId: SKILL_CTX.userId,
+      tenantId: 'tenant-1',
+      skill: envelope.skill,
+    });
+    expect(persisted.drafts[0].id).not.toBe(envelope.drafts[0].id); // rewritten
+  });
+
+  it('returns a clear failure envelope when recipient name is missing', async () => {
+    const supabase = mockSupabase({});
+    const envelope = await draftMessageSkill(supabase, SKILL_CTX, {
+      recipient_type: 'buyer',
+      recipient_name: '',
+      context: 'hi',
+    } as any);
+    expect(envelope.drafts).toHaveLength(0);
+    expect(envelope.summary).toMatch(/required/i);
+  });
+});
+
+describe('draftBuyerFollowups (Session 6D)', () => {
+  it('produces one draft per resolved unit in a single envelope', async () => {
+    const supabase = mockSupabase({
+      developments: [{ id: 'dev-1', name: 'Árdan View' }],
+      units: [
+        { id: 'u-19', development_id: 'dev-1', unit_number: '19', unit_uid: 'AV-19', purchaser_name: 'Laura Hayes', purchaser_email: 'laura@example.com' },
+        { id: 'u-37', development_id: 'dev-1', unit_number: '37', unit_uid: 'AV-37', purchaser_name: 'Dylan Rogers', purchaser_email: 'dylan@example.com' },
+        { id: 'u-36', development_id: 'dev-1', unit_number: '36', unit_uid: 'AV-36', purchaser_name: 'Prem Rai', purchaser_email: 'prem@example.com' },
+      ],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+      ],
+    });
+
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [
+        { unit_identifier: '19', scheme_name: 'Árdan View' },
+        { unit_identifier: '37', scheme_name: 'Árdan View' },
+        { unit_identifier: '36', scheme_name: 'Árdan View' },
+      ],
+      topic: 'Asking when they expect to sign the contracts.',
+    });
+
+    expect(envelope.drafts.length).toBe(3);
+    expect(envelope.summary).toMatch(/Drafted 3/);
+    for (const d of envelope.drafts) {
+      expect(d.body.length).toBeGreaterThan(50);
+      expect(d.affected_record.kind).toBe('sales_unit');
+    }
+  });
+
+  it('returns an empty-drafts envelope (not a hallucination) when no targets resolve', async () => {
+    const supabase = mockSupabase({
+      developments: [{ id: 'dev-1', name: 'Árdan View' }],
+      units: [],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+      ],
+    });
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: '999', scheme_name: 'Árdan View' }],
+      topic: 'something',
+    });
+    expect(envelope.drafts).toHaveLength(0);
+    expect(envelope.summary).toMatch(/could not resolve/i);
+  });
+});
+
+describe('Tool registry invariant (Session 6D)', () => {
+  it('every tool named like a draft-producer is wired through runAgenticSkill', () => {
+    const DRAFT_PRODUCERS = new Set([
+      'draft_message',
+      'draft_buyer_followups',
+      'chase_aged_contracts',
+      'draft_viewing_followup',
+      'draft_lease_renewal',
+      'weekly_monday_briefing',
+      'schedule_viewing_draft',
+    ]);
+    for (const tool of AGENT_TOOL_DEFINITIONS) {
+      if (!DRAFT_PRODUCERS.has(tool.name)) continue;
+      // runAgenticSkill produces an anonymous arrow in registry.ts; the
+      // identity guard here is "does it NOT point at a raw write-tools
+      // function" — all raw write-tools functions are named. An arrow
+      // wrapping a skill has empty name.
+      expect(tool.execute.name).toBe('');
+    }
+  });
+});


### PR DESCRIPTION
Root cause: draft_message was a template helper returning an `instruction` string for the model to inline the email — not an envelope-producing skill. No pending_drafts row, no envelope, no drawer, yet the model reported drafts as ready. Session 5A hardened the envelope path for chase_aged_contracts and friends, but never touched this one.

- New draftMessageSkill + draft_buyer_followups agentic skills, both routed through runAgenticSkill → persistSkillEnvelope → pending_drafts
- Registry points draft_message at the new skill; old write-tools draftMessage removed to eliminate the dead path
- Chat route merges all envelopes from a turn into one combined envelope so the drawer (which replaces state on each open call) shows the full set rather than only the last
- Anti-hallucination guard: pre-stream system correction when a draft tool fires but no drafts land, post-stream `override` SSE frame when the model claims drafts-are-ready without any envelope, telemetry via intelligence_interactions.response_type = 'hallucinated_drafts' and a console.error for Vercel
- Both /agent/intelligence and /agent/dashboard/intelligence handle the override frame and replace the streamed content