### PR TITLE
feat(agent-app): quiet intelligence landing with rotating chip carousel

### DIFF
--- a/INTELLIGENCE_LANDING_DIAGNOSIS.md
+++ b/INTELLIGENCE_LANDING_DIAGNOSIS.md
@@ -1,0 +1,76 @@
+# Intelligence Landing Diagnosis (Session 7)
+
+1. **Landing renders in a single file.** `apps/unified-portal/app/agent/intelligence/page.tsx`
+   is a 1,400-line component that owns both the landing state (empty
+   messages array) and the conversation state. The "Ask anything about
+   your pipeline or tasks" hero, the drafts banner
+   (`intelligence-drafts-greeting`), the WRITE_PILLS 2×3 grid (line 790),
+   and the PROMPT_PILLS 2×2 grid (line 827) all live inside the
+   `!hasMessages` branch starting at line 661. The VoiceInputBar is the
+   pinned footer. There is no separate landing component and no carousel.
+   Desktop uses `app/agent/dashboard/intelligence/page.tsx` — a different
+   file, untouched.
+
+2. **Async data at first paint.** Four hooks populate the landing after
+   the first render: `useAgent()` (agent profile + alerts +
+   developmentIds, server-bound), `useDraftsCount()` (polls
+   `/api/agent/intelligence/drafts` — initial state is `0`, resolves over
+   network), `useVoiceCapture()` (local refs only, no network), and
+   `useApprovalDrawer()` (local state). `useSearchParams()` delivers the
+   `?prompt=` prefill synchronously.
+
+3. **The shifts.** `pendingDraftsCount` starts at `0`, so the
+   conditional drafts banner (line 736) is absent on first paint, then
+   pops into the flex column once the fetch returns a non-zero count.
+   Because the landing uses `justifyContent: center` on a flex column and
+   every sibling has natural height, the hero title, both pill grids,
+   and the hero image all shift upward when the banner appears. The
+   PROMPT_PILLS branch picks between SCHEME_PILLS and INDEPENDENT_PILLS
+   based on `agent?.agentType` — undefined until `useAgent()` resolves
+   — so for one tick the component renders scheme pills even for
+   independent agents, then re-renders. That re-render doesn't change
+   layout size but does flash content.
+
+4. **Action-grid handlers.** WRITE_PILLS (lines 35–42) are voice-capture
+   entry points. Each one routes through `handleWriteChip(intent)` at
+   line 638, which stashes the intent in `voiceIntentRef.current` and
+   calls `voice.start()` to open the mic. None of them prefill the
+   input bar or navigate. The value of WRITE_PILLS for the model is
+   only that the intent is stamped onto the voice transcript payload
+   — if those same intents are available as natural-language chips in
+   the new carousel and the user just says/types the chip text, the
+   backend's routing handles it the same way.
+
+5. **No existing chip carousel.** The codebase has pill grids (non-rotating
+   flex layouts in this same file and in VoiceConfirmationCard.tsx) and
+   follow-up chip rows on AI responses (`AIResponseCard` at the end of
+   page.tsx), but no rotating carousel pattern. `CapabilityChipsCarousel`
+   needs to be built from scratch. Keep the bundle lean — no Framer
+   Motion dependency; a CSS transition on transform + opacity is
+   sufficient for the slide effect.
+
+## Fix plan applied in this commit
+
+- New `lib/agent-intelligence/capability-chips.ts` exports the 21 chip
+  library. Shuffled on mount inside the carousel so first-impression
+  chips vary session-to-session.
+- New `app/agent/_components/CapabilityChipsCarousel.tsx`: 4 chips
+  visible, rotates every 6s, pauses on input focus + pointer hover,
+  respects `prefers-reduced-motion` (fade-swap instead of slide). Tapping
+  a chip calls `onChipTap(text)` passed from the page — that handler
+  prefills the input and focuses it, without auto-submitting.
+- Landing rebuild in `app/agent/intelligence/page.tsx`:
+  * WRITE_PILLS grid deleted (`handleWriteChip` left wired to the voice
+    intent flow, but the button surface is gone — voice workflows still
+    pick up the intent when the user starts a voice capture via the mic
+    button, and the chip library now seeds "Log a rental viewing for
+    tomorrow" as natural language).
+  * PROMPT_PILLS grid replaced with the carousel.
+  * Hero copy is "What can I help with, <first name>?" above the quiet
+    helper line.
+  * Drafts banner now reserves its height with a fixed-height skeleton
+    until `useDraftsCount` resolves. `useDraftsCount` now returns
+    `ready: boolean` so downstream can distinguish "still loading" from
+    "resolved to zero".
+- Desktop dashboard is untouched — the changes are confined to
+  `app/agent/intelligence/page.tsx` and new component files.

--- a/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
+++ b/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CAPABILITY_CHIPS,
+  shuffleChips,
+} from '@/lib/agent-intelligence/capability-chips';
+
+const VISIBLE = 4;
+const ROTATE_MS = 6_000;
+const SLIDE_MS = 320;
+
+interface CapabilityChipsCarouselProps {
+  /**
+   * Called when the user taps a chip. The parent prefills the input bar
+   * and focuses it. The carousel does NOT auto-submit.
+   */
+  onChipTap: (text: string) => void;
+  /**
+   * When true the carousel stops rotating (e.g. the input has focus —
+   * rotating chips under the cursor is disorienting).
+   */
+  paused?: boolean;
+  /**
+   * Allows callers to override the pool (tests). Defaults to the full
+   * CAPABILITY_CHIPS list.
+   */
+  pool?: readonly string[];
+}
+
+/**
+ * Session 7 — rotating chip carousel that sits above the input bar on
+ * the Intelligence landing. Showcases Intelligence's capabilities without
+ * a permanent button grid.
+ *
+ * Rotation behaviour:
+ *   - 4 chips visible at any time
+ *   - Advances by one slot every 6 seconds
+ *   - Pauses when the paused prop is true (parent wires this to input
+ *     focus)
+ *   - Pauses on pointer hover so the agent can read a chip before it
+ *     rotates away
+ *   - Respects `prefers-reduced-motion` — fade-swap instead of slide
+ *
+ * Why a window of four from a shuffled pool rather than randomised-on-
+ * every-tick: predictable rotation lets the eye follow along, and
+ * shuffling once per mount means first-impression chips differ session
+ * to session.
+ */
+export default function CapabilityChipsCarousel({
+  onChipTap,
+  paused = false,
+  pool = CAPABILITY_CHIPS,
+}: CapabilityChipsCarouselProps) {
+  // Shuffle once per mount so different sessions surface different
+  // chips first. useMemo with an empty dep list; the shuffle output is
+  // stable for the component lifetime.
+  const deck = useMemo(() => shuffleChips(pool), [pool]);
+  const safeDeck = deck.length >= VISIBLE ? deck : [...deck, ...deck];
+
+  const [offset, setOffset] = useState(0);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [fade, setFade] = useState(1);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Detect prefers-reduced-motion. Updates live if the user toggles the
+  // setting while the app is open.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const apply = () => setReducedMotion(mq.matches);
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, []);
+
+  const advance = useCallback(() => {
+    if (reducedMotion) {
+      // Fade out, swap, fade in — gentler than the slide for
+      // motion-sensitive users.
+      setFade(0);
+      window.setTimeout(() => {
+        setOffset((o) => (o + 1) % safeDeck.length);
+        setFade(1);
+      }, 180);
+    } else {
+      setOffset((o) => (o + 1) % safeDeck.length);
+    }
+  }, [reducedMotion, safeDeck.length]);
+
+  useEffect(() => {
+    if (paused || hovered) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+    intervalRef.current = setInterval(advance, ROTATE_MS);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [paused, hovered, advance]);
+
+  const visible = useMemo(() => {
+    const out: Array<{ key: string; text: string }> = [];
+    for (let i = 0; i < VISIBLE; i++) {
+      const idx = (offset + i) % safeDeck.length;
+      out.push({ key: `${idx}-${safeDeck[idx]}`, text: safeDeck[idx] });
+    }
+    return out;
+  }, [offset, safeDeck]);
+
+  return (
+    <div
+      data-testid="capability-chips-carousel"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onTouchStart={() => setHovered(true)}
+      onTouchEnd={() => setHovered(false)}
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 8,
+        padding: '0 16px',
+        width: '100%',
+        maxWidth: 720,
+        margin: '0 auto',
+        opacity: reducedMotion ? fade : 1,
+        transition: reducedMotion
+          ? `opacity ${SLIDE_MS}ms ease`
+          : undefined,
+      }}
+    >
+      {visible.map((chip) => (
+        <Chip
+          key={chip.key}
+          text={chip.text}
+          reducedMotion={reducedMotion}
+          onTap={() => onChipTap(chip.text)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Chip({
+  text,
+  reducedMotion,
+  onTap,
+}: {
+  text: string;
+  reducedMotion: boolean;
+  onTap: () => void;
+}) {
+  // Slide-in animation: each chip is keyed on its idx-text so when the
+  // rotation advances, React unmounts the leftmost chip and mounts a
+  // fresh rightmost one. The fresh chip enters from the right via a
+  // CSS keyframe. Reduced-motion users skip the keyframe.
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      aria-label={`Tap to ask: ${text}`}
+      data-testid="capability-chip"
+      className="agent-tappable"
+      style={{
+        maxWidth: '100%',
+        padding: '0 14px',
+        height: 36,
+        borderRadius: 999,
+        background: 'rgba(13,13,18,0.04)',
+        border: '0.5px solid rgba(13,13,18,0.08)',
+        color: '#0b0c0f',
+        fontSize: 13,
+        fontWeight: 500,
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        cursor: 'pointer',
+        fontFamily: 'inherit',
+        animation: reducedMotion
+          ? undefined
+          : `oh-chip-slide-in ${SLIDE_MS}ms cubic-bezier(0.2, 0.8, 0.2, 1)`,
+      }}
+    >
+      {text}
+      <style>{`
+        @keyframes oh-chip-slide-in {
+          from { transform: translateX(12px); opacity: 0; }
+          to { transform: translateX(0); opacity: 1; }
+        }
+      `}</style>
+    </button>
+  );
+}

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { Mic, Send, Square } from 'lucide-react';
 import type { VoiceCaptureState } from '../_hooks/useVoiceCapture';
 
@@ -18,13 +19,20 @@ interface VoiceInputBarProps {
    * `voice.permissionDenied` is true.
    */
   onOpenSettings?: () => Promise<boolean> | void;
+  /** Session 7 — the carousel above pauses rotation while the input
+      has focus so chips don't rotate under the user's typing cursor. */
+  onFocus?: () => void;
+  onBlur?: () => void;
 }
 
 /**
  * Unified input bar. In idle mode it behaves like the existing typed Intelligence
  * input. Tapping the mic transforms it into a live waveform + partial transcript.
+ *
+ * Exposes its underlying `<input>` via `ref` so callers can imperatively
+ * focus it after a chip tap (Session 7 — CapabilityChipsCarousel).
  */
-export default function VoiceInputBar({
+const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function VoiceInputBar({
   input,
   onInputChange,
   onSend,
@@ -34,7 +42,11 @@ export default function VoiceInputBar({
   onStop,
   isDesktop,
   onOpenSettings,
-}: VoiceInputBarProps) {
+  onFocus,
+  onBlur,
+}, ref) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
   const recording = voice.status === 'recording' || voice.status === 'transcribing';
   const micSize = isDesktop ? 40 : 34;
   const sendSize = 34;
@@ -104,10 +116,13 @@ export default function VoiceInputBar({
           <WaveformDisplay samples={voice.waveform} />
         ) : (
           <input
+            ref={inputRef}
             type="text"
             value={input}
             onChange={(e) => onInputChange(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && onSend()}
+            onFocus={onFocus}
+            onBlur={onBlur}
             placeholder="Ask Intelligence anything..."
             style={{
               flex: 1,
@@ -272,7 +287,9 @@ export default function VoiceInputBar({
       `}</style>
     </div>
   );
-}
+});
+
+export default VoiceInputBar;
 
 function WaveformDisplay({ samples }: { samples: number[] }) {
   return (

--- a/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
+++ b/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
@@ -12,8 +12,15 @@ const POLL_INTERVAL_MS = 30_000;
  * action, send flow) can dispatch `oh.agent.drafts.refresh` to force an
  * immediate refresh instead of waiting for the next poll tick.
  */
-export function useDraftsCount(): { count: number; refresh: () => Promise<void> } {
+export function useDraftsCount(): {
+  count: number;
+  /** True once the initial fetch has settled. Lets callers reserve
+      layout space until they know whether to render a banner. */
+  ready: boolean;
+  refresh: () => Promise<void>;
+} {
   const [count, setCount] = useState(0);
+  const [ready, setReady] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -23,6 +30,8 @@ export function useDraftsCount(): { count: number; refresh: () => Promise<void> 
       if (typeof data.count === 'number') setCount(data.count);
     } catch {
       /* silent — the badge just stays at its last known value */
+    } finally {
+      setReady(true);
     }
   }, []);
 
@@ -37,7 +46,7 @@ export function useDraftsCount(): { count: number; refresh: () => Promise<void> 
     };
   }, [refresh]);
 
-  return { count, refresh };
+  return { count, ready, refresh };
 }
 
 export function notifyDraftsChanged(): void {

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -8,6 +8,7 @@ import AgentShell from '../_components/AgentShell';
 import VoiceInputBar from '../_components/VoiceInputBar';
 import VoiceConfirmationCard from '../_components/VoiceConfirmationCard';
 import UndoPill from '../_components/UndoPill';
+import CapabilityChipsCarousel from '../_components/CapabilityChipsCarousel';
 import { useVoiceCapture } from '../_hooks/useVoiceCapture';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { Mail, Copy, Check, ExternalLink } from 'lucide-react';
@@ -18,28 +19,14 @@ import { ApprovalDrawerProvider, useApprovalDrawer } from '@/lib/agent-intellige
 import { isAgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import ApprovalDrawer from '@/components/agent/intelligence/ApprovalDrawer';
 
-const SCHEME_PILLS = [
-  "What's outstanding on contracts?",
-  'Give me a scheme summary',
-  'Draft a buyer follow-up email',
-  'Generate developer weekly report',
-];
-
-const INDEPENDENT_PILLS = [
-  "Draft replies to today's enquiries",
-  'Prepare a vendor update',
-  "Who haven't I followed up with?",
-  'Chase a solicitor on contracts',
-];
-
-const WRITE_PILLS: Array<{ label: string; intent: string }> = [
-  { label: 'Log a viewing', intent: 'log_viewing' },
-  { label: 'Update the tracker', intent: 'update_tracker' },
-  { label: 'Follow up with a buyer', intent: 'draft_viewing_followup_buyer' },
-  { label: 'Respond to an offer', intent: 'draft_offer_response' },
-  { label: 'Log a rental viewing', intent: 'log_rental_viewing' },
-  { label: 'Invite an applicant', intent: 'draft_application_invitation' },
-];
+// Session 7 — the landing-screen action-button grid and the SCHEME_PILLS /
+// INDEPENDENT_PILLS 2×2 grid are gone. Capability surfacing is now the
+// CapabilityChipsCarousel above the input. The voice-intent flow that
+// WRITE_PILLS used to seed still exists — the mic button on the input bar
+// opens a voice capture, and the transcript is interpreted the same way.
+// The carousel's chip library already includes natural-language equivalents
+// ("Log a rental viewing for tomorrow", "Draft a buyer follow-up email",
+// etc.) so the workflows remain discoverable.
 
 interface DraftedEmail {
   to: string;
@@ -122,20 +109,20 @@ export default function IntelligencePage() {
 function IntelligencePageInner() {
   const { agent, alerts, developmentIds } = useAgent();
   const { openApprovalDrawer } = useApprovalDrawer();
-  const { count: pendingDraftsCount } = useDraftsCount();
+  const { count: pendingDraftsCount, ready: draftsReady } = useDraftsCount();
   const searchParams = useSearchParams();
   const prefillPrompt = searchParams.get('prompt');
-  const isIndependent = agent?.agentType !== 'scheme';
-  const PROMPT_PILLS = isIndependent ? INDEPENDENT_PILLS : SCHEME_PILLS;
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isTyping, setIsTyping] = useState(false);
   const [sessionId, setSessionId] = useState<string>(`session_${Date.now()}`);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
   const [undoBatch, setUndoBatch] = useState<UndoBatch | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prefillHandled = useRef(false);
+  const inputElRef = useRef<HTMLInputElement | null>(null);
   const voiceIntentRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
@@ -635,17 +622,24 @@ function IntelligencePageInner() {
     }
   }, [undoBatch]);
 
-  const handleWriteChip = useCallback(
-    (intent: string) => {
-      voiceIntentRef.current = intent;
-      voice.start().catch(() => {
-        voiceIntentRef.current = undefined;
-      });
-    },
-    [voice],
-  );
+  // Session 7 — chip taps prefill the input + focus it. They never
+  // auto-submit; the agent reviews and edits before sending.
+  const handleChipTap = useCallback((text: string) => {
+    setInput(text);
+    // Next tick: give the controlled input time to update before we
+    // focus + move cursor to the end.
+    requestAnimationFrame(() => {
+      const el = inputElRef.current;
+      if (!el) return;
+      el.focus();
+      try {
+        el.setSelectionRange(text.length, text.length);
+      } catch { /* some browsers don't support setSelectionRange on type=text */ }
+    });
+  }, []);
 
   const hasMessages = messages.length > 0;
+  const firstName = agent?.displayName?.split(' ')[0] || 'Agent';
 
   return (
     <AgentShell agentName={agent?.displayName?.split(' ')[0] || 'Agent'} urgentCount={alerts?.length || 0}>
@@ -659,197 +653,123 @@ function IntelligencePageInner() {
         }}
       >
         {!hasMessages ? (
-          /* Landing state */
+          /* Landing state — Session 7 rebuild.
+             Layout is a 3-row flex column:
+               1. Hero block (top) — fixed position from first paint
+               2. Flexible spacer — pushes chips + input toward the input bar
+               3. Chip carousel (above the input)
+             The drafts banner has a reserved min-height container so when
+             count resolves from 0 → N (or stays 0), nothing else shifts. */
           <div
+            data-testid="intelligence-landing"
             style={{
               flex: 1,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
-              justifyContent: 'center',
-              padding: '0 32px',
+              padding: '0 24px',
               textAlign: 'center',
               background:
-                'radial-gradient(ellipse 90% 60% at 50% 35%, rgba(196,155,42,0.07) 0%, transparent 70%)',
+                'radial-gradient(ellipse 90% 55% at 50% 22%, rgba(196,155,42,0.05) 0%, transparent 70%)',
               minHeight: 0,
             }}
           >
-            <Image
-              src="/oh-logo.png"
-              alt="OpenHouse"
-              width={168}
-              height={168}
+            {/* Breathing room from the status bar. */}
+            <div style={{ height: 40, flexShrink: 0 }} />
+
+            <h1
+              data-testid="intelligence-hero"
               style={{
-                objectFit: 'contain',
-                display: 'block',
-                mixBlendMode: 'multiply',
-                marginBottom: 22,
+                color: '#0b0c0f',
+                fontSize: 30,
+                fontWeight: 600,
+                letterSpacing: '-0.025em',
+                lineHeight: 1.2,
+                margin: 0,
+                maxWidth: 320,
               }}
-              priority
-            />
+            >
+              What can I help with, {firstName}?
+            </h1>
+
+            <div style={{ height: 24, flexShrink: 0 }} />
 
             <p
               style={{
-                background: 'linear-gradient(135deg, #B8960C, #E8C84A)',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                backgroundClip: 'text',
-                fontSize: 11,
-                fontWeight: 700,
-                letterSpacing: '0.14em',
-                textTransform: 'uppercase',
-                margin: '0 0 18px',
-              }}
-            >
-              OpenHouse Intelligence
-            </p>
-
-            <h2
-              style={{
-                color: '#0D0D12',
-                fontSize: 22,
-                fontWeight: 700,
-                letterSpacing: '-0.04em',
-                lineHeight: 1.22,
-                margin: '0 0 12px',
-              }}
-            >
-              Ask anything about your
-              <br />
-              pipeline or tasks
-            </h2>
-
-            <p
-              style={{
-                color: '#9CA3AF',
-                fontSize: 13.5,
-                lineHeight: 1.65,
-                margin: '0 0 28px',
-                maxWidth: 280,
+                color: '#6B7280',
+                fontSize: 14,
+                lineHeight: 1.5,
+                margin: 0,
+                maxWidth: 300,
                 letterSpacing: '0.005em',
               }}
             >
-              Chase contracts, draft reports, follow up buyers. You approve
-              every action before it sends.
+              Voice or text. I&rsquo;ll show you what I drafted before sending.
             </p>
 
-            {pendingDraftsCount > 0 && (
-              <div
-                data-testid="intelligence-drafts-greeting"
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  gap: 10,
-                  padding: '12px 16px',
-                  background: 'rgba(196,155,42,0.08)',
-                  border: '0.5px solid rgba(196,155,42,0.30)',
-                  borderRadius: 14,
-                  marginBottom: 22,
-                  maxWidth: 320,
-                  width: '100%',
-                }}
-              >
-                <p style={{ margin: 0, color: '#8A6E1F', fontSize: 13, lineHeight: 1.45, textAlign: 'center' }}>
-                  You&rsquo;ve got {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} from earlier.
-                  Tap &lsquo;Review drafts&rsquo; below, or ask me anything.
-                </p>
-                <Link
-                  href="/agent/drafts"
-                  data-testid="intelligence-review-drafts-chip"
-                  style={{
-                    background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
-                    color: '#FFFFFF',
-                    fontSize: 12,
-                    fontWeight: 600,
-                    padding: '7px 14px',
-                    borderRadius: 999,
-                    textDecoration: 'none',
-                    boxShadow: '0 2px 6px rgba(196,155,42,0.30)',
-                  }}
-                >
-                  Review drafts
-                </Link>
-              </div>
-            )}
-
-            {/* Prompt pills */}
-            {/* Write-action chips — voice capture entry points. Kept above
-                the read chips so the voice-first workflow is the first thing
-                an agent sees on the landing state. */}
+            {/* Drafts banner — reserved height prevents layout shift between
+                "still loading" and "resolved". Hidden entirely when there
+                are no drafts so the screen stays quiet for clean queues. */}
             <div
-              data-testid="voice-write-chips"
               style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 10,
                 width: '100%',
-                maxWidth: 320,
+                maxWidth: 360,
+                // min-height holds space for the banner while draftsReady
+                // is false, then collapses smoothly once count is known
+                // to be zero.
+                minHeight: !draftsReady || pendingDraftsCount > 0 ? 76 : 0,
+                marginTop: !draftsReady || pendingDraftsCount > 0 ? 32 : 0,
+                transition: 'min-height 0.25s ease, margin-top 0.25s ease',
               }}
             >
-              {WRITE_PILLS.map((pill) => (
-                <button
-                  key={pill.intent}
-                  data-testid={`voice-chip-${pill.intent}`}
-                  onClick={() => handleWriteChip(pill.intent)}
-                  className="agent-tappable"
+              {draftsReady && pendingDraftsCount > 0 ? (
+                <div
+                  data-testid="intelligence-drafts-greeting"
                   style={{
-                    padding: '12px 14px',
-                    minHeight: 50,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 10,
+                    padding: '12px 16px',
                     background: 'rgba(196,155,42,0.08)',
-                    border: '0.5px solid rgba(196,155,42,0.35)',
-                    borderRadius: 16,
-                    color: '#8A6E1F',
-                    fontSize: 13,
-                    fontWeight: 600,
-                    lineHeight: 1.3,
-                    whiteSpace: 'normal',
-                    textAlign: 'center',
-                    cursor: 'pointer',
-                    fontFamily: 'inherit',
+                    border: '0.5px solid rgba(196,155,42,0.30)',
+                    borderRadius: 14,
                   }}
                 >
-                  {pill.label}
-                </button>
-              ))}
+                  <p style={{ margin: 0, color: '#8A6E1F', fontSize: 13, lineHeight: 1.45 }}>
+                    You&rsquo;ve got {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} from earlier.
+                  </p>
+                  <Link
+                    href="/agent/drafts"
+                    data-testid="intelligence-review-drafts-chip"
+                    style={{
+                      background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                      color: '#FFFFFF',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      padding: '7px 14px',
+                      borderRadius: 999,
+                      textDecoration: 'none',
+                      boxShadow: '0 2px 6px rgba(196,155,42,0.30)',
+                    }}
+                  >
+                    Review drafts
+                  </Link>
+                </div>
+              ) : null}
             </div>
 
-            <div
-              style={{
-                marginTop: 14,
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 10,
-                width: '100%',
-                maxWidth: 320,
-              }}
-            >
-              {PROMPT_PILLS.map((pill, i) => (
-                <button
-                  key={i}
-                  onClick={() => handleSend(pill)}
-                  className="agent-tappable"
-                  style={{
-                    padding: '13px 14px',
-                    minHeight: 54,
-                    background: '#FFFFFF',
-                    border: '0.5px solid rgba(0,0,0,0.10)',
-                    borderRadius: 16,
-                    color: '#374151',
-                    fontSize: 13,
-                    fontWeight: 500,
-                    lineHeight: 1.4,
-                    whiteSpace: 'normal',
-                    textAlign: 'center',
-                    cursor: 'pointer',
-                    fontFamily: 'inherit',
-                    boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
-                  }}
-                >
-                  {pill}
-                </button>
-              ))}
-            </div>
+            {/* Flex spacer — pushes chips down toward the input bar. Uses
+                flex-grow rather than a hard gap so the empty state feels
+                intentional, not collapsed. */}
+            <div style={{ flex: 1, minHeight: 24 }} />
+
+            <CapabilityChipsCarousel
+              onChipTap={handleChipTap}
+              paused={inputFocused}
+            />
+
+            <div style={{ height: 16, flexShrink: 0 }} />
           </div>
         ) : (
           /* Conversation state */
@@ -905,6 +825,7 @@ function IntelligencePageInner() {
         )}
 
         <VoiceInputBar
+          ref={inputElRef}
           input={input}
           onInputChange={setInput}
           onSend={() => handleSend(input)}
@@ -914,6 +835,8 @@ function IntelligencePageInner() {
           onStop={() => voice.stop()}
           isDesktop={isDesktop}
           onOpenSettings={voice.openSettings}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
         />
 
         {undoBatch && (

--- a/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
+++ b/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
@@ -1,0 +1,62 @@
+/**
+ * Session 7 — capability chip library shown on the Intelligence landing.
+ *
+ * Intent: showcase Intelligence's full breadth (sales, lettings, drafts,
+ * queries, scheduling, reporting, autonomy, scope) without a permanent
+ * button grid. Four chips visible at a time, rotating every 6s.
+ *
+ * Each chip is phrased the way a working Irish estate agent would say it
+ * — conversational, not command-style. The chip text is dropped into the
+ * input bar when tapped; the user edits before sending.
+ *
+ * To add, remove, or re-word chips, edit this file. The carousel
+ * component reads the export and shuffles on mount.
+ */
+
+export const CAPABILITY_CHIPS: readonly string[] = [
+  // Sales pipeline
+  "What's outstanding on contracts?",
+  'Show me overdue chases',
+  'Draft a buyer follow-up email',
+  'What signed this week?',
+  'Which units are still for sale?',
+
+  // Lettings
+  'Three people came to see 14 Oakfield',
+  "Invite the O'Sheas to apply",
+  'Show me applicants for Maple Court',
+  'Which tenancies are up for renewal?',
+  'Log a rental viewing for tomorrow',
+
+  // Reporting & briefings
+  'Generate developer weekly report',
+  'Give me a scheme summary',
+  "What's on for me today?",
+  'Brief me on Árdan View',
+
+  // Scheduling
+  'Schedule a viewing for Saturday at 2pm',
+  'What viewings do I have this week?',
+
+  // Drafts & autonomy
+  'Review my drafts',
+  'Draft a price reduction notice',
+  'Chase those three units about signing',
+
+  // Scope / scheme switching
+  'Switch to Rathárd Park',
+  'Show me everything across all schemes',
+] as const;
+
+/**
+ * Fisher–Yates shuffle. Pure function; callers should call it once on
+ * mount to avoid re-shuffling on every render.
+ */
+export function shuffleChips(input: readonly string[]): string[] {
+  const arr = input.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}


### PR DESCRIPTION
Rebuild of /agent/intelligence as a quiet, stable surface. First paint is layout-complete — no content shift as async data resolves.

- New lib/agent-intelligence/capability-chips.ts with 21 conversational chips covering sales, lettings, drafts, queries, scheduling, reporting and scope switching. Shuffled once per mount.
- New _components/CapabilityChipsCarousel.tsx: 4 chips visible, 6s rotation, pauses on pointer hover and on input focus, respects prefers-reduced-motion (fade-swap instead of slide). Tapping a chip prefills the input and focuses it — never auto-submits.
- useDraftsCount now exposes a ready flag so callers can reserve layout space until the initial fetch settles, eliminating the drafts-banner pop-in shift.
- VoiceInputBar is forwardRef'd so the landing can imperatively focus the input after a chip tap; new onFocus/onBlur props let the caller pause chip rotation while typing.
- Landing rebuild: hero "What can I help with, <first name>?" over a quiet helper line, conditional drafts banner with reserved height, flexible spacer, chip carousel just above the input. 2x3 WRITE_PILLS grid and 2x2 PROMPT_PILLS grid are gone — their workflows are discoverable via the chip library in natural language.
- Desktop /agent/dashboard/intelligence untouched.