### PR TITLE
fix(agent): hard navigation on workspace switch (resolves state desync)

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -121,7 +121,10 @@ export default function StatusBar({
       try {
         const { destinationUrl } = await switchWorkspace(workspaceId);
         setShowWorkspaceSwitcher(false);
-        router.push(destinationUrl);
+        // Hard navigation: the new workspace mode has its own AgentProvider
+        // tree, so a soft router.push creates a state-desync race condition.
+        // window.location ensures a clean page rebuild.
+        window.location.href = destinationUrl;
       } catch (err) {
         console.error('[StatusBar] switchWorkspace failed', err);
         setShowWorkspaceSwitcher(false);


### PR DESCRIPTION
## Summary

Workspace-switch from sales ↔ lettings was landing the StatusBar label, page content, and BottomNav in three different states because each layout (`app/agent/layout.tsx` and `app/agent/lettings/layout.tsx`) wraps its children in a separate `<AgentProvider>` instance. A soft `router.push` keeps in-memory state, so cross-mode navigation mounts a fresh provider mid-flight and stale state renders.

Swapping to `window.location.href` forces a full page reload, killing all in-memory state and rebuilding cleanly. Hard navigation is the conceptually-right model for an app-level mode switch.

Single-line behaviour change inside `handleSwitchWorkspace` in `apps/unified-portal/app/agent/_components/StatusBar.tsx` (+ a 3-line comment explaining why).

## Test plan

- [ ] Sign in as the test agent, default into Sales workspace
- [ ] Tap the StatusBar agency name → workspace sheet opens
- [ ] Switch to Lettings → confirm full reload (no flash of stale Sales nav/content)
- [ ] Verify StatusBar label, page route (`/agent/lettings/home`), and BottomNav (lettings tabs) are all in sync
- [ ] Switch back to Sales → same end-to-end consistency
- [ ] Confirm `/agent/home` and `/agent/lettings/home` both load cleanly on first visit (no regression to first-load behaviour)


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_