### PR TITLE
fix(agent): single-source greeting/signoff in drafts and clean markdo…

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -303,7 +303,14 @@ function IntelligencePageInner() {
                 }];
               });
             } else if (data.type === 'followups') {
-              followups = data.questions || [];
+              // Defensive: strip wrapping quote characters and leading bullet
+              // glyphs the upstream model may emit despite the prompt.
+              const raw: string[] = Array.isArray(data.questions) ? data.questions : [];
+              followups = raw
+                .map((q) => typeof q === 'string' ? q : '')
+                .map((q) => q.trim().replace(/^[-*•]\s+/, ''))
+                .map((q) => q.replace(/^["“”'](.*)["“”']$/, '$1').trim())
+                .filter(Boolean);
             } else if (data.type === 'tools_used') {
               toolsUsed = data.tools || [];
             } else if (data.type === 'envelope') {
@@ -1140,6 +1147,110 @@ function formatReminder(iso: string): string {
 
 /* ---- Sub-components ---- */
 
+// Minimal markdown renderer for assistant chat bubbles. Handles the patterns
+// the LLM actually emits today: `**bold**`, `*italic*`, bullet lines (`- `,
+// `* `), and numbered lines (`1. `). Anything else is rendered verbatim and
+// preserves line breaks like the previous pre-wrap span. Kept inline so the
+// component avoids pulling in react-markdown (not in package.json) for what
+// is effectively three regex patterns.
+function MarkdownText({ source }: { source: string }) {
+  // Strip surrounding straight or curly double quotes when an entire line is
+  // wrapped in them — older system-prompt examples encouraged the model to
+  // emit `"..."` for suggestions, which would otherwise survive verbatim.
+  function stripWrappingQuotes(s: string): string {
+    const trimmed = s.trim();
+    if (trimmed.length >= 2) {
+      const first = trimmed.charAt(0);
+      const last = trimmed.charAt(trimmed.length - 1);
+      const isQuote = (c: string) => c === '"' || c === '“' || c === '”' || c === '“' || c === '”';
+      if (isQuote(first) && isQuote(last)) return trimmed.slice(1, -1).trim();
+    }
+    return s;
+  }
+
+  function renderInline(text: string): React.ReactNode[] {
+    // Bold (**...**) wins over italic (*...*). Parse by splitting on ** then
+    // walk each segment for single-asterisk italics. Plenty of edge cases
+    // (escaped asterisks, intra-word emphasis) are not handled — chat copy
+    // doesn't need them.
+    const out: React.ReactNode[] = [];
+    const boldParts = text.split(/(\*\*[^*]+\*\*)/g);
+    boldParts.forEach((part, i) => {
+      if (/^\*\*[^*]+\*\*$/.test(part)) {
+        out.push(<strong key={`b${i}`}>{part.slice(2, -2)}</strong>);
+        return;
+      }
+      const italicParts = part.split(/(\*[^*]+\*)/g);
+      italicParts.forEach((sub, j) => {
+        if (/^\*[^*]+\*$/.test(sub)) {
+          out.push(<em key={`i${i}-${j}`}>{sub.slice(1, -1)}</em>);
+        } else if (sub) {
+          out.push(<span key={`t${i}-${j}`}>{sub}</span>);
+        }
+      });
+    });
+    return out;
+  }
+
+  const lines = source.split('\n');
+  const blocks: React.ReactNode[] = [];
+  let bulletBuffer: string[] = [];
+  let numberedBuffer: string[] = [];
+
+  function flushBullets(key: string) {
+    if (!bulletBuffer.length) return;
+    blocks.push(
+      <ul key={`ul-${key}`} style={{ margin: '4px 0', paddingLeft: 20 }}>
+        {bulletBuffer.map((item, i) => (
+          <li key={i} style={{ marginBottom: 2 }}>{renderInline(stripWrappingQuotes(item))}</li>
+        ))}
+      </ul>,
+    );
+    bulletBuffer = [];
+  }
+
+  function flushNumbered(key: string) {
+    if (!numberedBuffer.length) return;
+    blocks.push(
+      <ol key={`ol-${key}`} style={{ margin: '4px 0', paddingLeft: 22 }}>
+        {numberedBuffer.map((item, i) => (
+          <li key={i} style={{ marginBottom: 2 }}>{renderInline(stripWrappingQuotes(item))}</li>
+        ))}
+      </ol>,
+    );
+    numberedBuffer = [];
+  }
+
+  lines.forEach((rawLine, idx) => {
+    const line = rawLine;
+    const bulletMatch = line.match(/^\s*[-*]\s+(.*)$/);
+    const numberedMatch = line.match(/^\s*\d+\.\s+(.*)$/);
+
+    if (bulletMatch) {
+      flushNumbered(`n${idx}`);
+      bulletBuffer.push(bulletMatch[1]);
+      return;
+    }
+    if (numberedMatch) {
+      flushBullets(`b${idx}`);
+      numberedBuffer.push(numberedMatch[1]);
+      return;
+    }
+    flushBullets(`b${idx}`);
+    flushNumbered(`n${idx}`);
+    if (line.trim() === '') {
+      blocks.push(<div key={`sp${idx}`} style={{ height: 8 }} />);
+    } else {
+      blocks.push(<div key={`p${idx}`}>{renderInline(line)}</div>);
+    }
+  });
+
+  flushBullets('end');
+  flushNumbered('end');
+
+  return <>{blocks}</>;
+}
+
 function UserBubble({ text }: { text: string }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
@@ -1443,10 +1554,9 @@ function AIResponseCard({
               lineHeight: 1.6,
               color: '#374151',
               letterSpacing: '-0.005em',
-              whiteSpace: 'pre-wrap',
             }}
           >
-            {text}
+            <MarkdownText source={text} />
           </div>
         )}
 

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -690,10 +690,11 @@ export async function POST(request: NextRequest) {
 
 RULES:
 - Every suggestion must be an ACTION the agent can take, not a question back to the agent.
-- Start each suggestion with a verb: "Draft...", "Check...", "Show...", "Create...", "Generate...", "Log..."
+- Start each suggestion with a verb: Draft, Check, Show, Create, Generate, Log.
 - Never ask the agent a clarifying question. Never use "Would you like..." or "Should I..."
 - Keep each suggestion under 8 words.
 - Make suggestions contextual to what was just discussed.
+- Each string is a clean suggestion. Do NOT wrap suggestions in quote characters, do not start them with a hyphen or bullet, do not add markdown.
 - Return ONLY a JSON array of strings, no explanation.`,
                 },
                 {

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -91,6 +91,62 @@ function shouldBlockDraft(draft: AgenticSkillDraft): { block: boolean; reason: s
   return { block: false, reason: '' };
 }
 
+// Defence-in-depth scrub for assembled email bodies. The skill template is
+// the single source of truth for greeting + sign-off, so a body should
+// carry exactly one of each. If a regression slips greeting/sign-off into
+// the free-text fields the skill template wraps, we end up with two of
+// each. Strip a duplicated leading greeting and any duplicated trailing
+// sign-off block before persisting. Conservative — only fires when the
+// duplication is unambiguous (two adjacent greeting lines, or two sign-off
+// lines within four lines of the tail).
+const GREETING_LINE = /^\s*(hi|hello|hey|dear|good\s+(morning|afternoon|evening))\b[^\n]{0,60}[,!.]?\s*$/i;
+const SIGNOFF_LINE = /^\s*(thanks|thank you|thanks so much|many thanks|best|best regards|kind regards|warm regards|warmest regards|regards|sincerely|sincerely yours|yours|yours sincerely|yours faithfully|cheers|talk soon|speak soon)\b[^\n]{0,30}[,!.]?\s*$/i;
+
+export function dedupeBoilerplate(body: string | null | undefined): string {
+  if (!body) return '';
+  const lines = String(body).replace(/\r\n/g, '\n').split('\n');
+
+  // Leading: drop consecutive duplicate greeting lines, keep one.
+  let firstGreetingIdx = -1;
+  for (let i = 0; i < Math.min(lines.length, 5); i++) {
+    if (lines[i].trim() === '') continue;
+    if (GREETING_LINE.test(lines[i])) firstGreetingIdx = i;
+    break;
+  }
+  if (firstGreetingIdx >= 0) {
+    let j = firstGreetingIdx + 1;
+    // Skip blank lines after the first greeting.
+    while (j < lines.length && lines[j].trim() === '') j++;
+    while (j < lines.length && GREETING_LINE.test(lines[j])) {
+      // Remove this duplicated greeting line.
+      lines.splice(j, 1);
+      while (j < lines.length && lines[j].trim() === '') {
+        lines.splice(j, 1);
+      }
+    }
+  }
+
+  // Trailing: detect repeated sign-off blocks within the last 8 lines.
+  // A "sign-off block" is a sign-off line plus the 0–3 short lines that
+  // follow it (name, optional title, optional company). If we find two
+  // sign-off lines in the tail, drop the EARLIER one and the lines
+  // between it and the later sign-off (those are the duplicate signature
+  // tail of the first block).
+  const tailStart = Math.max(0, lines.length - 8);
+  const signoffIndices: number[] = [];
+  for (let i = tailStart; i < lines.length; i++) {
+    if (SIGNOFF_LINE.test(lines[i])) signoffIndices.push(i);
+  }
+  if (signoffIndices.length >= 2) {
+    const firstSignoff = signoffIndices[0];
+    const lastSignoff = signoffIndices[signoffIndices.length - 1];
+    // Remove from firstSignoff up to (but not including) lastSignoff.
+    lines.splice(firstSignoff, lastSignoff - firstSignoff);
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
 export async function persistDraftsForEnvelope(
   supabase: SupabaseClient,
   envelope: AgenticSkillEnvelope,
@@ -116,9 +172,12 @@ export async function persistDraftsForEnvelope(
     }
 
     const draftType = resolveDraftType(ctx.skill, draft);
+    // Final-mile dedupe: strips duplicate greeting / sign-off blocks if the
+    // template ever ends up wrapping a body that already had them.
+    const cleanBody = draft.type === 'email' ? dedupeBoilerplate(draft.body) : draft.body;
     const contentJson: Record<string, any> = {
       subject: draft.subject ?? null,
-      body: draft.body,
+      body: cleanBody,
       skill: ctx.skill,
       affected_record: draft.affected_record,
       reasoning: draft.reasoning,
@@ -149,11 +208,11 @@ export async function persistDraftsForEnvelope(
       // Log but preserve the original id so the drawer still opens. The
       // draft simply won't be send/discard-able via the inbox endpoints.
       console.error('[persistDraftsForEnvelope] insert failed', { skill: ctx.skill, error: error?.message });
-      rewritten.push(draft);
+      rewritten.push({ ...draft, body: cleanBody });
       continue;
     }
 
-    rewritten.push({ ...draft, id: data.id });
+    rewritten.push({ ...draft, id: data.id, body: cleanBody });
   }
 
   // Thread the blocked list through meta so the chat route can force

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -540,9 +540,16 @@ ${independentContext || ''}
 ============================================================
 FOLLOW-UP SUGGESTIONS:
 ============================================================
-After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
-- After chase draft: "Approve chase email", "Show aged contracts by scheme", "Draft chase emails for other overdue buyers"
-- After briefing: "Approve briefing", "Draft chase emails for aged contracts", "Review units needing attention"
+Follow-up suggestions are surfaced by the UI as dedicated tappable chips that
+the platform generates separately. DO NOT embed a list of suggested next
+steps inside your response body — no bullet list, no numbered list, no
+inline "you might also want to..." prose. End your reply with the answer.
+Never wrap suggestions in quote characters of any kind.
+
+Examples of action-oriented chip copy (the platform generates these; do not
+write them yourself in the body): Approve chase email; Show aged contracts
+by scheme; Draft chase emails for other overdue buyers; Approve briefing;
+Review units needing attention.
 
 ============================================================
 PROACTIVE INTELLIGENCE:
@@ -689,10 +696,17 @@ ${viewingsSummary ? `LETTINGS VIEWINGS:\n${viewingsSummary}` : ''}
 ============================================================
 FOLLOW-UP SUGGESTIONS:
 ============================================================
-After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
-- After a draft to a tenant: "Send the draft now", "Edit the message", "Log maintenance ticket"
-- After a lease lookup: "Draft renewal offer", "Schedule check-in", "Show all leases ending in 30 days"
-- After a compliance gap: "Upload BER cert", "Mark RTB registered", "View property record"
+Follow-up suggestions are surfaced by the UI as dedicated tappable chips
+that the platform generates separately. DO NOT embed a list of suggested
+next steps inside your response body — no bullet list, no numbered list,
+no inline "you might also want to..." prose. End your reply with the
+answer. Never wrap suggestions in quote characters of any kind.
+
+Examples of action-oriented chip copy (the platform generates these; do
+not write them yourself in the body): Send the draft now; Edit the
+message; Log maintenance ticket; Draft renewal offer; Schedule check-in;
+Show all leases ending in 30 days; Upload BER cert; Mark RTB registered;
+View property record.
 
 ============================================================
 PROACTIVE INTELLIGENCE:

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -54,6 +54,51 @@ function firstName(fullName: string | null | undefined): string {
   return fullName.trim().split(/\s+/)[0] ?? 'there';
 }
 
+// Defensive scrubber for the free-text body content the model passes via
+// `topic` / `context` / `custom_instruction`. The skill template already
+// supplies the greeting and the sign-off + signature block, so any greeting
+// or sign-off the model wrote into the body produces a duplicate. Strip a
+// leading greeting line (Hi/Hello/Dear/Hey ...,) and a trailing sign-off
+// block (Thanks/Best/Best regards/Kind regards/Sincerely/Yours/Cheers/
+// Warm regards/Many thanks ... followed by name(s) and an optional company
+// line) before assembly. Conservative on purpose — only strips when the
+// pattern clearly matches a salutation or closing block.
+export function stripGreetingAndSignoff(input: string | null | undefined): string {
+  if (!input) return '';
+  let text = String(input).replace(/\r\n/g, '\n').trim();
+  if (!text) return '';
+
+  const lines = text.split('\n');
+
+  // Leading greeting: Hi X,  /  Hello there,  /  Dear Eoin,  /  Hey,
+  const greetingRe = /^\s*(hi|hello|hey|dear|good\s+(morning|afternoon|evening))\b[^\n]{0,60}[,!.]?\s*$/i;
+  while (lines.length && greetingRe.test(lines[0])) {
+    lines.shift();
+    while (lines.length && lines[0].trim() === '') lines.shift();
+  }
+
+  // Trailing sign-off block. Sign-off line is something like "Thanks,",
+  // "Best regards,", "Kind regards,", "Sincerely,", "Yours,", "Cheers,",
+  // "Warm regards,", "Many thanks,". Followed by 0–3 short non-empty
+  // lines (the agent's name, optional title, optional company) before EOF.
+  const signoffRe = /^\s*(thanks|thank you|thanks so much|many thanks|best|best regards|kind regards|warm regards|warmest regards|regards|sincerely|sincerely yours|yours|yours sincerely|yours faithfully|cheers|talk soon|speak soon)\b[^\n]{0,30}[,!.]?\s*$/i;
+  // Walk backwards skipping trailing blanks.
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+  // Find a sign-off line within the last 5 lines.
+  for (let i = lines.length - 1; i >= Math.max(0, lines.length - 5); i--) {
+    if (signoffRe.test(lines[i])) {
+      // Drop everything from this index onward (sign-off + name/company tail).
+      lines.length = i;
+      break;
+    }
+  }
+
+  // Trim trailing blanks one more time in case the pop loop above didn't.
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+
+  return lines.join('\n').trim();
+}
+
 function errorEnvelope(skill: string, query: string, err: unknown): AgenticSkillEnvelope {
   const message = err instanceof Error ? err.message : String(err);
   return {
@@ -1100,7 +1145,9 @@ async function draftTenantMessage(
   const skill = 'draft_message';
   const recipientName = (inputs.recipient_name || '').trim();
   const propertyHint = (inputs.related_property || '').trim();
-  const context = (inputs.context || '').trim();
+  // Scrub greeting/sign-off the model may have included — the template
+  // below adds them once, which is the single source of truth.
+  const context = stripGreetingAndSignoff(inputs.context);
   const tone = (inputs.tone || 'warm').trim();
   const query = `draft_message recipient_type=tenant recipient="${recipientName}" property="${propertyHint}"`;
 
@@ -1242,7 +1289,9 @@ export async function draftMessageSkill(
   // resolved unit's purchaser_name. We carry recipientName as a let so the
   // unit-resolution stage below can fill it in when empty.
   let recipientName = (inputs.recipient_name || '').trim();
-  const context = (inputs.context || '').trim();
+  // Scrub greeting/sign-off the model may have included — the template
+  // below adds them once, which is the single source of truth.
+  const context = stripGreetingAndSignoff(inputs.context);
   const tone = (inputs.tone || (inputs.recipient_type === 'solicitor' ? 'formal' : 'warm')).trim();
   const query = `draft_message recipient="${recipientName}" unit="${inputs.related_unit || ''}" scheme="${inputs.related_scheme || ''}"`;
 
@@ -1599,9 +1648,13 @@ function buildFollowupContent(opts: {
   tone: string;
   ctx: SkillAgentContext;
 }): { subject: string; body: string } {
-  const { purpose, topic, customInstruction, unitLabel, greeting, tone, ctx } = opts;
+  const { purpose, topic: rawTopic, customInstruction: rawCustom, unitLabel, greeting, tone, ctx } = opts;
   const sign = toneSignOff(tone);
   const sig = signature(ctx);
+  // Defensive: scrub any greeting / sign-off the model may have included in
+  // the free-text fields, since the template already supplies both.
+  const topic = stripGreetingAndSignoff(rawTopic);
+  const customInstruction = stripGreetingAndSignoff(rawCustom);
 
   if (purpose === 'congratulate_handover') {
     return {
@@ -1645,7 +1698,7 @@ function buildFollowupContent(opts: {
   }
 
   if (purpose === 'custom') {
-    const instruction = customInstruction?.trim() || topic;
+    const instruction = customInstruction || topic;
     return {
       subject: unitLabel,
       body: [greeting, '', instruction, '', sign, sig].join('\n'),

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -229,7 +229,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       properties: {
         recipient_type: { type: 'string', description: 'Type of recipient', enum: ['buyer', 'developer', 'solicitor', 'tenant'] },
         recipient_name: { type: 'string', description: 'Name of the recipient. OPTIONAL when related_unit (sales) or related_property (lettings) is supplied — the skill resolves the buyer or tenant from the record on file.' },
-        context: { type: 'string', description: 'What the message should cover, in the agent\'s own words — this becomes the body.' },
+        context: { type: 'string', description: 'Body content only — what the message should cover, in the agent\'s own words. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         related_unit: { type: 'string', description: 'Related unit number (sales mode)' },
         related_scheme: { type: 'string', description: 'Related scheme name (sales mode)' },
@@ -267,7 +267,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
             required: ['unit_identifier'],
           },
         },
-        topic: { type: 'string', description: 'Shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent.' },
+        topic: { type: 'string', description: 'Body content only — the shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         purpose: {
           type: 'string',


### PR DESCRIPTION
…wn rendering in chat

BUG-02 Intelligence chat output rendered raw markdown:
- AIResponseCard rendered text with whiteSpace pre-wrap and no markdown parsing. The model's bullet lists and bold spans surfaced as literal '- "..."' on screen during the promo build.
- The FOLLOW-UP SUGGESTIONS section of the system prompt encouraged the model to embed quote-wrapped suggestions inside the response body. The chat already surfaces follow-ups as dedicated tappable chips through a separate completion call, so the body should never carry a list.
- Added a small inline MarkdownText component (bullets, numbered lists, bold, italic) so any incidental markdown the model emits renders cleanly without pulling in react-markdown.
- Rewrote the FOLLOW-UP SUGGESTIONS section in both sales and lettings system prompts: chips-only, no inline lists, no quote-wrapped strings. Added a defensive client-side strip that drops wrapping quote characters and leading bullet glyphs from each follow-ups string.

BUG-01 Drafted emails contained duplicate greeting and sign-off blocks:
- The skill templates (chase, viewing follow-up, draft_message, draft_buyer_followups, schedule_viewing_draft) wrap the model-supplied free-text body in 'Hi {firstName},' + sign-off + signature. When the model also wrote those into 'topic'/'context' the recipient got two of each.
- Picked the template as the single source of truth. Updated the draft_message.context and draft_buyer_followups.topic tool descriptions to instruct the model not to include greetings or sign-offs.
- Added stripGreetingAndSignoff() in agentic-skills.ts and applied it to topic / context / custom_instruction before assembly in buildFollowupContent, draftMessageSkill, and draftTenantMessage.
- Added dedupeBoilerplate() in draft-store.ts as a defence-in-depth scrub that runs at persist time. Drops a duplicated leading greeting line and any duplicated trailing sign-off block before insert into pending_drafts, so future regressions don't reach the inbox.

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL