### PR TITLE
fix(lettings): use 'bulk_csv' source value to match DB constraint

### DIFF
--- a/apps/unified-portal/app/api/lettings/import/row/route.ts
+++ b/apps/unified-portal/app/api/lettings/import/row/route.ts
@@ -107,7 +107,7 @@ export async function POST(req: NextRequest) {
         ber_rating: target.ber_rating ? target.ber_rating.toLowerCase() : null,
         rent_pcm: isTenanted ? rentPcm : null,
         status,
-        source: 'csv_import',
+        source: 'bulk_csv',
       })
       .select('id')
       .single();
@@ -133,7 +133,7 @@ export async function POST(req: NextRequest) {
           rtb_registration_number: target.rtb_registration_number || null,
           rtb_registered: !!target.rtb_registration_number,
           status: 'active',
-          source: 'csv_import',
+          source: 'bulk_csv',
         });
         if (tErr) throw new Error(tErr.message);
       } catch (err) {


### PR DESCRIPTION
## Summary

Session 12b's `/api/lettings/import/row` endpoint wrote `source: 'csv_import'` for both the property and the optional active tenancy INSERTs. The live DB CHECK constraints on `agent_letting_properties.source` and `agent_tenancies.source` only allow `'manual' | 'bulk_csv' | 'bulk_daft' | 'lease_pdf' | 'intelligence_voice' | 'intelligence_text'`, so every CSV import row was failing with `violates check constraint`.

The schema convention across `agent_letting_properties`, `agent_tenancies`, and `lettings_field_provenance` is consistently `'bulk_csv'`. Two-line swap to match.

## Test plan

- [ ] Drop the bundled `lettings-import-template.csv` into the import flow
- [ ] Confirm all 3 rows insert without DB constraint errors
- [ ] Verify rows 1 + 2 (with tenant + rent) create both property + tenancy rows tagged `source = 'bulk_csv'`
- [ ] Verify row 3 (vacant, no tenant) creates property only, status `'vacant'`, source `'bulk_csv'`
- [ ] Verify the rent-roll dashboard and properties list still render the imported rows


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_