### PR TITLE
feat(intelligence): lettings empty-state chips + streaming progress narration (session 14a)

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -56,6 +56,9 @@ interface Message {
   followups?: string[];
   toolsUsed?: Array<{ name: string; summary: string }>;
   voice?: VoiceActionsPayload;
+  // Session 14a — server-emitted progress narration. Set when a 'progress'
+  // SSE frame arrives, cleared on the first non-empty token/override.
+  progress?: { stage: string; label: string };
 }
 
 interface UndoBatch {
@@ -150,11 +153,11 @@ function IntelligencePageInner() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const chips = await fetchCapabilityChips();
+      const chips = await fetchCapabilityChips(activeWorkspace?.mode);
       if (!cancelled) setLiveChips(chips);
     })();
     return () => { cancelled = true; };
-  }, []);
+  }, [activeWorkspace?.mode]);
 
   // Handle prefilled prompt from URL
   useEffect(() => {
@@ -220,19 +223,52 @@ function IntelligencePageInner() {
             if (data.type === 'token') {
               fullContent += data.content;
 
-              // Add or update the streaming message in real time
+              // Add or update the streaming message in real time. The first
+              // token clears any progress narration via `progress: undefined`.
               if (!streamingStarted) {
                 streamingStarted = true;
-                setMessages(prev => [...prev, {
-                  id: streamingMsgId,
-                  role: 'assistant',
-                  content: fullContent,
-                }]);
+                setMessages(prev => {
+                  const existing = prev.find(m => m.id === streamingMsgId);
+                  if (existing) {
+                    return prev.map(m =>
+                      m.id === streamingMsgId
+                        ? { ...m, content: fullContent, progress: undefined }
+                        : m
+                    );
+                  }
+                  return [...prev, {
+                    id: streamingMsgId,
+                    role: 'assistant',
+                    content: fullContent,
+                  }];
+                });
               } else {
                 setMessages(prev => prev.map(m =>
                   m.id === streamingMsgId ? { ...m, content: fullContent } : m
                 ));
               }
+            } else if (data.type === 'progress') {
+              // Session 14a — server-emitted narration ("Reading your
+              // portfolio", "Drafting message", etc). Renders a
+              // ProgressCard until the first token arrives.
+              const stage = typeof data.stage === 'string' ? data.stage : 'thinking';
+              const label = typeof data.label === 'string' ? data.label : 'Working on it';
+              setMessages(prev => {
+                const existing = prev.find(m => m.id === streamingMsgId);
+                if (existing) {
+                  return prev.map(m =>
+                    m.id === streamingMsgId
+                      ? { ...m, progress: { stage, label } }
+                      : m
+                  );
+                }
+                return [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: '',
+                  progress: { stage, label },
+                }];
+              });
             } else if (data.type === 'followups') {
               followups = data.questions || [];
             } else if (data.type === 'tools_used') {
@@ -245,19 +281,31 @@ function IntelligencePageInner() {
             } else if (data.type === 'override') {
               // Server detected the model hallucinated drafts. Replace
               // whatever tokens have streamed so far with the honest
-              // failure message.
+              // failure message. Also clears progress narration.
               fullContent = typeof data.content === 'string' ? data.content : fullContent;
               if (streamingStarted) {
                 setMessages(prev => prev.map(m =>
-                  m.id === streamingMsgId ? { ...m, content: fullContent } : m
+                  m.id === streamingMsgId
+                    ? { ...m, content: fullContent, progress: undefined }
+                    : m
                 ));
               } else {
                 streamingStarted = true;
-                setMessages(prev => [...prev, {
-                  id: streamingMsgId,
-                  role: 'assistant',
-                  content: fullContent,
-                }]);
+                setMessages(prev => {
+                  const existing = prev.find(m => m.id === streamingMsgId);
+                  if (existing) {
+                    return prev.map(m =>
+                      m.id === streamingMsgId
+                        ? { ...m, content: fullContent, progress: undefined }
+                        : m
+                    );
+                  }
+                  return [...prev, {
+                    id: streamingMsgId,
+                    role: 'assistant',
+                    content: fullContent,
+                  }];
+                });
               }
             } else if (data.type === 'done') {
               newSessionId = data.sessionId || sessionId;
@@ -861,6 +909,13 @@ function IntelligencePageInner() {
                   />
                 );
               }
+              // Session 14a — render the ProgressCard while the server is
+              // still narrating. Once the first token arrives the route
+              // clears msg.progress, this branch falls through, and the
+              // normal AIResponseCard renders the streaming content.
+              if (msg.progress && !msg.content) {
+                return <ProgressCard key={msg.id} progress={msg.progress} />;
+              }
               return (
                 <AIResponseCard
                   key={msg.id}
@@ -1048,6 +1103,126 @@ function UserBubble({ text }: { text: string }) {
         </p>
       </div>
     </div>
+  );
+}
+
+// Session 14a — ProgressCard. Shown while the chat route is doing its
+// pre-stream work (loading context, executing tool calls, opening the
+// final OpenAI stream). The route emits {type:'progress', stage, label}
+// events at four milestones; this card renders the latest label with a
+// pulsing OH logo, gold-shimmer text, and a trailing dots animation.
+//
+// The card is replaced by AIResponseCard the moment the first token
+// arrives — the streaming reader clears `msg.progress`, so the render
+// branch in the messages map falls through naturally. No imperative
+// teardown / no race window: state-driven swap.
+function ProgressCard({ progress }: { progress: { stage: string; label: string } }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      {/* Keyframes injected once with the card. Three named animations
+          (oh-shimmer, oh-dot, oh-progress-pulse) loop until the
+          ProgressCard is unmounted by the first-token state swap. */}
+      <style>{`
+        @keyframes oh-shimmer {
+          0% { background-position: 200% 50%; }
+          100% { background-position: -200% 50%; }
+        }
+        @keyframes oh-dot {
+          0%, 60%, 100% { opacity: 0.2; transform: translateY(0); }
+          30% { opacity: 1; transform: translateY(-2px); }
+        }
+        .oh-dot {
+          animation: oh-dot 1.4s ease-in-out infinite;
+          display: inline-block;
+        }
+        @keyframes oh-progress-pulse {
+          0%, 100% { transform: scale(1); opacity: 0.6; }
+          50% { transform: scale(1.4); opacity: 0; }
+        }
+        .oh-progress-pulse {
+          animation: oh-progress-pulse 2s ease-in-out infinite;
+        }
+      `}</style>
+      <div
+        style={{
+          background: '#FFFFFF',
+          borderRadius: 18,
+          padding: '14px 16px',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          minWidth: 200,
+        }}
+      >
+        {/* Pulsing OH logo — gold radial halo behind the mark */}
+        <div style={{ position: 'relative', width: 28, height: 28, flexShrink: 0 }}>
+          <Image
+            src="/oh-logo.png"
+            alt=""
+            width={28}
+            height={28}
+            style={{ objectFit: 'contain', mixBlendMode: 'multiply' }}
+          />
+          <div
+            className="oh-progress-pulse"
+            style={{
+              position: 'absolute',
+              inset: -4,
+              borderRadius: '50%',
+              background: 'radial-gradient(circle, rgba(212,175,55,0.25) 0%, rgba(212,175,55,0) 60%)',
+              pointerEvents: 'none',
+            }}
+          />
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: '#9EA8B5', letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Intelligence
+          </span>
+          <span
+            style={{
+              fontSize: 13.5,
+              fontWeight: 500,
+              letterSpacing: '-0.005em',
+              display: 'inline-flex',
+              alignItems: 'baseline',
+            }}
+          >
+            <ShimmerText>{progress.label}</ShimmerText>
+            <DotsTrail />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DotsTrail() {
+  return (
+    <span style={{ display: 'inline-flex', gap: 2, marginLeft: 4, color: '#374151' }}>
+      <span className="oh-dot" style={{ animationDelay: '0ms' }}>.</span>
+      <span className="oh-dot" style={{ animationDelay: '150ms' }}>.</span>
+      <span className="oh-dot" style={{ animationDelay: '300ms' }}>.</span>
+    </span>
+  );
+}
+
+function ShimmerText({ children }: { children: string }) {
+  return (
+    <span
+      className="oh-shimmer"
+      style={{
+        background: 'linear-gradient(90deg, #374151 0%, #374151 40%, #C49B2A 50%, #374151 60%, #374151 100%)',
+        backgroundSize: '200% 100%',
+        WebkitBackgroundClip: 'text',
+        backgroundClip: 'text',
+        WebkitTextFillColor: 'transparent',
+        animation: 'oh-shimmer 2.5s linear infinite',
+      }}
+    >
+      {children}
+    </span>
   );
 }
 

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -28,6 +28,32 @@ import { captureInferredAlias, suggestClosestScheme, normaliseSchemeName } from 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
+// Map a tool name to a human-readable label for the streaming progress
+// indicator. New tools fall back to a generic "Looking up details" label.
+function labelForTool(toolName: string): string {
+  switch (toolName) {
+    case 'draft_message': return 'Drafting message';
+    case 'draft_buyer_followups': return 'Drafting messages';
+    case 'draft_lease_renewal': return 'Drafting renewal offer';
+    case 'draft_viewing_followup': return 'Drafting viewing follow-up';
+    case 'chase_aged_contracts': return 'Drafting chase emails';
+    case 'weekly_monday_briefing': return 'Building briefing';
+    case 'schedule_viewing_draft': return 'Drafting viewing schedule';
+    case 'natural_query': return 'Looking up details';
+    case 'get_unit_status':
+    case 'get_unit_details':
+    case 'get_scheme_overview':
+    case 'get_scheme_summary':
+    case 'get_buyer_details':
+    case 'get_outstanding_items':
+    case 'get_communication_history':
+    case 'get_candidate_units':
+      return 'Checking your records';
+    default:
+      return 'Looking up details';
+  }
+}
+
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
 
@@ -495,9 +521,25 @@ export async function POST(request: NextRequest) {
 
     const readable = new ReadableStream({
       async start(controller) {
+        // Session 14a — progress instrumentation. The chat route's heavy
+        // lifting (resolveAgentContextV2, live-context Promise.all, the
+        // first OpenAI call, tool execution) all completes BEFORE the
+        // ReadableStream opens. We emit progress events inside start() to
+        // narrate what's happening to the user, so a 5–15s wait feels
+        // intentional rather than dead. Order: context → (tool, if fired) →
+        // thinking → finalising. The first 'token' frame on the client
+        // clears the indicator.
+        const emitProgress = (stage: string, label: string) => {
+          controller.enqueue(
+            encoder.encode(JSON.stringify({ type: 'progress', stage, label }) + '\n')
+          );
+        };
+        emitProgress('context', 'Reading your portfolio');
+
         try {
           // Send tool call metadata first so the UI knows tools were used
           if (toolsCalled.length > 0) {
+            emitProgress('tool', labelForTool(toolsCalled[0].tool_name));
             controller.enqueue(
               encoder.encode(JSON.stringify({
                 type: 'tools_used',
@@ -558,6 +600,7 @@ export async function POST(request: NextRequest) {
             fullContent = `${promptText}\n${marker}`;
           } else {
             // Stream the final LLM response
+            emitProgress('thinking', 'Composing reply');
             const stream = await openai.chat.completions.create({
               model: 'gpt-4o-mini',
               messages,
@@ -566,6 +609,9 @@ export async function POST(request: NextRequest) {
               max_tokens: 4000,
               stream: true,
             });
+            // Connection established, model is generating — last narration
+            // beat before tokens start arriving.
+            emitProgress('finalising', 'Almost there');
 
             for await (const chunk of stream) {
               const delta = chunk.choices[0]?.delta?.content;

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -33,7 +33,7 @@ interface ChipResponse {
   chips: string[];
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const supabase = getSupabaseAdmin();
     const cookieStore = cookies();
@@ -45,11 +45,104 @@ export async function GET() {
       return NextResponse.json<ChipResponse>({ chips: [...FALLBACK_CAPABILITY_CHIPS] });
     }
 
-    const chips = await composeChips(supabase, profile.id);
+    const url = new URL(request.url);
+    const mode = url.searchParams.get('mode') === 'lettings' ? 'lettings' : 'sales';
+
+    const chips = mode === 'lettings'
+      ? await composeLettingsChips(supabase, profile.id)
+      : await composeChips(supabase, profile.id);
     return NextResponse.json<ChipResponse>({ chips });
   } catch {
     return NextResponse.json<ChipResponse>({ chips: [...FALLBACK_CAPABILITY_CHIPS] });
   }
+}
+
+// Lettings-mode chip composer. Sources a dynamic chip from the nearest
+// expiring active tenancy and another from a real vacant property, plus
+// four evergreen action phrases. Falls back to safe lettings phrases if
+// the dynamic queries return nothing.
+async function composeLettingsChips(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  agentId: string,
+): Promise<string[]> {
+  const today = new Date();
+  const fourteenDaysOut = new Date(today.getTime() + 14 * 86_400_000);
+
+  const [tenanciesRes, vacantRes] = await Promise.all([
+    supabase
+      .from('agent_tenancies')
+      .select('id, tenant_name, lease_end, letting_property_id')
+      .eq('agent_id', agentId)
+      .eq('status', 'active')
+      .not('lease_end', 'is', null)
+      .gte('lease_end', today.toISOString().split('T')[0])
+      .lte('lease_end', fourteenDaysOut.toISOString().split('T')[0])
+      .order('lease_end', { ascending: true })
+      .limit(1),
+    supabase
+      .from('agent_letting_properties')
+      .select('id, address_line_1, address')
+      .eq('agent_id', agentId)
+      .in('status', ['vacant', 'available', 'empty'])
+      .order('created_at', { ascending: false })
+      .limit(1),
+  ]);
+
+  const chips: string[] = [];
+
+  // Dynamic chip 1: nearest expiring tenancy ("Aisling: lease in 2d")
+  const tenancy = (tenanciesRes.data ?? [])[0] as
+    | { id: string; tenant_name: string | null; lease_end: string | null; letting_property_id: string | null }
+    | undefined;
+  if (tenancy?.tenant_name && tenancy.lease_end) {
+    const firstName = tenancy.tenant_name.split(/[ &]/)[0];
+    const days = Math.ceil((new Date(tenancy.lease_end).getTime() - today.getTime()) / 86_400_000);
+    if (firstName && days >= 0 && days <= 14) {
+      chips.push(`${firstName}: lease in ${days}d`);
+    }
+  }
+
+  // Dynamic chip 2: a real vacant property ("Re-let 1 Rose Hill")
+  const vacant = (vacantRes.data ?? [])[0] as
+    | { id: string; address_line_1: string | null; address: string | null }
+    | undefined;
+  if (vacant) {
+    const addr = vacant.address_line_1 || (vacant.address || '').split(',')[0];
+    if (addr) {
+      const truncated = addr.length > 14 ? addr.slice(0, 14) : addr;
+      chips.push(`Re-let ${truncated}`);
+    }
+  }
+
+  // Evergreen action chips — always present, lettings-flavoured.
+  chips.push('Renewals due');
+  chips.push('Rent reminders');
+  chips.push('Compliance gaps');
+  chips.push('Vacancies summary');
+
+  // Pad with safe lettings fallbacks if dynamic queries returned nothing.
+  if (chips.length < 4) {
+    for (const fb of [
+      'Draft a rent reminder',
+      "This week’s viewings",
+      'Tenant queries',
+      'Maintenance tickets',
+    ]) {
+      if (!chips.includes(fb)) chips.push(fb);
+      if (chips.length >= 8) break;
+    }
+  }
+
+  // Dedupe + cap (the carousel rotates 4 visible at a time).
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const c of chips) {
+    if (!seen.has(c)) {
+      seen.add(c);
+      deduped.push(c);
+    }
+  }
+  return deduped;
 }
 
 async function composeChips(

--- a/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
+++ b/apps/unified-portal/lib/agent-intelligence/capability-chips.ts
@@ -44,10 +44,18 @@ export function shuffleChips(input: readonly string[]): string[] {
 /**
  * Client-side fetch for the live capability chips. Falls back to the
  * static context-free set on any failure. Never throws.
+ *
+ * `mode` (optional) — when set to 'lettings', the server-side route
+ * branches to the lettings chip composer (real tenancies + vacancies +
+ * lettings-flavoured action phrases). Defaults to the sales composer
+ * when omitted, preserving existing call-site behaviour.
  */
-export async function fetchCapabilityChips(): Promise<string[]> {
+export async function fetchCapabilityChips(mode?: 'sales' | 'lettings'): Promise<string[]> {
   try {
-    const res = await fetch('/api/agent/intelligence/capability-chips', {
+    const url = mode === 'lettings'
+      ? '/api/agent/intelligence/capability-chips?mode=lettings'
+      : '/api/agent/intelligence/capability-chips';
+    const res = await fetch(url, {
       cache: 'no-store',
     });
     if (!res.ok) return [...FALLBACK_CAPABILITY_CHIPS];


### PR DESCRIPTION
## Summary

Two surgical Intelligence-mode upgrades for Friday's investor demo. No UI redesign — both are extensions of existing infrastructure that's already there but wired wrong.

**P1 — Lettings-aware empty-state chips.** The carousel was sourcing `Brief on Árdan View / Scheme summary / Chase aged contracts / Weekly report` from `composeChips()` regardless of workspace mode, so a letting agent in lettings mode opened Intelligence to a sales pitch. Now: server route accepts `?mode=lettings`, client passes `activeWorkspace?.mode` through, new `composeLettingsChips()` reads the agent's nearest expiring active tenancy + a real vacant property, then layers four evergreen lettings phrases (`Renewals due / Rent reminders / Compliance gaps / Vacancies summary`). Falls back to safe lettings phrases if dynamic queries return nothing.

**P2 — Streaming progress narration.** The chat route does 5–15s of pre-stream work (context resolution, tool execution, opening the OpenAI stream) and the user saw an empty space the whole time — mum's verdict was "is it broken?". Server now emits `{type:'progress', stage, label}` events at four milestones inside the existing `start(controller)` callback (purely additive on the wire — no business logic moved). Stages: `context → tool (if fired) → thinking → finalising`. Tool labels mapped from tool names via `labelForTool` (e.g. `draft_message → "Drafting message"`). Client adds a `'progress'` branch to the streaming reader, sets `msg.progress`, renders a new `<ProgressCard>` (white card, pulsing OH logo with gold radial halo, gold-shimmer label text, three-dot bounce trail). The first `token` (or `override`) frame clears `msg.progress`, the render branch falls through, and `<AIResponseCard>` takes over. State-driven swap — no race window.

## Files (4)

- `app/api/agent/intelligence/capability-chips/route.ts` — `?mode` parsing + `composeLettingsChips`
- `lib/agent-intelligence/capability-chips.ts` — `fetchCapabilityChips(mode?)` forwards the param
- `app/agent/intelligence/page.tsx` — passes `activeWorkspace?.mode`, adds `'progress'` reader branch + `ProgressCard` / `DotsTrail` / `ShimmerText` / inline keyframes
- `app/api/agent-intelligence/chat/route.ts` — `labelForTool` helper + four `emitProgress` calls inside the existing readable stream

CSS keyframes ship inline inside `<ProgressCard>` (a `<style>` tag mounted with the card) rather than `globals.css`, to keep the file count at 4 per spec.

## Acceptance test trace — mum-test query

`"Can you ask Aisling Moran what time suits her for me to send a plumber to fix the shower?"`

Wire-order events the client receives:
1. `{type:'progress', stage:'context', label:'Reading your portfolio'}` — emitted at the very top of `start(controller)`. Client creates an assistant message with `progress` set, `content: ''`. `<ProgressCard>` renders with "Reading your portfolio".
2. `{type:'progress', stage:'tool', label:'Drafting message'}` — emitted when `toolsCalled.length > 0`. ProgressCard label updates to "Drafting message".
3. `{type:'tools_used', tools:[{name:'draft_message', summary:...}]}` — existing frame, unchanged.
4. `{type:'envelope', envelope:{...}}` — existing frame, opens the approval drawer.
5. `{type:'progress', stage:'thinking', label:'Composing reply'}` — emitted just before `openai.chat.completions.create({stream:true})`.
6. `{type:'progress', stage:'finalising', label:'Almost there'}` — emitted after `create()` resolves but before the for-await loop iterates. Visible during the OpenAI generation latency before tokens flow.
7. `{type:'token', content:'Here'}` — first token. `streamingStarted` flips, `setMessages` updates the message with `content: 'Here'` AND `progress: undefined`. ProgressCard render branch falls through, `<AIResponseCard>` takes over.
8. … subsequent tokens stream into the AIResponseCard normally.

**Race-condition flag** I checked carefully: the only way ProgressCard could remain visible after streaming starts is if `progress` is set in the same render that `content` becomes non-empty. The first-token handler sets both `content: fullContent` AND `progress: undefined` in a single `setMessages` call, so the next render sees `msg.progress === undefined && msg.content !== ''` — render branch order (`if (msg.progress && !msg.content) return ProgressCard; else return AIResponseCard`) deterministically falls through. Override path also clears `progress: undefined` when content updates. Verified by reading the committed code.

A second subtle case: if a `progress` event arrives AFTER a token event (out-of-order — shouldn't happen because the server emits them in source order, but defensive), the reader's `'progress'` branch would re-set `msg.progress` and the next render would show the ProgressCard again briefly. The route emits all progress events strictly before any token, so this can't happen in practice; if it ever could, an additional guard (`if (!streamingStarted) ...`) inside the progress branch would harden it. Flagging here for awareness, not adding the guard since it'd add noise without fixing a real bug.

## Test plan

P1:
- [ ] Switch test agent to Lettings, open Intelligence — confirm visible chips include `Aisling: lease in Nd` (dynamic, from her active tenancy), `Re-let <vacant address>` (dynamic, from a real vacancy), and at least two of `Renewals due / Rent reminders / Compliance gaps / Vacancies summary`. **No** sales chips like `Scheme summary / Chase aged contracts / Weekly report / Brief on Árdan View`.
- [ ] Switch to Sales, open Intelligence — confirm the existing sales chip set renders unchanged (no regression).

P2:
- [ ] Type the mum-test query in lettings mode and watch carefully — within ~200ms of tap, ProgressCard should render with "Reading your portfolio". Within another tick, label updates to "Drafting message" (because the tool fired). After the tool result lands, label updates to "Composing reply", then "Almost there", and then the card disappears as the first token streams.
- [ ] Type a non-tool query (e.g. "What's on today?") — confirm the progression skips the "Drafting message" stage (no tool fires) and goes context → thinking → finalising → tokens.
- [ ] Verify on iPhone: the ProgressCard renders left-aligned (matches AIResponseCard alignment), animations are smooth, the OH logo halo pulses without jank.


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_