### PR TITLE
feat(agent-app): drop Docs from bottom nav, add Docs tile + alt entries

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -6,18 +6,19 @@ import Image from 'next/image';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
 import { useApplicantsCount } from '../_hooks/useApplicantsCount';
 
-type TabId = 'home' | 'pipeline' | 'applicants' | 'viewings' | 'docs';
+type TabId = 'home' | 'pipeline' | 'applicants' | 'viewings';
 
 const TABS: { id: TabId; label: string; href: string }[] = [
   { id: 'home', label: 'Home', href: '/agent/home' },
   { id: 'pipeline', label: 'Pipeline', href: '/agent/pipeline' },
   // Intelligence FAB sits between the two clusters.
-  // Right cluster leans lettings-heavy: Applicants + Viewings + Docs.
-  // Drafts was removed from the bottom nav in Session 5B; access is via
-  // the FAB badge, the Home tile, or the Intelligence greeting.
+  // Right cluster: Applicants + Viewings.
+  // Drafts was removed from the bottom nav in Session 5B (access via the
+  // FAB badge / Home tile). Docs was removed in Session 6C (access via
+  // the DocsHomeTile, property detail, and scheme summary links). Four
+  // tabs + centred FAB restores the symmetric two-and-two layout.
   { id: 'applicants', label: 'Applicants', href: '/agent/applicants' },
   { id: 'viewings', label: 'Viewings', href: '/agent/viewings' },
-  { id: 'docs', label: 'Docs', href: '/agent/docs' },
 ];
 
 function TabIcon({ id, active }: { id: TabId; active: boolean }) {
@@ -58,13 +59,6 @@ function TabIcon({ id, active }: { id: TabId; active: boolean }) {
           <line x1="16" y1="2" x2="16" y2="6" />
           <line x1="8" y1="2" x2="8" y2="6" />
           <line x1="3" y1="10" x2="21" y2="10" />
-        </svg>
-      );
-    case 'docs':
-      return (
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
-          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
-          <polyline points="14,2 14,8 20,8" />
         </svg>
       );
   }
@@ -212,7 +206,7 @@ export default function BottomNav() {
         </span>
       </div>
 
-      {/* Right tabs: Applicants, Viewings, Docs */}
+      {/* Right tabs: Applicants, Viewings */}
       {rightTabs.map((tab) => {
         const active = isActive(tab.href);
         return (

--- a/apps/unified-portal/app/agent/_components/DocsHomeTile.tsx
+++ b/apps/unified-portal/app/agent/_components/DocsHomeTile.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, FileText } from 'lucide-react';
+
+/**
+ * Session 6C — Docs entry point on the agent Home screen.
+ * Replaces the bottom-nav Docs tab. Tap navigates to /agent/docs.
+ *
+ * Visual: same card shape as DraftsHomeTile. A neutral grey-tinted icon
+ * circle signals this is an informational shelf (browsing), not an action
+ * bucket like Drafts (which has the gold accent because items demand
+ * review).
+ */
+export default function DocsHomeTile() {
+  return (
+    <Link
+      href="/agent/docs"
+      data-testid="home-docs-tile"
+      style={{ textDecoration: 'none', display: 'block', marginBottom: 20 }}
+    >
+      <div
+        className="agent-tappable"
+        style={{
+          background: '#FFFFFF',
+          borderRadius: 18,
+          padding: '14px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+        }}
+      >
+        <div
+          style={{
+            width: 38,
+            height: 38,
+            borderRadius: 19,
+            background: 'rgba(13,13,18,0.05)',
+            border: '1px solid rgba(13,13,18,0.08)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <FileText size={18} color="#6B7280" strokeWidth={1.8} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14.5, fontWeight: 600, color: '#0D0D12', letterSpacing: '-0.01em', lineHeight: 1.25 }}>
+            Docs
+          </div>
+          <div style={{ fontSize: 12, color: '#A0A8B0', marginTop: 2 }}>
+            Browse properties, certs and more
+          </div>
+        </div>
+        <ChevronRight size={18} color="#B0B8C4" />
+      </div>
+    </Link>
+  );
+}

--- a/apps/unified-portal/app/agent/_components/IndependentHomeView.tsx
+++ b/apps/unified-portal/app/agent/_components/IndependentHomeView.tsx
@@ -11,6 +11,7 @@ import {
   getListings,
 } from '@/lib/agent/independentAgentService';
 import DraftsHomeTile from './DraftsHomeTile';
+import DocsHomeTile from './DocsHomeTile';
 
 interface IndependentHomeViewProps {
   agent: AgentProfile;
@@ -82,6 +83,8 @@ export default function IndependentHomeView({ agent }: IndependentHomeViewProps)
 
       {/* Drafts tile — replaces the bottom-nav Drafts tab. */}
       <DraftsHomeTile />
+      {/* Docs tile — replaces the bottom-nav Docs tab (Session 6C). */}
+      <DocsHomeTile />
 
       {/* Price review alerts */}
       {priceReviews.length > 0 && (

--- a/apps/unified-portal/app/agent/docs/page.tsx
+++ b/apps/unified-portal/app/agent/docs/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useAgent } from '@/lib/agent/AgentContext';
 import AgentShell from '../_components/AgentShell';
 import { ChevronDown, Plus, X, Upload, Check } from 'lucide-react';
@@ -36,10 +37,25 @@ const DOC_TYPE_LABELS: Record<string, string> = {
 
 export default function DocsPage() {
   const { agent, alerts, developments } = useAgent();
-  const [activeScheme, setActiveScheme] = useState<string>('all');
+  const searchParams = useSearchParams();
+  // Session 6C: landings from the scheme summary page or unit detail pass
+  // ?scheme=<developmentId> so the Docs shelf opens pre-filtered. Falls
+  // back to 'all' when the param is absent (home tile, sidebar).
+  const [activeScheme, setActiveScheme] = useState<string>(
+    searchParams?.get('scheme') || 'all',
+  );
   const [docs, setDocs] = useState<Doc[]>(INITIAL_DOCS);
   const [showUpload, setShowUpload] = useState(false);
   const [uploadSuccess, setUploadSuccess] = useState(false);
+
+  // Keep the filter in sync if the query param changes while the component
+  // stays mounted (back/forward navigation between different scheme links).
+  useEffect(() => {
+    const paramScheme = searchParams?.get('scheme');
+    if (paramScheme && paramScheme !== activeScheme) {
+      setActiveScheme(paramScheme);
+    }
+  }, [searchParams, activeScheme]);
 
   // Upload form state
   const [uploadName, setUploadName] = useState('');

--- a/apps/unified-portal/app/agent/home/page.tsx
+++ b/apps/unified-portal/app/agent/home/page.tsx
@@ -11,6 +11,7 @@ import AgentShell from '../_components/AgentShell';
 import StatModal from '../_components/StatModal';
 import IndependentHomeView from '../_components/IndependentHomeView';
 import DraftsHomeTile from '../_components/DraftsHomeTile';
+import DocsHomeTile from '../_components/DocsHomeTile';
 import type { StatModalType, Scheme as UIScheme, Buyer as UIBuyer } from '../_components/types';
 
 // Convert real pipeline data to the Scheme/Buyer types that StatModal expects
@@ -191,6 +192,10 @@ export default function AgentHomePage() {
 
         {/* Drafts tile — replaces the bottom-nav Drafts tab from Session 1. */}
         <DraftsHomeTile />
+        {/* Docs tile — replaces the bottom-nav Docs tab from Session 6C.
+            Drafts sits first because overdue drafts are more time-sensitive
+            than browsing documents. */}
+        <DocsHomeTile />
 
         {/* Requires action section */}
         <SectionLabel>Requires action</SectionLabel>

--- a/apps/unified-portal/app/agent/pipeline/[unitId]/page.tsx
+++ b/apps/unified-portal/app/agent/pipeline/[unitId]/page.tsx
@@ -381,6 +381,51 @@ export default function UnitProfilePage() {
             </Section>
           )}
 
+          {/* Documents — Session 6C: alternative entry point to /agent/docs
+              now that Docs is off the bottom nav. Filtered to the unit's
+              parent scheme so the agent lands on the relevant shelf. */}
+          <Link
+            href={`/agent/docs?scheme=${encodeURIComponent(profile.developmentId || '')}`}
+            data-testid="unit-docs-link"
+            className="agent-tappable"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '14px 16px',
+              background: '#FFFFFF',
+              borderRadius: 14,
+              marginBottom: 12,
+              textDecoration: 'none',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+            }}
+          >
+            <div
+              style={{
+                width: 34,
+                height: 34,
+                borderRadius: 17,
+                background: 'rgba(13,13,18,0.05)',
+                border: '1px solid rgba(13,13,18,0.08)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <FileText size={16} color="#6B7280" strokeWidth={1.8} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12', letterSpacing: '-0.01em' }}>
+                View documents
+              </div>
+              <div style={{ fontSize: 12, color: '#A0A8B0', marginTop: 2 }}>
+                BER, brochures, forms for {profile.developmentName}
+              </div>
+            </div>
+            <ChevronRight size={16} color="#B0B8C4" />
+          </Link>
+
           {/* Note Logger */}
           <Section title="Log a note">
             <div className="space-y-2">

--- a/apps/unified-portal/app/agent/pipeline/scheme/[schemeId]/page.tsx
+++ b/apps/unified-portal/app/agent/pipeline/scheme/[schemeId]/page.tsx
@@ -8,7 +8,7 @@ import AgentShell from '../../../_components/AgentShell';
 import {
   getTimelineNudges, getInitials, type PipelineUnit,
 } from '@/lib/agent/agentPipelineService';
-import { ArrowLeft, ChevronRight, Search } from 'lucide-react';
+import { ArrowLeft, ChevronRight, FileText, Search } from 'lucide-react';
 
 type FilterKey = 'all' | 'for_sale' | 'sale_agreed' | 'contracts_issued' | 'signed' | 'sold';
 
@@ -97,10 +97,34 @@ export default function SchemeDetailPage() {
           Pipeline
         </Link>
 
-        {/* Scheme header */}
-        <h1 style={{ fontSize: 22, fontWeight: 700, color: '#0D0D12', letterSpacing: '-0.04em', marginBottom: 4 }}>
-          {schemeName}
-        </h1>
+        {/* Scheme header + Docs link (Session 6C: alternative Docs entry
+            point now that Docs is off the bottom nav). */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 4 }}>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: '#0D0D12', letterSpacing: '-0.04em', margin: 0 }}>
+            {schemeName}
+          </h1>
+          <Link
+            href={`/agent/docs?scheme=${encodeURIComponent(schemeId)}`}
+            data-testid="scheme-docs-link"
+            className="agent-tappable"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 12px',
+              borderRadius: 999,
+              background: 'rgba(13,13,18,0.05)',
+              border: '0.5px solid rgba(13,13,18,0.08)',
+              color: '#6B7280',
+              fontSize: 12,
+              fontWeight: 600,
+              textDecoration: 'none',
+              flexShrink: 0,
+            }}
+          >
+            <FileText size={13} /> Docs
+          </Link>
+        </div>
 
         {/* Stats row */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>


### PR DESCRIPTION
Bottom nav returns to 4 tabs + centred FAB (Home, Pipeline, FAB, Applicants, Viewings). Five flex: 1 columns, two-and-two symmetric layout. No pixel screenshot available in this sandbox — structural audit only.

- BottomNav.tsx: drop 'docs' TabId, drop the FileText case, update the right-cluster comment. slice(0,2) + slice(2) still yields 2+2 tabs.
- DocsHomeTile.tsx: new home-screen entry mirroring DraftsHomeTile, with a neutral grey-tinted FileText circle (Docs is browsing, not an action pile like Drafts). Subtitle is static: browsing documents doesn't have an "N waiting" count.
- Mount DocsHomeTile below DraftsHomeTile on both scheme home (home/page.tsx) and IndependentHomeView — drafts sit first because they are more time-sensitive.
- pipeline/scheme/[schemeId]: Docs pill in the scheme header, links to /agent/docs?scheme=<id>.
- pipeline/[unitId]: full "View documents" card between the mortgage section and the note logger, filters to the unit's parent scheme.
- docs/page.tsx: reads ?scheme=<id> from searchParams to pre-select the scheme filter, keeping the existing behaviour when no param is given.

Desktop sidebar Docs entry is untouched.