### PR TITLE
session 15 generalize agent resolver

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -192,73 +192,75 @@ export default function StatusBar({
           </span>
         </div>
 
-        {/* Session 14.13 — drafts chip in the top bar, beside the bell.
-            Promoted out of the hero so the agent landing centres entirely
-            on the brand mark + input. Tappable shortcut to /agent/drafts. */}
-        {draftsReady && draftsCount > 0 ? (
-          <button
-            type="button"
-            data-testid="statusbar-drafts-chip"
-            onClick={() => router.push('/agent/drafts')}
-            className="agent-tappable"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 8,
-              background: 'rgba(196,155,42,0.10)',
-              border: '0.5px solid rgba(196,155,42,0.22)',
-              borderRadius: 999,
-              padding: '4px 10px 4px 4px',
-              color: '#0b0c0f',
-              fontSize: 12,
-              fontFamily: 'inherit',
-              fontWeight: 500,
-              cursor: 'pointer',
-              marginRight: 6,
-              height: 28,
-            }}
-            aria-label={`${draftsCount} drafts waiting`}
-          >
-            <span
+        {/* Session 14.13.1 — right-side cluster: drafts chip + bell sit
+            together, anchored to the right edge. Wrapping them in one
+            flex group fixes the off-centre chip seen in the wild
+            (header was space-between with three children, which pushed
+            the chip into the middle). */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {draftsReady && draftsCount > 0 ? (
+            <button
+              type="button"
+              data-testid="statusbar-drafts-chip"
+              onClick={() => router.push('/agent/drafts')}
+              className="agent-tappable"
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 20,
-                height: 20,
+                gap: 8,
+                background: 'rgba(196,155,42,0.10)',
+                border: '0.5px solid rgba(196,155,42,0.22)',
                 borderRadius: 999,
-                background: '#C49B2A',
-                color: '#fff',
-                fontWeight: 700,
-                fontSize: 11,
-                padding: '0 6px',
-                lineHeight: 1,
+                padding: '4px 10px 4px 4px',
+                color: '#0b0c0f',
+                fontSize: 12,
+                fontFamily: 'inherit',
+                fontWeight: 500,
+                cursor: 'pointer',
+                height: 28,
               }}
+              aria-label={`${draftsCount} drafts waiting`}
             >
-              {draftsCount > 99 ? '99+' : draftsCount}
-            </span>
-            <span style={{ lineHeight: 1 }}>Drafts</span>
-          </button>
-        ) : null}
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 20,
+                  height: 20,
+                  borderRadius: 999,
+                  background: '#C49B2A',
+                  color: '#fff',
+                  fontWeight: 700,
+                  fontSize: 11,
+                  padding: '0 6px',
+                  lineHeight: 1,
+                }}
+              >
+                {draftsCount > 99 ? '99+' : draftsCount}
+              </span>
+              <span style={{ lineHeight: 1 }}>Drafts</span>
+            </button>
+          ) : null}
 
-        {/* Bell — opens notification panel */}
-        <button
-          onClick={() => setPanelOpen((prev) => !prev)}
-          className="agent-tappable"
-          style={{
-            position: 'relative',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'none',
-            border: 'none',
-            padding: 12,
-            margin: -12,
-            minWidth: 44,
-            minHeight: 44,
-            cursor: 'pointer',
-          }}
-        >
+          {/* Bell — opens notification panel */}
+          <button
+            onClick={() => setPanelOpen((prev) => !prev)}
+            className="agent-tappable"
+            style={{
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'none',
+              border: 'none',
+              padding: 12,
+              margin: -12,
+              minWidth: 44,
+              minHeight: 44,
+              cursor: 'pointer',
+            }}
+          >
           <svg
             width="20"
             height="20"
@@ -302,7 +304,8 @@ export default function StatusBar({
               </span>
             </div>
           )}
-        </button>
+          </button>
+        </div>
       </header>
 
       {/* Context switcher bottom sheet */}

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -274,19 +274,9 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
         </div>
       )}
 
-      {!recording && voice.status !== 'offline-queued' && voice.status !== 'error' && (
-        <p
-          style={{
-            textAlign: 'center',
-            fontSize: 10,
-            color: '#C0C8D4',
-            marginTop: 8,
-            letterSpacing: '0.01em',
-          }}
-        >
-          Powered by AI. Information for reference only.
-        </p>
-      )}
+      {/* Session 14.13.2 — disclaimer moved out of the input bar (it
+          was being occluded by the floating bottom-tab home glyph on
+          iOS). It now lives in the hero, above the brand mark. */}
 
       <style>{`
         @keyframes oh-voice-pulse {

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -714,8 +714,8 @@ function IntelligencePageInner() {
                 surface and should feel like it. */}
             <div
               style={{
-                width: isDesktop ? 256 : 208,
-                height: isDesktop ? 256 : 208,
+                width: isDesktop ? 320 : 260,
+                height: isDesktop ? 320 : 260,
                 borderRadius: '50%',
                 background: 'rgba(196,155,42,0.06)',
                 display: 'flex',
@@ -727,8 +727,8 @@ function IntelligencePageInner() {
               <Image
                 src="/oh-logo.png"
                 alt="OpenHouse"
-                width={isDesktop ? 184 : 152}
-                height={isDesktop ? 184 : 152}
+                width={isDesktop ? 230 : 190}
+                height={isDesktop ? 230 : 190}
                 priority
                 style={{
                   objectFit: 'contain',

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -704,7 +704,26 @@ function IntelligencePageInner() {
                 Same brand DNA: contained logo mark above the hero, all-caps
                 product label, larger H1 with intentional vertical rhythm,
                 drafts promoted from underline to a proper chip. */}
-            <div style={{ height: isDesktop ? 56 : 32, flexShrink: 0 }} />
+            <div style={{ height: isDesktop ? 40 : 18, flexShrink: 0 }} />
+
+            {/* Session 14.13.2 — disclaimer relocated to just above the
+                brand mark. It used to sit under the input bar, but on
+                iOS the floating bottom-tab home glyph occluded it. Now
+                it has its own breathing room in the hero and is always
+                visible regardless of bottom-bar UI. */}
+            <p
+              style={{
+                margin: 0,
+                marginBottom: isDesktop ? 18 : 14,
+                fontSize: 10,
+                color: '#9CA3AF',
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              Powered by AI · For reference only
+            </p>
 
             {/* Logo — contained mark, sized like a brand surface, not a
                 watermark. Sits in a soft circular frame so it reads as

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -197,19 +197,18 @@ async function resolveAgentProfile(
   supabase: ReturnType<typeof getSupabaseAdmin>,
   userId: string | undefined,
 ): Promise<{ id: string } | null> {
-  if (userId) {
-    const { data } = await supabase
-      .from('agent_profiles')
-      .select('id')
-      .eq('user_id', userId)
-      .maybeSingle();
-    if (data) return data as any;
-  }
+  // Session 15 — generalize-agent. Removed the "earliest profile"
+  // fallback. Without an authenticated user we now return null, which
+  // causes the route handler to send back the static
+  // `FALLBACK_CAPABILITY_CHIPS`. Previously this fell back to the first
+  // agent in the table (Orla, in production), which silently leaked her
+  // chip set — including scheme names and address fragments composed
+  // by `composeChips` — to unauthenticated visitors.
+  if (!userId) return null;
   const { data } = await supabase
     .from('agent_profiles')
     .select('id')
-    .order('created_at', { ascending: true })
-    .limit(1)
+    .eq('user_id', userId)
     .maybeSingle();
-  return (data as any) || null;
+  return (data as { id: string } | null) ?? null;
 }

--- a/apps/unified-portal/app/api/agent/intelligence/whoami/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/whoami/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Session 15 — GET /api/agent/intelligence/whoami.
+ *
+ * Operator-facing diagnostic endpoint. Returns the resolved agent identity
+ * for the *current* session: the auth user id, the matched agent profile
+ * id + display name, the tenant, and the active scheme assignments.
+ *
+ * Why this exists: during the Session 6A → Session 14 saga we burned days
+ * not knowing which agent profile a given session was actually resolving
+ * to. With the earliest-profile fallback in place, the answer was
+ * "always Orla" regardless of who logged in. With that fallback removed
+ * (Session 15), the answer becomes meaningful — and this endpoint makes
+ * it observable in one curl/browser tap.
+ *
+ * Response shape (200 always; never throws to the caller):
+ *   {
+ *     authenticated: boolean,
+ *     authUserId: string | null,
+ *     authEmail: string | null,
+ *     agentProfileId: string | null,
+ *     displayName: string | null,
+ *     tenantId: string | null,
+ *     agencyName: string | null,
+ *     assignedSchemeCount: number,
+ *     assignedSchemes: Array<{ id, name, unitCount }>,
+ *     resolvedVia: 'auth-user' | 'no-profile' | 'no-auth-user',
+ *     // when the resolver failed to match a profile, surface its trace so
+ *     // we can see which step blanked
+ *     trace?: Array<{ step, details, ms }>,
+ *   }
+ */
+
+export async function GET() {
+  try {
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({
+        authenticated: false,
+        authUserId: null,
+        authEmail: null,
+        agentProfileId: null,
+        displayName: null,
+        tenantId: null,
+        agencyName: null,
+        assignedSchemeCount: 0,
+        assignedSchemes: [],
+        resolvedVia: 'no-auth-user' as const,
+      });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { context, trace } = await resolveAgentContextV2(supabase, user.id);
+
+    if (!context) {
+      return NextResponse.json({
+        authenticated: true,
+        authUserId: user.id,
+        authEmail: user.email ?? null,
+        agentProfileId: null,
+        displayName: null,
+        tenantId: null,
+        agencyName: null,
+        assignedSchemeCount: 0,
+        assignedSchemes: [],
+        resolvedVia: 'no-profile' as const,
+        trace,
+      });
+    }
+
+    return NextResponse.json({
+      authenticated: true,
+      authUserId: user.id,
+      authEmail: user.email ?? null,
+      agentProfileId: context.agentProfileId,
+      displayName: context.displayName,
+      tenantId: context.tenantId,
+      agencyName: context.agencyName,
+      assignedSchemeCount: context.assignedSchemes.length,
+      assignedSchemes: context.assignedSchemes.map((s) => ({
+        id: s.developmentId,
+        name: s.schemeName,
+        unitCount: s.unitCount,
+      })),
+      resolvedVia: 'auth-user' as const,
+    });
+  } catch (err: any) {
+    return NextResponse.json(
+      {
+        authenticated: false,
+        error: err?.message ?? 'whoami failed',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/unified-portal/lib/agent-intelligence/agent-context.ts
+++ b/apps/unified-portal/lib/agent-intelligence/agent-context.ts
@@ -50,11 +50,16 @@ export async function resolveAgentContext(
   authUserId: string | null | undefined,
   opts: ResolveOptions = {},
 ): Promise<ResolvedAgentContext | null> {
-  let profile = authUserId ? await fetchProfileByUserId(supabase, authUserId) : null;
-
-  if (!profile) {
-    profile = await fetchEarliestProfile(supabase);
-  }
+  // Session 15 — generalize-agent. Removed the `fetchEarliestProfile`
+  // fallback that previously kicked in when no auth user resolved a
+  // profile. That fallback silently returned the first row in
+  // `agent_profiles` ordered by created_at — which, with Orla being the
+  // first seeded agent, meant any unauthenticated request silently
+  // received Orla's full agent context (assignments, schemes, units).
+  // That's a per-user data-isolation bug. The correct behaviour is to
+  // return `null` and let the caller render an unauthenticated/empty
+  // state, never another agent's data.
+  const profile = authUserId ? await fetchProfileByUserId(supabase, authUserId) : null;
 
   if (!profile) return null;
 
@@ -134,15 +139,10 @@ async function fetchProfileByUserId(supabase: SupabaseClient, userId: string) {
   return data as AgentProfileRow | null;
 }
 
-async function fetchEarliestProfile(supabase: SupabaseClient) {
-  const { data } = await supabase
-    .from('agent_profiles')
-    .select('id, user_id, tenant_id, display_name, agent_type, agency_name')
-    .order('created_at', { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  return data as AgentProfileRow | null;
-}
+// Session 15 — `fetchEarliestProfile` was removed. It used to be the
+// fallback for unresolved auth users, but it returned the first
+// row in `agent_profiles` (Orla, in production), silently leaking her
+// data to any session that lost its auth user. Do not re-add it.
 
 async function fetchAssignments(supabase: SupabaseClient, agentProfileId: string) {
   // Intentionally no tenant_id filter: the join through agent_profiles already

--- a/apps/unified-portal/lib/agent-intelligence/resolve-agent-v2.ts
+++ b/apps/unified-portal/lib/agent-intelligence/resolve-agent-v2.ts
@@ -65,20 +65,14 @@ export async function resolveAgentContextV2(
     profile = (profileRes.data as AgentProfileRow | null) ?? null;
   }
 
-  // 2. Fallback: earliest profile.
-  if (!profile) {
-    const fallbackRes = await supabase
-      .from('agent_profiles')
-      .select('id, user_id, tenant_id, display_name, agent_type, agency_name')
-      .order('created_at', { ascending: true })
-      .limit(1)
-      .maybeSingle();
-    log('profile-fallback', {
-      data: fallbackRes.data ? { id: (fallbackRes.data as any).id, user_id: (fallbackRes.data as any).user_id } : null,
-      error: fallbackRes.error?.message ?? null,
-    });
-    profile = (fallbackRes.data as AgentProfileRow | null) ?? null;
-  }
+  // Session 15 — generalize-agent. Removed the "earliest profile"
+  // fallback. Previously, when an auth user couldn't be resolved (logged
+  // out, expired session, missing JWT), we'd grab the first row from
+  // `agent_profiles` ordered by created_at. In production that's Orla,
+  // because she was seeded first — meaning every unauthenticated request
+  // silently received Orla's full agent context. That's a per-user data
+  // isolation bug. Now: no auth user → no profile → caller renders an
+  // unauthenticated state, never another agent's data.
 
   if (!profile) {
     log('no-profile', {});

--- a/apps/unified-portal/tests/agent-intelligence/scheme-context.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/scheme-context.test.ts
@@ -161,6 +161,33 @@ describe('resolveAgentContext', () => {
     expect(asgCall!.filters).toHaveProperty('is_active', true);
   });
 
+  it('returns null for an unauthenticated request — never falls back to the earliest agent (Session 15)', async () => {
+    const state = baseState();
+    const supabase = createMockSupabase(state);
+
+    // Pre-Session-15, this would have silently returned Orla's context
+    // because the resolver fell back to the earliest profile in the
+    // table when no auth user was supplied. Post-fix, an unauthenticated
+    // request must yield null so the caller renders an empty/auth-required
+    // state instead of leaking another agent's data.
+    const resolved = await resolveAgentContext(supabase, undefined);
+    expect(resolved).toBeNull();
+
+    const resolvedNull = await resolveAgentContext(supabase, null);
+    expect(resolvedNull).toBeNull();
+  });
+
+  it('returns null when the auth user has no agent_profile row — no fallback to another agent (Session 15)', async () => {
+    const state = baseState();
+    const supabase = createMockSupabase(state);
+
+    // Auth user exists but is not an agent. Pre-Session-15, this would
+    // have returned Orla's context via the earliest-profile fallback.
+    const ghostUserId = '00000000-0000-0000-0000-deadbeef0000';
+    const resolved = await resolveAgentContext(supabase, ghostUserId);
+    expect(resolved).toBeNull();
+  });
+
   it('matchAssignedScheme confirms a scheme is in scope (fuzzy, case-insensitive)', () => {
     const ctx = {
       assignedDevelopmentIds: [ARDAN_VIEW_ID],


### PR DESCRIPTION
- **fix(agent-landing): drafts chip docks beside bell + logo +25% bigger**
- **fix(agent-landing): move 'powered by AI' disclaimer above brand mark so it's not occluded by iOS bottom tab**
- **fix(agent): remove earliest-profile fallback that silently leaked Orla's data + add /whoami diagnostic**
