### PR TITLE
feat(agent-landing): hero + chips + drafts polish, OpenHouse Select D…

### DIFF
--- a/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
+++ b/apps/unified-portal/app/agent/_components/CapabilityChipsCarousel.tsx
@@ -129,18 +129,18 @@ export default function CapabilityChipsCarousel({
       onTouchStart={() => setHovered(true)}
       onTouchEnd={() => setHovered(false)}
       style={{
-        // Fixed 2x2 grid — exactly four cells, never more, never less.
-        // `overflow: hidden` clips any stray transform animation so a
-        // mid-transition chip can't escape its cell.
+        // Session 14.12 — give the grid breathing room. Wider cells, larger
+        // gap, more side padding so chips read as deliberate buttons rather
+        // than a tight cluster. Each row's height grows with its content
+        // (the 2-line wrap fallback inside Chip).
         display: 'grid',
         gridTemplateColumns: 'repeat(2, 1fr)',
-        gridTemplateRows: 'repeat(2, auto)',
-        gap: 8,
+        gridAutoRows: 'minmax(48px, auto)',
+        gap: 10,
         padding: '0 16px',
         width: '100%',
-        maxWidth: 360,
+        maxWidth: 420,
         margin: '0 auto',
-        overflow: 'hidden',
         opacity: reducedMotion ? fade : 1,
         transition: reducedMotion ? `opacity ${SLIDE_MS}ms ease` : undefined,
       }}
@@ -178,33 +178,42 @@ function Chip({
       data-testid="capability-chip"
       className="agent-tappable"
       style={{
+        // Session 14.12 — readable, real button. No more ellipsis-on-arrival.
+        // 2-line wrap allowed inside a 48–60px tall capsule. Slightly larger
+        // type. 0.7px border for a crisper edge on retina.
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         width: '100%',
         maxWidth: '100%',
-        padding: '0 12px',
-        height: 36,
-        borderRadius: 999,
+        minHeight: 48,
+        padding: '8px 14px',
+        borderRadius: 14,
         background: 'rgba(13,13,18,0.04)',
-        border: '0.5px solid rgba(13,13,18,0.08)',
+        border: '0.7px solid rgba(13,13,18,0.10)',
         color: '#0b0c0f',
-        fontSize: 12.5,
+        fontSize: 13.5,
         fontWeight: 500,
-        lineHeight: 1,
+        lineHeight: 1.25,
         cursor: 'pointer',
         fontFamily: 'inherit',
         overflow: 'hidden',
+        textAlign: 'center',
       }}
     >
       <span
         key={text}
         style={{
-          display: 'inline-block',
+          display: 'block',
           maxWidth: '100%',
-          whiteSpace: 'nowrap',
+          // Allow wrap to 2 lines; truncation kicks in only beyond that.
+          // Most chips fit on a single line at this width — wrap is the
+          // safety net for edge cases like long Irish placenames.
+          whiteSpace: 'normal',
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
+          display: '-webkit-box' as any,
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical' as any,
           animation: reducedMotion
             ? undefined
             : `oh-chip-slide-in ${SLIDE_MS}ms cubic-bezier(0.2, 0.8, 0.2, 1)`,

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -48,8 +48,11 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
   const inputRef = useRef<HTMLInputElement | null>(null);
   useImperativeHandle(ref, () => inputRef.current as HTMLInputElement, []);
   const recording = voice.status === 'recording' || voice.status === 'transcribing';
-  const micSize = isDesktop ? 40 : 34;
-  const sendSize = 34;
+  // Session 14.12 — more deliberate proportions. The input bar is the
+  // centre of gravity on this surface; bigger touch targets + larger
+  // type signal that.
+  const micSize = isDesktop ? 44 : 40;
+  const sendSize = isDesktop ? 40 : 38;
 
   return (
     <div
@@ -66,18 +69,23 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
         data-testid="voice-input-bar"
         data-recording={recording ? 'true' : 'false'}
         style={{
+          // Session 14.12 — pill input bar, more presence. White on the
+          // off-white page surface (instead of the same warm grey as the
+          // page) so it reads as a contained input. Soft outer shadow
+          // adds depth without weight. Slightly larger radius matches
+          // the OpenHouse Select reference.
           display: 'flex',
           alignItems: 'center',
           gap: 10,
-          background: '#F5F5F3',
-          borderRadius: 28,
+          background: '#FFFFFF',
+          borderRadius: 32,
           border: recording
             ? '0.5px solid rgba(196,155,42,0.45)'
-            : '0.5px solid rgba(0,0,0,0.08)',
-          padding: '6px 6px 6px 14px',
+            : '0.5px solid rgba(0,0,0,0.10)',
+          padding: '7px 7px 7px 16px',
           boxShadow: recording
-            ? '0 0 0 3px rgba(196,155,42,0.12), 0 1px 2px rgba(0,0,0,0.04) inset'
-            : '0 1px 2px rgba(0,0,0,0.04) inset',
+            ? '0 0 0 3px rgba(196,155,42,0.12), 0 6px 16px rgba(0,0,0,0.05)'
+            : '0 6px 16px rgba(0,0,0,0.05)',
           transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
           animation: recording ? 'oh-voice-pulse 1.6s ease-in-out infinite' : undefined,
         }}
@@ -123,17 +131,18 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
             onKeyDown={(e) => e.key === 'Enter' && onSend()}
             onFocus={onFocus}
             onBlur={onBlur}
-            placeholder="Ask Intelligence anything..."
+            placeholder="Ask Intelligence anything…"
             style={{
               flex: 1,
               border: 'none',
               background: 'transparent',
               outline: 'none',
-              fontSize: 14,
+              fontSize: 15,
               fontWeight: 400,
               color: '#0D0D12',
               fontFamily: 'inherit',
               letterSpacing: '-0.01em',
+              padding: '0 4px',
             }}
           />
         )}

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -700,65 +700,94 @@ function IntelligencePageInner() {
               minHeight: 0,
             }}
           >
-            {/* Breathing room from the status bar. */}
-            <div style={{ height: 24, flexShrink: 0 }} />
+            {/* Session 14.12 — landing redesign anchored to OpenHouse Select.
+                Same brand DNA: contained logo mark above the hero, all-caps
+                product label, larger H1 with intentional vertical rhythm,
+                drafts promoted from underline to a proper chip. */}
+            <div style={{ height: isDesktop ? 56 : 32, flexShrink: 0 }} />
 
-            {/* Session 11 restored, Session 12 enlarged — OPENHOUSE
-                logo centred above the hero. 80×80 on mobile, 96×96 on
-                desktop. Always rendered regardless of drafts state. */}
-            <Image
-              src="/oh-logo.png"
-              alt="OpenHouse"
-              width={isDesktop ? 96 : 80}
-              height={isDesktop ? 96 : 80}
-              priority
+            {/* Logo — contained mark, sized like a brand surface, not a
+                watermark. Sits in a soft circular frame so it reads as
+                deliberate rather than pasted in. */}
+            <div
               style={{
-                objectFit: 'contain',
-                display: 'block',
-                mixBlendMode: 'multiply',
-                marginBottom: 32,
+                width: isDesktop ? 128 : 104,
+                height: isDesktop ? 128 : 104,
+                borderRadius: '50%',
+                background: 'rgba(196,155,42,0.06)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginBottom: 14,
               }}
-            />
+            >
+              <Image
+                src="/oh-logo.png"
+                alt="OpenHouse"
+                width={isDesktop ? 92 : 76}
+                height={isDesktop ? 92 : 76}
+                priority
+                style={{
+                  objectFit: 'contain',
+                  display: 'block',
+                  mixBlendMode: 'multiply',
+                }}
+              />
+            </div>
+
+            {/* Product label — small, all-caps, calm. Mirrors the
+                "OPENHOUSE SELECT" treatment on the homeowner surface. */}
+            <div
+              style={{
+                color: '#C49B2A',
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+                marginBottom: 16,
+              }}
+            >
+              OpenHouse Intelligence
+            </div>
 
             <h1
               data-testid="intelligence-hero"
               style={{
                 color: '#0b0c0f',
-                fontSize: 26,
+                fontSize: isDesktop ? 38 : 30,
                 fontWeight: 600,
-                letterSpacing: '-0.025em',
-                lineHeight: 1.2,
+                letterSpacing: '-0.03em',
+                lineHeight: 1.15,
                 margin: 0,
-                maxWidth: 320,
+                maxWidth: 380,
               }}
             >
               What can I help with, {firstName}?
             </h1>
 
-            <div style={{ height: 18, flexShrink: 0 }} />
+            <div style={{ height: 14, flexShrink: 0 }} />
 
             <p
               style={{
                 color: '#6B7280',
-                fontSize: 14,
-                lineHeight: 1.5,
+                fontSize: 15,
+                lineHeight: 1.55,
                 margin: 0,
-                maxWidth: 300,
-                letterSpacing: '0.005em',
+                maxWidth: 320,
+                letterSpacing: 0,
               }}
             >
               Voice or text. I&rsquo;ll show you what I drafted before sending.
             </p>
 
-            {/* Session 11 — quiet drafts link.
-                Single muted line under the helper sentence; only
-                rendered when count resolves to > 0. 20px reserved so
-                the chip carousel doesn't shift when the link appears
-                or disappears. The FAB badge already shows the count. */}
+            {/* Session 14.12 — drafts chip. Promoted from a quiet underlined
+                link to a proper card. Light gold background, count badge on
+                the left, label and chevron. Reserves height even when count
+                is 0 so layout doesn't shift. */}
             <div
               style={{
-                marginTop: 12,
-                minHeight: 20,
+                marginTop: 22,
+                minHeight: 44,
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
@@ -771,19 +800,43 @@ function IntelligencePageInner() {
                   type="button"
                   data-testid="intelligence-drafts-link"
                   onClick={() => router.push('/agent/drafts')}
+                  className="agent-tappable"
                   style={{
-                    background: 'transparent',
-                    border: 'none',
-                    padding: 0,
-                    color: '#6B7280',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    background: 'rgba(196,155,42,0.10)',
+                    border: '0.5px solid rgba(196,155,42,0.22)',
+                    borderRadius: 999,
+                    padding: '8px 14px 8px 8px',
+                    color: '#0b0c0f',
                     fontSize: 13,
                     fontFamily: 'inherit',
-                    textDecoration: 'underline',
-                    textUnderlineOffset: 3,
+                    fontWeight: 500,
                     cursor: 'pointer',
                   }}
                 >
-                  {pendingDraftsCount} draft{pendingDraftsCount === 1 ? '' : 's'} waiting in your inbox
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      minWidth: 26,
+                      height: 26,
+                      borderRadius: 999,
+                      background: '#C49B2A',
+                      color: '#fff',
+                      fontWeight: 700,
+                      fontSize: 12,
+                      padding: '0 8px',
+                    }}
+                  >
+                    {pendingDraftsCount}
+                  </span>
+                  <span>draft{pendingDraftsCount === 1 ? '' : 's'} waiting</span>
+                  <span aria-hidden="true" style={{ color: '#9CA3AF', fontSize: 14, marginLeft: 2 }}>
+                    ›
+                  </span>
                 </button>
               ) : null}
             </div>

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -131,40 +131,47 @@ async function composeChips(
   const rentalViewingsCount = rentalViewingsCountRes.count ?? 0;
   const draftsCount = draftsCountRes.count ?? 0;
 
+  // Session 14.12 — chip copy is short, action-oriented, and never
+  // truncated in the carousel. Each phrase is ≤22 chars where possible.
+  // Scheme-specific phrases use the shortest scheme name (token 1) when
+  // including a name in the copy would otherwise blow the budget.
   const chips: string[] = [];
 
+  const shortest = (names: string[]): string => {
+    const ranked = [...names].sort((a, b) => a.length - b.length);
+    return ranked[0] || '';
+  };
+  const firstScheme = shortest(schemeNames);
+
   // --- Sales pipeline: scheme-specific, only when we have real names.
-  if (schemeNames.length) {
-    chips.push(`What's outstanding on contracts in ${schemeNames[0]}?`);
-    chips.push(`Brief me on ${schemeNames[0]}`);
-    if (schemeNames.length > 1) {
-      chips.push(`Switch to ${schemeNames[1]}`);
-      chips.push('Show me everything across all schemes');
-    }
+  if (firstScheme && firstScheme.length <= 14) {
+    chips.push(`Brief on ${firstScheme}`);
+  } else if (schemeNames.length) {
+    chips.push('Brief on a scheme');
   }
-  chips.push('Show me overdue chases');
-  chips.push('What signed this week?');
   chips.push('Chase aged contracts');
+  chips.push('Show overdue chases');
+  chips.push('Signed this week?');
 
   // --- Lettings: only when real rows exist.
   if (lettingAddresses.length) {
-    chips.push(`Log a rental viewing for ${lettingAddresses[0]}`);
+    chips.push('Log a rental viewing');
   }
   if (tenanciesCount > 0) {
-    chips.push('Which tenancies are up for renewal?');
+    chips.push('Renewals due');
   }
   if (applicantsCount > 0 && lettingAddresses.length) {
-    chips.push(`Show me applicants for ${lettingAddresses[0]}`);
+    chips.push('Letting applicants');
   }
   if (rentalViewingsCount > 0) {
-    chips.push("What rental viewings do I have this week?");
+    chips.push('Rental viewings');
   }
 
   // --- Reporting / scheduling / briefings: always safe.
-  chips.push('Generate developer weekly report');
-  chips.push('Give me a scheme summary');
-  chips.push("What's on for me today?");
-  chips.push('What viewings do I have this week?');
+  chips.push('Weekly report');
+  chips.push('Scheme summary');
+  chips.push("What's on today?");
+  chips.push('This week’s viewings');
 
   // --- Drafts: only surface when the inbox actually has items.
   if (draftsCount > 0) {
@@ -172,8 +179,8 @@ async function composeChips(
   }
 
   chips.push('Invite an applicant');
-  chips.push('Draft a buyer follow-up email');
-  chips.push('Schedule a viewing for Saturday at 2pm');
+  chips.push('Draft a follow-up');
+  chips.push('Schedule a viewing');
 
   const seen = new Set<string>();
   const deduped: string[] = [];

--- a/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
+++ b/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
@@ -14,18 +14,21 @@
  * says will disappoint when the user taps it.
  */
 
+// Session 14.12 — chip copy is now ≤22 chars per phrase so the carousel
+// chips render without ellipsis truncation on a 360px-wide grid. Each
+// phrase still maps to a clear, action-oriented intent the chat surface
+// can act on. Tap behaviour pre-fills the input with the chip text.
 export const FALLBACK_CAPABILITY_CHIPS: readonly string[] = [
-  'Show me overdue chases',
-  "What's on for me today?",
-  'What viewings do I have this week?',
-  'Generate developer weekly report',
-  'Give me a scheme summary',
-  'What signed this week?',
+  "What's on today?",
+  'Scheme summary',
   'Chase aged contracts',
-  'Draft a buyer follow-up email',
+  'Show overdue chases',
+  'This week’s viewings',
+  'Signed this week?',
+  'Draft a follow-up',
+  'Schedule a viewing',
+  'Weekly report',
   'Invite an applicant',
-  'Schedule a viewing for Saturday at 2pm',
-  'Show me everything across all schemes',
 ] as const;
 
 /** Fisher–Yates shuffle. Pure function; call once per mount. */


### PR DESCRIPTION
…NA (Session 14.12)

Anchor the agent intelligence landing to the OpenHouse Select reference:

- Logo gets a contained gold-tinted circle (104px mobile / 128px desktop) and a small 'OPENHOUSE INTELLIGENCE' all-caps label below, mirroring the 'OPENHOUSE SELECT' treatment on the homeowner surface.
- Hero H1 bumped to 30/38px with tighter tracking and intentional vertical rhythm.
- Drafts promoted from a quiet underlined link to a proper chip: gold-tinted pill with a solid count badge, label, and chevron.
- Capability chips no longer truncate — minHeight 48px, 14px radius, 13.5px font, 2-line wrap fallback. Grid widened to 420px with 10px gap. Each chip reads as a real button.
- Chip copy rewritten to ≤22 chars per phrase across both the live source and the fallback set: 'Scheme summary', 'Chase aged contracts', 'Draft a follow-up' etc. No more 'Log a rental viewing…' truncation.
- Input bar refined: white background (was warm grey) so it reads as a contained input, 32px radius, soft outer shadow, larger mic (40) and send (38) buttons, 15px placeholder.