### PR TITLE
fix(agent-intelligence): ENV-aware health probe + fail-fast service-r…

### DIFF
--- a/apps/unified-portal/app/api/agent/intelligence/health/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/health/route.ts
@@ -1,0 +1,298 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContext } from '@/lib/agent-intelligence/agent-context';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/agent/intelligence/health
+ *
+ * Session 14.4 — operator-facing self-test for the agent intelligence
+ * stack. Always returns environment diagnostics; if a caller is logged
+ * in, also runs a per-user resolver consistency check.
+ *
+ * Three checks, in order:
+ *
+ *   ENV: SUPABASE_SERVICE_ROLE_KEY is set and decodes to role=service_role
+ *        NEXT_PUBLIC_SUPABASE_URL is set and parsable
+ *        Service-role client can SELECT from a non-empty system table
+ *
+ *   AUTH: caller has a session (skipped if not — env block still returned)
+ *
+ *   USER: resolveAgentContext returns a profile with assignments, AND
+ *         the resolver count matches a service-role probe count
+ *
+ * The ENV block is intentionally PII-free — safe to call without auth.
+ * It exposes:
+ *   - URL host (project subdomain only — not a secret, public anyway)
+ *   - Whether the service-role key parses as service_role JWT
+ *   - First 6 / last 4 chars of the key (key-fingerprint, not the key
+ *     itself — enough to compare across Vercel scopes without leaking
+ *     the secret)
+ *   - Total key length
+ *   - A live SELECT against `agent_profiles` (count only) to prove the
+ *     client actually has service-role privileges
+ *
+ * Usage (env-only, no auth needed):
+ *   curl https://<deploy-url>/api/agent/intelligence/health
+ *
+ * Usage (full per-user check, logged in as the agent):
+ *   curl -b cookies.txt https://<deploy-url>/api/agent/intelligence/health
+ */
+export async function GET(_request: NextRequest) {
+  const startTime = Date.now();
+
+  // ----- ENV BLOCK -----
+  const envBlock = describeEnvironment();
+
+  // 1. Service-role client construction.
+  let supabase: ReturnType<typeof getSupabaseAdmin>;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err: any) {
+    return NextResponse.json(
+      {
+        ok: false,
+        stage: 'service_role_client',
+        env: envBlock,
+        error: err?.message || String(err),
+        verdict:
+          'SUPABASE_SERVICE_ROLE_KEY is missing or wrong on this Vercel environment. ' +
+          'Fix in Vercel dashboard → Settings → Environment Variables, then redeploy.',
+        latencyMs: Date.now() - startTime,
+      },
+      { status: 500 },
+    );
+  }
+
+  // 2. Live service-role probe — confirms the JWT is actually accepted by
+  //    PostgREST as service_role (not anon). Counts agent_profiles rows;
+  //    no PII. If count > 0 and the env-block says role=service_role we
+  //    know the chat path's data layer is healthy.
+  let serviceRoleProbe: { ok: boolean; profileCount: number | null; assignmentCount: number | null; error?: string } = {
+    ok: false,
+    profileCount: null,
+    assignmentCount: null,
+  };
+  try {
+    const [profilesRes, asaRes] = await Promise.all([
+      supabase.from('agent_profiles').select('id', { count: 'exact', head: true }),
+      supabase
+        .from('agent_scheme_assignments')
+        .select('id', { count: 'exact', head: true })
+        .eq('is_active', true),
+    ]);
+    serviceRoleProbe = {
+      ok: !profilesRes.error && !asaRes.error,
+      profileCount: profilesRes.count ?? null,
+      assignmentCount: asaRes.count ?? null,
+      error: profilesRes.error?.message || asaRes.error?.message,
+    };
+  } catch (err: any) {
+    serviceRoleProbe = { ok: false, profileCount: null, assignmentCount: null, error: err?.message || String(err) };
+  }
+
+  // ----- AUTH (optional) -----
+  const cookieStore = cookies();
+  const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+  const { data: { user } } = await supabaseAuth.auth.getUser();
+
+  // Unauthenticated path: return ENV + service-role probe results, no
+  // per-user data. Useful for the operator to compare a Preview deploy
+  // against Production without logging in as a particular agent.
+  if (!user) {
+    const envOk = envBlock.serviceKeyRolePayload === 'service_role' && serviceRoleProbe.ok && (serviceRoleProbe.profileCount ?? 0) > 0;
+    return NextResponse.json(
+      {
+        ok: envOk,
+        stage: 'env_only',
+        env: envBlock,
+        serviceRoleProbe,
+        verdict: envOk
+          ? 'ENV OK. Service-role JWT accepted by PostgREST. Per-user check skipped (no auth cookie).'
+          : verdictFromProbe(envBlock, serviceRoleProbe),
+        latencyMs: Date.now() - startTime,
+      },
+      { status: envOk ? 200 : 500 },
+    );
+  }
+
+  // ----- USER BLOCK -----
+  let resolved: Awaited<ReturnType<typeof resolveAgentContext>>;
+  try {
+    resolved = await resolveAgentContext(supabase, user.id);
+  } catch (err: any) {
+    return NextResponse.json(
+      {
+        ok: false,
+        stage: 'resolve_agent_context',
+        env: envBlock,
+        serviceRoleProbe,
+        error: err?.message || String(err),
+        authUserId: user.id,
+        verdict:
+          'resolveAgentContext threw. If the message mentions ' +
+          '"Assigned: (none)" failure mode, ENV is right but the per-user RLS path is broken. ' +
+          'Check Supabase policies on agent_scheme_assignments.',
+        latencyMs: Date.now() - startTime,
+      },
+      { status: 500 },
+    );
+  }
+
+  if (!resolved) {
+    return NextResponse.json(
+      {
+        ok: false,
+        stage: 'resolve_agent_context',
+        env: envBlock,
+        serviceRoleProbe,
+        error: 'resolveAgentContext returned null',
+        authUserId: user.id,
+        verdict:
+          'No agent_profiles row matches this auth user, and the earliest-profile fallback found nothing either. ' +
+          'Verify the agent_profiles seed data for this Supabase project.',
+        latencyMs: Date.now() - startTime,
+      },
+      { status: 500 },
+    );
+  }
+
+  const probe = await supabase
+    .from('agent_scheme_assignments')
+    .select('development_id', { count: 'exact', head: true })
+    .eq('agent_id', resolved.agentProfileId)
+    .eq('is_active', true);
+
+  const probeCount = probe.count ?? null;
+  const resolvedCount = resolved.assignedDevelopmentIds.length;
+  const matches = probeCount !== null && probeCount === resolvedCount;
+  const ok = matches && resolvedCount > 0;
+
+  return NextResponse.json(
+    {
+      ok,
+      stage: 'complete',
+      env: envBlock,
+      serviceRoleProbe,
+      latencyMs: Date.now() - startTime,
+      authUserId: resolved.authUserId,
+      agentProfileId: resolved.agentProfileId,
+      tenantId: resolved.tenantId,
+      displayName: resolved.displayName,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      assignmentCounts: {
+        viaResolver: resolvedCount,
+        viaServiceRoleProbe: probeCount,
+        match: matches,
+      },
+      verdict: ok
+        ? `OK — ${resolvedCount} assigned scheme(s), resolver and probe agree.`
+        : !matches
+          ? `MISMATCH — resolver returned ${resolvedCount} but service-role probe sees ${probeCount}. ` +
+            `RLS is filtering rows from the resolver path. Verify SUPABASE_SERVICE_ROLE_KEY value on this Vercel scope.`
+          : `EMPTY — resolver and probe agree at 0 assignments. Either the agent genuinely has none, or the seed data is missing.`,
+    },
+    { status: ok ? 200 : 500 },
+  );
+}
+
+interface EnvBlock {
+  urlPresent: boolean;
+  urlHost: string | null;
+  urlScheme: string | null;
+  serviceKeyPresent: boolean;
+  serviceKeyLength: number | null;
+  serviceKeyFingerprint: string | null;
+  serviceKeyRolePayload: 'service_role' | 'anon' | 'unknown' | 'invalid_jwt' | null;
+  serviceKeyIssuer: string | null;
+  serviceKeyRefHost: string | null;
+  vercelEnv: string | null;
+  vercelRegion: string | null;
+  vercelDeploymentId: string | null;
+}
+
+function describeEnvironment(): EnvBlock {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+  let urlHost: string | null = null;
+  let urlScheme: string | null = null;
+  try {
+    if (url) {
+      const u = new URL(url);
+      urlHost = u.host;
+      urlScheme = u.protocol.replace(':', '');
+    }
+  } catch {
+    /* swallow */
+  }
+
+  // JWT payload decode — same logic as getSupabaseAdmin's check, but
+  // here we surface the values for diagnosis rather than throwing.
+  let role: EnvBlock['serviceKeyRolePayload'] = key ? 'unknown' : null;
+  let issuer: string | null = null;
+  let refHost: string | null = null;
+  if (key) {
+    try {
+      const payloadBase64 = key.split('.')[1];
+      if (payloadBase64) {
+        const padded = payloadBase64.padEnd(payloadBase64.length + ((4 - (payloadBase64.length % 4)) % 4), '=');
+        const payloadJson = Buffer.from(padded, 'base64').toString('utf8');
+        const payload = JSON.parse(payloadJson);
+        role = payload?.role === 'service_role' || payload?.role === 'anon' ? payload.role : 'unknown';
+        issuer = payload?.iss ?? null;
+        refHost = payload?.ref ? `${payload.ref}.supabase.co` : null;
+      } else {
+        role = 'invalid_jwt';
+      }
+    } catch {
+      role = 'invalid_jwt';
+    }
+  }
+
+  // Fingerprint = first 6 + last 4 chars + length. Enough to compare
+  // values across Vercel scopes without revealing the secret.
+  const fingerprint = key.length >= 10 ? `${key.slice(0, 6)}…${key.slice(-4)}` : null;
+
+  return {
+    urlPresent: !!url,
+    urlHost,
+    urlScheme,
+    serviceKeyPresent: !!key,
+    serviceKeyLength: key ? key.length : null,
+    serviceKeyFingerprint: fingerprint,
+    serviceKeyRolePayload: role,
+    serviceKeyIssuer: issuer,
+    serviceKeyRefHost: refHost,
+    vercelEnv: process.env.VERCEL_ENV ?? null,
+    vercelRegion: process.env.VERCEL_REGION ?? null,
+    vercelDeploymentId: process.env.VERCEL_DEPLOYMENT_ID ?? null,
+  };
+}
+
+function verdictFromProbe(env: EnvBlock, probe: { ok: boolean; profileCount: number | null; error?: string }): string {
+  if (!env.serviceKeyPresent) {
+    return 'SUPABASE_SERVICE_ROLE_KEY is not set on this Vercel scope. Add it and redeploy.';
+  }
+  if (env.serviceKeyRolePayload === 'invalid_jwt') {
+    return 'SUPABASE_SERVICE_ROLE_KEY does not parse as a JWT. Re-paste the value from Supabase → Project Settings → API.';
+  }
+  if (env.serviceKeyRolePayload === 'anon') {
+    return 'The anon key has been pasted into SUPABASE_SERVICE_ROLE_KEY. Replace with the service_role secret from Supabase.';
+  }
+  if (env.serviceKeyRolePayload === 'unknown') {
+    return 'SUPABASE_SERVICE_ROLE_KEY is set but the role inside the JWT is neither service_role nor anon. Verify the value matches what Supabase shows under Project Settings → API.';
+  }
+  if (!probe.ok) {
+    return `Service-role probe failed: ${probe.error || 'unknown error'}. Check Supabase project URL and key match.`;
+  }
+  if ((probe.profileCount ?? 0) === 0) {
+    return 'Service-role client connected but agent_profiles is empty. Verify seed data on this Supabase project.';
+  }
+  return 'Unexpected: env looks healthy but verdict resolver flagged it. Inspect the response body for details.';
+}

--- a/apps/unified-portal/lib/agent-intelligence/agent-context.ts
+++ b/apps/unified-portal/lib/agent-intelligence/agent-context.ts
@@ -148,12 +148,91 @@ async function fetchAssignments(supabase: SupabaseClient, agentProfileId: string
   // Intentionally no tenant_id filter: the join through agent_profiles already
   // establishes tenant scope. Filtering here drops rows whose tenant_id
   // column is null on legacy data.
-  const { data } = await supabase
+  //
+  // Session 14.2 — capture and log errors instead of swallowing them.
+  // Pre-14.2 this function did `const { data } = …; return data ?? []`,
+  // which turned a transient Supabase error (network hiccup, cold
+  // start, revoked service-role key) into a silent empty assignment
+  // list. Downstream code (scheme-resolver, read-tools) then told the
+  // user "you have no schemes assigned" — the exact Session 6A
+  // regression. Now: if the call errors, log loudly AND throw, so the
+  // caller surfaces a 500 the operator will actually see instead of a
+  // silent "(none)".
+  //
+  // Session 14.4 — RLS-vs-service-role probe. If the SELECT returns zero
+  // rows, run a `head: true, count: 'exact'` probe against the same
+  // filter and compare. Equal counts → genuine empty data. Probe
+  // returns more rows → we're being filtered by RLS, which means the
+  // calling client is running as `anon` or `authenticated` even though
+  // we believe it's service-role. That's the smoking gun for a
+  // misconfigured SUPABASE_SERVICE_ROLE_KEY env var (or a stale value
+  // that doesn't decode to role=service_role). Either way, we throw a
+  // diagnostic error rather than letting the chat reply with the
+  // verifiable lie "you have no schemes assigned".
+  const { data, error } = await supabase
     .from('agent_scheme_assignments')
     .select('development_id, is_active, role')
     .eq('agent_id', agentProfileId)
     .eq('is_active', true);
-  return (data ?? []) as Array<{ development_id: string; is_active: boolean; role: string | null }>;
+  if (error) {
+    console.error('[agent-context] fetchAssignments error', {
+      agentProfileId,
+      code: error.code,
+      message: error.message,
+      details: error.details,
+    });
+    throw new Error(`fetchAssignments failed for agent ${agentProfileId}: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as Array<{ development_id: string; is_active: boolean; role: string | null }>;
+
+  if (rows.length === 0) {
+    // Defensive probe: re-run the same filter using head+count. If the
+    // probe also returns zero, the agent genuinely has no active
+    // assignments (legitimate empty state — log once, return empty).
+    // If the probe returns >0, RLS is hiding rows from the SELECT path,
+    // which only happens when the supabase client isn't operating as
+    // service_role. Throw with a precise message naming the env var.
+    try {
+      const probe = await supabase
+        .from('agent_scheme_assignments')
+        .select('development_id', { count: 'exact', head: true })
+        .eq('agent_id', agentProfileId)
+        .eq('is_active', true);
+      const probeCount = probe.count ?? null;
+      if (probeCount !== null && probeCount > 0) {
+        // Bug confirmed: rows exist server-side but the SELECT returned
+        // none. That's an RLS / service-role mismatch.
+        const msg = `[agent-context] fetchAssignments returned 0 rows but a head+count probe found ${probeCount}. ` +
+          `This is the "Assigned: (none)" failure mode. Root cause is almost always SUPABASE_SERVICE_ROLE_KEY ` +
+          `missing or stale on this Vercel environment scope (Preview vs Production). Verify the env var, ` +
+          `redeploy, and re-run.`;
+        console.error(msg, {
+          agentProfileId,
+          selectCount: 0,
+          probeCount,
+          urlHost: (process.env.NEXT_PUBLIC_SUPABASE_URL || '').replace(/^https?:\/\//, '').split('.')[0],
+          serviceKeyPresent: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+        });
+        throw new Error(msg);
+      }
+      // probeCount === 0 (or null) — genuine empty state, fall through.
+      console.error('[agent-context] fetchAssignments: 0 active assignments for this profile', {
+        agentProfileId,
+        probeCount,
+      });
+    } catch (err: any) {
+      // Re-throw our own diagnostic; for any other probe error log and
+      // continue — we don't want a probe failure to be worse than the
+      // empty-result we'd have returned anyway.
+      if (typeof err?.message === 'string' && err.message.includes('"Assigned: (none)" failure mode')) {
+        throw err;
+      }
+      console.error('[agent-context] fetchAssignments probe failed (continuing with empty result):', err?.message || err);
+    }
+  }
+
+  return rows;
 }
 
 async function fetchTenantName(supabase: SupabaseClient, tenantId: string): Promise<string | null> {

--- a/apps/unified-portal/lib/supabase-server.ts
+++ b/apps/unified-portal/lib/supabase-server.ts
@@ -12,11 +12,85 @@ export async function createServerSupabaseClient() {
   return createServerComponentClient({ cookies });
 }
 
+/**
+ * Service-role Supabase client. Bypasses RLS — use only in server code where
+ * the request has already been authorised by the route handler.
+ *
+ * Session 14.4 — fail-fast on misconfigured environments. Three regressions
+ * (Sessions 6A, 14, 14.2/3) all looked like data bugs but the smoking gun
+ * was that `process.env.SUPABASE_SERVICE_ROLE_KEY` was unset on the
+ * preview deployment scope. With the old `process.env.X!` pattern, an
+ * undefined value silently became `undefined` at runtime, supabase-js
+ * accepted it without complaint, every query then ran as `anon`, and
+ * RLS surfaced an empty-but-error-free result. Downstream code read
+ * "(none)" as "this agent has no schemes" and told the user a verifiable
+ * lie.
+ *
+ * Now: any call site discovers a misconfiguration on the FIRST request
+ * after deploy, with a message that names the missing variable and tells
+ * the operator exactly where to fix it. Anti-pattern #1 (silently anon)
+ * is gone; anti-pattern #2 (using the anon key by mistake) is detected
+ * with a structural check on the JWT payload.
+ */
 export function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) {
+    throw new Error(
+      '[supabase-admin] NEXT_PUBLIC_SUPABASE_URL is not set. ' +
+        'Add it to the Vercel project (all environments: Production, Preview, Development) and redeploy.',
+    );
+  }
+  if (!serviceKey) {
+    throw new Error(
+      '[supabase-admin] SUPABASE_SERVICE_ROLE_KEY is not set. ' +
+        'This is the bug behind every "Assigned: (none)" / "no schemes assigned" report. ' +
+        'Add it to the Vercel project and tick BOTH Production AND Preview, then redeploy. ' +
+        'Without it the chat route silently degrades to anon-role queries which RLS blocks.',
+    );
+  }
+
+  // Best-effort sanity check: a Supabase service-role JWT's payload
+  // contains `"role":"service_role"`. The anon key contains `"role":"anon"`.
+  // If somebody has accidentally pasted the anon key into the
+  // SUPABASE_SERVICE_ROLE_KEY slot (a specific real-world failure mode)
+  // we surface it loudly rather than silently degrading. We DON'T verify
+  // the JWT signature — that's overkill — we just inspect the visible
+  // payload. JWT format: header.payload.signature, all base64url.
+  try {
+    const payloadBase64 = serviceKey.split('.')[1];
+    if (payloadBase64) {
+      const padded = payloadBase64.padEnd(payloadBase64.length + ((4 - (payloadBase64.length % 4)) % 4), '=');
+      const payloadJson = Buffer.from(padded, 'base64').toString('utf8');
+      const payload = JSON.parse(payloadJson);
+      if (payload?.role && payload.role !== 'service_role') {
+        throw new Error(
+          `[supabase-admin] SUPABASE_SERVICE_ROLE_KEY decodes to role="${payload.role}" — expected "service_role". ` +
+            'You almost certainly pasted the anon key into the service-role slot in Vercel. ' +
+            'Fix: Vercel → Settings → Environment Variables → SUPABASE_SERVICE_ROLE_KEY → paste the value labelled "service_role secret" from Supabase → Project Settings → API.',
+        );
+      }
+    }
+  } catch (err: any) {
+    // If the message starts with our diagnostic, re-throw as-is. Otherwise
+    // the JWT couldn't be parsed (malformed key, etc.) — also a problem,
+    // surface it.
+    if (typeof err?.message === 'string' && err.message.startsWith('[supabase-admin]')) {
+      throw err;
+    }
+    throw new Error(
+      `[supabase-admin] SUPABASE_SERVICE_ROLE_KEY is set but does not look like a JWT (${err?.message || err}). ` +
+        'Verify the value in Vercel matches what Supabase shows under Project Settings → API → service_role secret.',
+    );
+  }
+
+  return createClient(url, serviceKey, {
+    // Service-role clients never need session persistence and shouldn't
+    // attempt token refresh; both default to true in supabase-js, which
+    // can introduce subtle quirks in serverless cold-start paths.
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
 }
 
 export type SessionResult = 


### PR DESCRIPTION
…ole client (Session 14.4)

Cherry-picked from claude/session-13-phonetic-aliases (PR #41 was never merged into main). Production currently runs Sessions 13.0-14.3 but is missing 14.4's defensive instrumentation, so the recurring 'Assigned: (none)' bug fires without any diagnostic output.

- getSupabaseAdmin throws on missing SUPABASE_SERVICE_ROLE_KEY and detects anon-key contamination via JWT payload check.
- fetchAssignments runs a head+count probe when SELECT returns 0 rows and throws if the probe finds rows the SELECT didn't.
- New GET /api/agent/intelligence/health returns ENV diagnostics + a per-user resolver consistency check when authenticated.