### PR TITLE
feat(lettings): address provenance + import dedup (session 13a)

### DIFF
--- a/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/import/page.tsx
@@ -8,7 +8,7 @@ import AgentShell from '../../../_components/AgentShell';
 type Confidence = 'high' | 'medium' | 'low';
 type Mapping = { header: string; suggestedField: string; confidence: Confidence };
 type Phase = 'upload' | 'confirm' | 'preview' | 'importing' | 'done';
-type ImportResult = { row: number; ok: boolean; address: string; error?: string; propertyId?: string };
+type ImportResult = { row: number; ok: boolean; address: string; error?: string; propertyId?: string; existingId?: string; existingAddress?: string };
 
 const TARGET_OPTIONS: Array<[string, string]> = [
   ['_skip', 'Skip this column'],
@@ -157,7 +157,7 @@ export default function ImportPage() {
         if (data.ok) {
           setResults((prev) => [...prev, { row: i + 1, ok: true, address, propertyId: data.propertyId }]);
         } else {
-          setResults((prev) => [...prev, { row: i + 1, ok: false, address, error: data.error || `Failed (${res.status})` }]);
+          setResults((prev) => [...prev, { row: i + 1, ok: false, address, error: data.error || `Failed (${res.status})`, existingId: data.existingId, existingAddress: data.existingAddress }]);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Network error';
@@ -169,7 +169,7 @@ export default function ImportPage() {
     setPhase('done');
   };
 
-  const retryRow = async (failed: ImportResult) => {
+  const retryRow = async (failed: ImportResult, opts?: { force?: boolean }) => {
     const idx = failed.row - 1;
     setRetryingRow(idx);
     const orig = rows[idx] ?? [];
@@ -187,7 +187,8 @@ export default function ImportPage() {
     const newAddress = addrHeader ? (rowObj[addrHeader] || '(no address)') : failed.address;
 
     try {
-      const res = await fetch('/api/lettings/import/row', {
+      const url = opts?.force ? '/api/lettings/import/row?force=true' : '/api/lettings/import/row';
+      const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ row: rowObj, mapping: mappingObj }),
@@ -200,7 +201,7 @@ export default function ImportPage() {
         setEditedFailedRows((prev) => { const next = { ...prev }; delete next[idx]; return next; });
       } else {
         setResults((prev) => prev.map((r) => r.row === failed.row
-          ? { ...r, address: newAddress, error: data.error || `Failed (${res.status})` }
+          ? { ...r, address: newAddress, error: data.error || `Failed (${res.status})`, existingId: data.existingId, existingAddress: data.existingAddress }
           : r));
       }
     } catch (err) {
@@ -373,12 +374,23 @@ export default function ImportPage() {
                         const orig = rows[idx] ?? [];
                         const edited = editedFailedRows[idx] ?? {};
                         const isRetrying = retryingRow === idx;
+                        const isDupe = f.error === 'duplicate';
+                        const accent = isDupe ? '#FBBF24' : '#F87171';
                         return (
-                          <div key={f.row} className="bg-white rounded-xl p-3" style={{ border: '0.5px solid #E5E7EB', borderLeft: '3px solid #F87171' }}>
+                          <div key={f.row} className="bg-white rounded-xl p-3" style={{ border: '0.5px solid #E5E7EB', borderLeft: `3px solid ${accent}` }}>
                             <div className="flex items-baseline justify-between mb-1 gap-2">
                               <span className="text-sm font-semibold text-[#0D0D12] truncate">Row {f.row}: {f.address}</span>
                             </div>
-                            <div className="text-xs text-[#B91C1C] mb-3">{f.error || 'Failed'}</div>
+                            {isDupe ? (
+                              <div className="text-xs mb-3" style={{ color: '#A16207' }}>
+                                Already exists in your portfolio
+                                {f.existingId && (
+                                  <> · <a href={`/agent/lettings/properties/${f.existingId}`} target="_blank" rel="noopener" className="underline">View existing →</a></>
+                                )}
+                              </div>
+                            ) : (
+                              <div className="text-xs text-[#B91C1C] mb-3">{f.error || 'Failed'}</div>
+                            )}
                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3">
                               {mappedHeaders.map((m) => {
                                 const colIdx = headers.indexOf(m.header);
@@ -397,8 +409,8 @@ export default function ImportPage() {
                               })}
                             </div>
                             <div className="flex justify-end">
-                              <button type="button" disabled={isRetrying} onClick={() => retryRow(f)} className="px-3 py-1.5 rounded-lg border-0 text-xs font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)', opacity: isRetrying ? 0.5 : 1, pointerEvents: isRetrying ? 'none' : 'auto' }}>
-                                {isRetrying ? 'Retrying…' : 'Retry'}
+                              <button type="button" disabled={isRetrying} onClick={() => retryRow(f, isDupe ? { force: true } : undefined)} className="px-3 py-1.5 rounded-lg border-0 text-xs font-semibold text-[#0D0D12] cursor-pointer" style={{ background: 'linear-gradient(135deg, #D4AF37, #C49B2A)', opacity: isRetrying ? 0.5 : 1, pointerEvents: isRetrying ? 'none' : 'auto' }}>
+                                {isRetrying ? 'Retrying…' : isDupe ? 'Create anyway' : 'Retry'}
                               </button>
                             </div>
                           </div>

--- a/apps/unified-portal/app/agent/lettings/properties/new/review/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/new/review/page.tsx
@@ -456,6 +456,16 @@ export default function ReviewPropertyPage() {
         source: src === 'lease_pdf' ? 'lease_pdf_extraction' : src,
       }));
 
+    // Address-component fields are auto-filled from lookupData (Google Places
+    // or Eircode) and locked in the UI — no form-state to compare against.
+    // Forward the lookup API's own provenance for those, normalising 'town'
+    // to the DB column name 'city'.
+    const ADDRESS_PROV_FIELDS = new Set(['address_line_1', 'town', 'county', 'eircode', 'latitude', 'longitude']);
+    for (const p of lookupData?.provenance ?? []) {
+      if (!ADDRESS_PROV_FIELDS.has(p.field)) continue;
+      provenance.push({ fieldName: p.field === 'town' ? 'city' : p.field, source: p.source });
+    }
+
     const body = {
       status: form.status,
       address: lookupData?.address ?? { line1: '' },

--- a/apps/unified-portal/app/api/lettings/import/row/route.ts
+++ b/apps/unified-portal/app/api/lettings/import/row/route.ts
@@ -79,6 +79,30 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: 'No lettings workspace' }, { status: 500 });
     }
 
+    // Dedup: skip rows whose address_line_1 + eircode already exists for this
+    // agent, unless ?force=true is set. Match is case-insensitive via ilike;
+    // null/empty eircodes match each other.
+    const force = req.nextUrl.searchParams.get('force') === 'true';
+    if (!force) {
+      const inputEircode = target.eircode?.trim() || '';
+      let dupeQuery = admin
+        .from('agent_letting_properties')
+        .select('id, address')
+        .eq('agent_id', agentProfile.id)
+        .ilike('address_line_1', addressLine1);
+      dupeQuery = inputEircode
+        ? dupeQuery.ilike('eircode', inputEircode)
+        : dupeQuery.or('eircode.is.null,eircode.eq.');
+      const { data: dupes } = await dupeQuery.limit(1);
+      if (dupes && dupes.length > 0) {
+        console.log(`[lettings-import-row] duplicate skipped existing_id=${dupes[0].id}`);
+        return NextResponse.json(
+          { ok: false, error: 'duplicate', existingId: dupes[0].id, existingAddress: dupes[0].address },
+          { status: 200 },
+        );
+      }
+    }
+
     const tenantName = target.tenant_name || null;
     const rentPcm = parseFloatOrNull(target.monthly_rent_eur);
     const isTenanted = !!tenantName || rentPcm != null;


### PR DESCRIPTION
## Summary

Two surgical launch-blocker fixes.

**Fix 1: Address provenance recording** — the single-property save endpoint receives a `provenance` array but it never included the address-component fields (`address_line_1`, `city`, `county`, `eircode`, `latitude`, `longitude`) even though those are auto-filled from Google Places / Eircode lookup. The `<SourceIcon>` therefore never appeared next to address fields in the review screen / property detail Overview tab — breaking the "we filled this for you" promise visually. Forward the lookup API's own provenance entries for those fields, normalising the API's `'town'` → DB column `'city'`.

**Fix 2: Import dedup** — the per-row import endpoint blindly created duplicate properties when the agent's CSV overlapped with what they'd already added manually. Now checks for an existing property with the same `address_line_1` + `eircode` (case-insensitive, null-eircodes match each other) and returns `{ ok: false, error: 'duplicate', existingId, existingAddress }` (HTTP 200 — expected outcome, not a server error). The Failed-rows UI gets a special amber-bordered state with "Already exists in your portfolio" + "View existing →" + "Create anyway" (which re-fires with `?force=true` to bypass the check).

## Test plan

- [ ] Add a property via the address-entry flow → save → confirm `<SourceIcon>` (MapPin / Hash) renders next to address-line-1, city, county, eircode in the Overview tab
- [ ] Verify the icon disappears if the agent edits an address field manually after save (provenance gets stale via the existing equality check)
- [ ] Run a CSV import that contains a row matching an already-saved property → confirm it lands as a "duplicate" failure with amber border + "View existing" link in a new tab
- [ ] Tap "Create anyway" on the duplicate row → confirm it bypasses the check and inserts the property (yes, this creates a real duplicate — that's the intent)
- [ ] Tap "View existing →" on a duplicate → confirm new-tab navigation to the existing property's detail page
- [ ] Verify a CSV import where eircode is blank in both sides still treats them as duplicates


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_