### PR TITLE
fix(intelligence): anchor input bar above FAB

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -874,20 +874,34 @@ function IntelligencePageInner() {
           </div>
         )}
 
-        <VoiceInputBar
-          ref={inputElRef}
-          input={input}
-          onInputChange={setInput}
-          onSend={() => handleSend(input)}
-          isTyping={isTyping}
-          voice={voice}
-          onStart={() => voice.start()}
-          onStop={() => voice.stop()}
-          isDesktop={isDesktop}
-          onOpenSettings={voice.openSettings}
-          onFocus={() => setInputFocused(true)}
-          onBlur={() => setInputFocused(false)}
-        />
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 88,
+            left: 0,
+            right: 0,
+            padding: '0 16px',
+            zIndex: 30,
+            pointerEvents: 'none',
+          }}
+        >
+          <div style={{ pointerEvents: 'auto' }}>
+            <VoiceInputBar
+              ref={inputElRef}
+              input={input}
+              onInputChange={setInput}
+              onSend={() => handleSend(input)}
+              isTyping={isTyping}
+              voice={voice}
+              onStart={() => voice.start()}
+              onStop={() => voice.stop()}
+              isDesktop={isDesktop}
+              onOpenSettings={voice.openSettings}
+              onFocus={() => setInputFocused(true)}
+              onBlur={() => setInputFocused(false)}
+            />
+          </div>
+        </div>
 
         {undoBatch && (
           <UndoPill


### PR DESCRIPTION
## Summary

The pb-28 page padding from 13c pushed page content up but VoiceInputBar still flowed inline with that content, so it was floating mid-page on iPhone instead of sitting just above the FAB. Wrapping it in a fixed-position container anchors it to the bottom of the viewport, with `bottom: 88` to clear the BottomNav (~64px) plus FAB protrusion (~20px). The wrapper has `pointerEvents: 'none'` so the gap between the input pill and the BottomNav is click-through; the inner div re-enables `pointerEvents: 'auto'` so the input itself remains tappable. The page's existing pb-28 stays — it's what keeps the last chat bubble from sliding underneath the now-fixed input.

## Test plan

- [ ] Open Intelligence on iPhone (390×844) — confirm the input pill is anchored at bottom, just above the FAB
- [ ] Tap into the input — focus lands on the input, not the FAB underneath
- [ ] Send several messages so chat overflows — confirm bubbles scroll behind the pill cleanly
- [ ] Tap the FAB through the wrapper gap — confirm the tap reaches the FAB (pointerEvents passthrough working)
- [ ] Verify on desktop that the input is still positioned correctly (fixed-position should be fine at all viewports)


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_