### PR TITLE
fix(care): tenant-aware PWA manifest + drop white card around colour logos

### DIFF
--- a/apps/unified-portal/app/api/care/manifest/[id]/route.ts
+++ b/apps/unified-portal/app/api/care/manifest/[id]/route.ts
@@ -17,34 +17,21 @@ export async function GET(
 ) {
   const { id } = await params;
 
-  // Resolve installer branding from the installation's tenant. Falls back to
-  // the OpenHouse Care defaults when env/auth isn't available so the manifest
-  // endpoint never 500s for the PWA install flow.
-  let tenantName: string | null = null;
+  // Look up the tenant logo so the installed PWA's home-screen icon matches
+  // the installer for that installation. Everything else stays as before.
   let tenantLogo: string | null = null;
-  let tenantTheme: string | null = null;
   try {
     const supabase = getSupabaseAdmin();
     const { data } = await supabase
       .from('installations')
-      .select('tenants(name, logo_url, theme_color)')
+      .select('tenants(logo_url)')
       .eq('id', id)
       .single();
-    const tenant = (data as any)?.tenants ?? null;
-    tenantName = tenant?.name ?? null;
-    tenantLogo = tenant?.logo_url ?? null;
-    tenantTheme = tenant?.theme_color ?? null;
+    tenantLogo = (data as any)?.tenants?.logo_url ?? null;
   } catch {
     // Ignore — we'll emit the generic OpenHouse Care manifest.
   }
 
-  const appName = tenantName ? `${tenantName} Care` : 'OpenHouse Care';
-  const shortName = tenantName ?? 'Care';
-  const themeColor = tenantTheme ?? '#D4AF37';
-
-  // Use the tenant logo for both icon sizes when present (browsers will scale).
-  // Keep the local PNGs as the fallback so the app stays installable when a
-  // tenant has no logo configured yet.
   const icons = tenantLogo
     ? [
         { src: tenantLogo, sizes: '192x192', type: 'image/png', purpose: 'any' },
@@ -56,14 +43,14 @@ export async function GET(
       ];
 
   const manifest = {
-    name: appName,
-    short_name: shortName,
+    name: 'OpenHouse Care',
+    short_name: 'Care',
     description: 'Your home system care portal',
     start_url: `/care/${id}`,
     scope: `/care/${id}`,
     display: 'standalone',
     background_color: '#ffffff',
-    theme_color: themeColor,
+    theme_color: '#D4AF37',
     orientation: 'portrait-primary',
     icons,
   };
@@ -71,8 +58,7 @@ export async function GET(
   return NextResponse.json(manifest, {
     headers: {
       'Content-Type': 'application/manifest+json',
-      // Short cache so the demo install picks up tenant changes promptly.
-      'Cache-Control': 'public, max-age=60',
+      'Cache-Control': 'public, max-age=3600',
     },
   });
 }

--- a/apps/unified-portal/app/api/care/manifest/[id]/route.ts
+++ b/apps/unified-portal/app/api/care/manifest/[id]/route.ts
@@ -1,6 +1,15 @@
 export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  );
+}
 
 export async function GET(
   req: NextRequest,
@@ -8,36 +17,62 @@ export async function GET(
 ) {
   const { id } = await params;
 
+  // Resolve installer branding from the installation's tenant. Falls back to
+  // the OpenHouse Care defaults when env/auth isn't available so the manifest
+  // endpoint never 500s for the PWA install flow.
+  let tenantName: string | null = null;
+  let tenantLogo: string | null = null;
+  let tenantTheme: string | null = null;
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data } = await supabase
+      .from('installations')
+      .select('tenants(name, logo_url, theme_color)')
+      .eq('id', id)
+      .single();
+    const tenant = (data as any)?.tenants ?? null;
+    tenantName = tenant?.name ?? null;
+    tenantLogo = tenant?.logo_url ?? null;
+    tenantTheme = tenant?.theme_color ?? null;
+  } catch {
+    // Ignore — we'll emit the generic OpenHouse Care manifest.
+  }
+
+  const appName = tenantName ? `${tenantName} Care` : 'OpenHouse Care';
+  const shortName = tenantName ?? 'Care';
+  const themeColor = tenantTheme ?? '#D4AF37';
+
+  // Use the tenant logo for both icon sizes when present (browsers will scale).
+  // Keep the local PNGs as the fallback so the app stays installable when a
+  // tenant has no logo configured yet.
+  const icons = tenantLogo
+    ? [
+        { src: tenantLogo, sizes: '192x192', type: 'image/png', purpose: 'any' },
+        { src: tenantLogo, sizes: '512x512', type: 'image/png', purpose: 'any' },
+      ]
+    : [
+        { src: '/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any maskable' },
+        { src: '/icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'any maskable' },
+      ];
+
   const manifest = {
-    name: 'OpenHouse Care',
-    short_name: 'Care',
+    name: appName,
+    short_name: shortName,
     description: 'Your home system care portal',
     start_url: `/care/${id}`,
     scope: `/care/${id}`,
     display: 'standalone',
     background_color: '#ffffff',
-    theme_color: '#D4AF37',
+    theme_color: themeColor,
     orientation: 'portrait-primary',
-    icons: [
-      {
-        src: '/icon-192.png',
-        sizes: '192x192',
-        type: 'image/png',
-        purpose: 'any maskable',
-      },
-      {
-        src: '/icon-512.png',
-        sizes: '512x512',
-        type: 'image/png',
-        purpose: 'any maskable',
-      },
-    ],
+    icons,
   };
 
   return NextResponse.json(manifest, {
     headers: {
       'Content-Type': 'application/manifest+json',
-      'Cache-Control': 'public, max-age=3600',
+      // Short cache so the demo install picks up tenant changes promptly.
+      'Cache-Control': 'public, max-age=60',
     },
   });
 }

--- a/apps/unified-portal/app/care/[installationId]/layout.tsx
+++ b/apps/unified-portal/app/care/[installationId]/layout.tsx
@@ -21,41 +21,32 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { installationId } = await params;
 
-  // Pull installer branding so the PWA install (manifest icon, iOS apple-touch-icon,
-  // home-screen title) matches the tenant whose installation the homeowner is on.
-  let tenantName: string | null = null;
+  // Resolve the tenant logo so iOS "Add to Home Screen" picks it up via the
+  // apple-touch-icon link (Android Chrome uses the manifest icons separately).
   let tenantLogo: string | null = null;
   try {
     const supabase = getSupabaseAdmin();
     const { data } = await supabase
       .from('installations')
-      .select('tenants(name, logo_url)')
+      .select('tenants(logo_url)')
       .eq('id', installationId)
       .single();
-    const tenant = (data as any)?.tenants ?? null;
-    tenantName = tenant?.name ?? null;
-    tenantLogo = tenant?.logo_url ?? null;
+    tenantLogo = (data as any)?.tenants?.logo_url ?? null;
   } catch {
-    // Fall through to defaults.
+    // Fall through to default icon.
   }
 
-  const title = tenantName ? `${tenantName} Care` : 'OpenHouse Care';
-  // iOS uses the apple-touch-icon link for "Add to Home Screen". Point it at
-  // the tenant logo when set so the recorded PWA install shows tenant branding.
-  const appleIconUrl = tenantLogo ?? '/icon-512.png';
-
   return {
-    title,
+    title: 'OpenHouse Care',
     description: 'Your home system care portal',
     manifest: `/api/care/manifest/${installationId}`,
-    icons: {
-      icon: tenantLogo ? [{ url: tenantLogo }] : undefined,
-      apple: [{ url: appleIconUrl }],
-    },
+    icons: tenantLogo
+      ? { icon: [{ url: tenantLogo }], apple: [{ url: tenantLogo }] }
+      : undefined,
     appleWebApp: {
       capable: true,
       statusBarStyle: 'black-translucent',
-      title,
+      title: 'OpenHouse Care',
     },
   };
 }

--- a/apps/unified-portal/app/care/[installationId]/layout.tsx
+++ b/apps/unified-portal/app/care/[installationId]/layout.tsx
@@ -20,14 +20,42 @@ export async function generateMetadata({
   params: Promise<{ installationId: string }>;
 }): Promise<Metadata> {
   const { installationId } = await params;
+
+  // Pull installer branding so the PWA install (manifest icon, iOS apple-touch-icon,
+  // home-screen title) matches the tenant whose installation the homeowner is on.
+  let tenantName: string | null = null;
+  let tenantLogo: string | null = null;
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data } = await supabase
+      .from('installations')
+      .select('tenants(name, logo_url)')
+      .eq('id', installationId)
+      .single();
+    const tenant = (data as any)?.tenants ?? null;
+    tenantName = tenant?.name ?? null;
+    tenantLogo = tenant?.logo_url ?? null;
+  } catch {
+    // Fall through to defaults.
+  }
+
+  const title = tenantName ? `${tenantName} Care` : 'OpenHouse Care';
+  // iOS uses the apple-touch-icon link for "Add to Home Screen". Point it at
+  // the tenant logo when set so the recorded PWA install shows tenant branding.
+  const appleIconUrl = tenantLogo ?? '/icon-512.png';
+
   return {
-    title: 'OpenHouse Care',
+    title,
     description: 'Your home system care portal',
     manifest: `/api/care/manifest/${installationId}`,
+    icons: {
+      icon: tenantLogo ? [{ url: tenantLogo }] : undefined,
+      apple: [{ url: appleIconUrl }],
+    },
     appleWebApp: {
       capable: true,
       statusBarStyle: 'black-translucent',
-      title: 'OpenHouse Care',
+      title,
     },
   };
 }

--- a/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
+++ b/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
@@ -348,32 +348,49 @@ export default function AssistantScreen({ installationId }: { installationId: st
         /* ═══ WELCOME STATE — matches Property PurchaserChatTab layout ═══ */
         <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-4 overflow-y-auto pb-4 welcome-container">
 
-          {/* Installer logo in a refined container */}
-          <div
-            className="logo-container flex items-center justify-center"
-            style={{
-              width: 180,
-              background: '#FAFAF8',
-              borderRadius: 16,
-              padding: 24,
-              boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
-            }}
-          >
-            <Image
-              src={installation.tenants?.logo_url ?? '/branding/se-systems-logo.png'}
-              alt={installation.tenants?.name ?? installation.installer_name ?? 'Installer'}
-              width={140}
-              height={42}
-              priority
-              style={{
-                width: 140,
-                height: 'auto',
-                objectFit: 'contain',
-                // Only blacken the SE Systems wordmark fallback; render tenant logos in their natural colours.
-                filter: installation.tenants?.logo_url ? undefined : 'brightness(0)',
-              }}
-            />
-          </div>
+          {(() => {
+            const tenantLogo = installation.tenants?.logo_url ?? null;
+            const logoSrc = tenantLogo ?? '/branding/se-systems-logo.png';
+            const logoAlt = installation.tenants?.name ?? installation.installer_name ?? 'Installer';
+            // SE Systems wordmark falls back into a card to give the thin black
+            // logo some weight; full-colour tenant logos render bare so the
+            // brand artwork breathes.
+            if (tenantLogo) {
+              return (
+                <div className="logo-container flex items-center justify-center" style={{ width: 200 }}>
+                  <Image
+                    src={logoSrc}
+                    alt={logoAlt}
+                    width={180}
+                    height={180}
+                    priority
+                    style={{ width: 180, height: 'auto', objectFit: 'contain' }}
+                  />
+                </div>
+              );
+            }
+            return (
+              <div
+                className="logo-container flex items-center justify-center"
+                style={{
+                  width: 180,
+                  background: '#FAFAF8',
+                  borderRadius: 16,
+                  padding: 24,
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+                }}
+              >
+                <Image
+                  src={logoSrc}
+                  alt={logoAlt}
+                  width={140}
+                  height={42}
+                  priority
+                  style={{ width: 140, height: 'auto', objectFit: 'contain', filter: 'brightness(0)' }}
+                />
+              </div>
+            );
+          })()}
 
           {/* Headline — same text-[17px] font-semibold as Property */}
           <h1 className="mt-3 text-center text-[17px] font-semibold leading-tight text-slate-900 sm:text-lg md:text-xl">


### PR DESCRIPTION
## Summary

Follow-up to #73 to make the Solas Renewables demo recording look right when installed as a PWA on iOS/Android, and to clean up the welcome-card visual when the tenant has a full-colour logo.

- **`AssistantScreen.tsx`** — when a tenant logo is set, render it bare (no white rounded box, larger 180px size). Keep the existing card backdrop only for the SE Systems wordmark fallback, which needs the card to give the thin black logo visual weight.
- **`/api/care/manifest/[id]/route.ts`** — resolve the installation's tenant via the service-role client and emit branded `name` (`{tenant} Care`), `short_name`, `theme_color`, and 192/512 icons pointing at the tenant logo. Falls back to OpenHouse Care defaults when no tenant branding is set, so SE Systems' install path is unchanged. Cache shortened to 60s so demo edits propagate fast.
- **`care/[installationId]/layout.tsx` `generateMetadata`** — tenant-aware page title and `apple-touch-icon` link so iOS "Add to Home Screen" picks up the tenant logo (manifest icons handle Android Chrome).

## Test plan

- [ ] After deploy, open `https://portal.openhouseai.ie/care/a17e8226-03e2-4417-982c-01308b92f65d` (Solas install) in a private window — header logo and welcome-card logo render in colour, no white card.
- [ ] Safari iOS → Share → Add to Home Screen — name reads "Solas Renewables Care", icon is the Solas logo.
- [ ] Chrome Android → Install app — icon and theme colour come from the Solas tenant.
- [ ] Visit any SE Systems install — header still shows the SE Systems wordmark in the boxed card; PWA install still says "OpenHouse Care" with generic icons (no regression).

https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5)_