### PR TITLE
feat(intelligence): lettings-aware brain — mode dispatch, portfolio context, lettings system prompt

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -108,7 +108,7 @@ export default function IntelligencePage() {
 }
 
 function IntelligencePageInner() {
-  const { agent, alerts, developmentIds } = useAgent();
+  const { agent, alerts, developmentIds, activeWorkspace } = useAgent();
   const { openApprovalDrawer } = useApprovalDrawer();
   const { count: pendingDraftsCount, ready: draftsReady } = useDraftsCount();
   const searchParams = useSearchParams();
@@ -187,6 +187,7 @@ function IntelligencePageInner() {
           history,
           sessionId,
           activeDevelopmentId: developmentIds?.[0] || null,
+          mode: activeWorkspace?.mode ?? 'sales',
         }),
       });
 

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -19,7 +19,7 @@ import {
 } from '@/lib/agent-intelligence/context';
 import { resolveAgentContext } from '@/lib/agent-intelligence/agent-context';
 import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
-import { buildAgentSystemPrompt, buildLiveContext, type LiveContextBlocks } from '@/lib/agent-intelligence/system-prompt';
+import { buildAgentSystemPrompt, buildLettingsAgentSystemPrompt, buildLiveContext, buildLettingsLiveContext, type LiveContextBlocks } from '@/lib/agent-intelligence/system-prompt';
 import { getToolDefinitionsForOpenAI, getToolByName } from '@/lib/agent-intelligence/tools/registry';
 import type { AgentContext } from '@/lib/agent-intelligence/types';
 import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
@@ -33,7 +33,8 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { message, history, sessionId, activeDevelopmentId } = body;
+    const { message, history, sessionId, activeDevelopmentId, mode } = body;
+    const resolvedMode: 'sales' | 'lettings' = mode === 'lettings' ? 'lettings' : 'sales';
 
     if (!message || typeof message !== 'string') {
       return new Response(JSON.stringify({ error: 'Message is required' }), {
@@ -164,7 +165,9 @@ export async function POST(request: NextRequest) {
       lettings,
       weekViewings,
     };
-    const liveContext = buildLiveContext(liveContextBlocks);
+    const liveContext = resolvedMode === 'lettings'
+      ? buildLettingsLiveContext(liveContextBlocks)
+      : buildLiveContext(liveContextBlocks);
 
     // 2b. Load independent agent context if applicable
     let independentContext = '';
@@ -173,8 +176,13 @@ export async function POST(request: NextRequest) {
       independentContext = await buildIndependentAgentContext(supabase, agentContext.agentProfileId);
     }
 
-    // 3. Build system prompt
-    const systemPrompt = buildAgentSystemPrompt(
+    // 3. Build system prompt — branch on workspace mode. Lettings mode swaps
+    // the sales TOOL-USE MANDATE / scheme/unit/buyer vocabulary for a
+    // tenant/property/lease one and reads from the LETTINGS PORTFOLIO block.
+    const promptBuilder = resolvedMode === 'lettings'
+      ? buildLettingsAgentSystemPrompt
+      : buildAgentSystemPrompt;
+    const systemPrompt = promptBuilder(
       agentContext,
       recentActivity,
       upcomingDeadlines,
@@ -611,7 +619,7 @@ export async function POST(request: NextRequest) {
           storeConversationMemory(supabase, agentContext, currentSessionId, message, fullContent, toolsCalled).catch(() => {});
           logInteraction(supabase, tenantId, authUserId, message, fullContent, toolsCalled, startTime, {
             hallucinatedDrafts: claimsDrafts && totalDraftsPersisted === 0,
-          }).catch(() => {});
+          }, resolvedMode).catch(() => {});
 
           // Generate follow-up suggestions (non-blocking, appended after main response)
           // Skip when we fired the Session 14 yes/no short-circuit — the
@@ -1036,9 +1044,11 @@ async function logInteraction(
   responseText: string,
   toolsCalled: Array<{ tool_name: string; params: any; result_summary: string }>,
   startTime: number,
-  flags: { hallucinatedDrafts?: boolean } = {}
+  flags: { hallucinatedDrafts?: boolean } = {},
+  mode: 'sales' | 'lettings' = 'sales'
 ) {
   const latencyMs = Date.now() - startTime;
+  const skinTag = mode === 'lettings' ? 'agent_lettings' : 'agent';
 
   // Detect knowledge gaps (responses indicating missing data)
   const isKnowledgeGap = responseText.toLowerCase().includes('i don\'t have that data') ||
@@ -1057,7 +1067,7 @@ async function logInteraction(
     tenant_id: tenantId,
     user_id: userId,
     user_role: 'agent',
-    skin: 'agent',
+    skin: skinTag,
     query_text: queryText,
     tools_called: toolsCalled,
     response_text: responseText.slice(0, 10000),
@@ -1071,7 +1081,7 @@ async function logInteraction(
     await supabase.from('intelligence_knowledge_gaps').insert({
       tenant_id: tenantId,
       query_text: queryText,
-      skin: 'agent',
+      skin: skinTag,
       user_role: 'agent',
       context: { tools_called: toolsCalled.map(t => t.tool_name) },
     });

--- a/apps/unified-portal/lib/agent-intelligence/context.ts
+++ b/apps/unified-portal/lib/agent-intelligence/context.ts
@@ -41,6 +41,14 @@ export interface LettingsSummary {
     city: string | null;
     status: string;
     rent: number | null;
+    activeTenant: {
+      tenancyId: string;
+      name: string;
+      email: string | null;
+      phone: string | null;
+      leaseEnd: string | null;
+      rtbRegistered: boolean;
+    } | null;
   }>;
 }
 
@@ -428,7 +436,7 @@ export async function getLettingsSummary(
 
   const { data: tenancies } = await supabase
     .from('agent_tenancies')
-    .select('id, agent_id, letting_property_id, status, rent_pcm')
+    .select('id, agent_id, letting_property_id, status, rent_pcm, tenant_name, tenant_email, tenant_phone, lease_end, rtb_registered')
     .eq('agent_id', agentId)
     .eq('status', 'active');
 
@@ -437,6 +445,22 @@ export async function getLettingsSummary(
     const rent = Number(t.rent_pcm ?? 0);
     return sum + (Number.isFinite(rent) ? rent : 0);
   }, 0);
+
+  // Build a map keyed by letting_property_id so we can attach the active
+  // tenant inline without an N+1 query. There's at most one active tenancy
+  // per property (partial unique index on agent_tenancies).
+  const tenantByProperty = new Map<string, NonNullable<LettingsSummary['properties'][number]['activeTenant']>>();
+  for (const t of (tenancies ?? []) as any[]) {
+    if (!t.letting_property_id || !t.tenant_name) continue;
+    tenantByProperty.set(t.letting_property_id, {
+      tenancyId: t.id,
+      name: t.tenant_name,
+      email: t.tenant_email ?? null,
+      phone: t.tenant_phone ?? null,
+      leaseEnd: t.lease_end ?? null,
+      rtbRegistered: !!t.rtb_registered,
+    });
+  }
 
   return {
     total,
@@ -450,6 +474,7 @@ export async function getLettingsSummary(
       city: p.city ?? null,
       status: p.status ?? 'unknown',
       rent: Number(p.rent_pcm ?? 0) || null,
+      activeTenant: tenantByProperty.get(p.id) ?? null,
     })),
   };
 }

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -132,6 +132,56 @@ function renderLettingsSummary(l: LettingsSummary | null): string {
   return `LETTINGS SUMMARY:\n- Total properties: ${l.total} (let: ${l.let}, vacant: ${l.vacant})\n- Active tenancies: ${l.activeTenancies}\n- Monthly rent roll: ${fmtEuro(l.monthlyRentRoll)}\n- Properties:\n${addressSample}${more}`;
 }
 
+// Render the LETTINGS PORTFOLIO block at the top of the live context for
+// lettings-mode prompts. One line per property with tenant + rent + lease end
+// when a tenancy is active; "VACANT" otherwise. Capped at 30 lines.
+function renderLettingsPortfolio(l: LettingsSummary | null): string {
+  if (!l || !l.total) return 'LETTINGS PORTFOLIO:\n- (no properties yet)';
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const lines = l.properties.slice(0, 30).map((p) => {
+    const cityPart = p.city ? `, ${p.city}` : '';
+    if (p.activeTenant) {
+      const t = p.activeTenant;
+      const rentPart = p.rent ? `${fmtEuro(p.rent)}/m` : '€—/m';
+      let leasePart = '';
+      if (t.leaseEnd) {
+        const end = new Date(t.leaseEnd);
+        const days = Math.round((end.getTime() - today.getTime()) / 86_400_000);
+        const daysPart = Number.isFinite(days)
+          ? days < 0 ? `${Math.abs(days)}d ago` : days === 0 ? 'today' : `${days}d`
+          : '';
+        leasePart = `, lease ends ${fmtDate(t.leaseEnd)}${daysPart ? ` (${daysPart})` : ''}`;
+      }
+      return `- ${p.address}${cityPart} — ${t.name} (${rentPart}${leasePart})`;
+    }
+    return `- ${p.address}${cityPart} — VACANT`;
+  });
+  const more = l.properties.length > 30 ? `\n- (+${l.properties.length - 30} more)` : '';
+  const header = `LETTINGS PORTFOLIO (${l.total} properties, ${l.activeTenancies} active tenancies, ${fmtEuro(l.monthlyRentRoll)}/m rent under management):`;
+  return `${header}\n${lines.join('\n')}${more}`;
+}
+
+// Lettings-mode live context: lead with the portfolio block (so the model
+// can resolve tenants ↔ addresses without asking), then keep the same
+// renewal-window / rent-arrears / agent-identity blocks the sales prompt
+// uses (those loaders are mode-agnostic).
+export function buildLettingsLiveContext(blocks: LiveContextBlocks): string {
+  const portfolio = renderLettingsPortfolio(blocks.lettings);
+  const identity = renderAgentIdentity(blocks.agentExtras);
+  const renewals = renderRenewalWindow(blocks.renewalWindow);
+  const arrears = renderRentArrears(blocks.rentArrears);
+  let combined = [portfolio, identity, renewals, arrears].join('\n\n');
+  if (estimateTokens(combined) > CONTEXT_TOKEN_BUDGET) {
+    // Drop arrears first, then renewals, to stay under budget.
+    combined = [portfolio, identity, renewals].join('\n\n');
+    if (estimateTokens(combined) > CONTEXT_TOKEN_BUDGET) {
+      combined = [portfolio, identity].join('\n\n');
+    }
+  }
+  return combined;
+}
+
 function renderWeekViewings(rows: ViewingRow[]): string {
   if (!rows.length) return 'UPCOMING 7-DAY VIEWINGS:\n- None.';
   const lines = rows.slice(0, 10).map(v => {
@@ -471,6 +521,156 @@ PROACTIVE INTELLIGENCE:
 ============================================================
 - Flag related issues the agent might not have thought of, but only when supported by the live context or a tool result.
 - Call out RPZ implications on renewals, upcoming lease ends inside the 90-day notice window, and contracts approaching the 42-day threshold.
+- Never invent patterns or communication history.`;
+
+  return `${identityBlock}\n\n${scopeBlock}\n\n${basePrompt}`;
+}
+
+// Lettings-mode system prompt. Same arity as buildAgentSystemPrompt but the
+// body is rebuilt from scratch for letting agents — drops the sales
+// TOOL-USE MANDATE, sales vocabulary (schemes/units/buyers/pipeline), and
+// the assigned-schemes scope block. The lettings live context (portfolio,
+// renewal window, arrears) is the source of truth for property/tenant data.
+export function buildLettingsAgentSystemPrompt(
+  agentContext: AgentContext,
+  recentActivitySummary: string,
+  upcomingDeadlines: string,
+  previousEntityContext: string,
+  ragResults: string,
+  independentContext?: string,
+  viewingsSummary?: string,
+  liveContext?: string,
+): string {
+  const identityBlock = `You are OpenHouse Intelligence, the AI operations assistant for letting agents in Ireland.
+
+You behave like a sharp colleague — you give answers, not questions. You draft, you never send. You reference specific properties, tenants, dates, and rents with precision. Every message or action requires the agent's explicit approval before it executes.
+
+You know Irish lettings practice: Residential Tenancies Board (RTB) registration and the 2021 reforms, Rent Pressure Zones (RPZ) — most of Cork City is in an RPZ where rent increases are capped at 2% annually, deposit protection schemes, Part 4 tenancies, the 90-day minimum notice period for lease end, BER requirements on listings, and standard maintenance protocols for landlord obligations.
+
+When you answer, cite specific records (e.g. "7 Lapps Quay, tenant Aisling Moran, lease ends 1 May — 2 days away"). Never speculate on financial or legal outcomes. Defer to the agent for judgement calls.
+
+Follow-up chips suggest ACTIONS ("Draft message to Aisling about plumber visit"), not clarifying questions.`;
+
+  const scopeBlock = `Current agent context:
+- Name: ${agentContext.displayName}
+- Workspace: Lettings
+
+The properties and tenants you can reference are listed in the LETTINGS PORTFOLIO block in the LIVE CONTEXT below. When the user mentions a tenant name without a property, look up the property from that block. When they mention an address, look up the tenant the same way. If a name or address isn't in the block, say so plainly — do not invent records.`;
+
+  const basePrompt = `You are not a generic chatbot. You are a specialist lettings operations assistant with deep knowledge of the Irish residential rental market, the RTB framework, tenant relationships, and the day-to-day reality of running a portfolio of let properties. You exist to make the letting agent faster, better informed, and more effective at their job.
+
+============================================================
+VOCABULARY — LETTINGS MODE:
+============================================================
+You use these terms:
+- "property" (not "scheme" or "unit")
+- "tenant" (not "buyer", "applicant", or "purchaser")
+- "lease" (not "contract")
+- "rent" / "rent roll" / "monthly rent"
+- "maintenance ticket" / "callout" (not "issue" or "task")
+- "lease end" / "renewal" (not "closing" or "completion")
+- "RTB" is Ireland's Residential Tenancies Board.
+
+You DO NOT mention: schemes, units, developers, buyers, contracts, pipeline, completions, snagging, kitchen selections. Those are sales-side concepts that don't apply here. If a user query in lettings mode names something that sounds like a scheme/unit, treat it as an address or tenant name and look it up in the LETTINGS PORTFOLIO.
+
+============================================================
+COMMON INTENTS — what to do when you see these patterns:
+============================================================
+- "Ask {tenant} when {time/date} suits for {action}" OR
+  "message {tenant} about {issue}" OR
+  "draft a note to {tenant} for {reason}"
+  → Resolve {tenant} to a property and tenancy from the LETTINGS PORTFOLIO. Generate a draft message to the tenant via the existing draft tools. Never just ask the user to clarify which property — the portfolio block has the answer.
+
+- "Send a plumber/electrician/contractor to {property|tenant}"
+  → This is a coordination intent. Two outputs:
+    (a) Draft a message to the tenant asking what time suits.
+    (b) Note for the agent: "After the tenant confirms, log this as a maintenance ticket against {address}."
+
+- "When does {tenant}'s lease end?" OR "How long left on {tenant}'s lease?"
+  → Look up directly in LETTINGS PORTFOLIO. Cite the date and days remaining.
+
+- "What rent are we getting for {address}?"
+  → Look up directly. Cite the monthly rent and tenant name.
+
+- "Is {address} compliant?" OR "What's outstanding for {address}?"
+  → Surface compliance gaps from the property's record (BER cert, gas safety cert, electrical cert, RTB registration, signed lease) using the LETTINGS PORTFOLIO data.
+
+============================================================
+TOOL USE — LETTINGS MODE:
+============================================================
+You may call the draft and message tools the platform already provides (draft_message, draft_buyer_followups when used for a tenant, etc.). The sales-side read tools (get_unit_status, get_scheme_overview, get_buyer_details, get_outstanding_items, get_candidate_units, etc.) do NOT apply here — the data lives in agent_letting_properties and agent_tenancies, which is already loaded into your live context. Read from the LETTINGS PORTFOLIO block above; do not attempt to call the sales read tools.
+
+When the user asks you to draft, write, send, follow up with, chase, or message a tenant — ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent — nothing leaves the system until the agent explicitly approves.
+
+Your text reply after a draft tool fires is a ONE-SENTENCE summary only. Do NOT paste the message body inline. The drawer renders the draft visually.
+
+============================================================
+ABSOLUTE RULES — NEVER VIOLATE:
+============================================================
+1. NEVER state that a communication happened (call, email, message, meeting) unless you retrieved it from the system in THIS conversation. If no tool returned communication data, say "No recent contact logged in the system."
+2. NEVER invent dates, calls, emails, or meetings. Every factual claim must trace to data in the live context or a tool result.
+3. If the live context or a tool returns no data, say so clearly. Do NOT fill the gap with assumed information.
+4. NEVER fabricate tenant names, addresses, dates, or rents. If it's not in the portfolio, you don't know it.
+5. NEVER refuse a draft request from the assigned-portfolio list. If a name doesn't match exactly, the draft tool's resolver handles fuzzy matches and aliases.
+
+============================================================
+RESPONSE STYLE:
+============================================================
+- Lead with the answer. Never lead with a preamble or pleasantry.
+- If the agent asks you to do something (draft a message, log a ticket), DO IT immediately by calling the appropriate tool.
+- State facts directly. "Aisling Moran's lease at 7 Lapps Quay ends 1 May — 2 days away." Not "It appears that…"
+- Be the confident expert. Uncertainty only when the data genuinely isn't available.
+- Never use these phrases: "I can help with that", "Would you like me to", "I'd be happy to", "Feel free to", "Don't hesitate to", "That's a great question".
+- Keep responses concise. The agent is reading on a phone between viewings.
+- Use natural, conversational Irish English.
+- Never use hashtags, asterisks, or markdown headers.
+- If you don't have the information, say: "I don't have that data in the system."
+
+============================================================
+IRISH LETTINGS PRACTICE CHEAT SHEET:
+============================================================
+- RTB registration: required for all residential tenancies. Re-register annually.
+- Rent Pressure Zones: most of Cork City and suburbs (Ballincollig, Bishopstown, Douglas, Rochestown, Glanmire, Ballyvolane, Mayfield) are RPZ. Rent increases capped at 2% per annum. Midleton is NOT RPZ.
+- Part 4 tenancies: security of tenure after 6 months, up to 6 years.
+- Notice periods on lease end: 90 days minimum for tenancies over 6 months.
+- Deposit protection and BER on listing are mandatory.
+- Maintenance: landlord is responsible for structural, plumbing, heating, and appliance issues unless tenant-caused. Document callouts as maintenance tickets.
+- Never give legal or financial advice — defer to solicitor / adviser.
+
+============================================================
+LIVE CONTEXT (generated per request — treat as ground truth for THIS turn):
+============================================================
+${liveContext || '(no live context available)'}
+
+RECENT ACTIVITY (last 7 days):
+${recentActivitySummary || 'No recent activity data available.'}
+
+UPCOMING DEADLINES (next 14 days):
+${upcomingDeadlines || 'No upcoming deadlines found.'}
+
+${previousEntityContext ? `PREVIOUS CONTEXT (background only — from prior conversations):
+${previousEntityContext}
+IMPORTANT: The above is background context ONLY. Do NOT reference names, events, or details from previous conversations unless the agent's current message specifically asks about those entities.` : ''}
+
+${ragResults ? `DOCUMENT RESULTS:\n${ragResults}` : ''}
+
+${independentContext || ''}
+
+${viewingsSummary ? `LETTINGS VIEWINGS:\n${viewingsSummary}` : ''}
+
+============================================================
+FOLLOW-UP SUGGESTIONS:
+============================================================
+After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
+- After a draft to a tenant: "Send the draft now", "Edit the message", "Log maintenance ticket"
+- After a lease lookup: "Draft renewal offer", "Schedule check-in", "Show all leases ending in 30 days"
+- After a compliance gap: "Upload BER cert", "Mark RTB registered", "View property record"
+
+============================================================
+PROACTIVE INTELLIGENCE:
+============================================================
+- Flag related issues the agent might not have thought of, but only when supported by the live context.
+- Call out RPZ implications on renewals (2% cap), upcoming lease ends inside the 90-day notice window, and missing RTB registrations on active tenancies.
 - Never invent patterns or communication history.`;
 
   return `${identityBlock}\n\n${scopeBlock}\n\n${basePrompt}`;


### PR DESCRIPTION
## Summary

Real letting agent (mum-test) asked Intelligence: "Can you ask Aisling Moran what time suits her for me to send a plumber to fix the shower?" Intelligence replied with a sales-baked refusal listing schemes. Three things broke at once: (1) the system prompt is sales-baked with a hard-coded TOOL-USE MANDATE built around `get_unit_status` / `get_scheme_overview`, (2) lettings data is loaded but the model never sees the tenant↔property connection because the lettings block lists addresses without tenants, (3) there's no mode signal in the chat request.

Fix end-to-end:

**A. Client** (`app/agent/intelligence/page.tsx`): pulls `activeWorkspace` from `useAgent()`, sends `mode: activeWorkspace?.mode ?? 'sales'` in the chat fetch body.

**B. Route** (`app/api/agent-intelligence/chat/route.ts`): parses `mode` from body, computes `resolvedMode: 'sales' | 'lettings'`, dispatches to `buildLettingsAgentSystemPrompt` (new) when lettings, otherwise `buildAgentSystemPrompt` (unchanged). The live-context builder also branches: lettings mode uses `buildLettingsLiveContext` which leads with the LETTINGS PORTFOLIO block. `logInteraction` accepts a `mode` param and tags `intelligence_interactions.skin = 'agent_lettings'` (vs `'agent'` for sales) — so the path served can be diagnosed via the analytics table.

**C. System prompt** (`lib/agent-intelligence/system-prompt.ts`): two new exports.
- `buildLettingsAgentSystemPrompt(...)` — same arity as the sales builder. Drops the entire sales TOOL-USE MANDATE, sales vocabulary (schemes/units/buyers/pipeline/contracts), and the assigned-schemes scope block. Replaces with: lettings identity, explicit vocabulary callout (property/tenant/lease/RTB), a COMMON INTENTS section that maps "ask {tenant} about {issue}" → resolve from portfolio + draft message, and a TOOL USE block that explicitly tells the model NOT to call sales read tools (the data is already in the live context).
- `buildLettingsLiveContext(...)` — leads with `renderLettingsPortfolio` (the new property+tenant+lease lines), then keeps agent identity, renewal window, rent arrears. Truncates at the 2000-token budget.
- `renderLettingsPortfolio(l)` — outputs `LETTINGS PORTFOLIO (N properties, X active tenancies, €Y/m): - {address}, {city} — {tenant} (€{rent}/m, lease ends {date} ({Nd}))` per row, capped at 30 lines.

**D. Live context** (`lib/agent-intelligence/context.ts`): `getLettingsSummary` now also fetches `tenant_name`, `tenant_email`, `tenant_phone`, `lease_end`, `rtb_registered` from the active tenancies query (one extra column list, same `.in()` style). Builds a `Map<letting_property_id, activeTenant>` and attaches it to each property in the response. The `LettingsSummary` type extends with the new `activeTenant` field.

The sales path is **untouched in behaviour** — `buildAgentSystemPrompt` is unchanged, `buildLiveContext` is unchanged, the route's default mode is `'sales'` so requests without a mode field land on the existing sales path.

## Acceptance test

After deploy: log in as `agent-test@test.ie`, switch to Lettings, ask:
> "Can you ask Aisling Moran what time suits her for me to send a plumber to fix the shower?"

The model now sees `LETTINGS PORTFOLIO` at the top of its live context with `7 Lapps Quay, Cork — Aisling Moran (€1,850/m, lease ends 1 May (2d))`. The COMMON INTENTS block maps "ask {tenant} when {time} suits for {action}" directly to "resolve from portfolio + call draft tool". The sales TOOL-USE MANDATE that previously triggered "I couldn't find a scheme matching 'Lapps Quay'" is no longer in the prompt at all.

Expected response shape:

> Here's a draft to Aisling Moran at 7 Lapps Quay:
> Hi Aisling, I'm arranging for a plumber to come fix the shower at 7 Lapps Quay. Could you let me know what time would suit you over the next few days? I'll confirm with the plumber once you reply. Thanks, Orla — Hennessy & Co Property
> After Aisling replies, log this as a maintenance ticket against 7 Lapps Quay so we have a record.

Plus follow-up chips: "Send the draft now", "Edit the message", "Log maintenance ticket for shower repair".

NOT acceptable: any reference to "schemes", "units", "buyers", "pipeline"; any "I couldn't find a scheme..." refusal; any clarifying-question that asks the agent to specify which property.

## Test plan

- [ ] Log in as the test agent, switch to Lettings workspace, navigate to Intelligence
- [ ] Run the exact mum-test query above — confirm the model resolves Aisling Moran → 7 Lapps Quay from the portfolio block, drafts a tenant message, and suggests action chips (not clarifying questions)
- [ ] Switch to Sales workspace and ask "What's the status of Unit 3 in Árdan View?" — confirm the sales TOOL-USE MANDATE still fires `get_unit_status` (no regression on the sales path)
- [ ] Check Supabase `intelligence_interactions` after both queries — confirm one row has `skin = 'agent_lettings'` and the other has `skin = 'agent'`
- [ ] Try a tenant-name query that doesn't exist in the portfolio — confirm the model says "I don't have that data in the system" rather than inventing
- [ ] Try "When does Aisling's lease end?" in lettings mode — confirm a direct, cited answer with days remaining


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_