### PR TITLE
Reconciled session 8 + 9 + 11 + 12

### DIFF
--- a/SESSION_12_DIAGNOSIS.md
+++ b/SESSION_12_DIAGNOSIS.md
@@ -1,0 +1,58 @@
+# Session 12 Diagnosis — address composition + larger logo
+
+1. **Chip address composition.**
+   `app/api/agent/intelligence/capability-chips/route.ts` (Session 11
+   addition, not yet merged to main) selects `id, address` from
+   `agent_letting_properties`, then feeds the `address` field into
+   `shortenAddress()` which keeps only the text before the first comma
+   and truncates at 38 chars. That is the lossy step: when the stored
+   `address` is `"Apt 12, Grand Parade, Cork"`, `shortenAddress` returns
+   `"Apt 12"`; when the stored value is a denormalised
+   `"12 Grand Parade"` (the bug Orla sees), we lose the "Apt" prefix
+   entirely and the chip reads `"12 Grand Parade"` — a different-
+   sounding property. The root cause is twofold: we read only the
+   single denormalised `address` column (never the structured
+   `address_line_1 / address_line_2 / city` fields that the spec says
+   carry the real data), and we split on the first comma. Fix is to
+   compose from the structured fields using a shared helper and never
+   drop any segment.
+
+2. **Other surfaces.** Addresses are fetched from
+   `agent_letting_properties` in six other spots:
+   `lib/agent-intelligence/context.ts:446` (letting summary),
+   `context.ts:506` and `:552` (renewal window + rent arrears joins),
+   `tools/agentic-skills.ts:501, 687, 886` (skill-side address
+   lookups), `app/api/agent/applicants/[id]/route.ts:67`. All read the
+   single `address` column. None of them currently compose
+   `address_line_1 + address_line_2` — so the Session 11 chip generator
+   is the only site where the Session 12 fix changes behaviour today.
+   Even so, the helper is worth extracting so if any of those spots
+   gains structured-field support later, one call swaps them over. The
+   helper also covers the `units` table which does have
+   `address_line_1 / address_line_2 / city` fields.
+
+3. **Logo render.**
+   `app/agent/intelligence/page.tsx` (Session 11 restore):
+   `<Image src="/oh-logo.png" width={48} height={48} priority … />`
+   sits with a `marginBottom: 24` above the hero. Both
+   width/height need to bump: 80×80 on mobile, 96×96 when
+   `isDesktop` is true. The `isDesktop` state already exists on the
+   page (line ~120 — derives from the `min-width: 900px` media
+   query).
+
+## Fix summary shipping with this commit
+
+- New `lib/agent/format-address.ts` exporting `formatAgentAddress`.
+  Takes a parts object (`address_line_1`, `address_line_2`, `city`,
+  `eircode`, optional fallback `address`) and a `'short' | 'full'`
+  format. Short drops city/eircode; full keeps everything. No field
+  is silently stripped; no prefix is removed. When only the
+  denormalised `address` exists, the helper returns it as-is without
+  comma-splitting.
+- Chip API now selects `id, address, address_line_1, address_line_2,
+  city, eircode` and composes the chip's address via
+  `formatAgentAddress(property, 'short')`. Removes the `shortenAddress`
+  comma-splitter entirely; a separate `truncateForChip` keeps the
+  chip text inside the 38-char cap without dropping segments.
+- Logo bumps to 80×80 on mobile and 96×96 on desktop (keyed off the
+  existing `isDesktop` state), with `marginBottom: 32` below.

--- a/SESSION_8_DIAGNOSIS.md
+++ b/SESSION_8_DIAGNOSIS.md
@@ -1,0 +1,151 @@
+# Session 8 Diagnosis — five regressions surfaced on the installed iOS PWA-Capacitor app
+
+## Bug 1 — "Microphone is not available in this browser"
+
+**File / line.** `apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts:144`
+surfaces `MIC_UNAVAILABLE_MESSAGE` when `navigator.mediaDevices` is falsy
+OR when `getUserMedia` isn't a function. The hook runs that pre-flight
+check before even attempting the call.
+
+**Why it's failing.** In the PWA-Capacitor shell that loads
+`portal.openhouseai.ie`, `@capacitor/microphone` is not installed, so
+`lib/capacitor-native.ts:64 → requestMicrophonePermission()` returns
+`{ status: 'unavailable' }`. The hook then falls through to the browser
+path — correct so far — and hits the `navigator.mediaDevices` guard.
+On this particular iOS configuration, either `navigator.mediaDevices` is
+undefined at that moment (WebView privacy default) or the property
+exists as a non-function. Either way the guard trips early and the user
+never gets a chance to prompt for permission. The pre-flight check is
+too eager: on iOS WKWebView `getUserMedia` has been observed to succeed
+even when the pre-flight property read looks suspicious, because the
+first call itself is what activates the permission subsystem.
+
+**Fix approach.** Drop the pre-flight check. Use optional chaining to
+resolve `getUserMedia`; if it's present, call it and let the browser
+throw `NotAllowedError` / `NotFoundError` / `TypeError` on failure. Map
+each thrown error name to a distinct user-facing message — denied
+(Settings hint), hardware-missing, or truly-unavailable. Only surface
+"not available" when the function reference is actually missing.
+
+## Bug 2 — Bottom-nav taps open Mobile Safari after mic interaction
+
+**File / line.** `apps/unified-portal/app/agent/_components/BottomNav.tsx:97–126`
+uses Next.js `<Link>` with plain hrefs (`/agent/home`,
+`/agent/pipeline`, `/agent/applicants`, `/agent/viewings`). The Links
+are correct. `window.open` and `target="_blank"` do not appear in
+BottomNav or its ancestors.
+
+**Why it's failing.** Trigger is specifically "after interacting with
+the mic". The path we believe breaks the WebView: `voice.start()` →
+`requestMicrophonePermission()` → dynamic import of
+`@capacitor/microphone` → bare-specifier import fails in the browser →
+the WebView's module loader emits a request for
+`https://portal.openhouseai.ie/@capacitor/microphone` → 404. On some
+iOS Capacitor shell configurations, a 404 on a `capacitor://`-prefixed
+or absolute-specifier import is treated as a decide-policy-for-url
+navigation attempt, and the iOS delegate's fallback is to hand the URL
+off to Mobile Safari. Subsequent taps within the same WebView session
+inherit the broken decide-policy state — any relative-href `<Link>`
+click is routed through the same delegate, which has now been conditioned
+to treat navigations as external. The mic flow doesn't directly add any
+`target="_blank"` — it corrupts the WebView's nav policy via the failed
+bare-specifier import.
+
+**Fix approach.** Stop emitting bare-specifier dynamic imports that can
+look like network URLs. Guard the mic plugin import behind a
+`isCapacitorNative()` check that ALSO confirms the global
+`(window as any).Capacitor?.Plugins?.Microphone` is already present.
+If the plugin isn't on `Capacitor.Plugins`, skip the `import()` entirely
+— the browser path will be used. Belt-and-braces: BottomNav now binds
+an explicit `onClick` handler that calls `router.push(href)` with
+`preventDefault`, so even if the WebView's decide-policy is in a broken
+state, we never actually follow a link, we programmatically navigate
+via Next.js.
+
+## Bug 3 — Six chips visible instead of four
+
+**File / line.** `apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx:115–147`
+renders into a flex container with `flexWrap: 'wrap'` and four chip
+children. Each chip has `animation: oh-chip-slide-in 320ms` on EVERY
+render — not just on mount.
+
+**Why it's failing.** Two issues. (a) Every chip re-runs the slide-in
+keyframe on every re-render (animation restarts as a fresh inline style
+string each time), so the outgoing chip is still painting its slide-in
+when the incoming chip begins its own, yielding a multi-frame overlap
+where >4 chips are visible. (b) When the offset tick lands on a cycle
+boundary, two adjacent `visible[i]` entries may receive keys that
+collide with chips rendered in the prior frame that React hasn't yet
+removed from the DOM — CSS animation transforms make the "lingering"
+old chip appear alongside the new one. On a narrow iPhone viewport
+`flex-wrap` spreads these over two rows, and the user counts 6.
+
+**Fix approach.** Render a fixed 2×2 grid so exactly 4 cells exist at
+all times — `display: grid; grid-template-columns: repeat(2, 1fr);
+grid-template-rows: repeat(2, auto)`. `overflow: hidden` on the grid so
+any stray transformed chip can't escape the cell. Move the keyframe
+animation off the chip element and onto a `key`-wrapped inner `<span>`
+that only animates once per mount. Drop `flex-wrap` entirely.
+
+## Bug 4 — OPENHOUSE logo treatment changed by Session 7
+
+**File / line.** `apps/unified-portal/app/agent/intelligence/page.tsx`.
+Session 7 (commit `8036656`, merged as `f70af6d`) removed the
+`<Image src="/oh-logo.png" width={168} height={168} … />` hero logo and
+the gold-gradient "OpenHouse Intelligence" label from the landing
+between the old position of the image and the hero title. Current state
+has "What can I help with, {firstName}?" at the top with no logo.
+
+**Why it's failing.** Intentional Session 7 change (the "quiet hero"
+spec said to drop them). The user wants the pre-7 logo treatment back.
+
+**Fix approach.** Reinstate the `<Image src="/oh-logo.png">` and the
+gold-gradient "OpenHouse Intelligence" label above the "What can I help
+with" question, at their prior sizing. Keep every other Session 7
+element (hero copy, helper line, drafts banner with reserved height,
+chip carousel) intact.
+
+## Bug 5 — `draft_buyer_followups` picks wrong units and duplicates joint purchasers
+
+**File / line.** `apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts:1164`
+(`draftBuyerFollowups`) has three separate problems:
+
+1. **No purpose parameter.** The body template is locked to "Could you
+   let me know where things stand on your end?" (line 1256) regardless
+   of whether the agent asked for a chase, a welcome message, an
+   introduction, or a price-review. The subject is fixed to
+   "Following up — Unit X".
+2. **No count-vs-explicit-units check.** The skill accepts any
+   `targets[]` the model passes. When the agent says "3 Ardan view" and
+   the model invents 3 targets (picking the most chat-salient units),
+   the skill happily drafts for them.
+3. **Treats one unit with joint purchasers as one target.** `units`
+   table has `purchaser_name` as a single text field that may contain
+   `"Laura Hayes and Dylan Rogers"`. The skill's template calls
+   `firstName(recipientName)` which splits on whitespace and picks the
+   first token ("Laura"), greeting only half the household. Separately,
+   if the model sends TWO targets for the same unit (one for each
+   purchaser), the skill produces two separate drafts instead of one
+   joint-addressed email. Both happen in the wild: the reported case
+   produced two drafts for Unit 19's joint buyers.
+
+**Fix approach.**
+- Add `purpose?: 'chase' | 'congratulate_handover' | 'introduce' | 'update' | 'custom'`
+  and `custom_instruction?: string`. Swap the subject/body template per
+  purpose. `congratulate_handover` → "Welcome to your new home — Unit X,
+  [Scheme]" + warm congratulations copy, no "where do you stand" tail.
+  `custom` uses `custom_instruction` as the body lead.
+- Parse the resolved unit's `purchaser_name` into separate names
+  (splitting on " and " / " & "), greet with "Hi Laura and Dylan,"
+  addressed to both — one draft per unit, never per name.
+- Deduplicate incoming targets by resolved `unit.id` so the model
+  sending two targets for the same unit still produces one draft.
+- System prompt update: when the user specifies a count ("draft email
+  to 3 X") without naming units AND the prior chat turn did not
+  produce an explicit list, Intelligence must ASK for clarification
+  with 3-5 candidate units, not invent a selection. When the user
+  says "those N" after a preceding tool-produced list, use that list
+  directly.
+
+Tests: single purchaser → 1 draft, joint ("A and B") → 1 draft greeting
+both names, 3 distinct units with one joint → 3 drafts.

--- a/SESSION_9_DIAGNOSIS.md
+++ b/SESSION_9_DIAGNOSIS.md
@@ -1,0 +1,140 @@
+# Session 9 Diagnosis — intent-aware resolution + identifier bug
+
+Main still sits at Session 7 (commit `f70af6d`); Session 8's `purpose`
+parameter, joint-purchaser parsing and hardened unit resolution never
+landed. Session 9 picks up all three bugs on top of the Session 8 skill
+surface, so this commit carries the Session 8 additions through as well
+as the Session 9 fixes.
+
+## Bug A — Clarification ignores intent
+
+**Where.** `lib/agent-intelligence/system-prompt.ts` only instructs
+Intelligence to ask "Which N units?" when a count is specified without
+unit identifiers. It does not constrain the candidate set by the intent
+of the request. There is no tool the model can call to get "units that
+have actually been handed over" as a filtered candidate list, so when
+the model generates an example set it picks the first three unit numbers
+by incidence ("Unit 1, Unit 2, Unit 3") regardless of handover status.
+
+**Why it's failing.** No `get_candidate_units(intent='handover')` tool
+exists. The clarification is text-level only; the model improvises the
+example set from conversational context.
+
+**Fix approach.** New `get_candidate_units` tool that takes `intent` +
+optional `scheme_name` + optional `limit`. For
+`intent='handover'`: filter to `handover_date IS NOT NULL` (or
+`unit_status = 'handed_over'`), ordered by `handover_date DESC`.
+System prompt updated so "congratulate on keys / handover" requests
+must call this tool first, then branch on count-vs-candidate comparison
+(fewer → propose the smaller set; same → draft them all; more → ask
+which N; zero → refuse honestly).
+
+## Bug B — Unit identifier resolves to wrong unit
+
+**Where.**
+`lib/agent-intelligence/tools/agentic-skills.ts:1235-1241` builds this
+Supabase query:
+
+```ts
+.or(`unit_number.ilike.%${unitRef}%,
+     unit_uid.ilike.%${unitRef}%,
+     purchaser_name.ilike.%${target.recipient_name || unitRef}%`)
+.limit(1);
+```
+
+**Why it's failing.** Three separate problems stacked:
+1. `ilike.%3%` matches unit_number '3', '13', '23', '30', '31', '33',
+   etc. The DB returns the first row in whatever order PostgREST picked;
+   with no `.order()` that's effectively arbitrary. Unit 10 isn't even
+   `%3%` — so the more likely failure is that "Unit 3" verbatim (with
+   the word "Unit ") hit none of the three branches (unit_number is
+   stored as "3", not "Unit 3"), the OR reduced to false, and PostgREST
+   returned the first row in the table → Unit 10 (whichever unit has
+   the lowest primary key).
+2. The `.or(…purchaser_name.ilike.%${unitRef}…)` branch is wide open —
+   any unitRef that happens to be a substring of someone's name yields
+   a match with no relation to the unit identifier.
+3. No `.eq('development_id', devId)` pre-filter inside the query — the
+   scheme scope is only established when the model passes
+   `scheme_name`. If it doesn't, we search the whole agent's estate.
+
+**Fix approach.** New `resolveUnitIdentifier(supabase, ref, {devIds})`
+helper that:
+- Normalises the ref: strips "unit", "#", whitespace, leaves the core
+  identifier (digits or alphanumeric code).
+- First tries exact `unit_number = <normalised>` with the devIds scope.
+- Falls back to exact `unit_uid = <normalised>` (e.g. "AV-3") and
+  `unit_uid` ending with `-<normalised>`.
+- NEVER wildcards on purchaser_name. NEVER `ilike.%<ref>%` on the
+  unit columns — "Unit 30" does not match Unit 3.
+- Returns `{ status: 'ok', unit }`, `{ status: 'not_found' }`, or
+  `{ status: 'ambiguous', candidates }` when multiple units match
+  across different developments.
+- `draft_buyer_followups` fails the draft for `not_found` / `ambiguous`,
+  surfacing a structured warning in the envelope so the 6D
+  anti-hallucination guard catches the "model claimed success" lie.
+
+## Bug C — No purpose-criterion validation against resolved unit
+
+**Where.** `draft_buyer_followups` (same file, ~line 1262) inserts a
+draft for whatever unit resolved, regardless of whether the email's
+purpose matches the unit's state.
+
+**Why it's failing.** The `purpose` field was never introduced (Session
+8 work that didn't land), and even with it introduced there was no
+precondition check — the skill would happily draft
+"Welcome to your new home — Unit 10" for a unit in `sale_agreed` that
+has never been handed over.
+
+**Fix approach.** Define `PURPOSE_PRECONDITIONS` at skill level — one
+predicate per purpose against the resolved unit row:
+
+```ts
+const PURPOSE_PRECONDITIONS: Record<DraftBuyerFollowupPurpose, (u: UnitRow) => boolean> = {
+  congratulate_handover: (u) => Boolean(u.handover_date) || u.unit_status === 'handed_over',
+  chase: (u) => !!u.contracts_issued_date && !u.signed_contracts_date,
+  introduce: (u) => !!u.purchaser_name,
+  update: () => true,
+  custom: () => true,
+};
+```
+
+Before persisting each draft, the skill runs the predicate. On failure
+the unit is skipped, a structured warning is appended to the envelope's
+summary and `meta.skipped` list, and the model is told the reason so it
+can surface it to the user ("Unit 10 hasn't been handed over yet — did
+you mean a different one?"). The precondition belongs at the skill
+level because it needs live DB fields; tool-call-time validation (at
+the registry or system-prompt level) can't see the same data.
+
+## Bug D — Tool description tightening
+
+The registry description for `draft_buyer_followups` only named the
+tool's purpose. New description in this commit:
+
+> Use this tool to draft follow-up emails for one or more buyers.
+> CRITICAL RULES:
+> 1. Each target's `unit_identifier` must be a unit number explicitly
+>    mentioned by the user OR returned by a previous tool. Do NOT guess.
+> 2. The `purpose` parameter must match what the user is asking for.
+>    "Congratulate on keys" → `congratulate_handover` ONLY for units
+>    that have actually been handed over.
+> 3. If you're unsure which units the user means, call
+>    `get_candidate_units` with the intent first; do not pick units
+>    silently.
+
+## Summary of fixes shipping with this commit
+
+1. New `get_candidate_units` tool (intent-aware filtering for
+   clarification).
+2. `draft_buyer_followups` gains `purpose` + `custom_instruction`
+   params, joint-purchaser greeting, per-target unit-id dedupe, strict
+   unit resolution, purpose-precondition gating, and skipped-unit
+   telemetry in the envelope meta.
+3. `resolveUnitIdentifier` helper used by both skills.
+4. System prompt updated: intent-aware clarification, strict unit
+   resolution rules, purpose-precondition note.
+5. Tests: strict resolver (`Unit 3` ≠ Unit 30, Unit 300 fails,
+   cross-scheme ambiguity), joint purchasers, purpose precondition
+   (cannot congratulate Unit 10, can congratulate Unit 3 with a
+   handover_date).

--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
 import { useApplicantsCount } from '../_hooks/useApplicantsCount';
@@ -66,6 +66,7 @@ function TabIcon({ id, active }: { id: TabId; active: boolean }) {
 
 export default function BottomNav() {
   const pathname = usePathname();
+  const router = useRouter();
   const isActive = (href: string) => pathname.startsWith(href);
   const intelActive = pathname.startsWith('/agent/intelligence');
   const { count: draftsCount } = useDraftsCount();
@@ -73,6 +74,21 @@ export default function BottomNav() {
 
   const leftTabs = TABS.slice(0, 2);
   const rightTabs = TABS.slice(2);
+
+  // Session 8 Bug 2 fix. On the installed PWA-Capacitor shell, iOS was
+  // handing bottom-nav taps off to Mobile Safari after the mic permission
+  // flow corrupted the WebView's decide-policy state. Even though <Link>
+  // should navigate internally, we now explicitly preventDefault and call
+  // router.push — Next.js client-side routing never hits the native
+  // delegate, so there's no opportunity for iOS to re-route to Safari.
+  const navigateInternal = (e: React.MouseEvent, href: string) => {
+    // Ignore non-left-click / modifier-key combinations (open-in-new-tab
+    // on desktop). Only the plain tap is forced through router.push.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if ((e as any).button && (e as any).button !== 0) return;
+    e.preventDefault();
+    router.push(href);
+  };
 
   return (
     <nav
@@ -97,6 +113,7 @@ export default function BottomNav() {
           <Link
             key={tab.id}
             href={tab.href}
+            onClick={(e) => navigateInternal(e, tab.href)}
             className="agent-tappable"
             style={{
               flex: 1,
@@ -152,6 +169,7 @@ export default function BottomNav() {
         {/* The FAB — 80px dark circle with OH logo */}
         <Link
           href="/agent/intelligence"
+          onClick={(e) => navigateInternal(e, '/agent/intelligence')}
           style={{
             position: 'absolute',
             bottom: 0,
@@ -213,6 +231,7 @@ export default function BottomNav() {
           <Link
             key={tab.id}
             href={tab.href}
+            onClick={(e) => navigateInternal(e, tab.href)}
             className="agent-tappable"
             style={{
               flex: 1,

--- a/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
+++ b/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  CAPABILITY_CHIPS,
+  FALLBACK_CAPABILITY_CHIPS,
   shuffleChips,
 } from '@/lib/agent-intelligence/capability-chips';
 
@@ -22,39 +22,52 @@ interface CapabilityChipsCarouselProps {
    */
   paused?: boolean;
   /**
-   * Allows callers to override the pool (tests). Defaults to the full
-   * CAPABILITY_CHIPS list.
+   * Session 11 — chips are sourced from live agent data by the parent.
+   * The parent passes them in here. While the live fetch is in flight
+   * the carousel falls back to a short context-free set so first paint
+   * is never blank.
    */
-  pool?: readonly string[];
+  chips?: readonly string[];
 }
 
 /**
- * Session 7 — rotating chip carousel that sits above the input bar on
- * the Intelligence landing. Showcases Intelligence's capabilities without
+ * Rotating chip carousel that sits above the input bar on the
+ * Intelligence landing. Showcases Intelligence's capabilities without
  * a permanent button grid.
  *
+ * Session 8 Bug 3 fix. Previous implementation rendered chips into a
+ * flex-wrap container with per-chip CSS keyframes on every render. On
+ * iPhone viewports that produced 5-6 visible chips during the slide
+ * transition — flex-wrap spread the mount/unmount overlap across two
+ * rows. The carousel now pins exactly four cells into a 2×2 grid
+ * (`display: grid; grid-template-columns: repeat(2, 1fr);
+ * grid-template-rows: repeat(2, auto)`). Outside the grid nothing ever
+ * renders. The slide animation is scoped to an inner `<span>` keyed on
+ * the chip's (idx,text) so it plays once on mount, not on every
+ * re-render of the parent.
+ *
+ * Session 11 — chips are sourced by the parent from live agent data.
+ * The parent passes them in via the `chips` prop. While the live
+ * fetch is in flight the carousel uses a short context-free fallback
+ * so first paint is never blank.
+ *
  * Rotation behaviour:
- *   - 4 chips visible at any time
+ *   - 4 chips visible at any time (no more, no less)
  *   - Advances by one slot every 6 seconds
  *   - Pauses when the paused prop is true (parent wires this to input
  *     focus)
  *   - Pauses on pointer hover so the agent can read a chip before it
  *     rotates away
  *   - Respects `prefers-reduced-motion` — fade-swap instead of slide
- *
- * Why a window of four from a shuffled pool rather than randomised-on-
- * every-tick: predictable rotation lets the eye follow along, and
- * shuffling once per mount means first-impression chips differ session
- * to session.
  */
 export default function CapabilityChipsCarousel({
   onChipTap,
   paused = false,
-  pool = CAPABILITY_CHIPS,
+  chips,
 }: CapabilityChipsCarouselProps) {
-  // Shuffle once per mount so different sessions surface different
-  // chips first. useMemo with an empty dep list; the shuffle output is
-  // stable for the component lifetime.
+  const pool = chips && chips.length ? chips : FALLBACK_CAPABILITY_CHIPS;
+  // Re-shuffle whenever the pool identity changes — this is how the
+  // live chips from the API replace the fallback set.
   const deck = useMemo(() => shuffleChips(pool), [pool]);
   const safeDeck = deck.length >= VISIBLE ? deck : [...deck, ...deck];
 
@@ -64,8 +77,6 @@ export default function CapabilityChipsCarousel({
   const [fade, setFade] = useState(1);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Detect prefers-reduced-motion. Updates live if the user toggles the
-  // setting while the app is open.
   useEffect(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return;
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -77,8 +88,6 @@ export default function CapabilityChipsCarousel({
 
   const advance = useCallback(() => {
     if (reducedMotion) {
-      // Fade out, swap, fade in — gentler than the slide for
-      // motion-sensitive users.
       setFade(0);
       window.setTimeout(() => {
         setOffset((o) => (o + 1) % safeDeck.length);
@@ -120,19 +129,20 @@ export default function CapabilityChipsCarousel({
       onTouchStart={() => setHovered(true)}
       onTouchEnd={() => setHovered(false)}
       style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: 'center',
-        alignItems: 'center',
+        // Fixed 2x2 grid — exactly four cells, never more, never less.
+        // `overflow: hidden` clips any stray transform animation so a
+        // mid-transition chip can't escape its cell.
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, 1fr)',
+        gridTemplateRows: 'repeat(2, auto)',
         gap: 8,
         padding: '0 16px',
         width: '100%',
-        maxWidth: 720,
+        maxWidth: 360,
         margin: '0 auto',
+        overflow: 'hidden',
         opacity: reducedMotion ? fade : 1,
-        transition: reducedMotion
-          ? `opacity ${SLIDE_MS}ms ease`
-          : undefined,
+        transition: reducedMotion ? `opacity ${SLIDE_MS}ms ease` : undefined,
       }}
     >
       {visible.map((chip) => (
@@ -156,10 +166,10 @@ function Chip({
   reducedMotion: boolean;
   onTap: () => void;
 }) {
-  // Slide-in animation: each chip is keyed on its idx-text so when the
-  // rotation advances, React unmounts the leftmost chip and mounts a
-  // fresh rightmost one. The fresh chip enters from the right via a
-  // CSS keyframe. Reduced-motion users skip the keyframe.
+  // The button fills its grid cell, never expands beyond it. The
+  // slide-in animation lives on an inner span so re-renders of the
+  // parent don't restart it — the <span>'s key is the chip text, so
+  // React only plays the animation once, when the chip first mounts.
   return (
     <button
       type="button"
@@ -168,30 +178,43 @@ function Chip({
       data-testid="capability-chip"
       className="agent-tappable"
       style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
         maxWidth: '100%',
-        padding: '0 14px',
+        padding: '0 12px',
         height: 36,
         borderRadius: 999,
         background: 'rgba(13,13,18,0.04)',
         border: '0.5px solid rgba(13,13,18,0.08)',
         color: '#0b0c0f',
-        fontSize: 13,
+        fontSize: 12.5,
         fontWeight: 500,
         lineHeight: 1,
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
         cursor: 'pointer',
         fontFamily: 'inherit',
-        animation: reducedMotion
-          ? undefined
-          : `oh-chip-slide-in ${SLIDE_MS}ms cubic-bezier(0.2, 0.8, 0.2, 1)`,
+        overflow: 'hidden',
       }}
     >
-      {text}
+      <span
+        key={text}
+        style={{
+          display: 'inline-block',
+          maxWidth: '100%',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          animation: reducedMotion
+            ? undefined
+            : `oh-chip-slide-in ${SLIDE_MS}ms cubic-bezier(0.2, 0.8, 0.2, 1)`,
+        }}
+      >
+        {text}
+      </span>
       <style>{`
         @keyframes oh-chip-slide-in {
-          from { transform: translateX(12px); opacity: 0; }
+          from { transform: translateX(8px); opacity: 0; }
           to { transform: translateX(0); opacity: 1; }
         }
       `}</style>

--- a/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
+++ b/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
@@ -11,9 +11,11 @@ const SILENCE_THRESHOLD = 0.012;
 const SILENCE_TIMEOUT_MS = 2000;
 
 const MIC_DENIED_MESSAGE =
-  'Microphone access is needed for voice capture. Open Settings → OpenHouse → Microphone to enable.';
+  'Allow microphone access in iOS Settings → Safari (or OpenHouse) → Microphone.';
 const MIC_UNAVAILABLE_MESSAGE =
-  'Microphone is not available in this browser. Use the typing input instead.';
+  'Microphone isn’t available on this device. Use the typing input instead.';
+const MIC_NO_HARDWARE_MESSAGE =
+  'No microphone was detected. Use the typing input instead.';
 
 export interface VoiceCaptureState {
   status: 'idle' | 'recording' | 'transcribing' | 'offline-queued' | 'error';
@@ -119,11 +121,18 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
     setPartialTranscript('');
 
     try {
-      // Capacitor iOS: request mic permission via the plugin FIRST.
-      // Without this, WKWebView rejects getUserMedia on cold start (and on
-      // older iOS builds `navigator.mediaDevices` is undefined until the
-      // plugin warms the path up). `unavailable` = not native; fall through
-      // to the web path.
+      // Session 8 Bug 1 fix. Previous sequence pre-flighted
+      // navigator.mediaDevices and bailed out with "unavailable" when the
+      // property looked falsy. On iOS WKWebView the property read is
+      // unreliable until the first getUserMedia call activates the
+      // permission subsystem — so we now attempt the call directly and
+      // branch on the thrown error name.
+      //
+      // The Capacitor plugin permission probe is best-effort: if the plugin
+      // is installed in the shell, it primes iOS to present the permission
+      // sheet; if not, it returns 'unavailable' and we carry on via the
+      // browser path. The plugin path can skip directly to 'denied' so we
+      // never prompt the user through two layers.
       const native = await requestMicrophonePermission();
       if (native.status === 'denied') {
         setPermissionDenied(true);
@@ -132,21 +141,39 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
         return;
       }
 
-      // Guard against `navigator.mediaDevices` being undefined — seen on
-      // older iOS WKWebView and on insecure-context browsers. Before this
-      // guard the app crashed with "undefined is not an object
-      // (evaluating 'navigator.mediaDevices.getUserMedia')".
-      if (
-        typeof navigator === 'undefined' ||
-        !navigator.mediaDevices ||
-        typeof navigator.mediaDevices.getUserMedia !== 'function'
-      ) {
+      const getUserMediaFn: MediaDevices['getUserMedia'] | undefined =
+        typeof navigator !== 'undefined'
+          ? navigator.mediaDevices?.getUserMedia?.bind(navigator.mediaDevices)
+          : undefined;
+
+      if (!getUserMediaFn) {
         setErrorMessage(MIC_UNAVAILABLE_MESSAGE);
         setStatus('error');
         return;
       }
 
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      let stream: MediaStream;
+      try {
+        stream = await getUserMediaFn({ audio: true });
+      } catch (err: any) {
+        const name: string = err?.name || '';
+        if (name === 'NotAllowedError' || name === 'SecurityError' || name === 'PermissionDeniedError') {
+          setPermissionDenied(true);
+          setErrorMessage(MIC_DENIED_MESSAGE);
+        } else if (name === 'NotFoundError' || name === 'DevicesNotFoundError' || name === 'OverconstrainedError') {
+          setErrorMessage(MIC_NO_HARDWARE_MESSAGE);
+        } else if (name === 'TypeError' || name === 'NotSupportedError') {
+          // iOS throws TypeError when the insecure-context / missing-entitlement
+          // path triggers. Fall back to the "unavailable" message.
+          setErrorMessage(MIC_UNAVAILABLE_MESSAGE);
+        } else {
+          setErrorMessage(err?.message || MIC_UNAVAILABLE_MESSAGE);
+        }
+        setStatus('error');
+        cleanup();
+        return;
+      }
+
       streamRef.current = stream;
 
       // Waveform monitor + silence detection.

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -3,13 +3,14 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import AgentShell from '../_components/AgentShell';
 import VoiceInputBar from '../_components/VoiceInputBar';
 import VoiceConfirmationCard from '../_components/VoiceConfirmationCard';
 import UndoPill from '../_components/UndoPill';
 import CapabilityChipsCarousel from '../_components/CapabilityChipsCarousel';
 import { useVoiceCapture } from '../_hooks/useVoiceCapture';
+import { fetchCapabilityChips } from '@/lib/agent-intelligence/capability-chips';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { Mail, Copy, Check, ExternalLink } from 'lucide-react';
 import type { ExecutedAction, ExtractedAction } from '@/lib/agent-intelligence/voice-actions';
@@ -111,6 +112,7 @@ function IntelligencePageInner() {
   const { openApprovalDrawer } = useApprovalDrawer();
   const { count: pendingDraftsCount, ready: draftsReady } = useDraftsCount();
   const searchParams = useSearchParams();
+  const router = useRouter();
   const prefillPrompt = searchParams.get('prompt');
 
   const [messages, setMessages] = useState<Message[]>([]);
@@ -120,6 +122,9 @@ function IntelligencePageInner() {
   const [isDesktop, setIsDesktop] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [undoBatch, setUndoBatch] = useState<UndoBatch | null>(null);
+  // Session 11 — live chip list, starts undefined so the carousel
+  // uses its fallback set on first paint; the live fetch replaces it.
+  const [liveChips, setLiveChips] = useState<string[] | undefined>(undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prefillHandled = useRef(false);
   const inputElRef = useRef<HTMLInputElement | null>(null);
@@ -137,6 +142,18 @@ function IntelligencePageInner() {
     update();
     mq.addEventListener('change', update);
     return () => mq.removeEventListener('change', update);
+  }, []);
+
+  // Session 11 — fetch real-data chips on mount. While the fetch is in
+  // flight the carousel uses its fallback set, so first paint is never
+  // blank.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const chips = await fetchCapabilityChips();
+      if (!cancelled) setLiveChips(chips);
+    })();
+    return () => { cancelled = true; };
   }, []);
 
   // Handle prefilled prompt from URL
@@ -675,13 +692,30 @@ function IntelligencePageInner() {
             }}
           >
             {/* Breathing room from the status bar. */}
-            <div style={{ height: 40, flexShrink: 0 }} />
+            <div style={{ height: 24, flexShrink: 0 }} />
+
+            {/* Session 11 restored, Session 12 enlarged — OPENHOUSE
+                logo centred above the hero. 80×80 on mobile, 96×96 on
+                desktop. Always rendered regardless of drafts state. */}
+            <Image
+              src="/oh-logo.png"
+              alt="OpenHouse"
+              width={isDesktop ? 96 : 80}
+              height={isDesktop ? 96 : 80}
+              priority
+              style={{
+                objectFit: 'contain',
+                display: 'block',
+                mixBlendMode: 'multiply',
+                marginBottom: 32,
+              }}
+            />
 
             <h1
               data-testid="intelligence-hero"
               style={{
                 color: '#0b0c0f',
-                fontSize: 30,
+                fontSize: 26,
                 fontWeight: 600,
                 letterSpacing: '-0.025em',
                 lineHeight: 1.2,
@@ -692,7 +726,7 @@ function IntelligencePageInner() {
               What can I help with, {firstName}?
             </h1>
 
-            <div style={{ height: 24, flexShrink: 0 }} />
+            <div style={{ height: 18, flexShrink: 0 }} />
 
             <p
               style={{
@@ -707,66 +741,51 @@ function IntelligencePageInner() {
               Voice or text. I&rsquo;ll show you what I drafted before sending.
             </p>
 
-            {/* Drafts banner — reserved height prevents layout shift between
-                "still loading" and "resolved". Hidden entirely when there
-                are no drafts so the screen stays quiet for clean queues. */}
+            {/* Session 11 — quiet drafts link.
+                Single muted line under the helper sentence; only
+                rendered when count resolves to > 0. 20px reserved so
+                the chip carousel doesn't shift when the link appears
+                or disappears. The FAB badge already shows the count. */}
             <div
               style={{
+                marginTop: 12,
+                minHeight: 20,
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
                 width: '100%',
                 maxWidth: 360,
-                // min-height holds space for the banner while draftsReady
-                // is false, then collapses smoothly once count is known
-                // to be zero.
-                minHeight: !draftsReady || pendingDraftsCount > 0 ? 76 : 0,
-                marginTop: !draftsReady || pendingDraftsCount > 0 ? 32 : 0,
-                transition: 'min-height 0.25s ease, margin-top 0.25s ease',
               }}
             >
               {draftsReady && pendingDraftsCount > 0 ? (
-                <div
-                  data-testid="intelligence-drafts-greeting"
+                <button
+                  type="button"
+                  data-testid="intelligence-drafts-link"
+                  onClick={() => router.push('/agent/drafts')}
                   style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: 10,
-                    padding: '12px 16px',
-                    background: 'rgba(196,155,42,0.08)',
-                    border: '0.5px solid rgba(196,155,42,0.30)',
-                    borderRadius: 14,
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                    color: '#6B7280',
+                    fontSize: 13,
+                    fontFamily: 'inherit',
+                    textDecoration: 'underline',
+                    textUnderlineOffset: 3,
+                    cursor: 'pointer',
                   }}
                 >
-                  <p style={{ margin: 0, color: '#8A6E1F', fontSize: 13, lineHeight: 1.45 }}>
-                    You&rsquo;ve got {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} from earlier.
-                  </p>
-                  <Link
-                    href="/agent/drafts"
-                    data-testid="intelligence-review-drafts-chip"
-                    style={{
-                      background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
-                      color: '#FFFFFF',
-                      fontSize: 12,
-                      fontWeight: 600,
-                      padding: '7px 14px',
-                      borderRadius: 999,
-                      textDecoration: 'none',
-                      boxShadow: '0 2px 6px rgba(196,155,42,0.30)',
-                    }}
-                  >
-                    Review drafts
-                  </Link>
-                </div>
+                  {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} waiting in your inbox
+                </button>
               ) : null}
             </div>
 
-            {/* Flex spacer — pushes chips down toward the input bar. Uses
-                flex-grow rather than a hard gap so the empty state feels
-                intentional, not collapsed. */}
+            {/* Flex spacer — pushes chips down toward the input bar. */}
             <div style={{ flex: 1, minHeight: 24 }} />
 
             <CapabilityChipsCarousel
               onChipTap={handleChipTap}
               paused={inputFocused}
+              chips={liveChips}
             />
 
             <div style={{ height: 16, flexShrink: 0 }} />

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -1,0 +1,208 @@
+import { NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { FALLBACK_CAPABILITY_CHIPS } from '@/lib/agent-intelligence/capability-chips';
+import { formatAgentAddress, truncateForChip } from '@/lib/agent/format-address';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Session 11 — GET /api/agent/intelligence/capability-chips.
+ *
+ * Returns an honest, live-data-sourced chip list for the Intelligence
+ * landing carousel. Every phrase either references a real scheme the
+ * agent is assigned to, a real letting-property address on their books,
+ * or is context-free ("Generate developer weekly report").
+ *
+ * Session 12 — address composition now goes through the shared
+ * `formatAgentAddress` helper so structured
+ * `address_line_1 / address_line_2 / city / eircode` fields are used
+ * when available. No silent prefix stripping (goodbye "Apt 12 → 12
+ * Grand Parade" bug).
+ *
+ * Chips are omitted when the underlying data doesn't exist:
+ *   - no letting properties → no rental-viewing or letting chips
+ *   - zero applicants → no "Show me applicants for X" chips
+ *   - zero tenancies → no renewal chips
+ *   - zero drafts → no "Review my drafts" chip
+ */
+
+interface ChipResponse {
+  chips: string[];
+}
+
+export async function GET() {
+  try {
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    const profile = await resolveAgentProfile(supabase, user?.id);
+    if (!profile) {
+      return NextResponse.json<ChipResponse>({ chips: [...FALLBACK_CAPABILITY_CHIPS] });
+    }
+
+    const chips = await composeChips(supabase, profile.id);
+    return NextResponse.json<ChipResponse>({ chips });
+  } catch {
+    return NextResponse.json<ChipResponse>({ chips: [...FALLBACK_CAPABILITY_CHIPS] });
+  }
+}
+
+async function composeChips(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  agentId: string,
+): Promise<string[]> {
+  const [
+    assignmentsRes,
+    lettingsRes,
+    tenanciesCountRes,
+    applicantsCountRes,
+    rentalViewingsCountRes,
+    draftsCountRes,
+  ] = await Promise.all([
+    supabase
+      .from('agent_scheme_assignments')
+      .select('development_id')
+      .eq('agent_id', agentId)
+      .eq('is_active', true),
+    // Session 12: pull the structured address fields alongside the
+    // legacy denormalised `address` column. The formatter picks
+    // structured fields when present and falls back verbatim otherwise.
+    supabase
+      .from('agent_letting_properties')
+      .select('id, address, address_line_1, address_line_2, city, eircode')
+      .eq('agent_id', agentId)
+      .order('created_at', { ascending: false })
+      .limit(3),
+    supabase
+      .from('agent_tenancies')
+      .select('id', { count: 'exact', head: true })
+      .eq('agent_id', agentId)
+      .eq('status', 'active'),
+    supabase
+      .from('agent_applicants')
+      .select('id', { count: 'exact', head: true })
+      .eq('agent_id', agentId),
+    supabase
+      .from('agent_viewings')
+      .select('id', { count: 'exact', head: true })
+      .eq('agent_id', agentId)
+      .not('letting_property_id', 'is', null),
+    supabase
+      .from('pending_drafts')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', agentId)
+      .eq('skin', 'agent')
+      .eq('status', 'pending_review'),
+  ]);
+
+  const developmentIds = Array.from(
+    new Set(
+      (assignmentsRes.data ?? []).map((a: any) => a.development_id).filter(Boolean),
+    ),
+  );
+  let schemeNames: string[] = [];
+  if (developmentIds.length) {
+    const { data: devs } = await supabase
+      .from('developments')
+      .select('name')
+      .in('id', developmentIds);
+    schemeNames = (devs ?? []).map((d: any) => d.name).filter(Boolean);
+  }
+
+  const lettingProps = (lettingsRes.data ?? []) as Array<{
+    id: string;
+    address: string | null;
+    address_line_1: string | null;
+    address_line_2: string | null;
+    city: string | null;
+    eircode: string | null;
+  }>;
+  const lettingAddresses = lettingProps
+    .map((p) => truncateForChip(formatAgentAddress(p, 'short')))
+    .filter(Boolean) as string[];
+
+  const tenanciesCount = tenanciesCountRes.count ?? 0;
+  const applicantsCount = applicantsCountRes.count ?? 0;
+  const rentalViewingsCount = rentalViewingsCountRes.count ?? 0;
+  const draftsCount = draftsCountRes.count ?? 0;
+
+  const chips: string[] = [];
+
+  // --- Sales pipeline: scheme-specific, only when we have real names.
+  if (schemeNames.length) {
+    chips.push(`What's outstanding on contracts in ${schemeNames[0]}?`);
+    chips.push(`Brief me on ${schemeNames[0]}`);
+    if (schemeNames.length > 1) {
+      chips.push(`Switch to ${schemeNames[1]}`);
+      chips.push('Show me everything across all schemes');
+    }
+  }
+  chips.push('Show me overdue chases');
+  chips.push('What signed this week?');
+  chips.push('Chase aged contracts');
+
+  // --- Lettings: only when real rows exist.
+  if (lettingAddresses.length) {
+    chips.push(`Log a rental viewing for ${lettingAddresses[0]}`);
+  }
+  if (tenanciesCount > 0) {
+    chips.push('Which tenancies are up for renewal?');
+  }
+  if (applicantsCount > 0 && lettingAddresses.length) {
+    chips.push(`Show me applicants for ${lettingAddresses[0]}`);
+  }
+  if (rentalViewingsCount > 0) {
+    chips.push("What rental viewings do I have this week?");
+  }
+
+  // --- Reporting / scheduling / briefings: always safe.
+  chips.push('Generate developer weekly report');
+  chips.push('Give me a scheme summary');
+  chips.push("What's on for me today?");
+  chips.push('What viewings do I have this week?');
+
+  // --- Drafts: only surface when the inbox actually has items.
+  if (draftsCount > 0) {
+    chips.push('Review my drafts');
+  }
+
+  chips.push('Invite an applicant');
+  chips.push('Draft a buyer follow-up email');
+  chips.push('Schedule a viewing for Saturday at 2pm');
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const c of chips) {
+    if (!seen.has(c)) {
+      seen.add(c);
+      deduped.push(c);
+    }
+  }
+  return deduped;
+}
+
+async function resolveAgentProfile(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  userId: string | undefined,
+): Promise<{ id: string } | null> {
+  if (userId) {
+    const { data } = await supabase
+      .from('agent_profiles')
+      .select('id')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (data) return data as any;
+  }
+  const { data } = await supabase
+    .from('agent_profiles')
+    .select('id')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return (data as any) || null;
+}

--- a/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
+++ b/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
@@ -1,57 +1,34 @@
 /**
- * Session 7 — capability chip library shown on the Intelligence landing.
+ * Honest capability chips (Session 11, polished in Session 12).
  *
- * Intent: showcase Intelligence's full breadth (sales, lettings, drafts,
- * queries, scheduling, reporting, autonomy, scope) without a permanent
- * button grid. Four chips visible at a time, rotating every 6s.
+ * The live chip list is sourced from real agent data via
+ * `GET /api/agent/intelligence/capability-chips`. That endpoint reads
+ * the agent's assigned schemes, letting properties, applicant /
+ * tenancy / rental-viewing counts, and composes phrases that only
+ * reference rows that actually exist.
  *
- * Each chip is phrased the way a working Irish estate agent would say it
- * — conversational, not command-style. The chip text is dropped into the
- * input bar when tapped; the user edits before sending.
- *
- * To add, remove, or re-word chips, edit this file. The carousel
- * component reads the export and shuffles on mount.
+ * This file keeps a short context-free fallback set — no scheme
+ * names, no property addresses, no buyer names, no "those three
+ * units" style context-dependent phrasing. If the live fetch fails
+ * or is still in flight, the carousel renders these; nothing it
+ * says will disappoint when the user taps it.
  */
 
-export const CAPABILITY_CHIPS: readonly string[] = [
-  // Sales pipeline
-  "What's outstanding on contracts?",
+export const FALLBACK_CAPABILITY_CHIPS: readonly string[] = [
   'Show me overdue chases',
-  'Draft a buyer follow-up email',
-  'What signed this week?',
-  'Which units are still for sale?',
-
-  // Lettings
-  'Three people came to see 14 Oakfield',
-  "Invite the O'Sheas to apply",
-  'Show me applicants for Maple Court',
-  'Which tenancies are up for renewal?',
-  'Log a rental viewing for tomorrow',
-
-  // Reporting & briefings
+  "What's on for me today?",
+  'What viewings do I have this week?',
   'Generate developer weekly report',
   'Give me a scheme summary',
-  "What's on for me today?",
-  'Brief me on Árdan View',
-
-  // Scheduling
+  'What signed this week?',
+  'Chase aged contracts',
+  'Draft a buyer follow-up email',
+  'Invite an applicant',
   'Schedule a viewing for Saturday at 2pm',
-  'What viewings do I have this week?',
-
-  // Drafts & autonomy
-  'Review my drafts',
-  'Draft a price reduction notice',
-  'Chase those three units about signing',
-
-  // Scope / scheme switching
-  'Switch to Rathárd Park',
   'Show me everything across all schemes',
 ] as const;
 
-/**
- * Fisher–Yates shuffle. Pure function; callers should call it once on
- * mount to avoid re-shuffling on every render.
- */
+/** Fisher–Yates shuffle. Pure function; call once per mount. */
 export function shuffleChips(input: readonly string[]): string[] {
   const arr = input.slice();
   for (let i = arr.length - 1; i > 0; i--) {
@@ -59,4 +36,25 @@ export function shuffleChips(input: readonly string[]): string[] {
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
   return arr;
+}
+
+/**
+ * Client-side fetch for the live capability chips. Falls back to the
+ * static context-free set on any failure. Never throws.
+ */
+export async function fetchCapabilityChips(): Promise<string[]> {
+  try {
+    const res = await fetch('/api/agent/intelligence/capability-chips', {
+      cache: 'no-store',
+    });
+    if (!res.ok) return [...FALLBACK_CAPABILITY_CHIPS];
+    const data = await res.json();
+    if (!Array.isArray(data?.chips) || data.chips.length === 0) {
+      return [...FALLBACK_CAPABILITY_CHIPS];
+    }
+    return (data.chips as unknown[])
+      .filter((c): c is string => typeof c === 'string' && c.length > 0);
+  } catch {
+    return [...FALLBACK_CAPABILITY_CHIPS];
+  }
 }

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -230,7 +230,7 @@ ANYONE — ALWAYS call the appropriate draft-producing tool. Pick the tightest f
 
   - "draft emails to those 3 units" / "follow up with those buyers" / "send those
     three a chase" → call draft_buyer_followups with a targets array (one entry
-    per unit) and a shared topic.
+    per unit) and the matching purpose.
   - "draft an email to [one person]" → call draft_message with that single
     recipient.
   - "chase all overdue contracts" → call chase_aged_contracts.
@@ -238,14 +238,67 @@ ANYONE — ALWAYS call the appropriate draft-producing tool. Pick the tightest f
   - Lease renewals → draft_lease_renewal. Weekly briefing → weekly_monday_briefing.
   - New viewing appointment → schedule_viewing_draft.
 
+ALWAYS set draft_buyer_followups purpose:
+  - "congratulate" / "welcome" / "keys" / "handed over" / "moved in"
+    → purpose="congratulate_handover"
+  - "chase" / "follow up" / "overdue" / "where do they stand"
+    → purpose="chase"
+  - "introduce" / "first contact" / "new buyer"
+    → purpose="introduce"
+  - "update" / "news" / "status"
+    → purpose="update"
+  - Anything else (price drop, invite, solicitor handover, etc.)
+    → purpose="custom" with a clear custom_instruction.
+
+INTENT-AWARE CLARIFICATION (Session 9 rule):
+When the user specifies a count but not specific unit identifiers (e.g. "draft
+email to 3 Ardan view and congratulate them on their keys"), you MUST:
+  1. Call get_candidate_units FIRST with the intent that matches the request:
+       - "congratulate / welcome / keys" → intent="handover"
+       - "chase / overdue" → intent="overdue_contracts"
+       - "sale agreed" → intent="sale_agreed"
+       - otherwise → intent="all"
+     Pass scheme_name when the user named one.
+  2. Branch on what comes back:
+       - candidates == requested count → draft them all, then confirm.
+       - candidates < requested count → tell the user honestly ("Only 2 units
+         have had handovers in Árdan View — Unit 3 and Unit 5. Draft both?"),
+         do NOT invent the rest.
+       - candidates > requested count → list the top (requested+2) with their
+         state, ask the user which ones.
+       - candidates == 0 → tell the user ("No units in Árdan View have been
+         handed over yet") and do not draft anything.
+
+NEVER pick units silently from chat recency, conversational salience, or by
+guessing from unit numbers you haven't verified. If the user asks for "the 3
+most overdue" and the immediately preceding turn produced a list, use that
+exact list — otherwise call get_candidate_units.
+
+STRICT UNIT RESOLUTION (Session 9):
+When you pass targets to draft_buyer_followups, the unit_identifier must be a
+unit number the user explicitly named OR that a previous tool returned. The
+skill matches EXACTLY — "Unit 3" will not match Unit 30 or Unit 13. If the
+skill can't resolve a ref it will skip the target and surface the reason in
+the envelope; relay that to the user ("I couldn't find Unit 3 in Árdan View
+— did you mean Unit 30?").
+
+PURPOSE PRECONDITIONS (Session 9):
+The skill refuses to draft when the resolved unit does not satisfy the
+purpose — e.g. congratulate_handover for a unit with no handover_date is
+rejected at skill level. When the envelope summary says a unit was skipped,
+surface the reason to the user ("Unit 10 hasn't been handed over yet. Did
+you mean a different unit?"). Do not re-call the skill with a different
+purpose to force it through.
+
+JOINT PURCHASERS:
+A unit with joint purchasers (e.g. "Laura Hayes and Dylan Rogers" at Unit 19)
+is ONE target, not two. Pass it once; the skill greets both names in one email.
+Do NOT call draft_buyer_followups twice for the same unit.
+
 NEVER reply with a numbered list describing drafts you would write. NEVER write
 email text inline in your response. The tool call IS the draft; the drafts it
 produces land in the Drafts inbox and open the approval drawer for the agent to
 review.
-
-If the user names a specific subset of records you just showed them (e.g. "those
-3 units" right after get_outstanding_items), ALWAYS use draft_buyer_followups
-with that exact subset's unit identifiers — never the bulk chase skill.
 
 If you claim drafts are ready but did not actually call a draft-producing tool,
 the system will OVERRIDE your response with an honest failure message. So: only

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -3,6 +3,11 @@ import { randomUUID } from 'node:crypto';
 import { getRenewalWindow, getRentArrears, getUpcomingWeekViewings } from '../context';
 import { isInRPZ, rpzUpliftCap } from '../rpz-zones';
 import type { AgenticSkillEnvelope } from '../envelope';
+import {
+  resolveUnitIdentifier,
+  getCandidateUnits,
+  type CandidateIntent,
+} from '../unit-resolver';
 
 // Envelope returned by every agentic skill. Draft ids generated here are
 // temporary — the registry adapter funnels the envelope through
@@ -1146,10 +1151,16 @@ export async function draftMessageSkill(
 // Skill 8 — draft_buyer_followups (explicit multi-recipient)
 // =====================================================================
 //
-// Session 6D fix. Gives the model a direct path for "draft emails to
-// those 3 units" without needing three parallel tool calls. Input is a
-// list of unit/scheme references plus a shared topic. Returns one draft
-// per resolved unit.
+// Session 6D introduced this skill. Session 8 was planned to add `purpose`
+// + joint-purchaser handling but didn't land. Session 9 adds those plus
+// strict unit resolution and purpose preconditions in one go.
+
+export type DraftBuyerFollowupPurpose =
+  | 'chase'
+  | 'congratulate_handover'
+  | 'introduce'
+  | 'update'
+  | 'custom';
 
 interface DraftBuyerFollowupsInput {
   targets: Array<{
@@ -1157,8 +1168,157 @@ interface DraftBuyerFollowupsInput {
     scheme_name?: string;
     recipient_name?: string;
   }>;
-  topic: string;
+  topic?: string;
   tone?: string;
+  purpose?: DraftBuyerFollowupPurpose;
+  custom_instruction?: string;
+}
+
+/**
+ * Parse a purchaser_name field into individual given names. The units
+ * table stores joint purchasers as a single free-text string like
+ * "Laura Hayes and Dylan Rogers" or "Laura Hayes & Dylan Rogers".
+ * One email per household, both names greeted — matches how an agent
+ * actually writes.
+ */
+export function parseJointPurchaserNames(raw: string | null | undefined): {
+  fullName: string;
+  firstNames: string[];
+  greeting: string;
+} {
+  const fallback = { fullName: 'Buyer', firstNames: ['there'], greeting: 'Hi there,' };
+  if (!raw) return fallback;
+  const cleaned = raw.replace(/\s+/g, ' ').trim();
+  if (!cleaned) return fallback;
+
+  const parts = cleaned
+    .split(/\s+and\s+|\s*&\s*/i)
+    .map((p) => p.replace(/\b(Mr|Mrs|Ms|Miss|Dr)\.?\s+/gi, '').trim())
+    .filter(Boolean);
+  if (!parts.length) return fallback;
+
+  const firstNames = parts.map((p) => p.split(/\s+/)[0] || 'there');
+  const greeting =
+    firstNames.length === 1
+      ? `Hi ${firstNames[0]},`
+      : firstNames.length === 2
+        ? `Hi ${firstNames[0]} and ${firstNames[1]},`
+        : `Hi ${firstNames.slice(0, -1).join(', ')} and ${firstNames[firstNames.length - 1]},`;
+  return { fullName: cleaned, firstNames, greeting };
+}
+
+// -- Purpose preconditions: the skill refuses to draft when the resolved
+//    unit doesn't satisfy the precondition for the requested purpose.
+//    "Welcome to your new home" for a unit with no handover_date is the
+//    bug we're killing.
+interface UnitStateForPrecondition {
+  handover_date: string | null;
+  unit_status: string | null;
+  contracts_issued_date: string | null;
+  signed_contracts_date: string | null;
+  counter_signed_date: string | null;
+  purchaser_name: string | null;
+}
+
+const PURPOSE_PRECONDITIONS: Record<
+  DraftBuyerFollowupPurpose,
+  { check: (u: UnitStateForPrecondition) => boolean; rejectionReason: (unitLabel: string) => string }
+> = {
+  congratulate_handover: {
+    check: (u) => Boolean(u.handover_date) || u.unit_status === 'handed_over' || u.unit_status === 'sold',
+    rejectionReason: (label) =>
+      `Cannot congratulate ${label} on receiving keys — handover hasn't happened yet.`,
+  },
+  chase: {
+    check: (u) => !!u.contracts_issued_date && !u.signed_contracts_date && !u.counter_signed_date,
+    rejectionReason: (label) =>
+      `Cannot draft a contract chase for ${label} — no unsigned contracts on file.`,
+  },
+  introduce: {
+    check: (u) => !!u.purchaser_name,
+    rejectionReason: (label) =>
+      `Cannot draft an introduction for ${label} — no buyer on file yet.`,
+  },
+  update: { check: () => true, rejectionReason: () => '' },
+  custom: { check: () => true, rejectionReason: () => '' },
+};
+
+function buildFollowupContent(opts: {
+  purpose: DraftBuyerFollowupPurpose;
+  topic: string;
+  customInstruction?: string;
+  unitLabel: string;
+  greeting: string;
+  tone: string;
+  ctx: SkillAgentContext;
+}): { subject: string; body: string } {
+  const { purpose, topic, customInstruction, unitLabel, greeting, tone, ctx } = opts;
+  const sign = toneSignOff(tone);
+  const sig = signature(ctx);
+
+  if (purpose === 'congratulate_handover') {
+    return {
+      subject: `Welcome to your new home — ${unitLabel}`,
+      body: [
+        greeting,
+        '',
+        `Congratulations on getting the keys to ${unitLabel} — delighted to see you over the line.`,
+        '',
+        topic || 'Wishing you every happiness settling in.',
+        '',
+        'If anything comes up over the first few weeks — snags, paperwork, anything we can help with — just let me know and I\'ll sort it.',
+        '',
+        sign,
+        sig,
+      ].join('\n'),
+    };
+  }
+
+  if (purpose === 'introduce') {
+    return {
+      subject: `Introduction — ${unitLabel}`,
+      body: [
+        greeting,
+        '',
+        topic || `I\'m getting in touch as the agent looking after ${unitLabel}.`,
+        '',
+        'Happy to answer any questions and walk you through the next steps whenever suits.',
+        '',
+        sign,
+        sig,
+      ].join('\n'),
+    };
+  }
+
+  if (purpose === 'update') {
+    return {
+      subject: `Update — ${unitLabel}`,
+      body: [greeting, '', topic || 'Quick update on where things stand.', '', sign, sig].join('\n'),
+    };
+  }
+
+  if (purpose === 'custom') {
+    const instruction = customInstruction?.trim() || topic;
+    return {
+      subject: unitLabel,
+      body: [greeting, '', instruction, '', sign, sig].join('\n'),
+    };
+  }
+
+  // Default: chase.
+  return {
+    subject: `Following up — ${unitLabel}`,
+    body: [
+      greeting,
+      '',
+      topic,
+      '',
+      'Could you let me know where things stand on your end? Happy to help work through anything that\'s holding things up.',
+      '',
+      sign,
+      sig,
+    ].join('\n'),
+  };
 }
 
 export async function draftBuyerFollowups(
@@ -1169,8 +1329,10 @@ export async function draftBuyerFollowups(
   const skill = 'draft_buyer_followups';
   const tone = (inputs.tone || 'gentle_chase').trim();
   const topic = (inputs.topic || '').trim();
+  const purpose: DraftBuyerFollowupPurpose = inputs.purpose || 'chase';
+  const customInstruction = inputs.custom_instruction?.trim();
   const targets = Array.isArray(inputs.targets) ? inputs.targets : [];
-  const query = `draft_buyer_followups targets=${targets.length} topic="${topic.slice(0, 80)}"`;
+  const query = `draft_buyer_followups targets=${targets.length} purpose=${purpose} topic="${topic.slice(0, 80)}"`;
 
   if (!targets.length) {
     return {
@@ -1181,7 +1343,9 @@ export async function draftBuyerFollowups(
       meta: { record_count: 0, generated_at: new Date().toISOString(), query },
     };
   }
-  if (!topic) {
+  // Most purposes need a topic. congratulate_handover has a built-in
+  // fallback; custom can rely on custom_instruction alone.
+  if (!topic && purpose !== 'congratulate_handover' && !(purpose === 'custom' && customInstruction)) {
     return {
       skill,
       status: 'awaiting_approval',
@@ -1193,9 +1357,9 @@ export async function draftBuyerFollowups(
 
   try {
     const drafts: AgenticSkillEnvelope['drafts'] = [];
+    const skipped: Array<{ ref: string; reason: string }> = [];
+    const seenUnitIds = new Set<string>();
 
-    // Pre-resolve the agent's assigned developments so scheme-less targets
-    // can still be matched. Same chain as resolveAgentContext uses.
     const { data: asgs } = await supabase
       .from('agent_scheme_assignments')
       .select('development_id')
@@ -1206,90 +1370,211 @@ export async function draftBuyerFollowups(
       ? await supabase.from('developments').select('id, name').in('id', devIds)
       : { data: [] };
     const devList = (devs || []) as Array<{ id: string; name: string }>;
-    const devIdByName = new Map<string, string>(devList.map((d) => [d.name.toLowerCase(), d.id]));
+
+    const schemeIdForName = (name: string | undefined): string | null => {
+      if (!name) return null;
+      const key = name.trim().toLowerCase();
+      for (const d of devList) {
+        if (d.name.toLowerCase().includes(key) || key.includes(d.name.toLowerCase())) {
+          return d.id;
+        }
+      }
+      return null;
+    };
 
     for (const target of targets) {
       const unitRef = (target.unit_identifier || '').trim();
       if (!unitRef) continue;
 
-      let targetDevId: string | null = null;
-      let targetDevName: string | null = null;
-      if (target.scheme_name) {
-        const key = target.scheme_name.trim().toLowerCase();
-        // Fuzzy match against assigned scheme names.
-        for (const d of devList) {
-          if (d.name.toLowerCase().includes(key) || key.includes(d.name.toLowerCase())) {
-            targetDevId = d.id;
-            targetDevName = d.name;
-            break;
-          }
-        }
-        if (!targetDevId) {
-          targetDevId = devIdByName.get(key) || null;
-          targetDevName = target.scheme_name;
-        }
+      const preferredDevId = schemeIdForName(target.scheme_name);
+      const resolution = await resolveUnitIdentifier(supabase, unitRef, {
+        developmentIds: devIds,
+        preferredDevelopmentId: preferredDevId,
+      });
+
+      if (resolution.status === 'not_found') {
+        skipped.push({ ref: unitRef, reason: `No unit "${resolution.normalised}" in your assigned schemes.` });
+        continue;
       }
-      const searchDevIds = targetDevId ? [targetDevId] : devIds;
-      if (!searchDevIds.length) continue;
+      if (resolution.status === 'ambiguous') {
+        const list = resolution.candidates
+          .map((c) => `${c.scheme_name ?? '?'} Unit ${c.unit_number ?? '?'}`)
+          .join(', ');
+        skipped.push({
+          ref: unitRef,
+          reason: `"${unitRef}" matches multiple units across schemes (${list}). Include the scheme name.`,
+        });
+        continue;
+      }
 
-      const { data: units } = await supabase
-        .from('units')
-        .select('id, unit_number, unit_uid, development_id, purchaser_name, purchaser_email')
-        .in('development_id', searchDevIds)
-        .or(`unit_number.ilike.%${unitRef}%,unit_uid.ilike.%${unitRef}%,purchaser_name.ilike.%${target.recipient_name || unitRef}%`)
-        .limit(1);
-      const unit = units?.[0];
-      if (!unit) continue;
+      const unit = resolution.unit;
+      const pipeline = resolution.pipeline;
+      if (seenUnitIds.has(unit.id)) continue;
+      seenUnitIds.add(unit.id);
 
-      const resolvedDevName = targetDevName
-        || devList.find((d) => d.id === unit.development_id)?.name
-        || 'Unknown scheme';
-      const resolvedUnitNumber = unit.unit_number || unit.unit_uid || unitRef;
-      const recipientName = target.recipient_name || unit.purchaser_name || 'Buyer';
+      const schemeName =
+        devList.find((d) => d.id === unit.development_id)?.name ?? target.scheme_name ?? 'Unknown scheme';
+      const unitLabel = `Unit ${unit.unit_number ?? unit.unit_uid ?? unitRef}, ${schemeName}`;
 
-      const unitLabel = `Unit ${resolvedUnitNumber}, ${resolvedDevName}`;
-      const body = [
-        toneGreeting(firstName(recipientName)),
-        '',
+      // Precondition: resolved unit must satisfy the purpose.
+      const preconditionState: UnitStateForPrecondition = {
+        handover_date: pipeline?.handover_date ?? null,
+        unit_status: unit.unit_status,
+        contracts_issued_date: pipeline?.contracts_issued_date ?? null,
+        signed_contracts_date: pipeline?.signed_contracts_date ?? null,
+        counter_signed_date: pipeline?.counter_signed_date ?? null,
+        purchaser_name: unit.purchaser_name,
+      };
+      const precondition = PURPOSE_PRECONDITIONS[purpose];
+      if (!precondition.check(preconditionState)) {
+        skipped.push({ ref: unitRef, reason: precondition.rejectionReason(unitLabel) });
+        continue;
+      }
+
+      const rawName =
+        target.recipient_name ||
+        unit.purchaser_name ||
+        pipeline?.purchaser_name ||
+        'Buyer';
+      const parsed = parseJointPurchaserNames(rawName);
+      const resolvedEmail = unit.purchaser_email || pipeline?.purchaser_email || 'buyer@tbc.invalid';
+
+      const { subject, body } = buildFollowupContent({
+        purpose,
         topic,
-        '',
-        'Could you let me know where things stand on your end? Happy to help work through anything that\'s holding things up.',
-        '',
-        toneSignOff(tone),
-        signature(agentContext),
-      ].join('\n');
+        customInstruction,
+        unitLabel,
+        greeting: parsed.greeting,
+        tone,
+        ctx: agentContext,
+      });
 
       drafts.push({
         id: randomUUID(),
         type: 'email' as const,
-        recipient: {
-          name: recipientName,
-          email: unit.purchaser_email || 'buyer@tbc.invalid',
-          role: 'buyer',
-        },
-        subject: `Following up — ${unitLabel}`,
+        recipient: { name: parsed.fullName, email: resolvedEmail, role: 'buyer' },
+        subject,
         body,
         affected_record: { kind: 'sales_unit', id: unit.id, label: unitLabel },
-        reasoning: `Requested follow-up to ${recipientName} at ${unitLabel}. Tone: ${tone}.${unit.purchaser_email ? '' : ' Recipient email missing — placeholder used, please fill in before approving.'}`,
+        reasoning: `${purpose} email to ${parsed.fullName} at ${unitLabel}. Tone: ${tone}.${resolvedEmail === 'buyer@tbc.invalid' ? ' Recipient email missing — placeholder used, please fill in before approving.' : ''}`,
       });
     }
 
-    if (!drafts.length) {
-      return {
-        skill,
-        status: 'awaiting_approval',
-        summary: 'Could not resolve any of the requested units to real buyers. Try naming them more specifically.',
-        drafts: [],
-        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
-      };
+    const summaryParts: string[] = [];
+    if (drafts.length) {
+      summaryParts.push(`Drafted ${drafts.length} ${purpose} email${drafts.length === 1 ? '' : 's'}.`);
+    }
+    if (skipped.length) {
+      summaryParts.push(`Skipped ${skipped.length}: ${skipped.map((s) => s.reason).join(' ')}`);
+    }
+    if (!summaryParts.length) {
+      summaryParts.push(
+        'Could not resolve any of the requested units. Try naming them more specifically.',
+      );
     }
 
     return {
       skill,
       status: 'awaiting_approval',
-      summary: `Drafted ${drafts.length} follow-up email${drafts.length === 1 ? '' : 's'}.`,
+      summary: summaryParts.join(' '),
       drafts,
-      meta: { record_count: drafts.length, generated_at: new Date().toISOString(), query },
+      meta: {
+        record_count: drafts.length,
+        generated_at: new Date().toISOString(),
+        query,
+        // @ts-ignore — extra diagnostic field read by the chat route
+        skipped,
+      } as any,
+    };
+  } catch (err) {
+    return errorEnvelope(skill, query, err);
+  }
+}
+
+// =====================================================================
+// Skill 9 — get_candidate_units (intent-aware clarification helper)
+// =====================================================================
+//
+// Session 9 fix. Before prompting "which N units?", the model must see
+// a candidate set filtered by INTENT, not the first N unit numbers in
+// whatever order they sit in the DB. For "congratulate on keys" intent
+// that means handed-over units only.
+//
+// This skill is technically read-only — it returns an envelope with
+// zero drafts and surfaces the candidate list in the summary + meta.
+// Not strictly an agentic skill (no approvals), but registered as one
+// so it lives on the same runAgenticSkill adapter and benefits from
+// the anti-hallucination telemetry.
+
+export async function getCandidateUnitsSkill(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: { intent: CandidateIntent; scheme_name?: string; limit?: number },
+): Promise<AgenticSkillEnvelope> {
+  const skill = 'get_candidate_units';
+  const intent: CandidateIntent = (inputs.intent || 'all') as CandidateIntent;
+  const limit = Math.max(1, Math.min(20, inputs.limit ?? 6));
+  const query = `get_candidate_units intent=${intent} scheme=${inputs.scheme_name ?? '(any)'}`;
+
+  try {
+    const { data: asgs } = await supabase
+      .from('agent_scheme_assignments')
+      .select('development_id')
+      .eq('agent_id', agentContext.agentId)
+      .eq('is_active', true);
+    const devIds = Array.from(new Set((asgs || []).map((a: any) => a.development_id).filter(Boolean)));
+    if (!devIds.length) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: 'No assigned schemes — no candidate units.',
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    let preferredDevId: string | null = null;
+    if (inputs.scheme_name) {
+      const key = inputs.scheme_name.trim().toLowerCase();
+      const { data: devs } = await supabase
+        .from('developments')
+        .select('id, name')
+        .in('id', devIds);
+      const match = (devs || []).find((d: any) => {
+        const n = String(d.name).toLowerCase();
+        return n === key || n.includes(key) || key.includes(n);
+      });
+      if (match) preferredDevId = match.id as string;
+    }
+
+    const candidates = await getCandidateUnits(supabase, intent, {
+      developmentIds: devIds,
+      preferredDevelopmentId: preferredDevId,
+      limit,
+    });
+
+    const summaryLines = candidates.length
+      ? [
+          `Found ${candidates.length} candidate unit${candidates.length === 1 ? '' : 's'} (${intent}):`,
+          ...candidates.map((c) => {
+            const buyer = c.purchaser_name ? ` — ${c.purchaser_name}` : '';
+            return `- ${c.scheme_name} Unit ${c.unit_number}${buyer} (${c.status_hint})`;
+          }),
+        ]
+      : [`No candidate units found for intent '${intent}'.`];
+
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: summaryLines.join('\n'),
+      drafts: [],
+      meta: {
+        record_count: candidates.length,
+        generated_at: new Date().toISOString(),
+        query,
+        // @ts-ignore extra diagnostic
+        candidates,
+      } as any,
     };
   } catch (err) {
     return errorEnvelope(skill, query, err);

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -34,6 +34,7 @@ import {
   scheduleViewingDraft,
   draftMessageSkill,
   draftBuyerFollowups,
+  getCandidateUnitsSkill,
   SkillAgentContext,
 } from './agentic-skills';
 import type { AgenticSkillEnvelope } from '../envelope';
@@ -240,30 +241,62 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: 'draft_buyer_followups',
-    description: 'Draft follow-up emails to a SPECIFIC list of units / buyers in one call. Use when the agent says "draft emails to those 3 units", "follow up with those buyers", "send those three a chase", etc. Each target produces one draft in the approval drawer.',
+    description: [
+      'Draft follow-up emails for one or more buyers. One draft per unit; joint purchasers (e.g. "Laura Hayes and Dylan Rogers") at a single unit share ONE email addressed to both names.',
+      'CRITICAL RULES:',
+      '1. Each target unit_identifier must be a unit number the user explicitly named OR that a previous tool returned. Do NOT guess.',
+      '2. The purpose parameter must match what the user is asking for. "Congratulate on keys" → congratulate_handover ONLY for units that have actually been handed over (handover_date present).',
+      '3. If the user gave a count but no specific units, call get_candidate_units with the right intent first; do not pick units silently.',
+      '4. The skill refuses to draft when the resolved unit does not satisfy the purpose (e.g. congratulate_handover for a unit with no handover_date). Surfaces skipped units via the envelope summary — relay those to the user.',
+    ].join(' '),
     parameters: {
       type: 'object',
       properties: {
         targets: {
           type: 'array',
-          description: 'Units to draft emails for. Each item must reference a unit (and optionally the scheme / recipient name).',
+          description: 'Units to draft emails for. One entry per unit; joint purchasers are NOT separate targets.',
           items: {
             type: 'object',
             properties: {
-              unit_identifier: { type: 'string', description: 'Unit number or unit reference (e.g. "19", "Unit 37", "AV-36").' },
-              scheme_name: { type: 'string', description: 'Name of the scheme the unit lives in. Optional when the agent only has one assigned scheme.' },
-              recipient_name: { type: 'string', description: 'Override the purchaser name on the unit if the agent named someone specifically.' },
+              unit_identifier: { type: 'string', description: 'Exact unit number or unit uid (e.g. "19", "Unit 37", "AV-36"). Matched exactly against units.unit_number then units.unit_uid — no wildcards, no buyer-name fuzz.' },
+              scheme_name: { type: 'string', description: 'Name of the scheme the unit lives in. Required when the agent has multiple assigned schemes; otherwise optional.' },
+              recipient_name: { type: 'string', description: 'Override the purchaser name if the agent named someone specifically. Usually leave blank so the skill greets the purchasers on file.' },
             },
             required: ['unit_identifier'],
           },
         },
-        topic: { type: 'string', description: 'Shared topic / reason for the follow-up (e.g. "asking when they expect to sign the contracts"). Becomes the lead of each email body.' },
+        topic: { type: 'string', description: 'Shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent. For congratulate_handover: a personal note (optional — there is a sensible default).' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
+        purpose: {
+          type: 'string',
+          description: 'Email intent — shapes subject + body template and drives the precondition check against the resolved unit. Defaults to chase.',
+          enum: ['chase', 'congratulate_handover', 'introduce', 'update', 'custom'],
+        },
+        custom_instruction: { type: 'string', description: 'Required when purpose="custom". Free-text description of the email\'s intent; becomes the body lead.' },
       },
-      required: ['targets', 'topic'],
+      required: ['targets'],
     },
     execute: ((supabase, _tenantId, agentContext, params) =>
       runAgenticSkill(draftBuyerFollowups, supabase, agentContext, params as any)) as ToolFunction,
+  },
+  {
+    name: 'get_candidate_units',
+    description: 'Return units from the agent\'s assigned schemes filtered by INTENT, for use as clarification candidates when the user specified a count but no specific unit identifiers. Read-only — returns an envelope with zero drafts and the candidate list in the summary. ALWAYS call this BEFORE asking the user "which N units?" so the example set reflects the actual eligible pool.',
+    parameters: {
+      type: 'object',
+      properties: {
+        intent: {
+          type: 'string',
+          description: 'Filter criterion. "handover" = units with handover_date (congratulate on keys). "overdue_contracts" = contracts issued >28d ago and unsigned. "sale_agreed" = sale_agreed but not yet signed/handed-over. "all" = every unit.',
+          enum: ['handover', 'overdue_contracts', 'sale_agreed', 'all'],
+        },
+        scheme_name: { type: 'string', description: 'Optional — narrow the candidates to one scheme.' },
+        limit: { type: 'number', description: 'Max candidates to return (default 6, max 20).' },
+      },
+      required: ['intent'],
+    },
+    execute: ((supabase, _tenantId, agentContext, params) =>
+      runAgenticSkill(getCandidateUnitsSkill, supabase, agentContext, params as any)) as ToolFunction,
   },
   {
     name: 'generate_developer_report',

--- a/apps/unified-portal/lib/agent-intelligence/unit-resolver.ts
+++ b/apps/unified-portal/lib/agent-intelligence/unit-resolver.ts
@@ -1,0 +1,340 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Session 9 — strict unit identifier resolution.
+ *
+ * The pre-9 draft skills resolved a target like "Unit 3" via
+ * `.or('unit_number.ilike.%3%,unit_uid.ilike.%3%,purchaser_name.ilike.%…')`.
+ * That fuzz matched Unit 30, Unit 31, Unit 13, any buyer whose name
+ * contained the ref, and on a literal "Unit 3" (where unit_number is
+ * stored as "3" not "Unit 3") the OR reduced to false and PostgREST
+ * returned the arbitrary first row — in production that was Unit 10 for
+ * Árdan View.
+ *
+ * This resolver:
+ *   - Normalises the user-supplied identifier (strips the word "Unit",
+ *     "unit", "#", whitespace). "Unit 3" → "3".
+ *   - Matches EXACTLY against unit_number, then unit_uid, then a suffix
+ *     match on unit_uid ("AV-3" matches ref "3").
+ *   - Scopes every query to the agent's assigned developments.
+ *   - Surfaces three outcomes: ok (one unit), not_found (zero), and
+ *     ambiguous (multiple units across different developments with no
+ *     scheme scope from the caller).
+ */
+
+export interface ResolvedUnitRow {
+  id: string;
+  development_id: string;
+  unit_number: string | null;
+  unit_uid: string | null;
+  purchaser_name: string | null;
+  purchaser_email: string | null;
+  unit_status: string | null;
+}
+
+export interface UnitPipelineRow {
+  unit_id: string;
+  development_id: string | null;
+  handover_date: string | null;
+  sale_agreed_date: string | null;
+  contracts_issued_date: string | null;
+  signed_contracts_date: string | null;
+  counter_signed_date: string | null;
+  deposit_date: string | null;
+  purchaser_name: string | null;
+  purchaser_email: string | null;
+}
+
+export type UnitResolution =
+  | { status: 'ok'; unit: ResolvedUnitRow; pipeline: UnitPipelineRow | null }
+  | { status: 'not_found'; ref: string; normalised: string }
+  | { status: 'ambiguous'; ref: string; normalised: string; candidates: Array<{ id: string; unit_number: string | null; scheme_name: string | null }> };
+
+export interface ResolveOptions {
+  /** Agent's assigned development ids — the outer scope for all queries. */
+  developmentIds: string[];
+  /** When set, narrows to this single development. */
+  preferredDevelopmentId?: string | null;
+}
+
+/** Strips "Unit "/"unit "/"#"/whitespace. "Unit 3" → "3", "Unit  12" → "12",
+ *  "AV-3" → "AV-3" (alphanumeric codes preserved). */
+export function normaliseUnitRef(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .trim()
+    .replace(/^unit\s*#?\s*/i, '')
+    .replace(/^#\s*/, '')
+    .replace(/\s+/g, '')
+    .trim();
+}
+
+export async function resolveUnitIdentifier(
+  supabase: SupabaseClient,
+  ref: string,
+  opts: ResolveOptions,
+): Promise<UnitResolution> {
+  const normalised = normaliseUnitRef(ref);
+  if (!normalised) return { status: 'not_found', ref, normalised };
+
+  const scope = opts.preferredDevelopmentId
+    ? [opts.preferredDevelopmentId]
+    : opts.developmentIds;
+  if (!scope.length) return { status: 'not_found', ref, normalised };
+
+  const selectCols = 'id, development_id, unit_number, unit_uid, purchaser_name, purchaser_email, unit_status';
+
+  // 1) Exact unit_number match — this is the common case ("3" or "Unit 3").
+  //    Stored as text but exact equality only — no substring / LIKE fuzz.
+  const { data: byNumber } = await supabase
+    .from('units')
+    .select(selectCols)
+    .in('development_id', scope)
+    .eq('unit_number', normalised);
+
+  let candidates = (byNumber || []) as ResolvedUnitRow[];
+
+  // 2) Exact unit_uid match.
+  if (candidates.length === 0) {
+    const { data: byUid } = await supabase
+      .from('units')
+      .select(selectCols)
+      .in('development_id', scope)
+      .eq('unit_uid', normalised);
+    candidates = (byUid || []) as ResolvedUnitRow[];
+  }
+
+  // 3) unit_uid ending with "-<normalised>". "AV-3" / "RP-3" patterns.
+  if (candidates.length === 0) {
+    // Use ilike with an explicit suffix so "3" matches "AV-3" but NOT
+    // "AV-30". The anchor is the character before the digit.
+    const { data: bySuffix } = await supabase
+      .from('units')
+      .select(selectCols)
+      .in('development_id', scope)
+      .ilike('unit_uid', `%-${normalised}`);
+    candidates = (bySuffix || []) as ResolvedUnitRow[];
+  }
+
+  if (candidates.length === 0) {
+    return { status: 'not_found', ref, normalised };
+  }
+
+  if (candidates.length > 1) {
+    // Multiple units matched — either the same unit_number exists in
+    // several of the agent's developments (e.g. every scheme has a
+    // "Unit 3"), or a loose ref hit multiple uids. Surface for the
+    // caller to disambiguate. No silent pick.
+    const { data: devs } = await supabase
+      .from('developments')
+      .select('id, name')
+      .in('id', candidates.map((c) => c.development_id).filter(Boolean));
+    const nameById = new Map<string, string>(
+      (devs || []).map((d: any) => [d.id, d.name]),
+    );
+    return {
+      status: 'ambiguous',
+      ref,
+      normalised,
+      candidates: candidates.map((c) => ({
+        id: c.id,
+        unit_number: c.unit_number,
+        scheme_name: nameById.get(c.development_id) ?? null,
+      })),
+    };
+  }
+
+  const unit = candidates[0];
+  const { data: pipelineRow } = await supabase
+    .from('unit_sales_pipeline')
+    .select(
+      'unit_id, development_id, handover_date, sale_agreed_date, contracts_issued_date, signed_contracts_date, counter_signed_date, deposit_date, purchaser_name, purchaser_email',
+    )
+    .eq('unit_id', unit.id)
+    .maybeSingle();
+
+  return {
+    status: 'ok',
+    unit,
+    pipeline: (pipelineRow || null) as UnitPipelineRow | null,
+  };
+}
+
+/**
+ * Session 9 — intent-aware candidate selection for clarification.
+ *
+ * When the user gives a count but no specific units (e.g. "draft email
+ * to 3 Ardan View and congratulate them on their keys"), the model
+ * must see a candidate set filtered by the INTENT, not the first N
+ * unit numbers. Intent is mapped from the user's verb:
+ *   "congratulate" / "welcome" / "keys" / "moved in" → 'handover'
+ *   "chase" / "overdue" / "follow up"                → 'overdue_contracts'
+ *   "sale agreed" / "reserved"                        → 'sale_agreed'
+ *   anything else                                     → 'all'
+ */
+export type CandidateIntent = 'handover' | 'sale_agreed' | 'overdue_contracts' | 'all';
+
+export interface UnitCandidate {
+  id: string;
+  development_id: string;
+  scheme_name: string;
+  unit_number: string;
+  purchaser_name: string | null;
+  status_hint: string;
+}
+
+export async function getCandidateUnits(
+  supabase: SupabaseClient,
+  intent: CandidateIntent,
+  opts: { developmentIds: string[]; preferredDevelopmentId?: string | null; limit?: number },
+): Promise<UnitCandidate[]> {
+  const scope = opts.preferredDevelopmentId
+    ? [opts.preferredDevelopmentId]
+    : opts.developmentIds;
+  if (!scope.length) return [];
+  const limit = Math.max(1, Math.min(20, opts.limit ?? 10));
+
+  // Every intent needs the scheme names for display.
+  const { data: devs } = await supabase
+    .from('developments')
+    .select('id, name')
+    .in('id', scope);
+  const schemeNameById = new Map<string, string>(
+    (devs || []).map((d: any) => [d.id, d.name]),
+  );
+
+  if (intent === 'handover') {
+    // Primary filter: pipeline rows with handover_date set, most recent
+    // first. Units table carries `unit_status` too but pipeline's
+    // handover_date is the canonical indicator.
+    const { data: rows } = await supabase
+      .from('unit_sales_pipeline')
+      .select('unit_id, development_id, handover_date, purchaser_name')
+      .in('development_id', scope)
+      .not('handover_date', 'is', null)
+      .order('handover_date', { ascending: false })
+      .limit(limit);
+    const pipelineRows = (rows || []) as Array<{
+      unit_id: string;
+      development_id: string;
+      handover_date: string;
+      purchaser_name: string | null;
+    }>;
+    if (!pipelineRows.length) return [];
+    const unitIds = pipelineRows.map((r) => r.unit_id).filter(Boolean);
+    const { data: units } = unitIds.length
+      ? await supabase
+          .from('units')
+          .select('id, unit_number, purchaser_name')
+          .in('id', unitIds)
+      : { data: [] };
+    const unitById = new Map<string, { unit_number: string | null; purchaser_name: string | null }>(
+      (units || []).map((u: any) => [u.id, { unit_number: u.unit_number, purchaser_name: u.purchaser_name }]),
+    );
+    return pipelineRows.map((r) => ({
+      id: r.unit_id,
+      development_id: r.development_id,
+      scheme_name: schemeNameById.get(r.development_id) ?? 'Unknown scheme',
+      unit_number: unitById.get(r.unit_id)?.unit_number ?? '?',
+      purchaser_name: r.purchaser_name ?? unitById.get(r.unit_id)?.purchaser_name ?? null,
+      status_hint: `handed over ${r.handover_date.slice(0, 10)}`,
+    }));
+  }
+
+  if (intent === 'overdue_contracts') {
+    const cutoff = new Date(Date.now() - 28 * 86400000).toISOString();
+    const { data: rows } = await supabase
+      .from('unit_sales_pipeline')
+      .select('unit_id, development_id, contracts_issued_date, purchaser_name')
+      .in('development_id', scope)
+      .not('contracts_issued_date', 'is', null)
+      .is('signed_contracts_date', null)
+      .lt('contracts_issued_date', cutoff)
+      .order('contracts_issued_date', { ascending: true })
+      .limit(limit);
+    const pipelineRows = (rows || []) as Array<{
+      unit_id: string;
+      development_id: string;
+      contracts_issued_date: string;
+      purchaser_name: string | null;
+    }>;
+    if (!pipelineRows.length) return [];
+    const unitIds = pipelineRows.map((r) => r.unit_id).filter(Boolean);
+    const { data: units } = unitIds.length
+      ? await supabase
+          .from('units')
+          .select('id, unit_number, purchaser_name')
+          .in('id', unitIds)
+      : { data: [] };
+    const unitById = new Map<string, { unit_number: string | null; purchaser_name: string | null }>(
+      (units || []).map((u: any) => [u.id, { unit_number: u.unit_number, purchaser_name: u.purchaser_name }]),
+    );
+    return pipelineRows.map((r) => ({
+      id: r.unit_id,
+      development_id: r.development_id,
+      scheme_name: schemeNameById.get(r.development_id) ?? 'Unknown scheme',
+      unit_number: unitById.get(r.unit_id)?.unit_number ?? '?',
+      purchaser_name: r.purchaser_name ?? unitById.get(r.unit_id)?.purchaser_name ?? null,
+      status_hint: `contracts issued ${r.contracts_issued_date.slice(0, 10)}, unsigned`,
+    }));
+  }
+
+  if (intent === 'sale_agreed') {
+    const { data: rows } = await supabase
+      .from('unit_sales_pipeline')
+      .select('unit_id, development_id, sale_agreed_date, purchaser_name')
+      .in('development_id', scope)
+      .not('sale_agreed_date', 'is', null)
+      .is('signed_contracts_date', null)
+      .is('handover_date', null)
+      .order('sale_agreed_date', { ascending: false })
+      .limit(limit);
+    const pipelineRows = (rows || []) as Array<{
+      unit_id: string;
+      development_id: string;
+      sale_agreed_date: string;
+      purchaser_name: string | null;
+    }>;
+    if (!pipelineRows.length) return [];
+    const unitIds = pipelineRows.map((r) => r.unit_id).filter(Boolean);
+    const { data: units } = unitIds.length
+      ? await supabase
+          .from('units')
+          .select('id, unit_number, purchaser_name')
+          .in('id', unitIds)
+      : { data: [] };
+    const unitById = new Map<string, { unit_number: string | null; purchaser_name: string | null }>(
+      (units || []).map((u: any) => [u.id, { unit_number: u.unit_number, purchaser_name: u.purchaser_name }]),
+    );
+    return pipelineRows.map((r) => ({
+      id: r.unit_id,
+      development_id: r.development_id,
+      scheme_name: schemeNameById.get(r.development_id) ?? 'Unknown scheme',
+      unit_number: unitById.get(r.unit_id)?.unit_number ?? '?',
+      purchaser_name: r.purchaser_name ?? unitById.get(r.unit_id)?.purchaser_name ?? null,
+      status_hint: `sale agreed ${r.sale_agreed_date.slice(0, 10)}`,
+    }));
+  }
+
+  // 'all' — every unit in scope.
+  const { data: rows } = await supabase
+    .from('units')
+    .select('id, development_id, unit_number, purchaser_name, unit_status')
+    .in('development_id', scope)
+    .order('unit_number', { ascending: true })
+    .limit(limit);
+  return ((rows || []) as Array<{
+    id: string;
+    development_id: string;
+    unit_number: string | null;
+    purchaser_name: string | null;
+    unit_status: string | null;
+  }>).map((r) => ({
+    id: r.id,
+    development_id: r.development_id,
+    scheme_name: schemeNameById.get(r.development_id) ?? 'Unknown scheme',
+    unit_number: r.unit_number ?? '?',
+    purchaser_name: r.purchaser_name,
+    status_hint: r.unit_status ?? 'unknown',
+  }));
+}

--- a/apps/unified-portal/lib/agent/format-address.ts
+++ b/apps/unified-portal/lib/agent/format-address.ts
@@ -1,0 +1,86 @@
+/**
+ * Session 12 — canonical address renderer.
+ *
+ * Agent-facing surfaces (chips, drafts, applicant lists, viewing rows)
+ * used to ad-hoc-concatenate address fields and, in at least one place,
+ * silently drop the "Apt" prefix by comma-splitting the denormalised
+ * `address` column. That produced chips like "Log a rental viewing for
+ * 12 Grand Parade" when the real record was "Apt 12, Grand Parade,
+ * Cork" — the data WAS real, the rendering was misleading.
+ *
+ * Rule for this helper: no field is dropped, no prefix is stripped. A
+ * short render keeps only address_line_1 + address_line_2; a full
+ * render adds city + eircode. If the caller only has the legacy single
+ * `address` column, we return it verbatim — never try to parse or
+ * trim it.
+ */
+
+export interface AddressParts {
+  address_line_1?: string | null;
+  address_line_2?: string | null;
+  city?: string | null;
+  eircode?: string | null;
+  /** Legacy single-column fallback. Used as-is when no structured
+   *  line fields are populated. */
+  address?: string | null;
+}
+
+export type AddressFormat = 'short' | 'full';
+
+export function formatAgentAddress(parts: AddressParts, format: AddressFormat = 'short'): string {
+  const line1 = cleanSegment(parts.address_line_1);
+  const line2 = cleanSegment(parts.address_line_2);
+
+  // Structured fields win when at least one line is present.
+  if (line1 || line2) {
+    const segments: string[] = [];
+    if (line1) segments.push(line1);
+    if (line2) segments.push(line2);
+    if (format === 'full') {
+      const city = cleanSegment(parts.city);
+      const eircode = cleanSegment(parts.eircode);
+      if (city) segments.push(city);
+      if (eircode) segments.push(eircode);
+    }
+    return segments.join(', ');
+  }
+
+  // Fallback: the legacy single `address` column. Use verbatim —
+  // splitting on commas is what caused the "Apt 12" prefix loss in the
+  // first place.
+  const legacy = cleanSegment(parts.address);
+  if (legacy) {
+    if (format === 'full') {
+      const city = cleanSegment(parts.city);
+      const eircode = cleanSegment(parts.eircode);
+      if (city && !legacy.toLowerCase().includes(city.toLowerCase())) {
+        const parts2: string[] = [legacy, city];
+        if (eircode) parts2.push(eircode);
+        return parts2.join(', ');
+      }
+      if (eircode && !legacy.toLowerCase().includes(eircode.toLowerCase())) {
+        return `${legacy}, ${eircode}`;
+      }
+    }
+    return legacy;
+  }
+
+  return '';
+}
+
+function cleanSegment(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Truncate an already-composed address so it fits on a single chip
+ * without dropping segments silently. If the full string would overflow
+ * the character cap, we append a trailing ellipsis and keep the
+ * leading characters intact.
+ */
+export function truncateForChip(composed: string, maxChars = 42): string {
+  if (composed.length <= maxChars) return composed;
+  return `${composed.slice(0, maxChars - 1).trimEnd()}…`;
+}

--- a/apps/unified-portal/lib/capacitor-native.ts
+++ b/apps/unified-portal/lib/capacitor-native.ts
@@ -65,18 +65,25 @@ export async function requestMicrophonePermission(): Promise<NativeMicPermission
   const native = await isCapacitorNative();
   if (!native) return { status: 'unavailable' };
 
-  try {
-    const specifier = '@capacitor/microphone';
-    // @ts-ignore — optional plugin; loaded only on native
-    const mod = await import(/* webpackIgnore: true */ specifier);
-    const plugin = mod?.Microphone;
-    if (!plugin || typeof plugin.requestPermissions !== 'function') {
-      // Plugin missing in the wrapper — best-effort: let getUserMedia try.
-      return { status: 'prompt' };
-    }
+  // Session 8 Bug 2 fix. Previous implementation always ran
+  // `await import('@capacitor/microphone')`. When the plugin isn't
+  // installed in the shell (the PWA-Capacitor config), the bare specifier
+  // hits the WebView as an unresolved fetch — on iOS that can corrupt the
+  // WebView's decide-policy state, causing subsequent relative-href taps
+  // to be treated as external navigations and handed off to Mobile Safari.
+  // Gate the `import()` behind a pre-check that the plugin is already
+  // registered on `Capacitor.Plugins.Microphone`. If it isn't, never run
+  // the bare-specifier import — just return 'unavailable' so the browser
+  // path handles permission directly via getUserMedia.
+  const cap = await getCapacitor();
+  const preregistered = cap?.Plugins?.Microphone;
+  if (!preregistered || typeof preregistered.requestPermissions !== 'function') {
+    return { status: 'unavailable' };
+  }
 
-    const check = typeof plugin.checkPermissions === 'function'
-      ? await plugin.checkPermissions().catch(() => null)
+  try {
+    const check = typeof preregistered.checkPermissions === 'function'
+      ? await preregistered.checkPermissions().catch(() => null)
       : null;
 
     if (check?.microphone === 'granted') return { status: 'granted' };
@@ -84,14 +91,13 @@ export async function requestMicrophonePermission(): Promise<NativeMicPermission
       return { status: 'denied', canOpenSettings: true };
     }
 
-    const res = await plugin.requestPermissions();
+    const res = await preregistered.requestPermissions();
     if (res?.microphone === 'granted') return { status: 'granted' };
     if (res?.microphone === 'denied') {
       return { status: 'denied', canOpenSettings: true };
     }
     return { status: 'prompt' };
   } catch {
-    // Plugin import failed — treat as unavailable so the web path still works.
     return { status: 'unavailable' };
   }
 }
@@ -102,17 +108,16 @@ export async function requestMicrophonePermission(): Promise<NativeMicPermission
  * no-op if the App plugin is not installed.
  */
 export async function openNativeSettings(): Promise<boolean> {
+  // Same hardening as the mic path: only try the App plugin if it's
+  // already on Capacitor.Plugins. Never emit a bare-specifier import
+  // that could be interpreted as a network URL by the WebView.
+  const cap = await getCapacitor();
+  const App = cap?.Plugins?.App;
+  if (!App || typeof App.openSettings !== 'function') return false;
   try {
-    const specifier = '@capacitor/app';
-    // @ts-ignore
-    const mod = await import(/* webpackIgnore: true */ specifier);
-    const App = mod?.App;
-    if (App && typeof App.openSettings === 'function') {
-      await App.openSettings();
-      return true;
-    }
+    await App.openSettings();
+    return true;
   } catch {
-    /* no-op */
+    return false;
   }
-  return false;
 }

--- a/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
@@ -13,6 +13,7 @@
 import {
   draftMessageSkill,
   draftBuyerFollowups,
+  parseJointPurchaserNames,
 } from '../../lib/agent-intelligence/tools/agentic-skills';
 import { AGENT_TOOL_DEFINITIONS } from '../../lib/agent-intelligence/tools/registry';
 import { persistDraftsForEnvelope } from '../../lib/agent-intelligence/draft-store';
@@ -185,6 +186,117 @@ describe('draftBuyerFollowups (Session 6D)', () => {
     });
     expect(envelope.drafts).toHaveLength(0);
     expect(envelope.summary).toMatch(/could not resolve/i);
+  });
+});
+
+describe('parseJointPurchaserNames (Session 8 Bug 5)', () => {
+  it('single purchaser → one first name, "Hi Laura,"', () => {
+    const p = parseJointPurchaserNames('Laura Hayes');
+    expect(p.firstNames).toEqual(['Laura']);
+    expect(p.greeting).toBe('Hi Laura,');
+  });
+  it('joint purchasers via "and" → two first names, "Hi Laura and Dylan,"', () => {
+    const p = parseJointPurchaserNames('Laura Hayes and Dylan Rogers');
+    expect(p.firstNames).toEqual(['Laura', 'Dylan']);
+    expect(p.greeting).toBe('Hi Laura and Dylan,');
+  });
+  it('joint purchasers via "&" → two first names', () => {
+    const p = parseJointPurchaserNames('Laura Hayes & Dylan Rogers');
+    expect(p.firstNames).toEqual(['Laura', 'Dylan']);
+  });
+  it('strips titles', () => {
+    const p = parseJointPurchaserNames('Mr John O\'Shea and Mrs Mary O\'Shea');
+    expect(p.firstNames).toEqual(['John', 'Mary']);
+    expect(p.greeting).toBe('Hi John and Mary,');
+  });
+  it('empty input → fallback', () => {
+    const p = parseJointPurchaserNames(null);
+    expect(p.firstNames).toEqual(['there']);
+    expect(p.greeting).toBe('Hi there,');
+  });
+});
+
+describe('draftBuyerFollowups — Session 8 purpose + joint + dedupe', () => {
+  const joint_state = {
+    developments: [{ id: 'dev-1', name: 'Árdan View' }],
+    units: [
+      // Joint purchasers at Unit 19.
+      { id: 'u-19', development_id: 'dev-1', unit_number: '19', unit_uid: 'AV-19', purchaser_name: 'Laura Hayes and Dylan Rogers', purchaser_email: 'laura@example.com' },
+      { id: 'u-37', development_id: 'dev-1', unit_number: '37', unit_uid: 'AV-37', purchaser_name: 'Prem Rai', purchaser_email: 'prem@example.com' },
+    ],
+    agent_scheme_assignments: [
+      { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+    ],
+  };
+
+  it('joint-purchaser unit produces ONE draft greeting both names', async () => {
+    const supabase = mockSupabase(joint_state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: '19', scheme_name: 'Árdan View' }],
+      topic: 'Asking when they expect to sign the contracts.',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+    expect(envelope.drafts[0].body).toContain('Laura and Dylan');
+    expect(envelope.drafts[0].recipient?.name).toBe('Laura Hayes and Dylan Rogers');
+  });
+
+  it('dedupe — two targets for the same unit id yield ONE draft', async () => {
+    const supabase = mockSupabase(joint_state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [
+        { unit_identifier: '19', scheme_name: 'Árdan View', recipient_name: 'Laura Hayes' },
+        { unit_identifier: '19', scheme_name: 'Árdan View', recipient_name: 'Dylan Rogers' },
+      ],
+      topic: 'Chase signing',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+  });
+
+  it('three distinct units, one joint → three drafts total', async () => {
+    const supabase = mockSupabase({
+      developments: [{ id: 'dev-1', name: 'Árdan View' }],
+      units: [
+        { id: 'u-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Anna Byrne', purchaser_email: 'anna@x.com' },
+        { id: 'u-7', development_id: 'dev-1', unit_number: '7', unit_uid: 'AV-7', purchaser_name: 'Seán Murphy and Aoife Murphy', purchaser_email: 'sean@x.com' },
+        { id: 'u-12', development_id: 'dev-1', unit_number: '12', unit_uid: 'AV-12', purchaser_name: 'Priya Shah', purchaser_email: 'priya@x.com' },
+      ],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+      ],
+    });
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [
+        { unit_identifier: '3', scheme_name: 'Árdan View' },
+        { unit_identifier: '7', scheme_name: 'Árdan View' },
+        { unit_identifier: '12', scheme_name: 'Árdan View' },
+      ],
+      topic: 'Congrats on getting the keys',
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(3);
+    // Welcome subject for all three.
+    for (const d of envelope.drafts) {
+      expect(d.subject).toMatch(/^Welcome to your new home/);
+      // No "where do you stand" chase tail.
+      expect(d.body).not.toMatch(/where things stand/i);
+    }
+    // Joint-purchaser unit greets both names.
+    const joint = envelope.drafts.find((d) => d.affected_record.id === 'u-7');
+    expect(joint?.body).toContain('Seán and Aoife');
+  });
+
+  it('congratulate_handover subject + body shape', async () => {
+    const supabase = mockSupabase(joint_state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: '37', scheme_name: 'Árdan View' }],
+      topic: '',
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+    const d = envelope.drafts[0];
+    expect(d.subject).toMatch(/Welcome to your new home — Unit 37/);
+    expect(d.body).toMatch(/[Cc]ongratulations/);
+    expect(d.body).not.toMatch(/where things stand/i);
   });
 });
 

--- a/apps/unified-portal/tests/agent-intelligence/session-9.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/session-9.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Session 9 regression guards.
+ *
+ * Covers:
+ *   - normaliseUnitRef — "Unit 3" → "3", preserves alphanumeric codes
+ *   - resolveUnitIdentifier — strict exact-match, no LIKE fuzz, ambiguity
+ *   - getCandidateUnits — intent-aware filtering
+ *   - draftBuyerFollowups — purpose preconditions + skipped telemetry
+ *   - parseJointPurchaserNames — "Laura and Dylan" → one greeting
+ *
+ * Hermetic — stubbed Supabase, no network.
+ */
+
+import {
+  normaliseUnitRef,
+  resolveUnitIdentifier,
+  getCandidateUnits,
+} from '../../lib/agent-intelligence/unit-resolver';
+import {
+  draftBuyerFollowups,
+  parseJointPurchaserNames,
+} from '../../lib/agent-intelligence/tools/agentic-skills';
+
+const SKILL_CTX = {
+  agentId: 'profile-1',
+  userId: 'user-1',
+  displayName: 'Orla Hennessy',
+  agencyName: 'Hennessy Property',
+};
+
+type Row = Record<string, any>;
+
+// Richer mock than the Session 6D one — handles ilike suffix/prefix
+// patterns, `not.is.null`, `is.null`, `lt`, and `order`.
+function mockSupabase(state: {
+  developments?: Row[];
+  units?: Row[];
+  agent_scheme_assignments?: Row[];
+  unit_sales_pipeline?: Row[];
+}) {
+  const data: Record<string, Row[]> = {
+    developments: state.developments ?? [],
+    units: state.units ?? [],
+    agent_scheme_assignments: state.agent_scheme_assignments ?? [],
+    unit_sales_pipeline: state.unit_sales_pipeline ?? [],
+  };
+
+  function qb(table: string) {
+    const predicates: Array<(r: Row) => boolean> = [];
+    let orderKey: string | null = null;
+    let orderAsc = true;
+    let limitVal: number | null = null;
+
+    const builder: any = {
+      select() { return builder; },
+      eq(col: string, val: any) {
+        predicates.push((r) => r[col] === val);
+        return builder;
+      },
+      in(col: string, vals: any[]) {
+        const set = new Set(vals);
+        predicates.push((r) => set.has(r[col]));
+        return builder;
+      },
+      not(col: string, _op: string, val: any) {
+        if (val === null) predicates.push((r) => r[col] != null);
+        else predicates.push((r) => r[col] !== val);
+        return builder;
+      },
+      is(col: string, val: any) {
+        predicates.push((r) => r[col] === val);
+        return builder;
+      },
+      lt(col: string, val: any) {
+        predicates.push((r) => r[col] != null && r[col] < val);
+        return builder;
+      },
+      ilike(col: string, pattern: string) {
+        // Support `%-N` (ends with "-N"), `%N%`, and `N%`.
+        const p = pattern.toLowerCase();
+        if (p.startsWith('%') && p.endsWith('%') && p.length > 2) {
+          const needle = p.slice(1, -1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().includes(needle));
+        } else if (p.startsWith('%')) {
+          const needle = p.slice(1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().endsWith(needle));
+        } else if (p.endsWith('%')) {
+          const needle = p.slice(0, -1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().startsWith(needle));
+        } else {
+          predicates.push((r) => String(r[col] ?? '').toLowerCase() === p);
+        }
+        return builder;
+      },
+      or() { return builder; },
+      order(col: string, opts?: { ascending?: boolean }) {
+        orderKey = col;
+        orderAsc = opts?.ascending !== false;
+        return builder;
+      },
+      limit(n: number) { limitVal = n; return builder; },
+      async single() {
+        const rows = resolve();
+        return { data: rows[0] ?? null, error: rows.length ? null : new Error('no rows') };
+      },
+      async maybeSingle() {
+        const rows = resolve();
+        return { data: rows[0] ?? null, error: null };
+      },
+      then(onResolve: any) {
+        return Promise.resolve({ data: resolve(), error: null }).then(onResolve);
+      },
+    };
+
+    function resolve(): Row[] {
+      let rows = data[table].filter((r) => predicates.every((p) => p(r)));
+      if (orderKey) {
+        const key = orderKey;
+        rows = rows.slice().sort((a, b) => {
+          const av = a[key], bv = b[key];
+          if (av === bv) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          return (av < bv ? -1 : 1) * (orderAsc ? 1 : -1);
+        });
+      }
+      if (limitVal != null) rows = rows.slice(0, limitVal);
+      return rows;
+    }
+
+    return builder;
+  }
+
+  return { from: (table: string) => qb(table) } as any;
+}
+
+describe('normaliseUnitRef', () => {
+  it('strips "Unit "/"unit "/"#"', () => {
+    expect(normaliseUnitRef('Unit 3')).toBe('3');
+    expect(normaliseUnitRef('unit 3')).toBe('3');
+    expect(normaliseUnitRef('Unit #3')).toBe('3');
+    expect(normaliseUnitRef('#3')).toBe('3');
+  });
+  it('preserves alphanumeric uid', () => {
+    expect(normaliseUnitRef('AV-3')).toBe('AV-3');
+    expect(normaliseUnitRef('Unit AV-3')).toBe('AV-3');
+  });
+  it('collapses whitespace', () => {
+    expect(normaliseUnitRef('Unit  3')).toBe('3');
+  });
+});
+
+describe('resolveUnitIdentifier (Session 9)', () => {
+  const stateOneScheme = {
+    developments: [{ id: 'dev-1', name: 'Árdan View' }],
+    units: [
+      { id: 'u-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Robert and Cordelia Foley', purchaser_email: 'foleys@x.com', unit_status: 'handed_over' },
+      { id: 'u-5', development_id: 'dev-1', unit_number: '5', unit_uid: 'AV-5', purchaser_name: 'Marcelo and Lislaine Acher', purchaser_email: 'achers@x.com', unit_status: 'handed_over' },
+      { id: 'u-10', development_id: 'dev-1', unit_number: '10', unit_uid: 'AV-10', purchaser_name: 'Carmen Baumgartner', purchaser_email: 'carmen@x.com', unit_status: 'sale_agreed' },
+      { id: 'u-13', development_id: 'dev-1', unit_number: '13', unit_uid: 'AV-13', purchaser_name: 'Laura Hayes and Dylan Rogers', purchaser_email: 'laura@x.com', unit_status: 'contracts_issued' },
+      { id: 'u-30', development_id: 'dev-1', unit_number: '30', unit_uid: 'AV-30', purchaser_name: 'Prem Rai', purchaser_email: 'prem@x.com', unit_status: 'sale_agreed' },
+    ],
+    agent_scheme_assignments: [
+      { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+    ],
+    unit_sales_pipeline: [
+      { unit_id: 'u-3', development_id: 'dev-1', handover_date: '2026-04-13', sale_agreed_date: '2026-01-15', contracts_issued_date: '2026-02-01', signed_contracts_date: '2026-02-20', counter_signed_date: '2026-02-25', deposit_date: '2026-01-20', purchaser_name: 'Robert and Cordelia Foley', purchaser_email: 'foleys@x.com' },
+      { unit_id: 'u-5', development_id: 'dev-1', handover_date: '2026-04-15', sale_agreed_date: '2026-01-20', contracts_issued_date: '2026-02-05', signed_contracts_date: '2026-02-22', counter_signed_date: '2026-02-27', deposit_date: '2026-01-25', purchaser_name: 'Marcelo and Lislaine Acher', purchaser_email: 'achers@x.com' },
+      { unit_id: 'u-10', development_id: 'dev-1', handover_date: null, sale_agreed_date: '2026-03-01', contracts_issued_date: null, signed_contracts_date: null, counter_signed_date: null, deposit_date: '2026-03-05', purchaser_name: 'Carmen Baumgartner', purchaser_email: 'carmen@x.com' },
+    ],
+  };
+
+  it('"Unit 3" → Unit 3 (Foleys), NOT Unit 10', async () => {
+    const supabase = mockSupabase(stateOneScheme);
+    const r = await resolveUnitIdentifier(supabase, 'Unit 3', { developmentIds: ['dev-1'] });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.unit.id).toBe('u-3');
+      expect(r.unit.purchaser_name).toContain('Foley');
+      expect(r.pipeline?.handover_date).toBe('2026-04-13');
+    }
+  });
+
+  it('"3" → Unit 3, NOT Unit 30, NOT Unit 13', async () => {
+    const supabase = mockSupabase(stateOneScheme);
+    const r = await resolveUnitIdentifier(supabase, '3', { developmentIds: ['dev-1'] });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') expect(r.unit.id).toBe('u-3');
+  });
+
+  it('"Unit 300" in 86-unit estate → not_found', async () => {
+    const supabase = mockSupabase(stateOneScheme);
+    const r = await resolveUnitIdentifier(supabase, 'Unit 300', { developmentIds: ['dev-1'] });
+    expect(r.status).toBe('not_found');
+  });
+
+  it('alphanumeric "AV-3" resolves via unit_uid exact match', async () => {
+    const supabase = mockSupabase(stateOneScheme);
+    const r = await resolveUnitIdentifier(supabase, 'AV-3', { developmentIds: ['dev-1'] });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') expect(r.unit.id).toBe('u-3');
+  });
+
+  it('"Unit 3" across two schemes without scheme scope → ambiguous', async () => {
+    const supabase = mockSupabase({
+      developments: [
+        { id: 'dev-1', name: 'Árdan View' },
+        { id: 'dev-2', name: 'Rathárd Park' },
+      ],
+      units: [
+        { id: 'u-av-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Foleys', purchaser_email: 'a@x.com', unit_status: 'handed_over' },
+        { id: 'u-rp-3', development_id: 'dev-2', unit_number: '3', unit_uid: 'RP-3', purchaser_name: 'Someone Else', purchaser_email: 'b@x.com', unit_status: 'sale_agreed' },
+      ],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+        { agent_id: 'profile-1', development_id: 'dev-2', is_active: true },
+      ],
+    });
+    const r = await resolveUnitIdentifier(supabase, 'Unit 3', { developmentIds: ['dev-1', 'dev-2'] });
+    expect(r.status).toBe('ambiguous');
+    if (r.status === 'ambiguous') {
+      expect(r.candidates.length).toBe(2);
+      expect(r.candidates.map((c) => c.scheme_name).sort()).toEqual(['Rathárd Park', 'Árdan View']);
+    }
+  });
+
+  it('"Unit 3" with scheme scope → resolves to the right scheme', async () => {
+    const supabase = mockSupabase({
+      developments: [
+        { id: 'dev-1', name: 'Árdan View' },
+        { id: 'dev-2', name: 'Rathárd Park' },
+      ],
+      units: [
+        { id: 'u-av-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Foleys', purchaser_email: 'a@x.com', unit_status: 'handed_over' },
+        { id: 'u-rp-3', development_id: 'dev-2', unit_number: '3', unit_uid: 'RP-3', purchaser_name: 'Someone Else', purchaser_email: 'b@x.com', unit_status: 'sale_agreed' },
+      ],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+        { agent_id: 'profile-1', development_id: 'dev-2', is_active: true },
+      ],
+    });
+    const r = await resolveUnitIdentifier(supabase, 'Unit 3', {
+      developmentIds: ['dev-1', 'dev-2'],
+      preferredDevelopmentId: 'dev-1',
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') expect(r.unit.id).toBe('u-av-3');
+  });
+});
+
+describe('getCandidateUnits — intent=handover (Session 9 Bug A)', () => {
+  const state = {
+    developments: [{ id: 'dev-1', name: 'Árdan View' }],
+    units: [
+      { id: 'u-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Foleys', unit_status: 'handed_over' },
+      { id: 'u-5', development_id: 'dev-1', unit_number: '5', unit_uid: 'AV-5', purchaser_name: 'Achers', unit_status: 'handed_over' },
+      { id: 'u-10', development_id: 'dev-1', unit_number: '10', unit_uid: 'AV-10', purchaser_name: 'Carmen', unit_status: 'sale_agreed' },
+    ],
+    unit_sales_pipeline: [
+      { unit_id: 'u-3', development_id: 'dev-1', handover_date: '2026-04-13', purchaser_name: 'Foleys' },
+      { unit_id: 'u-5', development_id: 'dev-1', handover_date: '2026-04-15', purchaser_name: 'Achers' },
+      { unit_id: 'u-10', development_id: 'dev-1', handover_date: null, purchaser_name: 'Carmen' },
+    ],
+  };
+
+  it('returns only the two handed-over units, most-recent first', async () => {
+    const supabase = mockSupabase(state);
+    const cands = await getCandidateUnits(supabase, 'handover', { developmentIds: ['dev-1'] });
+    expect(cands).toHaveLength(2);
+    // Most recent (Unit 5, 15 Apr) should come first.
+    expect(cands[0].unit_number).toBe('5');
+    expect(cands[1].unit_number).toBe('3');
+    // Unit 10 must not appear.
+    expect(cands.find((c) => c.unit_number === '10')).toBeUndefined();
+  });
+});
+
+describe('draftBuyerFollowups — purpose precondition + resolver (Session 9)', () => {
+  const state = {
+    developments: [{ id: 'dev-1', name: 'Árdan View' }],
+    units: [
+      { id: 'u-3', development_id: 'dev-1', unit_number: '3', unit_uid: 'AV-3', purchaser_name: 'Robert and Cordelia Foley', purchaser_email: 'foleys@x.com', unit_status: 'handed_over' },
+      { id: 'u-10', development_id: 'dev-1', unit_number: '10', unit_uid: 'AV-10', purchaser_name: 'Carmen Baumgartner', purchaser_email: 'carmen@x.com', unit_status: 'sale_agreed' },
+    ],
+    agent_scheme_assignments: [
+      { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+    ],
+    unit_sales_pipeline: [
+      { unit_id: 'u-3', development_id: 'dev-1', handover_date: '2026-04-13', sale_agreed_date: '2026-01-15', contracts_issued_date: null, signed_contracts_date: null, counter_signed_date: null, deposit_date: null, purchaser_name: 'Robert and Cordelia Foley', purchaser_email: 'foleys@x.com' },
+      { unit_id: 'u-10', development_id: 'dev-1', handover_date: null, sale_agreed_date: '2026-03-01', contracts_issued_date: null, signed_contracts_date: null, counter_signed_date: null, deposit_date: null, purchaser_name: 'Carmen Baumgartner', purchaser_email: 'carmen@x.com' },
+    ],
+  };
+
+  it('"Unit 3" + congratulate_handover → one draft greeting Robert and Cordelia', async () => {
+    const supabase = mockSupabase(state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: 'Unit 3', scheme_name: 'Árdan View' }],
+      topic: '',
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+    const d = envelope.drafts[0];
+    expect(d.subject).toMatch(/^Welcome to your new home — Unit 3/);
+    expect(d.body).toMatch(/Robert and Cordelia/);
+    expect(d.body).toMatch(/[Cc]ongratulations/);
+    // Must NOT have the chase tail.
+    expect(d.body).not.toMatch(/where things stand/i);
+    // Unit 10 did not come through — not in drafts, not greeted.
+    expect(d.body).not.toMatch(/Carmen/);
+  });
+
+  it('"Unit 10" + congratulate_handover → refused (no handover_date), zero drafts, reason surfaced', async () => {
+    const supabase = mockSupabase(state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: 'Unit 10', scheme_name: 'Árdan View' }],
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(0);
+    expect(envelope.summary).toMatch(/Unit 10/);
+    expect(envelope.summary).toMatch(/handover/i);
+  });
+
+  it('Unit 3 and Unit 10 together → 1 draft for Unit 3, Unit 10 skipped with reason', async () => {
+    const supabase = mockSupabase(state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [
+        { unit_identifier: 'Unit 3', scheme_name: 'Árdan View' },
+        { unit_identifier: 'Unit 10', scheme_name: 'Árdan View' },
+      ],
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+    expect(envelope.drafts[0].affected_record.id).toBe('u-3');
+    expect(envelope.summary).toMatch(/Skipped/);
+    expect(envelope.summary).toMatch(/Unit 10/);
+  });
+
+  it('Unit 3 × 2 (joint purchaser dedupe) → 1 draft', async () => {
+    const supabase = mockSupabase(state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [
+        { unit_identifier: 'Unit 3', scheme_name: 'Árdan View', recipient_name: 'Robert Foley' },
+        { unit_identifier: 'Unit 3', scheme_name: 'Árdan View', recipient_name: 'Cordelia Foley' },
+      ],
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(1);
+  });
+
+  it('"Unit 300" (nonexistent) → zero drafts, skipped reason surfaced', async () => {
+    const supabase = mockSupabase(state);
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX, {
+      targets: [{ unit_identifier: 'Unit 300', scheme_name: 'Árdan View' }],
+      purpose: 'congratulate_handover',
+    });
+    expect(envelope.drafts).toHaveLength(0);
+    expect(envelope.summary).toMatch(/No unit "300"/);
+  });
+});
+
+describe('parseJointPurchaserNames (Session 9 base)', () => {
+  it('single → one greeting', () => {
+    expect(parseJointPurchaserNames('Robert Foley').greeting).toBe('Hi Robert,');
+  });
+  it('joint with "and" → both names', () => {
+    expect(parseJointPurchaserNames('Robert and Cordelia Foley').greeting).toBe('Hi Robert and Cordelia,');
+  });
+  it('joint with "&" → both names', () => {
+    expect(parseJointPurchaserNames('Marcelo & Lislaine Acher').greeting).toBe('Hi Marcelo and Lislaine,');
+  });
+  it('null → safe fallback', () => {
+    expect(parseJointPurchaserNames(null).greeting).toBe('Hi there,');
+  });
+});


### PR DESCRIPTION
Carries four un-merged session branches into a single coherent commit, ready to merge to main. Main still sits at Session 7 (`f70af6d`); this PR brings in everything that's been shipped since.

## Session contributions

- **Session 8** — iOS PWA-Capacitor stability. Mic permission flow that tolerates a missing `@capacitor/microphone` plugin, bottom-nav explicit `router.push` so taps never escape to Mobile Safari, chip carousel rebuilt as a fixed 2×2 grid (no more 6-chip mid-transition overflow), logo restored, joint-purchaser parsing for `draft_buyer_followups`, `purpose` parameter, per-unit dedupe.
- **Session 9** — architectural. Strict unit resolver (`lib/agent-intelligence/unit-resolver.ts`) replaces `ilike.%N%` fuzz that was returning Unit 10 when the model asked for Unit 3. Intent-aware candidate selection via a new `get_candidate_units` skill, purpose preconditions that refuse to draft `congratulate_handover` for units with no `handover_date`, and updated system prompt requiring Intelligence to clarify before drafting when a count is specified without units.
- **Session 11** — live-data capability chips. New `GET /api/agent/intelligence/capability-chips` composes chips from the agent's real assigned schemes, letting properties, applicant / tenancy / rental-viewing counts. Static 21-phrase library collapsed to an honest context-free fallback. Big gold drafts banner replaced with a quiet "N drafts waiting in your inbox" link under the helper sentence.
- **Session 12** — polish. `formatAgentAddress` helper so "Apt 12, Grand Parade" stays intact (no silent prefix stripping). Logo bumps to 80×80 mobile / 96×96 desktop.

## Conflict resolution

Preferred the later session's version throughout:
- `agentic-skills.ts`, `registry.ts`, `system-prompt.ts` — Session 9 (includes Session 8's joint-purchaser work as a prerequisite).
- `CapabilityChipsCarousel.tsx` — merged: Session 8's 2×2 grid + Session 12's `chips` prop, Session 8's explanatory comments preserved.
- `intelligence/page.tsx` — Session 12's smaller logo (80/96px) wins over Session 8's 136px with gold label. Session 12's drafts inline link wins over Session 8's gold banner restore.
- `capability-chips.ts` — Session 11's honest fallback set.
- `capacitor-native.ts`, `BottomNav.tsx`, `useVoiceCapture.ts` — Session 8 (only session that touches these).

## Files changed and owners

| File | Owner |
|---|---|
| `lib/agent-intelligence/unit-resolver.ts` (new) | Session 9 |
| `lib/agent-intelligence/tools/agentic-skills.ts` | Session 9 (joint-purchaser, purpose, preconditions) |
| `lib/agent-intelligence/tools/registry.ts` | Session 9 (get_candidate_units registration) |
| `lib/agent-intelligence/system-prompt.ts` | Session 9 (intent-aware clarification) |
| `tests/agent-intelligence/session-9.test.ts` (new) | Session 9 |
| `tests/agent-intelligence/drafts-pipeline.test.ts` | Session 8 (parseJointPurchaserNames tests) |
| `lib/capacitor-native.ts` | Session 8 |
| `app/agent/_components/BottomNav.tsx` | Session 8 |
| `app/agent/_hooks/useVoiceCapture.ts` | Session 8 |
| `app/agent/_components/CapabilityChipsCarousel.tsx` | Session 8 grid + Session 12 chips prop |
| `app/api/agent/intelligence/capability-chips/route.ts` (new) | Session 11 |
| `lib/agent-intelligence/capability-chips.ts` | Session 11/12 |
| `lib/agent/format-address.ts` (new) | Session 12 |
| `app/agent/intelligence/page.tsx` | Session 12 (logo + drafts inline link) |
| `SESSION_8_DIAGNOSIS.md` / `SESSION_9_DIAGNOSIS.md` / `SESSION_12_DIAGNOSIS.md` | carried forward |

## Verification

- [x] No `<<<<<<< HEAD` markers anywhere in the tree (excluding `node_modules`).
- [x] TypeScript clean on all modified files (strict check, ignoreDeprecations shim).
- [x] `npm run build` — `✓ Compiled successfully`.
- [x] Diff vs main shows all 12 files listed in the verification step of the session brief (plus the three diagnosis markdowns and two test files).
- [ ] Existing Jest-style test files are authored but the repo has no runner wired up — structural guards only.

## Test plan

- Load Intelligence landing as Orla: logo visible at 80px, chips 2×2 grid, "N drafts waiting" inline link under the helper sentence.
- Tap any bottom-nav tab after a mic interaction — stays in the WebView.
- Ask Intelligence "draft 3 Ardan View congratulations" — gets intent-aware clarification, resolves units strictly, refuses to draft Unit 10 (no handover), greets joint purchasers once.
- Log a rental viewing chip shows the full "Apt 12, Grand Parade" address, not "12 Grand Parade".
- Desktop `/agent/dashboard/intelligence` unaffected.

https://claude.ai/code/session_015D4gvpjTi5LY43SzJKavCf

---
_Generated by [Claude Code](https://claude.ai/code/session_015D4gvpjTi5LY43SzJKavCf)_