### PR TITLE
feat(lettings): cross-product polish — vacant urgency, tile deep-links, address truncation (session 14c)

### DIFF
--- a/apps/unified-portal/app/agent/lettings/home/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/home/page.tsx
@@ -114,24 +114,31 @@ export default function LettingsHomePage() {
             </>
           ) : (
             <>
-              <Tile
-                icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>}
-                label="VACANCIES"
-                value={`${s.vacantCount} ${s.vacantCount === 1 ? 'vacancy' : 'vacancies'}`}
-                subtext={s.vacantCount === 0 ? 'All let — nice work' : s.vacantCount === 1 ? '1 to fill' : `${s.vacantCount} to fill`}
-              />
-              <Tile
-                icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" /><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" /><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" /><path d="M10 6h4" /><path d="M10 10h4" /><path d="M10 14h4" /></svg>}
-                label="PORTFOLIO"
-                value={`${s.totalProperties} ${s.totalProperties === 1 ? 'property' : 'properties'}`}
-                subtext={s.vacantCount === 0 ? 'All let' : `${s.vacantCount} ${s.vacantCount === 1 ? 'vacancy' : 'vacancies'}`}
-              />
-              <Tile
-                icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /><path d="m9 12 2 2 4-4" /></svg>}
-                label="COMPLETENESS"
-                value={`${s.avgCompleteness}%`}
-                subtext={completenessHint}
-              />
+              {/* Session 14c — tiles deep-link into Properties pre-filtered. */}
+              <Link href="/agent/lettings/properties?status=vacant" style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+                <Tile
+                  icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>}
+                  label="VACANCIES"
+                  value={`${s.vacantCount} ${s.vacantCount === 1 ? 'vacancy' : 'vacancies'}`}
+                  subtext={s.vacantCount === 0 ? 'All let — nice work' : s.vacantCount === 1 ? '1 to fill' : `${s.vacantCount} to fill`}
+                />
+              </Link>
+              <Link href="/agent/lettings/properties" style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+                <Tile
+                  icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" /><path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" /><path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" /><path d="M10 6h4" /><path d="M10 10h4" /><path d="M10 14h4" /></svg>}
+                  label="PORTFOLIO"
+                  value={`${s.totalProperties} ${s.totalProperties === 1 ? 'property' : 'properties'}`}
+                  subtext={s.vacantCount === 0 ? 'All let' : `${s.vacantCount} ${s.vacantCount === 1 ? 'vacancy' : 'vacancies'}`}
+                />
+              </Link>
+              <Link href="/agent/lettings/properties?sort=completeness_asc" style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+                <Tile
+                  icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#C49B2A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /><path d="m9 12 2 2 4-4" /></svg>}
+                  label="COMPLETENESS"
+                  value={`${s.avgCompleteness}%`}
+                  subtext={completenessHint}
+                />
+              </Link>
             </>
           )}
         </div>
@@ -199,7 +206,22 @@ export default function LettingsHomePage() {
 
 function Tile({ icon, label, value, subtext }: { icon: React.ReactNode; label: string; value: string; subtext: string }) {
   return (
-    <div style={{ background: '#fff', border: '0.5px solid #E5E7EB', borderRadius: 12, padding: 16, display: 'flex', alignItems: 'center', gap: 14 }}>
+    <div style={{ position: 'relative', background: '#fff', border: '0.5px solid #E5E7EB', borderRadius: 12, padding: 16, display: 'flex', alignItems: 'center', gap: 14 }}>
+      {/* Session 14c — soft chevron telegraphs that the tile is tappable. */}
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          opacity: 0.35,
+          fontSize: 12,
+          color: '#6B7280',
+          pointerEvents: 'none',
+        }}
+      >
+        ›
+      </span>
       <div style={{ flexShrink: 0, width: 36, height: 36, borderRadius: 18, background: 'rgba(212,175,55,0.10)', border: '0.5px solid rgba(212,175,55,0.22)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {icon}
       </div>

--- a/apps/unified-portal/app/agent/lettings/properties/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import AgentShell from '../../_components/AgentShell';
 
 type ActiveTenancy = { tenantName: string | null; rentPcm: number | null; leaseEnd: string | null };
@@ -25,6 +26,31 @@ type Category = 'all' | 'tenanted' | 'vacant' | 'off_market' | 'other';
 
 // Live DB status values come in many shapes (Sessions 5-8 introduced new ones
 // while older rows still use the originals). Collapse to four UI buckets.
+// Session 14c — pick the most readable label for a property row at iPhone
+// width. Prefers address_line_1 when it's a real street address (not an
+// apartment/unit prefix), appending city for context. Falls back to the
+// first one or two comma-separated segments of the full address, which
+// strips eircode + county tail so the row doesn't truncate mid-name.
+function bestRowLabel(p: Property): string {
+  const al1 = (p.addressLine1 ?? '').trim();
+  if (al1 && !/^apt\s/i.test(al1) && !/^unit\s/i.test(al1)) {
+    const city = (p.city ?? '').trim();
+    if (city && !al1.toLowerCase().includes(city.toLowerCase())) {
+      return `${al1}, ${city}`;
+    }
+    return al1;
+  }
+  const full = (p.address ?? '').trim();
+  if (full) {
+    const segments = full.split(',').map((s) => s.trim()).filter(Boolean);
+    if (segments.length >= 2 && segments[0].length > 2 && segments[1].length > 2) {
+      return `${segments[0]}, ${segments[1]}`;
+    }
+    return segments[0] || full;
+  }
+  return 'Untitled property';
+}
+
 function categorise(s: string): Exclude<Category, 'all'> {
   const v = (s ?? '').toLowerCase();
   if (v === 'let' || v === 'occupied' || v === 'tenanted') return 'tenanted';
@@ -35,12 +61,27 @@ function categorise(s: string): Exclude<Category, 'all'> {
 }
 
 export default function LettingsPropertiesPage() {
+  // Session 14c — deep-linkable filter + sort. Tiles on the lettings home
+  // can hand the user here pre-filtered (e.g. ?status=vacant from the
+  // VACANCIES tile) or pre-sorted (?sort=completeness_asc from the
+  // COMPLETENESS tile). Pill interactions still override these — once
+  // the user touches a pill, the URL param is no longer authoritative.
+  const searchParams = useSearchParams();
+  const initialFilter: Category = (() => {
+    const s = searchParams.get('status');
+    if (s === 'vacant' || s === 'tenanted' || s === 'off_market') return s as Category;
+    return 'all';
+  })();
+  const initialSort: 'default' | 'completeness_asc' =
+    searchParams.get('sort') === 'completeness_asc' ? 'completeness_asc' : 'default';
+
   const [data, setData] = useState<ListResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [filter, setFilter] = useState<Category>('all');
+  const [filter, setFilter] = useState<Category>(initialFilter);
   const [city, setCity] = useState<string>('all');
+  const [sortMode, setSortMode] = useState<'default' | 'completeness_asc'>(initialSort);
 
   useEffect(() => {
     let cancelled = false;
@@ -85,6 +126,17 @@ export default function LettingsPropertiesPage() {
       return p.address.toLowerCase().includes(q) || tenant.includes(q);
     });
   }, [data, search, filter, city]);
+
+  // Session 14c — sort mode applied after filtering. The default keeps
+  // server order (created_at desc); 'completeness_asc' surfaces the most
+  // incomplete properties first so the agent can fill them in.
+  const sorted = useMemo(() => {
+    const list = [...filtered];
+    if (sortMode === 'completeness_asc') {
+      list.sort((a, b) => a.completenessScore - b.completenessScore);
+    }
+    return list;
+  }, [filtered, sortMode]);
 
   const totalCount = data?.totalCount ?? 0;
   const tenantedCount = data?.tenantedCount ?? 0;
@@ -191,16 +243,16 @@ export default function LettingsPropertiesPage() {
                     </div>
                   ))}
                 </>
-              ) : filtered.length === 0 ? (
+              ) : sorted.length === 0 ? (
                 <p className="text-center text-sm text-[#A0A8B0] mt-8">No properties match these filters.</p>
               ) : (
-                filtered.map((p) => {
+                sorted.map((p) => {
                   const cat = categorise(p.status);
                   const ringPct = Math.max(0, Math.min(100, p.completenessScore));
                   const offset = 2 * Math.PI * 13 * (1 - ringPct / 100);
                   const pillStyle =
                     cat === 'tenanted' ? { background: '#FAF3DD', color: '#A47E1B' }
-                    : cat === 'vacant' ? { background: '#F3F4F6', color: '#6B7280' }
+                    : cat === 'vacant' ? { background: '#FEF2F2', color: '#B91C1C' }
                     : cat === 'off_market' ? { background: '#E5E7EB', color: '#4B5563' }
                     : { background: '#F3F4F6', color: '#6B7280' };
                   const pillLabel = cat === 'tenanted' ? 'Tenanted' : cat === 'vacant' ? 'Vacant' : cat === 'off_market' ? 'Off-market' : 'Other';
@@ -214,7 +266,7 @@ export default function LettingsPropertiesPage() {
                         <div className="absolute inset-0 flex items-center justify-center text-[9px] font-semibold text-[#0D0D12]">{ringPct}</div>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <div className="text-sm font-semibold text-[#0D0D12] truncate">{p.address || p.addressLine1 || 'Untitled property'}</div>
+                        <div className="text-sm font-semibold text-[#0D0D12] truncate">{bestRowLabel(p)}</div>
                         <div className="text-xs text-[#6B7280] truncate">{p.activeTenancy?.tenantName || (cat === 'tenanted' ? 'Tenanted' : 'Vacant')}</div>
                       </div>
                       <div className="flex flex-col items-end gap-1 flex-shrink-0">


### PR DESCRIPTION
## Summary

Four targeted polish items across the lettings home + properties surfaces. Each one closes a 30-second-investor-noticeable gap.

**P-A — Vacant pill urgency.** Vacant rows had a neutral grey pill, identical to off-market. For a letting agent, vacant ≠ neutral — it's the thing that needs attention. Swapped to soft red (`#FEF2F2 / #B91C1C` — Tailwind red-50 + red-700, visible warning, not alarm). Tenanted stays gold (goal state), off-market stays grey (intentionally calm).

**P-B — Home tiles tappable.** Three home tiles (VACANCIES, PORTFOLIO, COMPLETENESS) wrapped in `<Link>`s with sensible deep-links: VACANCIES → `?status=vacant`, PORTFOLIO → no params, COMPLETENESS → `?sort=completeness_asc`. Tile component itself gains `position: relative` + a soft right-pointing chevron at top-right (opacity 0.35, color `#6B7280`) so the tap affordance is visible without competing with the value.

**P-C — Properties reads URL params.** P-B is useless without this. Page now imports `useSearchParams`, computes `initialFilter` from `?status` and `initialSort` from `?sort` at mount, seeds `useState`. New `sorted` memo applies `completeness_asc` ordering on top of the existing `filtered` chain; render swaps `filtered.map` / `filtered.length` for `sorted.map` / `sorted.length`. Pill interactions still override (`useState` controls truth after mount).

**P-D — Address truncation polish.** Long seeded addresses (`"1 Rose Hill, Kilmoney, Carrigaline, County Cork, P43 V257"`) were truncating mid-string at iPhone width — agent couldn't see the road name. New `bestRowLabel(p)` helper prefers `address_line_1 + city` when line 1 looks like a real street (not "Apt 7" / "Unit 3"), otherwise falls back to the first 1-2 comma-segments of `address` so eircode + county tail get stripped cleanly.

## Investor click-path trace

Home tab → see three tiles (VACANCIES is the lead with the new soft chevron in the corner) → tap VACANCIES tile → router pushes `/agent/lettings/properties?status=vacant`.

The properties page mounts: `useSearchParams().get('status')` returns `'vacant'`, `initialFilter` resolves to `'vacant'`, `useState<Category>(initialFilter)` seeds the filter pill at "Vacant". `useState<...>(initialSort)` is `'default'` (no sort param). The `filtered` memo's `if (filter !== 'all' && categorise(p.status) !== filter) return false` filters to vacant rows only. `sorted` memo no-ops when sortMode is default.

Render: visible filter pills show "Vacant (3)" selected (gold bg). Three rows render. Each row's status pill is now soft red (`#FEF2F2` bg, `#B91C1C` text) — instantly visible as "needs action". Each row's address renders via `bestRowLabel(p)`: "1 Rose Hill, Kilmoney" / "23 Innishmore, Ballincollig" / "Apt 4 The Quay, Cork" — readable at iPhone width without mid-string truncation.

Agent taps a row → `<Link href="/agent/lettings/properties/{id}">` → property detail page (Session 10 surface, untouched).

Alternate path: Home → tap COMPLETENESS tile → `?sort=completeness_asc` → properties page mounts with `sortMode='completeness_asc'`, `sorted` memo orders rows by `completenessScore` ascending — lowest scores first, exactly the work-needs-doing surface the agent wants.

Override behaviour: from the deep-linked Vacant view, tap the "All" pill → `setFilter('all')` flips local state, the `filtered` memo recomputes without the URL param mattering. Pills are uncontrolled by URL once the user interacts.

## Test plan

- [ ] **P-A**: Open Properties — confirm vacant rows render soft-red status pill, tenanted rows stay gold, off-market stays grey.
- [ ] **P-B**: Home page — confirm each of the three tiles has a faint right chevron in the top-right; tap each in turn and confirm correct destination + filter/sort state.
- [ ] **P-C**: Visit `/agent/lettings/properties?status=vacant` directly → Vacant pill selected on mount. Visit `?sort=completeness_asc` → rows sorted ascending by completeness. Tap "All" pill → switches filter regardless of URL param.
- [ ] **P-D**: Find Sam's "1 Rose Hill, Kilmoney, Carrigaline, County Cork, P43 V257" — confirm row reads as "1 Rose Hill, Kilmoney" or similar. Find Aisling's row — confirm it reads as "7 Lapps Quay, Cork".
- [ ] Confirm no regression on properties without `addressLine1` (the helper falls back to comma-split).


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_