### PR TITLE
feat(sales): wire dead Intelligence surfaces to prefill rail + FAB badge cleanup (session 14d)

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -246,7 +246,11 @@ export default function BottomNav() {
               priority
             />
           </div>
-          {draftsCount > 0 && <FabDraftsBadge count={draftsCount} />}
+          {/* Session 14d — FAB drafts badge removed. The StatusBar Drafts
+              chip already surfaces the same count, and the badge here was
+              adding visual clutter. FabDraftsBadge component left in
+              place for now (unreferenced) — not aggressively purging
+              during freeze. */}
         </Link>
 
         {/* Intelligence nav label */}

--- a/apps/unified-portal/app/agent/_components/StatModal.tsx
+++ b/apps/unified-portal/app/agent/_components/StatModal.tsx
@@ -5,6 +5,17 @@ import Link from 'next/link';
 import Image from 'next/image';
 import type { StatModalType, Scheme, Buyer } from './types';
 
+// Session 14d — second slice of the urgent drill-down. Mortgage-expiry
+// alerts now render in their own section so the modal count matches the
+// home stat. Shape mirrors the home page's `ExpiringMortgage` exactly.
+export interface ExpiringMortgage {
+  id: string;
+  name: string;
+  unit: string;
+  schemeName: string;
+  daysUntilExpiry: number;
+}
+
 interface StatModalProps {
   type: StatModalType;
   onClose: () => void;
@@ -12,6 +23,7 @@ interface StatModalProps {
   totalSold: number;
   totalActive: number;
   urgentBuyers: Buyer[];
+  expiringMortgages: ExpiringMortgage[];
 }
 
 export default function StatModal({
@@ -21,6 +33,7 @@ export default function StatModal({
   totalSold,
   totalActive,
   urgentBuyers,
+  expiringMortgages,
 }: StatModalProps) {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -101,7 +114,7 @@ export default function StatModal({
             <ActiveContent schemes={schemes} totalActive={totalActive} />
           )}
           {type === 'urgent' && (
-            <UrgentContent urgentBuyers={urgentBuyers} />
+            <UrgentContent urgentBuyers={urgentBuyers} expiringMortgages={expiringMortgages} />
           )}
         </div>
       </div>
@@ -341,7 +354,51 @@ function ActiveContent({
 }
 
 /* ─── Urgent / needs attention drill-down ─── */
-function UrgentContent({ urgentBuyers }: { urgentBuyers: Buyer[] }) {
+
+// Session 14d — build a dynamic Intelligence prompt from the urgent
+// items. Sales-side draft tools (chase_aged_contracts, draft_message)
+// understand "Draft contract chase emails to: …" and "Draft mortgage
+// approval extension follow-ups to: …" intents per Session 14's
+// TOOL-USE MANDATE; the Intelligence page auto-fires on ?prompt=… so
+// the agent lands directly in the approval drawer.
+function buildChasePrompt(contracts: Buyer[], mortgages: ExpiringMortgage[]): string {
+  const parts: string[] = [];
+  if (contracts.length > 0) {
+    const list = contracts
+      .map((c) => `${c.name} at ${c.schemeName} ${c.unit} (${c.daysOverdue}d overdue)`)
+      .join('; ');
+    parts.push(`Draft contract chase emails to: ${list}.`);
+  }
+  if (mortgages.length > 0) {
+    const list = mortgages
+      .map((m) => `${m.name} at ${m.schemeName} ${m.unit} (mortgage approval expires in ${m.daysUntilExpiry}d)`)
+      .join('; ');
+    parts.push(`Draft mortgage approval extension follow-ups to: ${list}.`);
+  }
+  return parts.join(' ');
+}
+
+function UrgentContent({
+  urgentBuyers,
+  expiringMortgages,
+}: {
+  urgentBuyers: Buyer[];
+  expiringMortgages: ExpiringMortgage[];
+}) {
+  const total = urgentBuyers.length + expiringMortgages.length;
+  const subhead = urgentBuyers.length > 0 && expiringMortgages.length > 0
+    ? 'Contracts overdue · Mortgage approvals expiring'
+    : urgentBuyers.length > 0
+      ? 'Contracts overdue — solicitor follow-up needed'
+      : expiringMortgages.length > 0
+        ? 'Mortgage approvals expiring — extension needed'
+        : 'No urgent items';
+
+  const chasePrompt = buildChasePrompt(urgentBuyers, expiringMortgages);
+  const chaseHref = chasePrompt
+    ? `/agent/intelligence?prompt=${encodeURIComponent(chasePrompt)}`
+    : '/agent/intelligence';
+
   return (
     <>
       <SectionLabel>Requires action</SectionLabel>
@@ -354,7 +411,7 @@ function UrgentContent({ urgentBuyers }: { urgentBuyers: Buyer[] }) {
           margin: '4px 0 4px',
         }}
       >
-        {urgentBuyers.length} items flagged
+        {total} items flagged
       </h3>
       <p
         style={{
@@ -364,61 +421,30 @@ function UrgentContent({ urgentBuyers }: { urgentBuyers: Buyer[] }) {
           letterSpacing: '0.005em',
         }}
       >
-        Contracts overdue &mdash; solicitor follow-up needed
+        {subhead}
       </p>
 
-      {urgentBuyers.map((b) => (
-        <div
-          key={b.id}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-            padding: '12px 0',
-            borderBottom: '1px solid rgba(0,0,0,0.04)',
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontSize: 13.5,
-                fontWeight: 500,
-                color: '#0D0D12',
-                letterSpacing: '-0.01em',
-              }}
-            >
-              {b.name}
-            </div>
-            <div
-              style={{
-                fontSize: 11.5,
-                color: '#A0A8B0',
-                marginTop: 2,
-              }}
-            >
-              {b.schemeName} &middot; {b.unit}
-            </div>
-          </div>
-          <span
-            style={{
-              background: '#FEF2F2',
-              border: '1px solid rgba(239,68,68,0.2)',
-              borderRadius: 20,
-              padding: '3px 8px',
-              fontSize: 10,
-              fontWeight: 700,
-              color: '#DC2626',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {b.daysOverdue}d
-          </span>
+      {urgentBuyers.length > 0 && (
+        <>
+          <SectionLabel>Contracts overdue</SectionLabel>
+          {urgentBuyers.map((b) => (
+            <UrgentRow key={b.id} name={b.name} subtitle={`${b.schemeName} · ${b.unit}`} pillText={`${b.daysOverdue}d`} pillTone="red" />
+          ))}
+        </>
+      )}
+
+      {expiringMortgages.length > 0 && (
+        <div style={{ marginTop: urgentBuyers.length > 0 ? 20 : 0 }}>
+          <SectionLabel>Mortgage approvals expiring</SectionLabel>
+          {expiringMortgages.map((m) => (
+            <UrgentRow key={m.id} name={m.name} subtitle={`${m.schemeName} · ${m.unit}`} pillText={`${m.daysUntilExpiry}d`} pillTone="amber" />
+          ))}
         </div>
-      ))}
+      )}
 
       {/* CTA button */}
       <Link
-        href="/agent/intelligence"
+        href={chaseHref}
         className="agent-tappable"
         style={{
           display: 'flex',
@@ -453,6 +479,50 @@ function UrgentContent({ urgentBuyers }: { urgentBuyers: Buyer[] }) {
         </span>
       </Link>
     </>
+  );
+}
+
+function UrgentRow({
+  name,
+  subtitle,
+  pillText,
+  pillTone,
+}: {
+  name: string;
+  subtitle: string;
+  pillText: string;
+  pillTone: 'red' | 'amber';
+}) {
+  const pillStyle = pillTone === 'red'
+    ? { background: '#FEF2F2', border: '1px solid rgba(239,68,68,0.2)', color: '#DC2626' }
+    : { background: '#FEF3C7', border: '1px solid rgba(217,119,6,0.25)', color: '#92400E' };
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 0',
+        borderBottom: '1px solid rgba(0,0,0,0.04)',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13.5, fontWeight: 500, color: '#0D0D12', letterSpacing: '-0.01em' }}>{name}</div>
+        <div style={{ fontSize: 11.5, color: '#A0A8B0', marginTop: 2 }}>{subtitle}</div>
+      </div>
+      <span
+        style={{
+          ...pillStyle,
+          borderRadius: 20,
+          padding: '3px 8px',
+          fontSize: 10,
+          fontWeight: 700,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {pillText}
+      </span>
+    </div>
   );
 }
 

--- a/apps/unified-portal/app/agent/home/page.tsx
+++ b/apps/unified-portal/app/agent/home/page.tsx
@@ -79,6 +79,31 @@ function buildUrgentBuyers(pipeline: PipelineUnit[], alerts: Alert[]): UIBuyer[]
     });
 }
 
+// Session 14d — second slice of the alerts feed for the StatModal's
+// urgent drill-down. The home stat counts ALL alerts; previously only
+// overdue_contracts surfaced in the modal so the headline number and
+// the visible list disagreed. Mortgage approvals get their own section
+// with amber pills to differentiate from red contract overdue rows.
+export interface ExpiringMortgage {
+  id: string;
+  name: string;
+  unit: string;
+  schemeName: string;
+  daysUntilExpiry: number;
+}
+
+function buildExpiringMortgages(alerts: Alert[]): ExpiringMortgage[] {
+  return alerts
+    .filter(a => a.type === 'mortgage_expiry')
+    .map(a => ({
+      id: a.unitId,
+      name: a.purchaserName,
+      unit: `Unit ${a.unitNumber}`,
+      schemeName: a.developmentName,
+      daysUntilExpiry: a.daysUntilExpiry || 0,
+    }));
+}
+
 export default function AgentHomePage() {
   const { agent, pipeline, alerts, developments, loading } = useAgent();
   const router = useRouter();
@@ -109,6 +134,7 @@ export default function AgentHomePage() {
 
   const schemes = useMemo(() => buildSchemes(pipeline, developments), [pipeline, developments]);
   const urgentBuyers = useMemo(() => buildUrgentBuyers(pipeline, alerts), [pipeline, alerts]);
+  const expiringMortgages = useMemo(() => buildExpiringMortgages(alerts), [alerts]);
 
   if (loading) {
     return (
@@ -147,6 +173,7 @@ export default function AgentHomePage() {
           totalSold={stats.sold}
           totalActive={stats.active}
           urgentBuyers={urgentBuyers}
+          expiringMortgages={expiringMortgages}
         />
       ) : undefined}
     >

--- a/apps/unified-portal/app/agent/pipeline/[unitId]/page.tsx
+++ b/apps/unified-portal/app/agent/pipeline/[unitId]/page.tsx
@@ -109,6 +109,18 @@ export default function UnitProfilePage() {
   const isMortgageUrgent =
     mortgageDays !== null && mortgageDays <= 45 && mortgageDays > 0;
 
+  // Session 14d — wire the dead "Follow up with Intelligence" surfaces
+  // to the existing Intelligence prefill rail. Builds a unit-specific
+  // prompt that auto-fires via /agent/intelligence?prompt=...
+  const unitContext = `${profile.unitNumber} ${profile.developmentName}`;
+  const purchaserName = profile.purchaserName || 'the buyer';
+  const followUpPrompt = isOverdue
+    ? `Draft a contract chase email to ${purchaserName}'s solicitor for ${unitContext} — contracts have been outstanding for ${contractDays} days.`
+    : isMortgageUrgent
+      ? `Draft a mortgage approval extension follow-up email to ${purchaserName} for ${unitContext} — their mortgage approval expires in ${mortgageDays} days.`
+      : `Draft a follow-up email to ${purchaserName} for ${unitContext}.`;
+  const followUpHref = `/agent/intelligence?prompt=${encodeURIComponent(followUpPrompt)}`;
+
   const statusLabel: Record<string, string> = {
     for_sale: 'For Sale',
     sale_agreed: 'Sale Agreed',
@@ -186,23 +198,32 @@ export default function UnitProfilePage() {
             <p className="text-sm text-amber-800">{summary}</p>
           </div>
 
-          {/* Alert banners */}
+          {/* Alert banners — Session 14d: now tappable, route to the
+              Intelligence page with a unit-specific draft prompt that
+              auto-fires. Chevron at the trailing edge signals tappability. */}
           {isOverdue && (
-            <div className="bg-red-50 border border-red-100 rounded-xl p-3 flex items-center gap-2.5 mb-2">
+            <Link
+              href={followUpHref}
+              className="bg-red-50 border border-red-100 rounded-xl p-3 flex items-center gap-2.5 mb-2 no-underline agent-tappable hover:bg-red-100/50 transition-colors"
+            >
               <AlertTriangle size={16} className="text-red-500 flex-shrink-0" />
-              <span className="text-sm text-red-600">
-                Contracts {contractDays} days overdue: solicitor follow-up
-                needed
+              <span className="text-sm text-red-600 flex-1">
+                Contracts {contractDays} days overdue: solicitor follow-up needed
               </span>
-            </div>
+              <span className="text-red-400 text-sm" aria-hidden>›</span>
+            </Link>
           )}
           {isMortgageUrgent && (
-            <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 flex items-center gap-2.5 mb-2">
+            <Link
+              href={followUpHref}
+              className="bg-amber-50 border border-amber-200 rounded-xl p-3 flex items-center gap-2.5 mb-2 no-underline agent-tappable hover:bg-amber-100/50 transition-colors"
+            >
               <Clock size={16} className="text-amber-600 flex-shrink-0" />
-              <span className="text-sm text-amber-700">
+              <span className="text-sm text-amber-700 flex-1">
                 Mortgage approval expires in {mortgageDays} days
               </span>
-            </div>
+              <span className="text-amber-500 text-sm" aria-hidden>›</span>
+            </Link>
           )}
 
           {/* Intelligence Activity */}
@@ -453,11 +474,15 @@ export default function UnitProfilePage() {
         className="fixed bottom-[76px] left-0 right-0 bg-[#FAFAF8] border-t border-gray-100 px-5 py-3 z-40"
         style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
       >
-        {/* Intelligence button */}
-        <button className="w-full py-3 rounded-full bg-gray-900 text-white text-sm font-medium flex items-center justify-center gap-2 mb-2 transition-all duration-150 active:scale-[0.98]">
+        {/* Intelligence button — Session 14d: real Link to a prefilled
+            Intelligence prompt that auto-fires the appropriate draft tool. */}
+        <Link
+          href={followUpHref}
+          className="w-full py-3 rounded-full bg-gray-900 text-white text-sm font-medium flex items-center justify-center gap-2 mb-2 transition-all duration-150 active:scale-[0.98] no-underline"
+        >
           <Zap size={16} className="text-[#D4AF37]" />
           Follow up with Intelligence
-        </button>
+        </Link>
         {/* Action row */}
         <div className="flex gap-2">
           {profile.purchaserPhone ? (


### PR DESCRIPTION
## Summary

Four targeted connectivity fixes on the sales-agent surface. Three sites that promised Intelligence-driven actions and delivered nothing now route to the existing prefill rail (`/agent/intelligence?prompt=...` already auto-fires `handleSend(prefillPrompt)`). One cosmetic removal on the FAB.

**Fix A — "Need attention" modal split.** Home stat counts ALL alerts (`alerts.length` = 5 for Orla); the modal's `UrgentContent` only rendered alerts where `type === 'overdue_contracts'` (3 of 5), silently dropping the 2 mortgage-expiry alerts. Headline number and visible list disagreed. Now: home page builds two arrays (`urgentBuyers` for overdue contracts, `expiringMortgages` for mortgage expiry) and passes both to the modal. Modal renders two sections with eyebrow labels — "Contracts overdue" with red `Nd` pills, "Mortgage approvals expiring" with amber `Nd` pills — and a single combined header showing the true total ("5 items flagged"). Empty sections collapse cleanly.

**Fix B — "Chase all with Intelligence" actually drafts.** The CTA button at the bottom of the urgent modal pointed at bare `/agent/intelligence` — the agent landed on the empty Intelligence landing screen. Now it constructs a dynamic prompt from both arrays via `buildChasePrompt(contracts, mortgages)`:

> Draft contract chase emails to: Laura Hayes at Árdan View Unit 19 (66d overdue); ... Draft mortgage approval extension follow-ups to: Prem Rai at Árdan View Unit 12 (mortgage approval expires in 18d); ...

URL becomes `/agent/intelligence?prompt=<encoded>`. The Intelligence page detects `prefillPrompt` and auto-fires `handleSend()` on mount. Sales-side draft tools handle the request per Session 14's TOOL-USE MANDATE; the approval drawer opens with one draft per buyer.

**Fix C — Unit detail: red banner, amber banner, "Follow up with Intelligence" button all wired.** All three were inert. Now each is a `<Link>` to `/agent/intelligence?prompt=<encoded>`. The prompt is unit-specific and chooses the contract-vs-mortgage-vs-generic flavour based on which alert is active:

- `isOverdue` → `Draft a contract chase email to {buyer}'s solicitor for {unit} {scheme} — contracts have been outstanding for {N} days.`
- `isMortgageUrgent` → `Draft a mortgage approval extension follow-up email to {buyer} for {unit} {scheme} — their mortgage approval expires in {N} days.`
- otherwise → `Draft a follow-up email to {buyer} for {unit} {scheme}.`

Banners gain a chevron `›` at the trailing edge to signal tappability. The big black "Follow up with Intelligence" button in the sticky bottom action bar converts from inert `<button>` to `<Link>`.

**Fix D — Remove the FAB drafts badge.** The "9+" gold pill on the protruding Intelligence FAB at the bottom-nav was visual clutter; the StatusBar's Drafts chip already surfaces the count more clearly. Removed the conditional render `{draftsCount > 0 && <FabDraftsBadge count={draftsCount} />}`. The `FabDraftsBadge` component itself stays defined (unreferenced) — not aggressively purging during freeze.

## Investor click-path trace

1. **Home → "Need attention" stat shows 5** (Orla has 3 overdue contracts + 2 mortgage approvals expiring soon). Tap.
2. **Modal opens** with `<UrgentContent>` rendering. Header: **"5 items flagged"** + subhead **"Contracts overdue · Mortgage approvals expiring"**. Below: section eyebrow "Contracts overdue" + 3 buyer rows with red `Nd` pills (Laura Hayes 66d / etc). Below that: section eyebrow "Mortgage approvals expiring" + 2 buyer rows with amber `Nd` pills.
3. **Tap "Chase all with Intelligence →"** at the bottom. `buildChasePrompt` constructs the full request string, URL becomes `/agent/intelligence?prompt=<encoded>` (~600 chars).
4. **Intelligence page mounts.** `prefillPrompt` detected, `handleSend(prompt)` auto-fires within ~50ms of mount. The user sees their query bubble appear, then the 14a `<ProgressCard>` cycles through stages (Reading your portfolio → Drafting messages → Composing reply → Almost there).
5. **Approval drawer opens** with up to 5 drafts (3 contract chases + 2 mortgage extensions). Each is independently reviewable, editable, sendable. The chat thread shows the AIResponseCard with the new 14b chip hierarchy (primary "Send the drafts now" gold + Mail icon; secondaries with appropriate icons).
6. **Approve a draft** → 14b sent confirmation card lands in the chat: "Sent to Laura Hayes · 11:56 PM" + "View in Drafts" CTA.

Alternate path — **single-buyer follow-up via unit detail**:
1. From the home requires-action list → tap a row → land on `/agent/pipeline/[unitId]`.
2. **Red banner is now tappable** with a chevron, says "Contracts 66 days overdue: solicitor follow-up needed". Tap → `/agent/intelligence?prompt=Draft a contract chase email to Laura Hayes's solicitor for Unit 19 Árdan View — contracts have been outstanding for 66 days.`
3. Same flow as #4–6 above but with one targeted draft.
4. The same `followUpHref` powers the amber mortgage banner (mortgage-flavoured prompt) and the big black "Follow up with Intelligence" sticky button at the bottom.

## Test plan

Fix A:
- [ ] Home stat shows 5, tap to open modal — confirm header reads "5 items flagged" and visible rows total 5 (3 contracts + 2 mortgages).
- [ ] Confirm contract rows have red `Nd` pills, mortgage rows have amber `Nd` pills.
- [ ] If only one section has items, confirm the other section header doesn't render.

Fix B:
- [ ] Tap "Chase all with Intelligence" — confirm URL has `?prompt=...` with both contracts and mortgages encoded.
- [ ] Intelligence page auto-fires the prompt; approval drawer opens with multiple drafts.

Fix C:
- [ ] On a unit with overdue contracts, tap red banner — confirm Intelligence flow with single contract chase draft.
- [ ] On a unit with mortgage_expiry, tap amber banner — confirm mortgage extension draft.
- [ ] On any unit, tap "Follow up with Intelligence" sticky button — confirm flow with appropriate prompt flavour.

Fix D:
- [ ] FAB no longer shows a "9+" badge; OH logo only.


---
_Generated by [Claude Code](https://claude.ai/code/session_014y7PRhJe3xp15LADLndJJa)_