### PR TITLE
Claude/lettings csv import

### DIFF
--- a/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
@@ -7,7 +7,8 @@ import AgentShell from '../../../_components/AgentShell';
 
 type Confidence = 'high' | 'medium' | 'low';
 type Mapping = { header: string; suggestedField: string; confidence: Confidence };
-type Phase = 'upload' | 'confirm' | 'preview';
+type Phase = 'upload' | 'confirm' | 'preview' | 'importing' | 'done';
+type ImportResult = { row: number; ok: boolean; address: string; error?: string; propertyId?: string };
 
 const TARGET_OPTIONS: Array<[string, string]> = [
   ['_skip', 'Skip this column'],
@@ -66,6 +67,11 @@ export default function ImportPage() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [dragActive, setDragActive] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [currentAddress, setCurrentAddress] = useState('');
+  const [results, setResults] = useState<ImportResult[]>([]);
+  const [cancelled, setCancelled] = useState(false);
+  const cancelledRef = useRef(false);
 
   const handleFile = async (file: File | null) => {
     setError(null);
@@ -112,6 +118,53 @@ export default function ImportPage() {
   const fieldFor = (target: string) => {
     const idx = mappings.findIndex((m) => m.suggestedField === target);
     return idx >= 0 ? idx : -1;
+  };
+
+  const runImport = async () => {
+    cancelledRef.current = false;
+    setCancelled(false);
+    setResults([]);
+    setProgress({ current: 0, total: rows.length });
+    setPhase('importing');
+
+    // Build the {header → targetField} mapping object the API expects.
+    const mappingObj: Record<string, string> = {};
+    for (const m of mappings) {
+      if (m.suggestedField && m.suggestedField !== '_skip') mappingObj[m.header] = m.suggestedField;
+    }
+    const addrIdx = fieldFor('address_line_1');
+
+    for (let i = 0; i < rows.length; i++) {
+      if (cancelledRef.current) break;
+      const row = rows[i];
+      const address = (addrIdx >= 0 ? row[addrIdx] : '') || '(no address)';
+      setCurrentAddress(address);
+      setProgress({ current: i, total: rows.length });
+
+      // Build {header: value} object scoped to mapped headers only.
+      const rowObj: Record<string, string> = {};
+      headers.forEach((h, idx) => { if (mappingObj[h]) rowObj[h] = row[idx] ?? ''; });
+
+      try {
+        const res = await fetch('/api/lettings/import/row', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ row: rowObj, mapping: mappingObj }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (data.ok) {
+          setResults((prev) => [...prev, { row: i + 1, ok: true, address, propertyId: data.propertyId }]);
+        } else {
+          setResults((prev) => [...prev, { row: i + 1, ok: false, address, error: data.error || `Failed (${res.status})` }]);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Network error';
+        setResults((prev) => [...prev, { row: i + 1, ok: false, address, error: msg }]);
+      }
+    }
+
+    setProgress({ current: rows.length, total: rows.length });
+    setPhase('done');
   };
 
   return (
@@ -211,12 +264,59 @@ export default function ImportPage() {
               <p className="text-xs text-[#A0A8B0] mb-4 text-center">Estimated time: ~{Math.max(1, Math.round(rows.length * 0.5))}s</p>
               <div className="flex gap-2">
                 <button type="button" onClick={() => setPhase('confirm')} className="flex-1 h-11 rounded-lg border border-[#E5E7EB] bg-white text-sm font-medium text-[#6B7280] cursor-pointer">Back</button>
-                <button type="button" onClick={() => { console.log('TODO 12b: import', rows.length, 'rows'); window.alert(`Import flow stub — 12b will run the actual ${rows.length}-row import.`); }} className="flex-1 h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
+                <button type="button" onClick={runImport} className="flex-1 h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
                   Import {rows.length} properties
                 </button>
               </div>
             </>
           )}
+
+          {(phase === 'importing' || phase === 'done') && (() => {
+            const successCount = results.filter((r) => r.ok).length;
+            const failedCount = results.filter((r) => !r.ok).length;
+            const total = progress.total || rows.length;
+            const pct = total > 0 ? Math.round((progress.current / total) * 100) : 0;
+            const offset = 2 * Math.PI * 40 * (1 - pct / 100);
+            return (
+              <>
+                <h2 className="text-lg font-semibold text-[#0D0D12] mb-5 text-center">
+                  {phase === 'done' ? 'Import complete' : 'Importing properties'}
+                </h2>
+                <div className="bg-white border border-[#E5E7EB] rounded-xl p-6 flex flex-col items-center mb-4">
+                  <div className="relative w-24 h-24 mb-4">
+                    <svg width="96" height="96" viewBox="0 0 96 96" className="-rotate-90">
+                      <circle cx="48" cy="48" r="40" fill="none" stroke="#F3F4F6" strokeWidth="6" />
+                      <circle cx="48" cy="48" r="40" fill="none" stroke="#D4AF37" strokeWidth="6" strokeLinecap="round" strokeDasharray={2 * Math.PI * 40} strokeDashoffset={offset} style={{ transition: 'stroke-dashoffset 250ms cubic-bezier(0.16, 1, 0.3, 1)' }} />
+                    </svg>
+                    <div className="absolute inset-0 flex items-center justify-center text-2xl font-semibold text-[#0D0D12]">{pct}</div>
+                  </div>
+                  <div className="text-base font-semibold text-[#0D0D12]">{progress.current} of {total}</div>
+                  {phase === 'importing' && (
+                    <div className="text-xs text-[#6B7280] mt-1 max-w-full truncate">Adding {currentAddress}…</div>
+                  )}
+                  {cancelled && (
+                    <div className="mt-3 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider rounded-full" style={{ background: 'rgba(245,158,11,0.12)', color: '#A16207' }}>
+                      Cancelled. Already-imported properties were kept.
+                    </div>
+                  )}
+                  <div className="mt-3 text-xs">
+                    <span style={{ color: '#A47E1B', fontWeight: 600 }}>{successCount} imported</span>
+                    <span className="text-[#A0A8B0]"> · </span>
+                    <span style={{ color: failedCount > 0 ? '#B91C1C' : '#A0A8B0', fontWeight: failedCount > 0 ? 600 : 400 }}>{failedCount} failed</span>
+                  </div>
+                </div>
+                {phase === 'importing' ? (
+                  <div className="text-center">
+                    <button type="button" onClick={() => { cancelledRef.current = true; setCancelled(true); }} className="text-sm font-medium text-[#6B7280] bg-transparent border-0 cursor-pointer">Cancel import</button>
+                  </div>
+                ) : (
+                  <button type="button" onClick={() => router.push('/agent/lettings/properties')} className="w-full h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
+                    Back to properties
+                  </button>
+                )}
+              </>
+            );
+          })()}
         </div>
       </div>
     </AgentShell>

--- a/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import AgentShell from '../../../_components/AgentShell';
+
+type Confidence = 'high' | 'medium' | 'low';
+type Mapping = { header: string; suggestedField: string; confidence: Confidence };
+type Phase = 'upload' | 'confirm' | 'preview';
+
+const TARGET_OPTIONS: Array<[string, string]> = [
+  ['_skip', 'Skip this column'],
+  ['address_line_1', 'Address line 1 *'],
+  ['address_line_2', 'Address line 2'],
+  ['city', 'Town / City'],
+  ['county', 'County'],
+  ['eircode', 'Eircode'],
+  ['property_type', 'Property type'],
+  ['bedrooms', 'Bedrooms'],
+  ['bathrooms', 'Bathrooms'],
+  ['floor_area_sqm', 'Floor area (sqm)'],
+  ['ber_rating', 'BER rating'],
+  ['tenant_name', 'Tenant name'],
+  ['tenant_email', 'Tenant email'],
+  ['tenant_phone', 'Tenant phone'],
+  ['monthly_rent_eur', 'Monthly rent (€)'],
+  ['lease_start_date', 'Lease start'],
+  ['lease_end_date', 'Lease end'],
+  ['rtb_registration_number', 'RTB registration'],
+];
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const MAX_ROWS = 500;
+
+function parseCsv(text: string): { headers: string[]; rows: string[][] } {
+  const out: string[][] = [];
+  let row: string[] = []; let cell = ''; let inQ = false; let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (inQ) {
+      if (c === '"' && text[i + 1] === '"') { cell += '"'; i += 2; continue; }
+      if (c === '"') { inQ = false; i++; continue; }
+      cell += c; i++;
+    } else {
+      if (c === '"') { inQ = true; i++; }
+      else if (c === ',') { row.push(cell); cell = ''; i++; }
+      else if (c === '\n' || c === '\r') {
+        if (c === '\r' && text[i + 1] === '\n') i++;
+        row.push(cell); out.push(row); row = []; cell = ''; i++;
+      } else { cell += c; i++; }
+    }
+  }
+  if (cell !== '' || row.length > 0) { row.push(cell); out.push(row); }
+  const filtered = out.filter((r) => r.length > 1 || (r[0] ?? '').trim() !== '');
+  return { headers: filtered[0] ?? [], rows: filtered.slice(1) };
+}
+
+export default function ImportPage() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [phase, setPhase] = useState<Phase>('upload');
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<string[][]>([]);
+  const [mappings, setMappings] = useState<Mapping[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+
+  const handleFile = async (file: File | null) => {
+    setError(null);
+    if (!file) return;
+    if (!file.name.toLowerCase().endsWith('.csv') && file.type !== 'text/csv') {
+      setError('CSV files only for now. XLSX support is coming.');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      setError('File is over 5 MB. Try splitting into smaller CSVs.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const text = await file.text();
+      const { headers: h, rows: r } = parseCsv(text);
+      if (h.length === 0 || r.length === 0) throw new Error('CSV needs at least a header row and one data row.');
+      if (r.length > MAX_ROWS) throw new Error(`Imports of >${MAX_ROWS} rows aren't supported yet. Please split your CSV.`);
+      setHeaders(h); setRows(r);
+      const res = await fetch('/api/lettings/import/suggest-mapping', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ headers: h, sampleRows: r.slice(0, 5) }),
+      });
+      const json = await res.json().catch(() => ({}));
+      const ai: Mapping[] = Array.isArray(json?.mappings) ? json.mappings : h.map((header) => ({ header, suggestedField: '_skip', confidence: 'low' as Confidence }));
+      // Backfill any header missing from the AI response
+      const map = new Map(ai.map((m) => [m.header, m]));
+      setMappings(h.map((header) => map.get(header) ?? { header, suggestedField: '_skip', confidence: 'low' }));
+      setPhase('confirm');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not parse CSV');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const updateMapping = (idx: number, suggestedField: string) => {
+    setMappings((prev) => prev.map((m, i) => i === idx ? { ...m, suggestedField, confidence: 'high' } : m));
+  };
+
+  const addrMappedIdx = mappings.findIndex((m) => m.suggestedField === 'address_line_1');
+  const addrMapped = addrMappedIdx >= 0;
+
+  const fieldFor = (target: string) => {
+    const idx = mappings.findIndex((m) => m.suggestedField === target);
+    return idx >= 0 ? idx : -1;
+  };
+
+  return (
+    <AgentShell>
+      <div style={{ minHeight: '100%', background: '#FAFAF8', fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif", paddingBottom: 80 }}>
+        <div className="max-w-2xl mx-auto px-4 pt-6">
+          <div className="flex items-center gap-2 mb-4">
+            <Link href="/agent/lettings/properties/new" aria-label="Back" className="inline-flex items-center justify-center w-9 h-9 rounded-lg -ml-2">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#0D0D12" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+            </Link>
+            <h1 className="text-base font-semibold text-[#0D0D12] m-0">Import properties from a spreadsheet</h1>
+          </div>
+
+          {error && <div role="alert" className="mb-4 px-3 py-2.5 bg-red-50 border border-red-200 rounded-lg text-xs text-red-700">{error}</div>}
+
+          {phase === 'upload' && (
+            <>
+              <p className="text-sm text-[#6B7280] mb-5">We&rsquo;ll match your columns to ours, then bring everything in. CSV files only for now.</p>
+              <div
+                onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
+                onDragLeave={() => setDragActive(false)}
+                onDrop={(e) => { e.preventDefault(); setDragActive(false); handleFile(e.dataTransfer.files?.[0] ?? null); }}
+                onClick={() => fileInputRef.current?.click()}
+                className="bg-white border-2 border-dashed rounded-xl p-12 text-center cursor-pointer transition-colors"
+                style={{ borderColor: dragActive ? '#D4AF37' : '#E5E7EB', background: dragActive ? 'rgba(212,175,55,0.04)' : '#fff' }}
+              >
+                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#D4AF37" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" className="mx-auto mb-4">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+                </svg>
+                <div className="text-base font-semibold text-[#0D0D12] mb-1">{busy ? 'Reading CSV…' : 'Drop your CSV here'}</div>
+                <div className="text-sm text-[#6B7280]">{busy ? 'Hold tight while we look for column matches' : 'Or click to browse'}</div>
+                <input ref={fileInputRef} type="file" accept=".csv,text/csv" hidden onChange={(e) => handleFile(e.target.files?.[0] ?? null)} />
+              </div>
+              <div className="text-center mt-4">
+                <a href="/lettings-import-template.csv" download className="text-sm text-[#A47E1B] no-underline">Need help formatting? Download template</a>
+              </div>
+            </>
+          )}
+
+          {phase === 'confirm' && (
+            <>
+              <p className="text-sm text-[#6B7280] mb-5">{headers.length} columns detected, {rows.length} rows to import. Edit any mapping that looks wrong.</p>
+              <div className="flex flex-col gap-2 mb-4">
+                {mappings.map((m, idx) => {
+                  const sample = rows.slice(0, 2).map((r) => r[idx] ?? '').filter(Boolean).join(' / ') || '—';
+                  const dot = m.confidence === 'high' ? '#10B981' : m.confidence === 'medium' ? '#F59E0B' : '#EF4444';
+                  return (
+                    <div key={`${m.header}-${idx}`} className="bg-white border border-[#E5E7EB] rounded-xl p-3 flex items-center gap-3">
+                      <span className="flex-shrink-0 w-2 h-2 rounded-full" style={{ background: dot }} />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-mono font-medium text-[#0D0D12] truncate">{m.header}</div>
+                        <div className="text-xs text-[#A0A8B0] truncate">{sample}</div>
+                      </div>
+                      <select value={m.suggestedField} onChange={(e) => updateMapping(idx, e.target.value)} className="h-9 border border-[#E5E7EB] rounded-lg px-2 text-sm text-[#0D0D12] bg-white focus:outline-none focus:border-[#D4AF37]">
+                        {TARGET_OPTIONS.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+                      </select>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className={`mb-4 px-3 py-2 rounded-lg text-xs ${addrMapped ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+                Required field: Address — {addrMapped ? 'mapped' : 'please map a column to Address line 1'}
+              </div>
+              <div className="flex gap-2">
+                <button type="button" onClick={() => router.push('/agent/lettings/properties/new')} className="flex-1 h-11 rounded-lg border border-[#E5E7EB] bg-white text-sm font-medium text-[#6B7280] cursor-pointer">Cancel</button>
+                <button type="button" disabled={!addrMapped} onClick={() => setPhase('preview')} className="flex-1 h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)', opacity: addrMapped ? 1 : 0.5, pointerEvents: addrMapped ? 'auto' : 'none' }}>
+                  Continue
+                </button>
+              </div>
+            </>
+          )}
+
+          {phase === 'preview' && (
+            <>
+              <p className="text-sm text-[#6B7280] mb-5">{rows.length} rows will be imported. We&rsquo;ll skip any that fail; you can review them after.</p>
+              <div className="flex flex-col gap-2 mb-4">
+                {rows.slice(0, 3).map((r, i) => {
+                  const addr = fieldFor('address_line_1') >= 0 ? r[fieldFor('address_line_1')] : '';
+                  const city = fieldFor('city') >= 0 ? r[fieldFor('city')] : '';
+                  const tenant = fieldFor('tenant_name') >= 0 ? r[fieldFor('tenant_name')] : '';
+                  const rent = fieldFor('monthly_rent_eur') >= 0 ? r[fieldFor('monthly_rent_eur')] : '';
+                  const isTenanted = !!(tenant || rent);
+                  return (
+                    <div key={i} className="bg-white border border-[#E5E7EB] rounded-xl p-4 flex items-center gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-semibold text-[#0D0D12] truncate">{[addr, city].filter(Boolean).join(', ') || 'Untitled property'}</div>
+                        <div className="text-xs text-[#6B7280] truncate">{tenant || 'Vacant'}{rent ? ` · €${rent}/m` : ''}</div>
+                      </div>
+                      <span className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded-full" style={isTenanted ? { background: '#FAF3DD', color: '#A47E1B' } : { background: '#F3F4F6', color: '#6B7280' }}>
+                        {isTenanted ? 'Tenanted' : 'Vacant'}
+                      </span>
+                    </div>
+                  );
+                })}
+                {rows.length > 3 && <div className="text-center text-xs text-[#A0A8B0] py-2">+ {rows.length - 3} more</div>}
+              </div>
+              <p className="text-xs text-[#A0A8B0] mb-4 text-center">Estimated time: ~{Math.max(1, Math.round(rows.length * 0.5))}s</p>
+              <div className="flex gap-2">
+                <button type="button" onClick={() => setPhase('confirm')} className="flex-1 h-11 rounded-lg border border-[#E5E7EB] bg-white text-sm font-medium text-[#6B7280] cursor-pointer">Back</button>
+                <button type="button" onClick={() => { console.log('TODO 12b: import', rows.length, 'rows'); window.alert(`Import flow stub — 12b will run the actual ${rows.length}-row import.`); }} className="flex-1 h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
+                  Import {rows.length} properties
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </AgentShell>
+  );
+}

--- a/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
@@ -72,6 +72,8 @@ export default function ImportPage() {
   const [results, setResults] = useState<ImportResult[]>([]);
   const [cancelled, setCancelled] = useState(false);
   const cancelledRef = useRef(false);
+  const [editedFailedRows, setEditedFailedRows] = useState<Record<number, Record<string, string>>>({});
+  const [retryingRow, setRetryingRow] = useState<number | null>(null);
 
   const handleFile = async (file: File | null) => {
     setError(null);
@@ -165,6 +167,48 @@ export default function ImportPage() {
 
     setProgress({ current: rows.length, total: rows.length });
     setPhase('done');
+  };
+
+  const retryRow = async (failed: ImportResult) => {
+    const idx = failed.row - 1;
+    setRetryingRow(idx);
+    const orig = rows[idx] ?? [];
+    const edited = editedFailedRows[idx] ?? {};
+
+    const mappingObj: Record<string, string> = {};
+    for (const m of mappings) {
+      if (m.suggestedField && m.suggestedField !== '_skip') mappingObj[m.header] = m.suggestedField;
+    }
+    const rowObj: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      if (mappingObj[h]) rowObj[h] = h in edited ? edited[h] : (orig[i] ?? '');
+    });
+    const addrHeader = headers.find((h) => mappingObj[h] === 'address_line_1');
+    const newAddress = addrHeader ? (rowObj[addrHeader] || '(no address)') : failed.address;
+
+    try {
+      const res = await fetch('/api/lettings/import/row', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ row: rowObj, mapping: mappingObj }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (data.ok) {
+        setResults((prev) => prev.map((r) => r.row === failed.row
+          ? { row: r.row, ok: true, address: newAddress, propertyId: data.propertyId }
+          : r));
+        setEditedFailedRows((prev) => { const next = { ...prev }; delete next[idx]; return next; });
+      } else {
+        setResults((prev) => prev.map((r) => r.row === failed.row
+          ? { ...r, address: newAddress, error: data.error || `Failed (${res.status})` }
+          : r));
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Network error';
+      setResults((prev) => prev.map((r) => r.row === failed.row ? { ...r, error: msg } : r));
+    } finally {
+      setRetryingRow(null);
+    }
   };
 
   return (
@@ -271,7 +315,7 @@ export default function ImportPage() {
             </>
           )}
 
-          {(phase === 'importing' || phase === 'done') && (() => {
+          {phase === 'importing' && (() => {
             const successCount = results.filter((r) => r.ok).length;
             const failedCount = results.filter((r) => !r.ok).length;
             const total = progress.total || rows.length;
@@ -279,9 +323,7 @@ export default function ImportPage() {
             const offset = 2 * Math.PI * 40 * (1 - pct / 100);
             return (
               <>
-                <h2 className="text-lg font-semibold text-[#0D0D12] mb-5 text-center">
-                  {phase === 'done' ? 'Import complete' : 'Importing properties'}
-                </h2>
+                <h2 className="text-lg font-semibold text-[#0D0D12] mb-5 text-center">Importing properties</h2>
                 <div className="bg-white border border-[#E5E7EB] rounded-xl p-6 flex flex-col items-center mb-4">
                   <div className="relative w-24 h-24 mb-4">
                     <svg width="96" height="96" viewBox="0 0 96 96" className="-rotate-90">
@@ -291,29 +333,105 @@ export default function ImportPage() {
                     <div className="absolute inset-0 flex items-center justify-center text-2xl font-semibold text-[#0D0D12]">{pct}</div>
                   </div>
                   <div className="text-base font-semibold text-[#0D0D12]">{progress.current} of {total}</div>
-                  {phase === 'importing' && (
-                    <div className="text-xs text-[#6B7280] mt-1 max-w-full truncate">Adding {currentAddress}…</div>
-                  )}
-                  {cancelled && (
-                    <div className="mt-3 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider rounded-full" style={{ background: 'rgba(245,158,11,0.12)', color: '#A16207' }}>
-                      Cancelled. Already-imported properties were kept.
-                    </div>
-                  )}
+                  <div className="text-xs text-[#6B7280] mt-1 max-w-full truncate">Adding {currentAddress}…</div>
                   <div className="mt-3 text-xs">
                     <span style={{ color: '#A47E1B', fontWeight: 600 }}>{successCount} imported</span>
                     <span className="text-[#A0A8B0]"> · </span>
                     <span style={{ color: failedCount > 0 ? '#B91C1C' : '#A0A8B0', fontWeight: failedCount > 0 ? 600 : 400 }}>{failedCount} failed</span>
                   </div>
                 </div>
-                {phase === 'importing' ? (
-                  <div className="text-center">
-                    <button type="button" onClick={() => { cancelledRef.current = true; setCancelled(true); }} className="text-sm font-medium text-[#6B7280] bg-transparent border-0 cursor-pointer">Cancel import</button>
+                <div className="text-center">
+                  <button type="button" onClick={() => { cancelledRef.current = true; setCancelled(true); }} className="text-sm font-medium text-[#6B7280] bg-transparent border-0 cursor-pointer">Cancel import</button>
+                </div>
+              </>
+            );
+          })()}
+
+          {phase === 'done' && (() => {
+            const successful = results.filter((r) => r.ok);
+            const failed = results.filter((r) => !r.ok);
+            const skipped = cancelled ? Math.max(0, rows.length - results.length) : 0;
+            const mappedHeaders = mappings.filter((m) => m.suggestedField && m.suggestedField !== '_skip');
+            return (
+              <>
+                <div className="bg-white border border-[#E5E7EB] rounded-xl p-4 mb-4">
+                  <h2 className="text-xl font-semibold text-[#0D0D12] m-0 mb-3">{cancelled ? 'Import cancelled' : 'Import complete'}</h2>
+                  <div className="flex flex-wrap gap-2 mb-3">
+                    <span className="px-3 py-1 rounded-full text-xs font-semibold" style={{ background: 'rgba(212,175,55,0.12)', color: '#A47E1B' }}>{successful.length} imported</span>
+                    {failed.length > 0 && <span className="px-3 py-1 rounded-full text-xs font-semibold" style={{ background: 'rgba(239,68,68,0.10)', color: '#B91C1C' }}>{failed.length} failed</span>}
+                    {skipped > 0 && <span className="px-3 py-1 rounded-full text-xs font-semibold" style={{ background: '#F3F4F6', color: '#6B7280' }}>{skipped} skipped</span>}
                   </div>
-                ) : (
-                  <button type="button" onClick={() => router.push('/agent/lettings/properties')} className="w-full h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
-                    Back to properties
-                  </button>
+                  <p className="text-sm text-[#6B7280] m-0">{failed.length > 0 ? 'Review the failures below to fix and retry.' : successful.length > 0 ? 'All properties are now in your portfolio.' : 'No properties were imported.'}</p>
+                </div>
+
+                {failed.length > 0 && (
+                  <div className="mb-4">
+                    <div className="text-[11px] font-semibold tracking-wider uppercase text-[#B91C1C] mb-2">Failed rows ({failed.length})</div>
+                    <div className="flex flex-col gap-2">
+                      {failed.map((f) => {
+                        const idx = f.row - 1;
+                        const orig = rows[idx] ?? [];
+                        const edited = editedFailedRows[idx] ?? {};
+                        const isRetrying = retryingRow === idx;
+                        return (
+                          <div key={f.row} className="bg-white rounded-xl p-3" style={{ border: '0.5px solid #E5E7EB', borderLeft: '3px solid #F87171' }}>
+                            <div className="flex items-baseline justify-between mb-1 gap-2">
+                              <span className="text-sm font-semibold text-[#0D0D12] truncate">Row {f.row}: {f.address}</span>
+                            </div>
+                            <div className="text-xs text-[#B91C1C] mb-3">{f.error || 'Failed'}</div>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3">
+                              {mappedHeaders.map((m) => {
+                                const colIdx = headers.indexOf(m.header);
+                                const value = m.header in edited ? edited[m.header] : (colIdx >= 0 ? orig[colIdx] ?? '' : '');
+                                return (
+                                  <div key={m.header}>
+                                    <label className="block text-[10px] font-medium text-[#6B7280] mb-0.5 truncate">{m.header}</label>
+                                    <input
+                                      type="text"
+                                      value={value}
+                                      onChange={(e) => setEditedFailedRows((prev) => ({ ...prev, [idx]: { ...(prev[idx] ?? {}), [m.header]: e.target.value } }))}
+                                      className="h-8 w-full border border-[#E5E7EB] rounded-md px-2 text-xs text-[#0D0D12] bg-white focus:outline-none focus:border-[#D4AF37]"
+                                    />
+                                  </div>
+                                );
+                              })}
+                            </div>
+                            <div className="flex justify-end">
+                              <button type="button" disabled={isRetrying} onClick={() => retryRow(f)} className="px-3 py-1.5 rounded-lg border-0 text-xs font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)', opacity: isRetrying ? 0.5 : 1, pointerEvents: isRetrying ? 'none' : 'auto' }}>
+                                {isRetrying ? 'Retrying…' : 'Retry'}
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
                 )}
+
+                {successful.length > 0 && (
+                  <div className="mb-4">
+                    <div className="text-[11px] font-semibold tracking-wider uppercase text-[#9EA8B5] mb-2">Imported ({successful.length})</div>
+                    <div className="flex flex-col gap-1.5">
+                      {successful.slice(0, 10).map((s) => (
+                        <Link key={s.row} href={`/agent/lettings/properties/${s.propertyId}`} className="flex items-center gap-3 bg-white border border-[#E5E7EB] rounded-lg px-3 py-2 no-underline">
+                          <div className="flex-1 min-w-0">
+                            <div className="text-sm font-medium text-[#0D0D12] truncate">{s.address}</div>
+                          </div>
+                          <span className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded-full flex-shrink-0" style={{ background: '#FAF3DD', color: '#A47E1B' }}>Saved</span>
+                        </Link>
+                      ))}
+                      {successful.length > 10 && (
+                        <Link href="/agent/lettings/properties" className="text-xs text-[#6B7280] no-underline text-center py-2">
+                          Showing 10 of {successful.length} · View all
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                <button type="button" onClick={() => router.push('/agent/lettings/properties')} className="w-full h-11 rounded-lg border-0 text-sm font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)' }}>
+                  Done — back to Properties
+                </button>
               </>
             );
           })()}

--- a/apps/unified-portal/app/api/lettings/import/row/route.ts
+++ b/apps/unified-portal/app/api/lettings/import/row/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/lettings/import/row — single-row import. Mirrors the create-
+ * property flow from /api/lettings/properties (Session 8c-iii) but driven
+ * by a CSV row + the agent-confirmed column mapping. Same rollback-on-
+ * tenancy-failure pattern: INSERT property, then INSERT tenancy if the
+ * row implies one, DELETE the property if the tenancy insert fails.
+ */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseIntOrNull(s: string | undefined): number | null {
+  if (!s) return null;
+  const n = parseInt(s.trim(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+function parseFloatOrNull(s: string | undefined): number | null {
+  if (!s) return null;
+  const cleaned = s.trim().replace(/[€£$,]/g, '');
+  const n = parseFloat(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+function isoOrNull(s: string | undefined): string | null {
+  if (!s) return null;
+  const t = s.trim();
+  return ISO_DATE.test(t) ? t : null;
+}
+
+export async function POST(req: NextRequest) {
+  const started = Date.now();
+  try {
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookies() });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+
+    const admin = getSupabaseAdmin();
+    const { data: agentProfile } = await admin
+      .from('agent_profiles')
+      .select('id, tenant_id')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (!agentProfile) return NextResponse.json({ ok: false, error: 'No agent profile' }, { status: 401 });
+
+    const body = await req.json().catch(() => null);
+    if (!body) return NextResponse.json({ ok: false, error: 'Invalid body' }, { status: 400 });
+    const row: Record<string, string> = body.row && typeof body.row === 'object' ? body.row : {};
+    const mapping: Record<string, string> = body.mapping && typeof body.mapping === 'object' ? body.mapping : {};
+
+    // Apply the mapping: build a target-field → value object
+    const target: Record<string, string> = {};
+    for (const [header, field] of Object.entries(mapping)) {
+      if (!field || field === '_skip') continue;
+      const v = row[header];
+      if (typeof v === 'string' && v.trim() !== '') target[field] = v.trim();
+    }
+
+    const addressLine1 = target.address_line_1?.trim() ?? '';
+    if (!addressLine1) {
+      return NextResponse.json({ ok: false, error: 'Missing address' }, { status: 400 });
+    }
+
+    const { data: workspace } = await admin
+      .from('agent_workspaces')
+      .select('id')
+      .eq('agent_id', agentProfile.id)
+      .eq('mode', 'lettings')
+      .limit(1)
+      .maybeSingle();
+    if (!workspace) {
+      return NextResponse.json({ ok: false, error: 'No lettings workspace' }, { status: 500 });
+    }
+
+    const tenantName = target.tenant_name || null;
+    const rentPcm = parseFloatOrNull(target.monthly_rent_eur);
+    const isTenanted = !!tenantName || rentPcm != null;
+    const status = isTenanted ? 'let' : 'vacant';
+
+    const formattedAddress = [
+      target.address_line_1, target.address_line_2, target.city, target.county, target.eircode,
+    ].filter(Boolean).join(', ');
+
+    const { data: inserted, error: propErr } = await admin
+      .from('agent_letting_properties')
+      .insert({
+        workspace_id: workspace.id,
+        agent_id: agentProfile.id,
+        tenant_id: agentProfile.tenant_id,
+        address: formattedAddress,
+        address_line_1: addressLine1,
+        address_line_2: target.address_line_2 || null,
+        city: target.city || null,
+        county: target.county || null,
+        eircode: target.eircode || null,
+        property_type: target.property_type || null,
+        bedrooms: parseIntOrNull(target.bedrooms),
+        bathrooms: parseIntOrNull(target.bathrooms),
+        floor_area_sqm: parseFloatOrNull(target.floor_area_sqm),
+        ber_rating: target.ber_rating ? target.ber_rating.toLowerCase() : null,
+        rent_pcm: isTenanted ? rentPcm : null,
+        status,
+        source: 'csv_import',
+      })
+      .select('id')
+      .single();
+    if (propErr || !inserted) {
+      console.error(`[lettings-import-row] property_insert_failed reason=${propErr?.message}`);
+      return NextResponse.json({ ok: false, error: propErr?.message ?? 'Property insert failed' }, { status: 500 });
+    }
+    const propertyId = inserted.id as string;
+
+    if (isTenanted) {
+      try {
+        const { error: tErr } = await admin.from('agent_tenancies').insert({
+          letting_property_id: propertyId,
+          workspace_id: workspace.id,
+          agent_id: agentProfile.id,
+          tenant_id: agentProfile.tenant_id,
+          tenant_name: tenantName,
+          tenant_email: target.tenant_email || null,
+          tenant_phone: target.tenant_phone || null,
+          rent_pcm: rentPcm,
+          lease_start: isoOrNull(target.lease_start_date),
+          lease_end: isoOrNull(target.lease_end_date),
+          rtb_registration_number: target.rtb_registration_number || null,
+          rtb_registered: !!target.rtb_registration_number,
+          status: 'active',
+          source: 'csv_import',
+        });
+        if (tErr) throw new Error(tErr.message);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : 'Unknown error';
+        await admin.from('agent_letting_properties').delete().eq('id', propertyId).then(() => null, () => null);
+        console.error(`[lettings-import-row] tenancy_failed_rolled_back reason=${reason}`);
+        return NextResponse.json({ ok: false, error: reason }, { status: 500 });
+      }
+    }
+
+    console.log(`[lettings-import-row] ok property_id=${propertyId} duration_ms=${Date.now() - started}`);
+    return NextResponse.json({ ok: true, propertyId }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`[lettings-import-row] error duration_ms=${Date.now() - started} reason=${message}`);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/lettings/import/suggest-mapping/route.ts
+++ b/apps/unified-portal/app/api/lettings/import/suggest-mapping/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import OpenAI from 'openai';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/lettings/import/suggest-mapping
+ *
+ * Body: { headers: string[], sampleRows: string[][] }
+ *
+ * Asks gpt-4o-mini to map each CSV header to one of our target fields.
+ * Falls back to a regex/keyword matcher if OpenAI is unavailable so the
+ * import flow never blocks on AI.
+ */
+
+const TARGET_FIELDS = [
+  'address_line_1', 'address_line_2', 'city', 'county', 'eircode',
+  'property_type', 'bedrooms', 'bathrooms', 'floor_area_sqm', 'ber_rating',
+  'tenant_name', 'tenant_email', 'tenant_phone', 'monthly_rent_eur',
+  'lease_start_date', 'lease_end_date', 'rtb_registration_number', '_skip',
+] as const;
+
+type Confidence = 'high' | 'medium' | 'low';
+type Mapping = { header: string; suggestedField: string; confidence: Confidence };
+
+const SYSTEM_PROMPT = `You are a CSV column mapper for an Irish lettings property database. Map each input header to exactly one of these target fields, using "_skip" if no good match.
+
+Targets: ${TARGET_FIELDS.join(', ')}.
+
+Return per-header suggestions with confidence:
+- high: header text is unambiguous (e.g. "Eircode" → eircode, "Monthly Rent" → monthly_rent_eur)
+- medium: clear meaning but multiple candidates (e.g. "Address" could be address_line_1 or city)
+- low: best-guess only
+
+If two headers map to the same target, pick the better fit and mark the loser as _skip.`;
+
+const RESPONSE_SCHEMA = {
+  name: 'csv_column_mapping',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      mappings: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            header: { type: 'string' },
+            suggestedField: { type: 'string', enum: [...TARGET_FIELDS] },
+            confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          },
+          required: ['header', 'suggestedField', 'confidence'],
+        },
+      },
+    },
+    required: ['mappings'],
+  },
+} as const;
+
+function regexFallback(headers: string[]): Mapping[] {
+  const rules: Array<[RegExp, string]> = [
+    [/^address[_\s]?line[_\s]?1$|^address$|^street$|^line[_\s]?1$/i, 'address_line_1'],
+    [/^address[_\s]?line[_\s]?2$|^line[_\s]?2$/i, 'address_line_2'],
+    [/^town$|^city$/i, 'city'],
+    [/^county$/i, 'county'],
+    [/^eir[\s]?code$|^postcode$|^post[\s]?code$/i, 'eircode'],
+    [/property[_\s]?type|^type$/i, 'property_type'],
+    [/^bedrooms?$|^beds?$/i, 'bedrooms'],
+    [/^bathrooms?$|^baths?$/i, 'bathrooms'],
+    [/floor[_\s]?area|^area$|sqm/i, 'floor_area_sqm'],
+    [/ber[_\s]?rating|^ber$/i, 'ber_rating'],
+    [/tenant[_\s]?name|^tenant$/i, 'tenant_name'],
+    [/tenant[_\s]?email|^email$/i, 'tenant_email'],
+    [/tenant[_\s]?phone|^phone$|^mobile$/i, 'tenant_phone'],
+    [/rent|monthly[_\s]?rent/i, 'monthly_rent_eur'],
+    [/lease[_\s]?start|start[_\s]?date/i, 'lease_start_date'],
+    [/lease[_\s]?end|end[_\s]?date/i, 'lease_end_date'],
+    [/rtb/i, 'rtb_registration_number'],
+  ];
+  return headers.map((h) => {
+    for (const [re, target] of rules) {
+      if (re.test(h)) return { header: h, suggestedField: target, confidence: 'medium' as Confidence };
+    }
+    return { header: h, suggestedField: '_skip', confidence: 'low' as Confidence };
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const started = Date.now();
+  try {
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookies() });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const admin = getSupabaseAdmin();
+    const { data: agentProfile } = await admin
+      .from('agent_profiles')
+      .select('id')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (!agentProfile) return NextResponse.json({ error: 'No agent profile' }, { status: 403 });
+
+    const body = await req.json().catch(() => null);
+    const headers: string[] = Array.isArray(body?.headers) ? body.headers.filter((h: unknown): h is string => typeof h === 'string') : [];
+    const sampleRows: string[][] = Array.isArray(body?.sampleRows)
+      ? body.sampleRows.slice(0, 5).map((r: unknown) => Array.isArray(r) ? r.map((c) => String(c ?? '')) : [])
+      : [];
+    if (headers.length === 0) {
+      return NextResponse.json({ error: 'No headers provided' }, { status: 400 });
+    }
+
+    console.log(`[lettings-import-mapping] start headers=${headers.length}`);
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      console.warn('[lettings-import-mapping] OPENAI_API_KEY missing — using regex fallback');
+      return NextResponse.json({ mappings: regexFallback(headers) });
+    }
+
+    try {
+      const openai = new OpenAI({ apiKey, timeout: 20_000 });
+      const sampleText = sampleRows
+        .map((r, i) => `Row ${i + 1}: ${headers.map((h, j) => `${h}=${r[j] ?? ''}`).join(' | ')}`)
+        .join('\n');
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        temperature: 0.1,
+        response_format: { type: 'json_schema', json_schema: RESPONSE_SCHEMA },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: `Headers: ${headers.join(', ')}\n\nSample rows:\n${sampleText}` },
+        ],
+      });
+      const raw = completion.choices?.[0]?.message?.content;
+      if (!raw) throw new Error('Empty completion');
+      const parsed = JSON.parse(raw) as { mappings: Mapping[] };
+      console.log(`[lettings-import-mapping] ai_ok duration_ms=${Date.now() - started}`);
+      return NextResponse.json({ mappings: parsed.mappings });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[lettings-import-mapping] ai_failed_fallback reason=${msg}`);
+      return NextResponse.json({ mappings: regexFallback(headers) });
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(`[lettings-import-mapping] error reason=${message}`);
+    return NextResponse.json({ error: 'Mapping suggestion failed' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/public/lettings-import-template.csv
+++ b/apps/unified-portal/public/lettings-import-template.csv
@@ -1,0 +1,4 @@
+Address,Town,County,Eircode,Property Type,Bedrooms,Bathrooms,Tenant,Monthly Rent,Lease Start
+"12 Main Street","Cork","County Cork","T12 ABCD","apartment",2,1,"John Murphy",1500,"2025-05-01"
+"7 Lapps Quay","Cork","County Cork","T12 W6F7","apartment",2,1,"Aisling Moran",1850,"2024-05-01"
+"24 Magazine Road","Cork","County Cork","T12 X9P2","house_terraced",3,2,"",,


### PR DESCRIPTION
Adds bulk CSV import to the lettings workspace.

## What's in
- **Upload screen** with drag-drop, CSV parser (inline, no new deps), 5MB limit
- **AI column mapping** via GPT-4o-mini (with regex fallback if AI fails)
- **Live progress UI** during import — sequential per-row, ring at 96px, current address shown, success/failure tally
- **Cancel mid-flight** keeps already-imported rows
- **Per-row retry** on failures with inline edits
- **Mid-flow templates** at `/lettings-import-template.csv` for new agents

## Architecture
- Client orchestrates the import loop (no streaming, no job queue, no Vercel timeout risk)
- Each row hits `/api/lettings/import/row` — same transactional pattern as the single-property save (property + optional tenancy, rollback on tenancy failure)
- Imported rows tagged `source: 'csv_import'` for future filtering

## Test agent
For Orla, drop the bundled template CSV. AI maps all 10 columns with high confidence. Tap Import — 3 rows: 2 tenanted (John Murphy, Aisling Moran) + 1 vacant (Magazine Road). Check `agent_letting_properties WHERE source = 'csv_import'` to verify.

## Known UX gaps (deferred to polish)
- Failed-row inputs show every mapped column, not just the failing one
- Cancellation doesn't list which rows were skipped (just a count)
- No localStorage persistence on edited-but-not-retried rows
- No deduplication on retry (creates duplicate if row already succeeded)