### PR TITLE
fix(agent): stop BTR/lettings copy leaking into sales workspaces

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -112,6 +112,7 @@ export async function POST(request: NextRequest) {
       assignedDevelopmentIds: resolved.assignedDevelopmentIds,
       assignedDevelopmentNames: resolved.assignedDevelopmentNames,
       activeDevelopmentId: activeDevelopmentId ?? null,
+      mode: resolvedMode,
     };
 
     // Session 14.2 — trip-wire log. If `resolveAgentContext` returned a

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -3,30 +3,23 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { FALLBACK_CAPABILITY_CHIPS } from '@/lib/agent-intelligence/capability-chips';
-import { formatAgentAddress, truncateForChip } from '@/lib/agent/format-address';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
- * Session 11 — GET /api/agent/intelligence/capability-chips.
+ * GET /api/agent/intelligence/capability-chips.
  *
  * Returns an honest, live-data-sourced chip list for the Intelligence
- * landing carousel. Every phrase either references a real scheme the
- * agent is assigned to, a real letting-property address on their books,
- * or is context-free ("Generate developer weekly report").
+ * landing carousel. The route branches on `?mode=` — `lettings` runs
+ * `composeLettingsChips` (real tenancies + vacancies + lettings phrases),
+ * anything else runs `composeChips` (sales-only chips: schemes, chase,
+ * weekly report, drafts).
  *
- * Session 12 — address composition now goes through the shared
- * `formatAgentAddress` helper so structured
- * `address_line_1 / address_line_2 / city / eircode` fields are used
- * when available. No silent prefix stripping (goodbye "Apt 12 → 12
- * Grand Parade" bug).
- *
- * Chips are omitted when the underlying data doesn't exist:
- *   - no letting properties → no rental-viewing or letting chips
- *   - zero applicants → no "Show me applicants for X" chips
- *   - zero tenancies → no renewal chips
- *   - zero drafts → no "Review my drafts" chip
+ * Lettings-flavoured chips ("Renewals due", "Log a rental viewing",
+ * "Letting applicants", "Rental viewings") live exclusively in
+ * composeLettingsChips. Mixing them into the sales composer leaks BTR
+ * vocabulary into Sales workspaces.
  */
 
 interface ChipResponse {
@@ -151,10 +144,6 @@ async function composeChips(
 ): Promise<string[]> {
   const [
     assignmentsRes,
-    lettingsRes,
-    tenanciesCountRes,
-    applicantsCountRes,
-    rentalViewingsCountRes,
     draftsCountRes,
   ] = await Promise.all([
     supabase
@@ -162,29 +151,6 @@ async function composeChips(
       .select('development_id')
       .eq('agent_id', agentId)
       .eq('is_active', true),
-    // Session 12: pull the structured address fields alongside the
-    // legacy denormalised `address` column. The formatter picks
-    // structured fields when present and falls back verbatim otherwise.
-    supabase
-      .from('agent_letting_properties')
-      .select('id, address, address_line_1, address_line_2, city, eircode')
-      .eq('agent_id', agentId)
-      .order('created_at', { ascending: false })
-      .limit(3),
-    supabase
-      .from('agent_tenancies')
-      .select('id', { count: 'exact', head: true })
-      .eq('agent_id', agentId)
-      .eq('status', 'active'),
-    supabase
-      .from('agent_applicants')
-      .select('id', { count: 'exact', head: true })
-      .eq('agent_id', agentId),
-    supabase
-      .from('agent_viewings')
-      .select('id', { count: 'exact', head: true })
-      .eq('agent_id', agentId)
-      .not('letting_property_id', 'is', null),
     supabase
       .from('pending_drafts')
       .select('id', { count: 'exact', head: true })
@@ -207,21 +173,6 @@ async function composeChips(
     schemeNames = (devs ?? []).map((d: any) => d.name).filter(Boolean);
   }
 
-  const lettingProps = (lettingsRes.data ?? []) as Array<{
-    id: string;
-    address: string | null;
-    address_line_1: string | null;
-    address_line_2: string | null;
-    city: string | null;
-    eircode: string | null;
-  }>;
-  const lettingAddresses = lettingProps
-    .map((p) => truncateForChip(formatAgentAddress(p, 'short')))
-    .filter(Boolean) as string[];
-
-  const tenanciesCount = tenanciesCountRes.count ?? 0;
-  const applicantsCount = applicantsCountRes.count ?? 0;
-  const rentalViewingsCount = rentalViewingsCountRes.count ?? 0;
   const draftsCount = draftsCountRes.count ?? 0;
 
   // Session 14.12 — chip copy is short, action-oriented, and never
@@ -245,20 +196,6 @@ async function composeChips(
   chips.push('Chase aged contracts');
   chips.push('Show overdue chases');
   chips.push('Signed this week?');
-
-  // --- Lettings: only when real rows exist.
-  if (lettingAddresses.length) {
-    chips.push('Log a rental viewing');
-  }
-  if (tenanciesCount > 0) {
-    chips.push('Renewals due');
-  }
-  if (applicantsCount > 0 && lettingAddresses.length) {
-    chips.push('Letting applicants');
-  }
-  if (rentalViewingsCount > 0) {
-    chips.push('Rental viewings');
-  }
 
   // --- Reporting / scheduling / briefings: always safe.
   chips.push('Weekly report');

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -513,14 +513,14 @@ ${independentContext || ''}
 FOLLOW-UP SUGGESTIONS:
 ============================================================
 After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
-- After chase draft: "Approve chase email", "Draft the next week's renewals", "Show aged contracts by scheme"
-- After briefing: "Approve briefing", "Draft chase emails for aged contracts", "Show arrears detail"
+- After chase draft: "Approve chase email", "Show aged contracts by scheme", "Draft chase emails for other overdue buyers"
+- After briefing: "Approve briefing", "Draft chase emails for aged contracts", "Review units needing attention"
 
 ============================================================
 PROACTIVE INTELLIGENCE:
 ============================================================
 - Flag related issues the agent might not have thought of, but only when supported by the live context or a tool result.
-- Call out RPZ implications on renewals, upcoming lease ends inside the 90-day notice window, and contracts approaching the 42-day threshold.
+- Call out aged contracts, upcoming closing dates inside the 30-day window, and units where buyer responsiveness has dropped.
 - Never invent patterns or communication history.`;
 
   return `${identityBlock}\n\n${scopeBlock}\n\n${basePrompt}`;

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -22,6 +22,12 @@ export interface SkillAgentContext {
   displayName: string;
   agencyName: string;
   phone?: string;
+  /**
+   * Active workspace mode. Skills that have lettings-flavoured copy
+   * (rent_roll, lease_end, fallback help text) branch on this to keep
+   * BTR vocabulary out of Sales workspaces. Undefined is treated as 'sales'.
+   */
+  mode?: 'sales' | 'lettings';
 }
 
 function formatIrishDate(iso: string | null | undefined): string {
@@ -663,50 +669,60 @@ export async function naturalQuery(
     let patternName: string = intent;
     let recordIds: string[] = [];
 
+    const mode = agentContext.mode === 'lettings' ? 'lettings' : 'sales';
+
     if (intent === 'rent_roll') {
-      const { data } = await supabase
-        .from('agent_tenancies')
-        .select('id, rent_pcm')
-        .eq('agent_id', agentContext.agentProfileId)
-        .eq('status', 'active');
-      const rows = data || [];
-      const total = rows.reduce((sum: number, r: any) => sum + (Number(r.rent_pcm) || 0), 0);
-      recordIds = rows.map((r: any) => r.id);
-      answer = `Your current monthly rent roll is €${total.toLocaleString('en-IE')} across ${rows.length} active tenanc${rows.length === 1 ? 'y' : 'ies'}.`;
-    } else if (intent === 'lease_end') {
-      const name = extractTenantName(question);
-      if (!name) {
-        answer = "I couldn't pick up a tenant name from that question. Try something like: when does Priya Shah's lease end?";
+      if (mode !== 'lettings') {
+        answer = "That's a lettings-mode capability. Switch to your Lettings workspace to ask about rent roll.";
       } else {
         const { data } = await supabase
           .from('agent_tenancies')
-          .select('id, letting_property_id, tenant_name, lease_end, status')
+          .select('id, rent_pcm')
           .eq('agent_id', agentContext.agentProfileId)
-          .eq('status', 'active')
-          .ilike('tenant_name', `%${name}%`);
+          .eq('status', 'active');
         const rows = data || [];
-        if (!rows.length) {
-          answer = "I couldn't find an active tenancy matching that name.";
+        const total = rows.reduce((sum: number, r: any) => sum + (Number(r.rent_pcm) || 0), 0);
+        recordIds = rows.map((r: any) => r.id);
+        answer = `Your current monthly rent roll is €${total.toLocaleString('en-IE')} across ${rows.length} active tenanc${rows.length === 1 ? 'y' : 'ies'}.`;
+      }
+    } else if (intent === 'lease_end') {
+      if (mode !== 'lettings') {
+        answer = "That's a lettings-mode capability. Switch to your Lettings workspace to ask about lease end dates.";
+      } else {
+        const name = extractTenantName(question);
+        if (!name) {
+          answer = "I couldn't pick up a tenant name from that question. Try something like: when does Priya Shah's lease end?";
         } else {
-          const propertyIds = Array.from(new Set(rows.map((t: any) => t.letting_property_id).filter(Boolean)));
-          const { data: props } = await supabase
-            .from('agent_letting_properties')
-            .select('id, address')
-            .in('id', propertyIds);
-          const addressById = new Map<string, string>((props || []).map((p: any) => [p.id, p.address]));
-          if (rows.length === 1) {
-            const t = rows[0];
-            const address = addressById.get(t.letting_property_id) || 'Unknown property';
-            const days = Math.max(0, Math.round((new Date(t.lease_end).getTime() - Date.now()) / 86400000));
-            answer = `${t.tenant_name}'s lease at ${address} ends on ${formatIrishDate(t.lease_end)} (${days} days).`;
+          const { data } = await supabase
+            .from('agent_tenancies')
+            .select('id, letting_property_id, tenant_name, lease_end, status')
+            .eq('agent_id', agentContext.agentProfileId)
+            .eq('status', 'active')
+            .ilike('tenant_name', `%${name}%`);
+          const rows = data || [];
+          if (!rows.length) {
+            answer = "I couldn't find an active tenancy matching that name.";
           } else {
-            const top = rows.slice(0, 3).map((t: any) => {
+            const propertyIds = Array.from(new Set(rows.map((t: any) => t.letting_property_id).filter(Boolean)));
+            const { data: props } = await supabase
+              .from('agent_letting_properties')
+              .select('id, address')
+              .in('id', propertyIds);
+            const addressById = new Map<string, string>((props || []).map((p: any) => [p.id, p.address]));
+            if (rows.length === 1) {
+              const t = rows[0];
               const address = addressById.get(t.letting_property_id) || 'Unknown property';
-              return `- ${t.tenant_name} at ${address} — ${formatIrishDate(t.lease_end)}`;
-            });
-            answer = [`Found ${rows.length} matching tenancies:`, ...top].join('\n');
+              const days = Math.max(0, Math.round((new Date(t.lease_end).getTime() - Date.now()) / 86400000));
+              answer = `${t.tenant_name}'s lease at ${address} ends on ${formatIrishDate(t.lease_end)} (${days} days).`;
+            } else {
+              const top = rows.slice(0, 3).map((t: any) => {
+                const address = addressById.get(t.letting_property_id) || 'Unknown property';
+                return `- ${t.tenant_name} at ${address} — ${formatIrishDate(t.lease_end)}`;
+              });
+              answer = [`Found ${rows.length} matching tenancies:`, ...top].join('\n');
+            }
+            recordIds = rows.map((r: any) => r.id);
           }
-          recordIds = rows.map((r: any) => r.id);
         }
       }
     } else if (intent === 'aged_contracts') {
@@ -757,15 +773,22 @@ export async function naturalQuery(
         answer = `You have ${n} unit${n === 1 ? '' : 's'} currently for sale across your schemes.`;
       }
     } else if (intent === 'needs_attention') {
-      const [aged, arrears, renewals] = await Promise.all([
-        loadAgedForBriefing(supabase, agentContext.agentProfileId, 42).catch(() => []),
-        getRentArrears(supabase, agentContext.agentProfileId).catch(() => []),
-        getRenewalWindow(supabase, agentContext.agentProfileId).catch(() => []),
-      ]);
-      answer = `Items needing attention: ${aged.length} aged contracts, ${arrears.length} rent arrears, ${renewals.length} renewals due.`;
+      if (mode === 'lettings') {
+        const [aged, arrears, renewals] = await Promise.all([
+          loadAgedForBriefing(supabase, agentContext.agentProfileId, 42).catch(() => []),
+          getRentArrears(supabase, agentContext.agentProfileId).catch(() => []),
+          getRenewalWindow(supabase, agentContext.agentProfileId).catch(() => []),
+        ]);
+        answer = `Items needing attention: ${aged.length} aged contracts, ${arrears.length} rent arrears, ${renewals.length} renewals due.`;
+      } else {
+        const aged = await loadAgedForBriefing(supabase, agentContext.agentProfileId, 42).catch(() => []);
+        answer = `Items needing attention: ${aged.length} aged contracts (issued over 6 weeks ago with no signature).`;
+      }
     } else {
       patternName = 'fallback';
-      answer = 'I can answer questions about your pipeline, lettings, viewings, and tenancies. Try asking about: aged contracts, rent roll, lease end for [tenant], upcoming viewings, or what needs your attention.';
+      answer = mode === 'lettings'
+        ? 'I can answer questions about your pipeline, lettings, viewings, and tenancies. Try asking about: aged contracts, rent roll, lease end for [tenant], upcoming viewings, or what needs your attention.'
+        : 'I can answer questions about your pipeline, viewings, and what needs your attention. Try asking about: aged contracts, units sale-agreed but not signed, buyers awaiting kitchen finishes, or upcoming closings.';
     }
 
     const draftId = randomUUID();

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -69,6 +69,7 @@ async function runAgenticSkill<I extends Record<string, any>>(
     authUserId: agentContext.authUserId,
     displayName: agentContext.displayName,
     agencyName,
+    mode: agentContext.mode,
   };
   const raw = await fn(supabase, skillCtx, params);
   const envelope = await persistSkillEnvelope(supabase, raw, agentContext);

--- a/apps/unified-portal/lib/agent-intelligence/types.ts
+++ b/apps/unified-portal/lib/agent-intelligence/types.ts
@@ -34,6 +34,13 @@ export interface AgentContext {
    * param.
    */
   activeDevelopmentId?: string | null;
+  /**
+   * Active workspace mode threaded from the chat route's `mode` body param.
+   * Skills branch on this to keep BTR-flavoured copy out of Sales workspaces
+   * and vice versa. Optional for backwards compatibility — undefined is
+   * treated as 'sales'.
+   */
+  mode?: 'sales' | 'lettings';
 }
 
 export interface ToolResult {


### PR DESCRIPTION
Three independent contamination surfaces in the agent intelligence assistant were surfacing BTR vocabulary to Sales agents:

1. Capability-chip carousel: the sales composer was querying agent_letting_properties / agent_tenancies / agent_applicants / agent_viewings and pushing "Log a rental viewing", "Renewals due", "Letting applicants", "Rental viewings" whenever those rows existed. Removed the four chip pushes plus the four feeding queries (and the now-unused formatAgentAddress / truncateForChip imports).

2. Sales system prompt: FOLLOW-UP SUGGESTIONS hard-coded "Draft the next week's renewals" and "Show arrears detail"; PROACTIVE INTELLIGENCE referenced RPZ implications and lease-end notice periods. Replaced with sales-relevant phrases (aged contracts, closing dates, buyer responsiveness).

3. naturalQuery skill: fallback help string and rent_roll / lease_end / needs_attention intent answers were lettings-flavoured regardless of workspace. Added optional mode field to AgentContext + SkillAgentContext, threaded resolvedMode through the chat route and runAgenticSkill, and gated the lettings-only intents to redirect sales agents to their Lettings workspace. needs_attention and the fallback string now branch on mode; sales fallback drops "lettings" and "tenancies" from the copy.