### PR TITLE
feat(lettings): visual polish — truncation + percentage sizing + save idempotency (session 13b)

### DIFF
--- a/apps/unified-portal/app/agent/lettings/home/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/home/page.tsx
@@ -172,11 +172,11 @@ export default function LettingsHomePage() {
                         </svg>
                       )}
                     </div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate" style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12' }}>
                         {ev.label}: {ev.propertyAddress}
                       </div>
-                      <div style={{ fontSize: 12, color: '#6B7280', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginTop: 2 }}>
+                      <div className="truncate" style={{ fontSize: 12, color: '#6B7280', marginTop: 2 }}>
                         {ev.contextLine}
                       </div>
                     </div>

--- a/apps/unified-portal/app/agent/lettings/properties/[id]/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/[id]/page.tsx
@@ -868,7 +868,7 @@ function ComplianceTab({ property, activeTenancy, documents }: { property: Prope
     <div className="bg-white border border-[#E5E7EB] rounded-xl p-4 mb-4">
       <div className="flex items-baseline justify-between mb-2">
         <span className="text-[11px] font-semibold tracking-wider uppercase text-[#9EA8B5]">Compliance status</span>
-        <span className="text-xs font-medium text-[#0D0D12]">{property.completenessScore}%</span>
+        <span className="text-base font-semibold text-[#0D0D12]">{property.completenessScore}%</span>
       </div>
       {rows.map((r, i) => (
         <div key={r.label} className="flex items-center justify-between py-2.5" style={{ borderTop: i === 0 ? 'none' : '0.5px solid #F3F4F6' }}>

--- a/apps/unified-portal/app/agent/lettings/properties/new/review/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/new/review/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import AgentShell from '../../../../_components/AgentShell';
 
@@ -382,6 +382,10 @@ export default function ReviewPropertyPage() {
 
   const [openPopover, setOpenPopover] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Synchronous guard: the saving state flag flips on a render boundary, so
+  // a fast double-tap can fire two requests before React re-renders. The ref
+  // is set inline before any await and reliably blocks the second tap.
+  const savingRef = useRef(false);
 
   // Close any open popover on outside click. The trigger button stops
   // propagation so taps on it never reach this listener.
@@ -428,7 +432,8 @@ export default function ReviewPropertyPage() {
         : 'Save property';
 
   const handleSave = async () => {
-    if (saving || saveDisabled) return;
+    if (savingRef.current || saveDisabled) return;
+    savingRef.current = true;
     setSaving(true);
     setError(null);
 
@@ -488,6 +493,7 @@ export default function ReviewPropertyPage() {
         console.error('[review/save] failed:', message);
         setError(`Couldn't save: ${message}`);
         setSaving(false);
+        savingRef.current = false;
         return;
       }
       router.push(`/agent/lettings/properties/${json.propertyId}`);
@@ -496,6 +502,7 @@ export default function ReviewPropertyPage() {
       console.error('[review/save] error:', message);
       setError(`Couldn't save: ${message}`);
       setSaving(false);
+      savingRef.current = false;
     }
   };
 


### PR DESCRIPTION
## Summary

Three small visual + correctness fixes ahead of the mum-test.

**Fix 1: Home feed truncation** — the COMING UP feed event card was already structurally correct via inline-style truncation (`overflow: hidden + textOverflow: ellipsis + whiteSpace: nowrap`), but switched to the equivalent Tailwind `truncate` class to match the spec form and remove any inline-vs-class cascade ambiguity that could be biting on mobile WebViews. The middle column is also explicitly `flex-1 min-w-0` (Tailwind classes now, was inline).

**Fix 2: Compliance percentage sizing** — the COMPLIANCE STATUS row's percentage on the property detail page was `text-xs font-medium` (12px/500), too weak to function as a primary status reading. Bumped to `text-base font-semibold` (16px/600) so the eye reads the percentage as the primary signal and the eyebrow as the label.

**Fix 3: Save idempotency** — the review-screen save button only relied on the `saving` state flag for double-tap protection, but state updates flip on a render boundary. A fast double-tap could fire two requests before React re-renders, creating duplicate properties. Added a `useRef<boolean>` synchronous guard set inline at the top of `handleSave` (before any await) and reset on both error paths.

## Test plan

- [ ] Navigate to `/agent/lettings/home` on iPhone width — confirm long addresses on COMING UP cards render as `Lease ending: 14 Longview Park, Cork…` (truncated with ellipsis, no mid-word break)
- [ ] Property detail → Compliance tab → confirm the right-side percentage renders as 16px / weight 600 next to the small-caps "COMPLIANCE STATUS" label
- [ ] Double-tap the "Save property" button on the review screen — confirm exactly **one** property is created (check Supabase `agent_letting_properties` for duplicates)
- [ ] Trigger a save failure (e.g. unmap address-line-1) → confirm the savingRef resets and a second tap can retry after fixing the validation


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_