### PR TITLE
feat(intelligence): drawer recovery + chip hierarchy + sent confirmation (session 14b)

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -12,12 +12,12 @@ import CapabilityChipsCarousel from '../_components/CapabilityChipsCarousel';
 import { useVoiceCapture } from '../_hooks/useVoiceCapture';
 import { fetchCapabilityChips } from '@/lib/agent-intelligence/capability-chips';
 import { useAgent } from '@/lib/agent/AgentContext';
-import { Mail, Copy, Check, ExternalLink } from 'lucide-react';
+import { Mail, Copy, Check, ExternalLink, Pencil, Wrench, Bell, RotateCcw, ArrowRight, FileText, Calendar } from 'lucide-react';
 import type { ExecutedAction, ExtractedAction } from '@/lib/agent-intelligence/voice-actions';
 import type { AutoSendUiState } from '../_components/VoiceConfirmationCard';
 import { notifyDraftsChanged, useDraftsCount } from '../_hooks/useDraftsCount';
 import { ApprovalDrawerProvider, useApprovalDrawer } from '@/lib/agent-intelligence/drawer-store';
-import { isAgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
+import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import ApprovalDrawer from '@/components/agent/intelligence/ApprovalDrawer';
 
 // Session 7 — the landing-screen action-button grid and the SCHEME_PILLS /
@@ -59,6 +59,13 @@ interface Message {
   // Session 14a — server-emitted progress narration. Set when a 'progress'
   // SSE frame arrives, cleared on the first non-empty token/override.
   progress?: { stage: string; label: string };
+  // Session 14b — drawer recovery. The envelope is stashed on the
+  // assistant message that produced it so the AIResponseCard can render
+  // a "Reopen draft" affordance after the drawer is dismissed.
+  envelope?: AgenticSkillEnvelope;
+  // Session 14b — sent confirmation. Set on a fresh synthetic message
+  // appended in response to the 'oh-draft-sent' window event.
+  sent?: { recipientName: string; time: string };
 }
 
 interface UndoBatch {
@@ -158,6 +165,32 @@ function IntelligencePageInner() {
     })();
     return () => { cancelled = true; };
   }, [activeWorkspace?.mode]);
+
+  // Session 14b — listen for the drawer-store's sent confirmation event
+  // and append a synthetic assistant message to the chat thread. Each
+  // successful approve fires once per draftId; approve-all fires once
+  // per draft in the batch.
+  useEffect(() => {
+    function onDraftSent(e: Event) {
+      const detail = (e as CustomEvent).detail || {};
+      const recipientName = typeof detail.recipientName === 'string' && detail.recipientName.length > 0
+        ? detail.recipientName
+        : 'recipient';
+      const sentAt = typeof detail.sentAt === 'string' ? detail.sentAt : new Date().toISOString();
+      const time = new Date(sentAt).toLocaleTimeString('en-IE', {
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+      setMessages(prev => [...prev, {
+        id: `sent_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+        role: 'assistant',
+        content: '',
+        sent: { recipientName, time },
+      }]);
+    }
+    window.addEventListener('oh-draft-sent', onDraftSent);
+    return () => window.removeEventListener('oh-draft-sent', onDraftSent);
+  }, []);
 
   // Handle prefilled prompt from URL
   useEffect(() => {
@@ -275,8 +308,26 @@ function IntelligencePageInner() {
               toolsUsed = data.tools || [];
             } else if (data.type === 'envelope') {
               if (isAgenticSkillEnvelope(data.envelope)) {
-                openApprovalDrawer(data.envelope);
+                const env = data.envelope;
+                openApprovalDrawer(env);
                 notifyDraftsChanged();
+                // Session 14b — stash the envelope on the streaming
+                // assistant message so AIResponseCard can render a
+                // "Reopen draft" pill if the agent closes the drawer.
+                setMessages(prev => {
+                  const existing = prev.find(m => m.id === streamingMsgId);
+                  if (existing) {
+                    return prev.map(m =>
+                      m.id === streamingMsgId ? { ...m, envelope: env } : m
+                    );
+                  }
+                  return [...prev, {
+                    id: streamingMsgId,
+                    role: 'assistant',
+                    content: '',
+                    envelope: env,
+                  }];
+                });
               }
             } else if (data.type === 'override') {
               // Server detected the model hallucinated drafts. Replace
@@ -909,6 +960,18 @@ function IntelligencePageInner() {
                   />
                 );
               }
+              // Session 14b — sent-confirmation card. Synthetic messages
+              // appended by the 'oh-draft-sent' window listener carry only
+              // a `sent` payload; render the green-tinted success card.
+              if (msg.sent) {
+                return (
+                  <SentConfirmationCard
+                    key={msg.id}
+                    recipientName={msg.sent.recipientName}
+                    time={msg.sent.time}
+                  />
+                );
+              }
               // Session 14a — render the ProgressCard while the server is
               // still narrating. Once the first token arrives the route
               // clears msg.progress, this branch falls through, and the
@@ -923,6 +986,8 @@ function IntelligencePageInner() {
                   emails={msg.emails}
                   followups={msg.followups}
                   onFollowup={handleSend}
+                  envelope={msg.envelope}
+                  onReopen={(env) => openApprovalDrawer(env)}
                 />
               );
             })}
@@ -1106,6 +1171,75 @@ function UserBubble({ text }: { text: string }) {
   );
 }
 
+// Session 14b — SentConfirmationCard. Synthetic chat message appended
+// by the 'oh-draft-sent' window listener after a successful drawer
+// approve. Green-tinted success card with a check icon, the recipient
+// name + send time, and a "View in Drafts" CTA that routes to the
+// Drafts inbox where the agent can see send history.
+function SentConfirmationCard({ recipientName, time }: { recipientName: string; time: string }) {
+  const router = useRouter();
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div
+        style={{
+          background: 'linear-gradient(180deg, rgba(34,197,94,0.06) 0%, rgba(34,197,94,0.02) 100%)',
+          border: '0.5px solid rgba(34,197,94,0.25)',
+          borderRadius: 18,
+          padding: '12px 14px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 13.5,
+          color: '#0D5132',
+          fontWeight: 500,
+        }}
+      >
+        <div
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: '50%',
+            background: '#22C55E',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          <Check size={13} color="#FFFFFF" strokeWidth={3} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+          <span style={{ fontWeight: 600, color: '#0D5132' }}>
+            Sent to {recipientName}
+          </span>
+          <span style={{ fontSize: 11.5, color: '#0D5132', opacity: 0.7 }}>
+            {time}
+          </span>
+        </div>
+        <button
+          onClick={() => router.push('/agent/drafts')}
+          className="agent-tappable"
+          style={{
+            marginLeft: 'auto',
+            padding: '5px 10px',
+            background: 'transparent',
+            border: '0.5px solid rgba(13,81,50,0.2)',
+            borderRadius: 999,
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#0D5132',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            flexShrink: 0,
+          }}
+        >
+          View in Drafts
+        </button>
+      </div>
+    </div>
+  );
+}
+
 // Session 14a — ProgressCard. Shown while the chat route is doing its
 // pre-stream work (loading context, executing tool calls, opening the
 // final OpenAI stream). The route emits {type:'progress', stage, label}
@@ -1226,16 +1360,35 @@ function ShimmerText({ children }: { children: string }) {
   );
 }
 
+// Session 14b — pick an intent-matching lucide icon for a follow-up chip
+// based on the chip text. Falls back to a generic ArrowRight when no
+// keyword matches. Order matters: more specific keywords win first.
+function iconForChip(text: string) {
+  const t = text.toLowerCase();
+  if (t.includes('send')) return Mail;
+  if (t.includes('edit')) return Pencil;
+  if (t.includes('maintenance') || t.includes('plumber') || t.includes('repair') || t.includes('callout')) return Wrench;
+  if (t.includes('reminder') || t.includes('chase') || t.includes('follow up') || t.includes('follow-up')) return Bell;
+  if (t.includes('renewal') || t.includes('lease')) return RotateCcw;
+  if (t.includes('viewing') || t.includes('schedule') || t.includes('book')) return Calendar;
+  if (t.includes('report') || t.includes('summary') || t.includes('brief') || t.includes('drafts')) return FileText;
+  return ArrowRight;
+}
+
 function AIResponseCard({
   text,
   emails,
   followups,
   onFollowup,
+  envelope,
+  onReopen,
 }: {
   text: string;
   emails?: DraftedEmail[];
   followups?: string[];
   onFollowup: (text: string) => void;
+  envelope?: AgenticSkillEnvelope;
+  onReopen?: (env: AgenticSkillEnvelope) => void;
 }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
@@ -1306,40 +1459,119 @@ function AIResponseCard({
           </div>
         )}
 
-        {/* Follow-up suggestion chips */}
+        {/* Session 14b — Reopen draft pill. Renders only when an envelope
+            with at least one draft is on the message. Tap re-opens the
+            same drawer (drawer-store rebuilds drafts from the envelope). */}
+        {envelope && envelope.drafts && envelope.drafts.length > 0 && onReopen && (
+          <button
+            type="button"
+            onClick={() => onReopen(envelope)}
+            className="agent-tappable"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 12px',
+              background: 'rgba(212, 175, 55, 0.08)',
+              border: '0.5px solid rgba(212, 175, 55, 0.32)',
+              borderRadius: 999,
+              fontSize: 12,
+              fontWeight: 600,
+              color: '#B8960C',
+              letterSpacing: '-0.01em',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              marginTop: emails && emails.length > 0 ? 12 : 0,
+              width: 'fit-content',
+            }}
+          >
+            <Mail size={13} strokeWidth={2.25} />
+            <span>{envelope.drafts.length === 1 ? 'Reopen draft' : `Reopen ${envelope.drafts.length} drafts`}</span>
+          </button>
+        )}
+
+        {/* Session 14b — Follow-up suggestion chips, hierarchy rework.
+            First chip is the gold "primary" action with leading icon;
+            subsequent chips wrap below as lighter secondaries. iconForChip
+            picks an intent-matching glyph from the chip text. */}
         {followups && followups.length > 0 && (
           <div
             style={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 8,
               marginTop: 16,
               paddingTop: 12,
               borderTop: '1px solid rgba(0,0,0,0.05)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
             }}
           >
-            {followups.map((suggestion, i) => (
-              <button
-                key={i}
-                onClick={() => onFollowup(suggestion)}
-                className="agent-tappable"
-                style={{
-                  padding: '8px 14px',
-                  background: '#FAFAF8',
-                  border: '0.5px solid rgba(0,0,0,0.08)',
-                  borderRadius: 20,
-                  fontSize: 12.5,
-                  fontWeight: 500,
-                  color: '#6B7280',
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                  lineHeight: 1.3,
-                  transition: 'all 0.15s ease',
-                }}
-              >
-                {suggestion}
-              </button>
-            ))}
+            {(() => {
+              const PrimaryIcon = iconForChip(followups[0]);
+              return (
+                <button
+                  onClick={() => onFollowup(followups[0])}
+                  className="agent-tappable"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '11px 16px',
+                    background: 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)',
+                    border: 'none',
+                    borderRadius: 999,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: '#FFFFFF',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                    lineHeight: 1.3,
+                    letterSpacing: '-0.01em',
+                    boxShadow: '0 1px 2px rgba(196, 155, 42, 0.25)',
+                    width: 'fit-content',
+                    maxWidth: '100%',
+                  }}
+                >
+                  <PrimaryIcon size={14} strokeWidth={2.25} />
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {followups[0]}
+                  </span>
+                </button>
+              );
+            })()}
+
+            {followups.length > 1 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {followups.slice(1).map((suggestion, i) => {
+                  const SecondaryIcon = iconForChip(suggestion);
+                  return (
+                    <button
+                      key={i}
+                      onClick={() => onFollowup(suggestion)}
+                      className="agent-tappable"
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        padding: '7px 12px',
+                        background: '#FFFFFF',
+                        border: '0.5px solid rgba(15,17,24,0.12)',
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 500,
+                        color: '#374151',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        lineHeight: 1.3,
+                        letterSpacing: '-0.005em',
+                      }}
+                    >
+                      <SecondaryIcon size={12} strokeWidth={2} color="#9EA8B5" />
+                      <span>{suggestion}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/unified-portal/lib/agent-intelligence/drawer-store.tsx
+++ b/apps/unified-portal/lib/agent-intelligence/drawer-store.tsx
@@ -70,6 +70,10 @@ export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
   // frame without `.open` so the CSS transition can play. We render closed
   // first, then flip to open on the next animation frame.
   const pendingOpenRef = useRef<AgenticSkillEnvelope | null>(null);
+  // Session 14b — keep a ref of the latest drafts so approveDraft can read
+  // recipient info synchronously without closing over stale state.
+  const draftsRef = useRef<DrawerDraft[]>([]);
+  useEffect(() => { draftsRef.current = state.drafts; }, [state.drafts]);
 
   const openApprovalDrawer = useCallback((envelope: AgenticSkillEnvelope) => {
     if (!envelope?.drafts?.length) return;
@@ -136,6 +140,20 @@ export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
         }
         mutateDraft(draftId, { status: 'sent' });
         try { window.dispatchEvent(new CustomEvent('oh:drafts:changed')); } catch { /* noop */ }
+        // Session 14b — fire a sent-confirmation event the chat surface
+        // listens for. Only dispatched after a 2xx send response, never on
+        // failure or discard. Recipient name is read from the latest
+        // drafts ref, falling back to the persisted draft fields.
+        try {
+          const sentDraft = draftsRef.current.find((d) => d.id === draftId);
+          window.dispatchEvent(new CustomEvent('oh-draft-sent', {
+            detail: {
+              recipientName: sentDraft?.recipient?.name ?? 'recipient',
+              draftId,
+              sentAt: new Date().toISOString(),
+            },
+          }));
+        } catch { /* noop */ }
       } catch (err) {
         mutateDraft(draftId, {
           status: 'failed',


### PR DESCRIPTION
## Summary

Three Intelligence polish items, surgical and additive. None of them touch the streaming infrastructure or the drawer's approve/discard logic — all changes are surface-level.

**P3 — Drawer recovery (sticky reopen on AIResponseCard)** — when the agent X-es the approval drawer, the assistant message that produced the draft now carries a small gold "Reopen draft" pill below the response text (or below the email cards if present). One tap re-opens the same envelope. Implemented by stashing the envelope on the streaming message in the existing `'envelope'` SSE branch, threading it through to `AIResponseCard`, and rendering a pill between the email cards and the followups separator when `envelope.drafts.length > 0`. Pluralises automatically (`Reopen draft` / `Reopen 3 drafts`).

**P4 — Follow-up chip rework (hierarchy, icons, weight)** — first followup is now the unmistakable primary action: gold gradient background, white text, weight 600, leading lucide icon picked from a `iconForChip` keyword map (Mail/Pencil/Wrench/Bell/RotateCcw/Calendar/FileText/ArrowRight). Subsequent followups wrap below as secondaries: white background, dark grey text, smaller, each with a lighter-coloured leading icon. Two-row layout: primary on its own row (max 80% width), secondaries flow-wrap below.

**P6 — Sent confirmation (clean success card after approve)** — drawer-store dispatches `oh-draft-sent` window event after a successful 2xx send response (only on success, never on failure or discard). Page listens, appends a synthetic `{role:'assistant', sent:{recipientName, time}}` message, render branch above ProgressCard renders a green-tinted `<SentConfirmationCard>` with a check icon, "Sent to {name} · {time}", and a "View in Drafts" CTA → `/agent/drafts`.

## Files (2)

- `app/agent/intelligence/page.tsx` — extended `Message` type with `envelope` + `sent`; lucide imports; `iconForChip` helper; envelope stash in the `'envelope'` SSE branch; `oh-draft-sent` listener `useEffect`; `AIResponseCard` now accepts `envelope` + `onReopen`, renders Reopen pill, renders new chip hierarchy; new `<SentConfirmationCard>`; render branches in the messages map.
- `lib/agent-intelligence/drawer-store.tsx` — `draftsRef` to read recipient synchronously; `oh-draft-sent` dispatch immediately after `mutateDraft({status:'sent'})` and the existing `oh:drafts:changed` event.

## Mum-test query — end-to-end trace

`"Can you ask Aisling Moran what time suits her for me to send a plumber to fix the shower?"`

| Stage | What's in the chat thread |
|---|---|
| User taps send | `[user bubble: query]` |
| 14a 'progress' frames arrive | `[user bubble]` + `<ProgressCard>` cycling Reading your portfolio → Drafting message → Composing reply → Almost there |
| First token arrives | `[user bubble]` + `<AIResponseCard>` streaming the response. Drawer opens with the Aisling draft. |
| 'envelope' SSE frame stashes envelope | Same render — but `msg.envelope` is now set |
| Agent taps X on drawer | Drawer dismisses. `<AIResponseCard>` now also renders the **gold "Reopen draft" pill** between the (no inline emails here) and the followups. Below it: **primary chip "Send the draft now"** (gold + Mail icon) + secondaries **"Edit the message"** (Pencil) and **"Log maintenance ticket"** (Wrench). |
| Agent taps "Reopen draft" | `onReopen(envelope)` → `openApprovalDrawer(env)` → drawer comes back with the same draft. |
| Agent taps Approve | `approveDraft` POSTs `/api/agent/intelligence/send-draft`. Success → `mutateDraft({status:'sent'})` → `oh-draft-sent` dispatched with `{recipientName: 'Aisling Moran', sentAt: ISO}`. Drawer dismisses. |
| Page listener receives event | New synthetic message appended: `<SentConfirmationCard>` renders below the AIResponseCard with green tint, check icon, "Sent to Aisling Moran · 11:53 PM", "View in Drafts" CTA. |
| Agent taps "View in Drafts" | `router.push('/agent/drafts')`. |

## Race-condition analysis

I traced rapid-tap and approve-then-close scenarios:

1. **Rapid double-tap on Approve** — the drawer's approve button uses `state === 'pending'` to gate further taps; `approveDraft` flips `status` to `'sending'` before the fetch, so a second tap finds the draft no longer in `'pending'` state and the existing UI guard returns early. Only one fetch fires, only one `oh-draft-sent` dispatches.
2. **Approve then close drawer rapidly** — `approveDraft` is async; the close button calls `close()` which sets `open: false` then clears state after a 280ms timeout. If approve resolves between close-tap and the 280ms cleanup, `mutateDraft({status:'sent'})` writes to drafts, then the cleanup wipes state via `INITIAL_STATE` — the dispatch already fired before the cleanup, so `oh-draft-sent` lands once. The synthetic chat message appends correctly.
3. **Approve fails on the network** — `mutateDraft({status:'failed'})` runs in the catch; the dispatch line is in the `try` branch *after* the success path, so it's never reached on failure. No false success cards.
4. **Discard** — `discardDraft` is a separate callback, doesn't touch the dispatch path. No spurious cards.
5. **`approveAll`** — calls `approveDraft` per draft in a sequential `for` loop. Each successful one fires its own event; the listener appends one card per success. For a 5-draft batch, agent sees 5 stacked sent cards (intentional — each is a real send). Failed ones don't dispatch.

Each synthetic sent message has a unique id (`sent_{Date.now()}_{rand}`), so React's keyed reconciliation never collides.

## Test plan

P3:
- [ ] Run mum-test query, wait for drawer to open, X out, confirm gold "Reopen draft" pill appears in the AIResponseCard.
- [ ] Tap pill — confirm same drawer opens with same draft.
- [ ] Verify pill does NOT appear on assistant messages with no envelope (e.g. a "What's on today?" reply).

P4:
- [ ] After mum-test query lands, confirm the followup chips render: primary chip is solid gold + Mail icon for "Send the draft now", secondaries below are white-bg with Pencil / Wrench / Bell icons matching the chip text.
- [ ] Tap primary chip — confirm it sends the chip text as a follow-up query (existing behaviour).
- [ ] Verify keyword routing: "Edit" → Pencil, "Maintenance" → Wrench, "Reminder/Chase" → Bell, "Renewal/Lease" → RotateCcw, "Viewing/Schedule" → Calendar, "Report/Summary/Brief/Drafts" → FileText, anything else → ArrowRight.

P6:
- [ ] Reopen the drawer via the Reopen pill, tap Approve — confirm green sent-confirmation card appears below the AIResponseCard with the recipient name + send time.
- [ ] Tap "View in Drafts" — confirm navigation to `/agent/drafts`.
- [ ] Discard a draft instead of approving — confirm NO sent card appears.
- [ ] Trigger a network failure on send (offline mode) — confirm the draft flips to 'failed' in the drawer and NO sent card appears.
- [ ] Run approve-all on a multi-draft envelope — confirm one sent card per successful draft, none for failed ones.


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_