### PR TITLE
feat(lettings): post-mum-test polish — top bar overflow, Intelligence padding, vacancies headline, location filter (session 13c)

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -183,12 +183,13 @@ export default function StatusBar({
             (homeowner / care / developer / agent). The wordmark used to be
             decorative; it became the trigger when the agent-name slot was
             taken over by the workspace switcher in Session 3. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9, minWidth: 0, flex: '1 1 auto' }}>
           <span
             onClick={() => setShowSwitcher((prev) => !prev)}
             role="button"
             aria-label="Switch product"
             style={{
+              flexShrink: 0,
               background: 'linear-gradient(135deg, #B8960C, #E8C84A, #C4A020)',
               WebkitBackgroundClip: 'text',
               WebkitTextFillColor: 'transparent',
@@ -203,6 +204,7 @@ export default function StatusBar({
           </span>
           <span
             style={{
+              flexShrink: 0,
               width: 1,
               height: 8,
               background: 'rgba(0,0,0,0.12)',
@@ -219,6 +221,8 @@ export default function StatusBar({
                 alignItems: 'center',
                 gap: 6,
                 cursor: 'pointer',
+                minWidth: 0,
+                flex: '1 1 auto',
               }}
             >
               <span
@@ -227,16 +231,16 @@ export default function StatusBar({
                   fontSize: 11,
                   fontWeight: 500,
                   letterSpacing: '0.04em',
-                  maxWidth: 160,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
+                  minWidth: 0,
                 }}
               >
                 {activeWorkspace!.displayName}
               </span>
               <ModeBadge mode={activeWorkspace!.mode} />
-              <span style={{ color: '#A0A8B0', fontSize: 11, lineHeight: 1 }}>&#9662;</span>
+              <span style={{ color: '#A0A8B0', fontSize: 11, lineHeight: 1, flexShrink: 0 }}>&#9662;</span>
             </span>
           ) : (
             // Empty-state grace: agents without seeded workspace rows see a
@@ -260,7 +264,7 @@ export default function StatusBar({
             flex group fixes the off-centre chip seen in the wild
             (header was space-between with three children, which pushed
             the chip into the middle). */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
           {draftsReady && draftsCount > 0 ? (
             <button
               type="button"

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -676,6 +676,9 @@ function IntelligencePageInner() {
           height: '100%',
           minHeight: 0,
           position: 'relative',
+          // Session 13c: clear the protruding Intelligence FAB on iPhone PWAs
+          // where the input pill was visually clipped by the FAB's notch.
+          paddingBottom: 112,
         }}
       >
         {!hasMessages ? (

--- a/apps/unified-portal/app/agent/lettings/home/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/home/page.tsx
@@ -98,7 +98,7 @@ export default function LettingsHomePage() {
               </h1>
               {s && (
                 <p style={{ color: '#6B7280', fontSize: 14, margin: 0 }}>
-                  {s.totalProperties} {s.totalProperties === 1 ? 'property' : 'properties'} · €{s.monthlyRentRoll.toLocaleString()}/month rent roll
+                  {s.totalProperties} {s.totalProperties === 1 ? 'property' : 'properties'} · {s.tenantedCount} tenanted
                 </p>
               )}
             </>
@@ -115,10 +115,10 @@ export default function LettingsHomePage() {
           ) : (
             <>
               <Tile
-                icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17" /><polyline points="16 7 22 7 22 13" /></svg>}
-                label="MONTHLY RENT ROLL"
-                value={`€${s.monthlyRentRoll.toLocaleString()}`}
-                subtext={`${s.tenantedCount} of ${s.totalProperties} tenanted`}
+                icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>}
+                label="VACANCIES"
+                value={`${s.vacantCount} ${s.vacantCount === 1 ? 'vacancy' : 'vacancies'}`}
+                subtext={s.vacantCount === 0 ? 'All let — nice work' : s.vacantCount === 1 ? '1 to fill' : `${s.vacantCount} to fill`}
               />
               <Tile
                 icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" /><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" /><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" /><path d="M10 6h4" /><path d="M10 10h4" /><path d="M10 14h4" /></svg>}

--- a/apps/unified-portal/app/agent/lettings/properties/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/page.tsx
@@ -40,6 +40,7 @@ export default function LettingsPropertiesPage() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<Category>('all');
+  const [city, setCity] = useState<string>('all');
 
   useEffect(() => {
     let cancelled = false;
@@ -64,16 +65,26 @@ export default function LettingsPropertiesPage() {
     return c;
   }, [data]);
 
+  const cities = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of data?.properties ?? []) {
+      const c = (p.city ?? '').trim();
+      if (c) set.add(c);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [data]);
+
   const filtered = useMemo(() => {
     const list = data?.properties ?? [];
     const q = search.trim().toLowerCase();
     return list.filter((p) => {
       if (filter !== 'all' && categorise(p.status) !== filter) return false;
+      if (city !== 'all' && (p.city ?? '').trim() !== city) return false;
       if (!q) return true;
       const tenant = p.activeTenancy?.tenantName?.toLowerCase() ?? '';
       return p.address.toLowerCase().includes(q) || tenant.includes(q);
     });
-  }, [data, search, filter]);
+  }, [data, search, filter, city]);
 
   const totalCount = data?.totalCount ?? 0;
   const tenantedCount = data?.tenantedCount ?? 0;
@@ -120,9 +131,12 @@ export default function LettingsPropertiesPage() {
           ) : (
             <>
               {totalCount > 0 && (
-                <div className="bg-white rounded-xl p-3 mb-3 flex items-baseline gap-3 border border-[#E5E7EB]" style={{ borderLeft: '3px solid #D4AF37' }}>
-                  <div className="text-lg font-semibold text-[#0D0D12]">€{rentRoll.toLocaleString()}<span className="text-xs font-normal text-[#6B7280]">/month</span></div>
-                  <div className="text-xs text-[#6B7280] ml-auto">{tenantedCount} of {totalCount} tenanted</div>
+                <div className="bg-white rounded-xl p-3 mb-3 border border-[#E5E7EB]" style={{ borderLeft: '3px solid #D4AF37' }}>
+                  <div className="text-[10px] font-semibold tracking-wider uppercase text-[#9EA8B5] mb-0.5">Rent under management</div>
+                  <div className="flex items-baseline gap-3">
+                    <div className="text-base font-semibold text-[#0D0D12]">€{rentRoll.toLocaleString()}<span className="text-xs font-normal text-[#6B7280]">/month</span></div>
+                    <div className="text-xs text-[#6B7280] ml-auto">{tenantedCount} of {totalCount} tenanted</div>
+                  </div>
                 </div>
               )}
 
@@ -151,6 +165,18 @@ export default function LettingsPropertiesPage() {
                   );
                 })}
               </div>
+              {cities.length > 1 && (
+                <div className="flex gap-2 mb-3 overflow-x-auto -mx-4 px-4 pb-1 [&::-webkit-scrollbar]:hidden">
+                  {(['all', ...cities] as string[]).map((c) => {
+                    const selected = city === c;
+                    return (
+                      <button key={c} type="button" onClick={() => setCity(c)} className="flex-shrink-0 h-8 px-3 rounded-full text-[12px] font-medium border transition-colors" style={selected ? { background: '#D4AF37', color: '#0D0D12', borderColor: '#D4AF37' } : { background: '#fff', color: '#6B7280', borderColor: '#E5E7EB' }}>
+                        {c === 'all' ? 'All locations' : c}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
 
               {loading ? (
                 <>


### PR DESCRIPTION
## Summary

Four post-mum-test fixes from real iPhone testing.

**Fix 1 — Top bar overflow on iPhone**: the StatusBar header was `space-between` with two unconstrained clusters. The workspace label (e.g. "Hennessy & Co — Lettings") had a hard `maxWidth: 160` instead of dynamic min-width-0 truncation, and the right cluster (Drafts pill + bell) had no `flex-shrink: 0`, so on narrow viewports the right side got clipped past the screen edge. Fix: left cluster now `flex: 1 1 auto, minWidth: 0`, the workspace switcher span uses dynamic `minWidth: 0` (no fixed maxWidth), the OPENHOUSE wordmark + divider + ModeBadge + chevron are explicitly `flex-shrink: 0`, and the right cluster is `flex-shrink: 0`. Tested mentally at 320 / 390 / 430px viewports.

**Fix 2 — Intelligence input behind FAB**: added `paddingBottom: 112` on the Intelligence page's column container so the VoiceInputBar sits above the protruding Intelligence FAB. Trusting your empirical pb-28 number — there's likely an iOS PWA-Capacitor quirk that makes the visible overlap larger than my code-reading suggests.

**Fix 3a — Demote rent roll, replace home headline**: lettings home page now leads with **VACANCIES** instead of MONTHLY RENT ROLL. Tile shows AlertCircle icon (gold), value `{N} vacancies` with proper singular/plural, subtext branches: 0 → "All let — nice work", 1 → "1 to fill", N → "N to fill". Greeting subtitle drops the rent roll and reads `"{N} properties · {tenanted} tenanted"`.

**Fix 3b — Properties banner reframe**: the rent banner stays but reframes — small caps `RENT UNDER MANAGEMENT` eyebrow on top, then `€{n}/month` at 16px (was 18px) on the same line as the existing `{tenanted} of {total} tenanted` subtext. Same gold left border.

**Fix 4 — Location filter**: added `cities` useMemo (deduped, sorted, drops null/empty) and a second pill row below the status pills, only rendered if `cities.length > 1`. State: `city` (default `'all'`), filters compose AND with status + search. For Orla's Cork-spread portfolio (Cork city, Ballincollig, Carrigaline, Glanmire, Mayfield, Midleton, Rochestown), the row has 8 pills (All locations + 7 cities). For an agent with one-city stock, the row hides itself.

## Notes

- **Intelligence page location**: found at `apps/unified-portal/app/agent/intelligence/page.tsx` — your guess was correct. The VoiceInputBar is at `apps/unified-portal/app/agent/_components/VoiceInputBar.tsx` and renders inline (not fixed-positioned), so the page-level padding fix is the right shape.

## Test plan

- [ ] Test on iPhone SE (320px), iPhone 13 (390px), iPhone Pro Max (430px) — confirm Drafts pill + bell are fully visible at all three widths
- [ ] Tap into Intelligence → confirm "Ask Intelligence anything…" pill is fully visible above the FAB and tappable without occlusion
- [ ] Lettings home → confirm greeting reads `"{N} properties · {N} tenanted"` (no rent roll mention) and the first stat tile is VACANCIES with the correct singular/plural
- [ ] Properties tab → confirm banner reads `"RENT UNDER MANAGEMENT" / "€{n}/month" / "{N} of {N} tenanted"` with smaller weight than before
- [ ] Properties tab with 2+ distinct cities → confirm location pill row appears below status pills, defaults to "All locations", filtering composes with status + search correctly
- [ ] Properties tab with single-city stock → confirm location pill row is hidden


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_