### PR TITLE
session 14.13.2 disclaimer above logo

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -192,73 +192,75 @@ export default function StatusBar({
           </span>
         </div>
 
-        {/* Session 14.13 — drafts chip in the top bar, beside the bell.
-            Promoted out of the hero so the agent landing centres entirely
-            on the brand mark + input. Tappable shortcut to /agent/drafts. */}
-        {draftsReady && draftsCount > 0 ? (
-          <button
-            type="button"
-            data-testid="statusbar-drafts-chip"
-            onClick={() => router.push('/agent/drafts')}
-            className="agent-tappable"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 8,
-              background: 'rgba(196,155,42,0.10)',
-              border: '0.5px solid rgba(196,155,42,0.22)',
-              borderRadius: 999,
-              padding: '4px 10px 4px 4px',
-              color: '#0b0c0f',
-              fontSize: 12,
-              fontFamily: 'inherit',
-              fontWeight: 500,
-              cursor: 'pointer',
-              marginRight: 6,
-              height: 28,
-            }}
-            aria-label={`${draftsCount} drafts waiting`}
-          >
-            <span
+        {/* Session 14.13.1 — right-side cluster: drafts chip + bell sit
+            together, anchored to the right edge. Wrapping them in one
+            flex group fixes the off-centre chip seen in the wild
+            (header was space-between with three children, which pushed
+            the chip into the middle). */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {draftsReady && draftsCount > 0 ? (
+            <button
+              type="button"
+              data-testid="statusbar-drafts-chip"
+              onClick={() => router.push('/agent/drafts')}
+              className="agent-tappable"
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 20,
-                height: 20,
+                gap: 8,
+                background: 'rgba(196,155,42,0.10)',
+                border: '0.5px solid rgba(196,155,42,0.22)',
                 borderRadius: 999,
-                background: '#C49B2A',
-                color: '#fff',
-                fontWeight: 700,
-                fontSize: 11,
-                padding: '0 6px',
-                lineHeight: 1,
+                padding: '4px 10px 4px 4px',
+                color: '#0b0c0f',
+                fontSize: 12,
+                fontFamily: 'inherit',
+                fontWeight: 500,
+                cursor: 'pointer',
+                height: 28,
               }}
+              aria-label={`${draftsCount} drafts waiting`}
             >
-              {draftsCount > 99 ? '99+' : draftsCount}
-            </span>
-            <span style={{ lineHeight: 1 }}>Drafts</span>
-          </button>
-        ) : null}
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 20,
+                  height: 20,
+                  borderRadius: 999,
+                  background: '#C49B2A',
+                  color: '#fff',
+                  fontWeight: 700,
+                  fontSize: 11,
+                  padding: '0 6px',
+                  lineHeight: 1,
+                }}
+              >
+                {draftsCount > 99 ? '99+' : draftsCount}
+              </span>
+              <span style={{ lineHeight: 1 }}>Drafts</span>
+            </button>
+          ) : null}
 
-        {/* Bell — opens notification panel */}
-        <button
-          onClick={() => setPanelOpen((prev) => !prev)}
-          className="agent-tappable"
-          style={{
-            position: 'relative',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'none',
-            border: 'none',
-            padding: 12,
-            margin: -12,
-            minWidth: 44,
-            minHeight: 44,
-            cursor: 'pointer',
-          }}
-        >
+          {/* Bell — opens notification panel */}
+          <button
+            onClick={() => setPanelOpen((prev) => !prev)}
+            className="agent-tappable"
+            style={{
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'none',
+              border: 'none',
+              padding: 12,
+              margin: -12,
+              minWidth: 44,
+              minHeight: 44,
+              cursor: 'pointer',
+            }}
+          >
           <svg
             width="20"
             height="20"
@@ -302,7 +304,8 @@ export default function StatusBar({
               </span>
             </div>
           )}
-        </button>
+          </button>
+        </div>
       </header>
 
       {/* Context switcher bottom sheet */}

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -274,19 +274,9 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
         </div>
       )}
 
-      {!recording && voice.status !== 'offline-queued' && voice.status !== 'error' && (
-        <p
-          style={{
-            textAlign: 'center',
-            fontSize: 10,
-            color: '#C0C8D4',
-            marginTop: 8,
-            letterSpacing: '0.01em',
-          }}
-        >
-          Powered by AI. Information for reference only.
-        </p>
-      )}
+      {/* Session 14.13.2 — disclaimer moved out of the input bar (it
+          was being occluded by the floating bottom-tab home glyph on
+          iOS). It now lives in the hero, above the brand mark. */}
 
       <style>{`
         @keyframes oh-voice-pulse {

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -714,8 +714,8 @@ function IntelligencePageInner() {
                 surface and should feel like it. */}
             <div
               style={{
-                width: isDesktop ? 256 : 208,
-                height: isDesktop ? 256 : 208,
+                width: isDesktop ? 320 : 260,
+                height: isDesktop ? 320 : 260,
                 borderRadius: '50%',
                 background: 'rgba(196,155,42,0.06)',
                 display: 'flex',
@@ -727,8 +727,8 @@ function IntelligencePageInner() {
               <Image
                 src="/oh-logo.png"
                 alt="OpenHouse"
-                width={isDesktop ? 184 : 152}
-                height={isDesktop ? 184 : 152}
+                width={isDesktop ? 230 : 190}
+                height={isDesktop ? 230 : 190}
                 priority
                 style={{
                   objectFit: 'contain',

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -704,7 +704,26 @@ function IntelligencePageInner() {
                 Same brand DNA: contained logo mark above the hero, all-caps
                 product label, larger H1 with intentional vertical rhythm,
                 drafts promoted from underline to a proper chip. */}
-            <div style={{ height: isDesktop ? 56 : 32, flexShrink: 0 }} />
+            <div style={{ height: isDesktop ? 40 : 18, flexShrink: 0 }} />
+
+            {/* Session 14.13.2 — disclaimer relocated to just above the
+                brand mark. It used to sit under the input bar, but on
+                iOS the floating bottom-tab home glyph occluded it. Now
+                it has its own breathing room in the hero and is always
+                visible regardless of bottom-bar UI. */}
+            <p
+              style={{
+                margin: 0,
+                marginBottom: isDesktop ? 18 : 14,
+                fontSize: 10,
+                color: '#9CA3AF',
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              Powered by AI · For reference only
+            </p>
 
             {/* Logo — contained mark, sized like a brand surface, not a
                 watermark. Sits in a soft circular frame so it reads as


### PR DESCRIPTION
- **fix(agent-landing): drafts chip docks beside bell + logo +25% bigger**
- **fix(agent-landing): move 'powered by AI' disclaimer above brand mark so it's not occluded by iOS bottom tab**
