### PR TITLE
fix(agent): chat rendering, draft greetings, contact resolver, viewing scheduler

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -303,7 +303,14 @@ function IntelligencePageInner() {
                 }];
               });
             } else if (data.type === 'followups') {
-              followups = data.questions || [];
+              // Defensive: strip wrapping quote characters and leading bullet
+              // glyphs the upstream model may emit despite the prompt.
+              const raw: string[] = Array.isArray(data.questions) ? data.questions : [];
+              followups = raw
+                .map((q) => typeof q === 'string' ? q : '')
+                .map((q) => q.trim().replace(/^[-*•]\s+/, ''))
+                .map((q) => q.replace(/^["“”'](.*)["“”']$/, '$1').trim())
+                .filter(Boolean);
             } else if (data.type === 'tools_used') {
               toolsUsed = data.tools || [];
             } else if (data.type === 'envelope') {
@@ -1140,6 +1147,110 @@ function formatReminder(iso: string): string {
 
 /* ---- Sub-components ---- */
 
+// Minimal markdown renderer for assistant chat bubbles. Handles the patterns
+// the LLM actually emits today: `**bold**`, `*italic*`, bullet lines (`- `,
+// `* `), and numbered lines (`1. `). Anything else is rendered verbatim and
+// preserves line breaks like the previous pre-wrap span. Kept inline so the
+// component avoids pulling in react-markdown (not in package.json) for what
+// is effectively three regex patterns.
+function MarkdownText({ source }: { source: string }) {
+  // Strip surrounding straight or curly double quotes when an entire line is
+  // wrapped in them — older system-prompt examples encouraged the model to
+  // emit `"..."` for suggestions, which would otherwise survive verbatim.
+  function stripWrappingQuotes(s: string): string {
+    const trimmed = s.trim();
+    if (trimmed.length >= 2) {
+      const first = trimmed.charAt(0);
+      const last = trimmed.charAt(trimmed.length - 1);
+      const isQuote = (c: string) => c === '"' || c === '“' || c === '”' || c === '“' || c === '”';
+      if (isQuote(first) && isQuote(last)) return trimmed.slice(1, -1).trim();
+    }
+    return s;
+  }
+
+  function renderInline(text: string): React.ReactNode[] {
+    // Bold (**...**) wins over italic (*...*). Parse by splitting on ** then
+    // walk each segment for single-asterisk italics. Plenty of edge cases
+    // (escaped asterisks, intra-word emphasis) are not handled — chat copy
+    // doesn't need them.
+    const out: React.ReactNode[] = [];
+    const boldParts = text.split(/(\*\*[^*]+\*\*)/g);
+    boldParts.forEach((part, i) => {
+      if (/^\*\*[^*]+\*\*$/.test(part)) {
+        out.push(<strong key={`b${i}`}>{part.slice(2, -2)}</strong>);
+        return;
+      }
+      const italicParts = part.split(/(\*[^*]+\*)/g);
+      italicParts.forEach((sub, j) => {
+        if (/^\*[^*]+\*$/.test(sub)) {
+          out.push(<em key={`i${i}-${j}`}>{sub.slice(1, -1)}</em>);
+        } else if (sub) {
+          out.push(<span key={`t${i}-${j}`}>{sub}</span>);
+        }
+      });
+    });
+    return out;
+  }
+
+  const lines = source.split('\n');
+  const blocks: React.ReactNode[] = [];
+  let bulletBuffer: string[] = [];
+  let numberedBuffer: string[] = [];
+
+  function flushBullets(key: string) {
+    if (!bulletBuffer.length) return;
+    blocks.push(
+      <ul key={`ul-${key}`} style={{ margin: '4px 0', paddingLeft: 20 }}>
+        {bulletBuffer.map((item, i) => (
+          <li key={i} style={{ marginBottom: 2 }}>{renderInline(stripWrappingQuotes(item))}</li>
+        ))}
+      </ul>,
+    );
+    bulletBuffer = [];
+  }
+
+  function flushNumbered(key: string) {
+    if (!numberedBuffer.length) return;
+    blocks.push(
+      <ol key={`ol-${key}`} style={{ margin: '4px 0', paddingLeft: 22 }}>
+        {numberedBuffer.map((item, i) => (
+          <li key={i} style={{ marginBottom: 2 }}>{renderInline(stripWrappingQuotes(item))}</li>
+        ))}
+      </ol>,
+    );
+    numberedBuffer = [];
+  }
+
+  lines.forEach((rawLine, idx) => {
+    const line = rawLine;
+    const bulletMatch = line.match(/^\s*[-*]\s+(.*)$/);
+    const numberedMatch = line.match(/^\s*\d+\.\s+(.*)$/);
+
+    if (bulletMatch) {
+      flushNumbered(`n${idx}`);
+      bulletBuffer.push(bulletMatch[1]);
+      return;
+    }
+    if (numberedMatch) {
+      flushBullets(`b${idx}`);
+      numberedBuffer.push(numberedMatch[1]);
+      return;
+    }
+    flushBullets(`b${idx}`);
+    flushNumbered(`n${idx}`);
+    if (line.trim() === '') {
+      blocks.push(<div key={`sp${idx}`} style={{ height: 8 }} />);
+    } else {
+      blocks.push(<div key={`p${idx}`}>{renderInline(line)}</div>);
+    }
+  });
+
+  flushBullets('end');
+  flushNumbered('end');
+
+  return <>{blocks}</>;
+}
+
 function UserBubble({ text }: { text: string }) {
   return (
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
@@ -1443,10 +1554,9 @@ function AIResponseCard({
               lineHeight: 1.6,
               color: '#374151',
               letterSpacing: '-0.005em',
-              whiteSpace: 'pre-wrap',
             }}
           >
-            {text}
+            <MarkdownText source={text} />
           </div>
         )}
 

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -12,7 +12,7 @@ import CapabilityChipsCarousel from '../_components/CapabilityChipsCarousel';
 import { useVoiceCapture } from '../_hooks/useVoiceCapture';
 import { fetchCapabilityChips } from '@/lib/agent-intelligence/capability-chips';
 import { useAgent } from '@/lib/agent/AgentContext';
-import { Mail, Copy, Check, ExternalLink, Pencil, Wrench, Bell, RotateCcw, ArrowRight, FileText, Calendar } from 'lucide-react';
+import { Mail, Copy, Check, ExternalLink, Pencil, Wrench, Bell, RotateCcw, ArrowRight, FileText, Calendar, AlertCircle, RefreshCw } from 'lucide-react';
 import type { ExecutedAction, ExtractedAction } from '@/lib/agent-intelligence/voice-actions';
 import type { AutoSendUiState } from '../_components/VoiceConfirmationCard';
 import { notifyDraftsChanged, useDraftsCount } from '../_hooks/useDraftsCount';
@@ -48,6 +48,13 @@ interface VoiceActionsPayload {
   retryingActionIds?: string[];
 }
 
+interface FailurePayload {
+  kind: 'hallucinated_drafts' | 'needs_recipient' | 'draft_blocked' | 'stream_failed';
+  correlationId: string | null;
+  retryable: boolean;
+  retryMessage: string | null;
+}
+
 interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -66,6 +73,10 @@ interface Message {
   // Session 14b — sent confirmation. Set on a fresh synthetic message
   // appended in response to the 'oh-draft-sent' window event.
   sent?: { recipientName: string; time: string };
+  // Tool-failure card. Set when the chat route emits an `error` SSE
+  // frame; renders as a red-bordered card with AlertCircle, the failure
+  // copy, an "error ref: <id>" footer, and a Retry button.
+  failure?: FailurePayload;
 }
 
 interface UndoBatch {
@@ -365,6 +376,36 @@ function IntelligencePageInner() {
                   }];
                 });
               }
+            } else if (data.type === 'error') {
+              // Structured tool-failure frame. Carries the failure kind,
+              // a correlation id surfaced to the user, the original
+              // user message for retry, and the user-visible content.
+              const failure: FailurePayload = {
+                kind: typeof data.kind === 'string' ? data.kind : 'stream_failed',
+                correlationId: typeof data.correlationId === 'string' ? data.correlationId : null,
+                retryable: data.retryable !== false,
+                retryMessage: typeof data.retryMessage === 'string' ? data.retryMessage : text.trim(),
+              };
+              if (typeof data.content === 'string' && data.content.length > 0) {
+                fullContent = data.content;
+              }
+              setMessages(prev => {
+                const existing = prev.find(m => m.id === streamingMsgId);
+                if (existing) {
+                  return prev.map(m =>
+                    m.id === streamingMsgId
+                      ? { ...m, content: fullContent, progress: undefined, failure }
+                      : m,
+                  );
+                }
+                return [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: fullContent,
+                  failure,
+                }];
+              });
+              streamingStarted = true;
             } else if (data.type === 'done') {
               newSessionId = data.sessionId || sessionId;
             }
@@ -389,10 +430,20 @@ function IntelligencePageInner() {
         } : m
       ));
     } catch {
+      // Network or parser failure — render a Retry card so the agent can
+      // re-fire the same message with one tap rather than retyping it.
+      const correlationId = Math.random().toString(16).slice(2, 10);
       const errorMsg: Message = {
         id: (Date.now() + 1).toString(),
         role: 'assistant',
-        content: 'Something went wrong connecting to Intelligence. Check your connection and try again.',
+        content:
+          "We couldn't complete this — the connection to Intelligence dropped before we got an answer. Tap Retry to try again.",
+        failure: {
+          kind: 'stream_failed',
+          correlationId,
+          retryable: true,
+          retryMessage: text.trim(),
+        },
       };
       setMessages(prev => [...prev, errorMsg]);
     } finally {
@@ -986,6 +1037,22 @@ function IntelligencePageInner() {
               if (msg.progress && !msg.content) {
                 return <ProgressCard key={msg.id} progress={msg.progress} />;
               }
+              // Tool-failure card (BUG-08). Distinct red-bordered styling,
+              // alert icon, optional Retry button. Surfaces the
+              // correlation id so support can trace the original error
+              // log line.
+              if (msg.failure) {
+                return (
+                  <FailureCard
+                    key={msg.id}
+                    text={msg.content}
+                    failure={msg.failure}
+                    onRetry={msg.failure.retryMessage
+                      ? () => handleSend(msg.failure!.retryMessage!)
+                      : undefined}
+                  />
+                );
+              }
               return (
                 <AIResponseCard
                   key={msg.id}
@@ -1249,6 +1316,127 @@ function MarkdownText({ source }: { source: string }) {
   flushNumbered('end');
 
   return <>{blocks}</>;
+}
+
+// Tool-failure card. Renders when the server emitted a structured
+// `error` SSE frame — distinct visual treatment so the agent can tell at
+// a glance that something didn't complete, plus a Retry button that
+// re-fires the original user message verbatim. The correlation id is
+// surfaced so support can trace it back to the server-side error log.
+function FailureCard({
+  text,
+  failure,
+  onRetry,
+}: {
+  text: string;
+  failure: FailurePayload;
+  onRetry?: () => void;
+}) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div
+        style={{
+          background: '#FFFFFF',
+          borderRadius: 14,
+          padding: '12px 14px 12px 16px',
+          maxWidth: '92%',
+          width: '100%',
+          borderLeft: '3px solid #DC2626',
+          boxShadow:
+            '0 1px 2px rgba(220,38,38,0.08), 0 4px 12px rgba(220,38,38,0.05), 0 0 0 0.5px rgba(220,38,38,0.18)',
+        }}
+      >
+        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+          <div
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: 'rgba(220,38,38,0.10)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              marginTop: 1,
+            }}
+          >
+            <AlertCircle size={14} color="#DC2626" strokeWidth={2.25} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 700,
+                color: '#991B1B',
+                letterSpacing: '0.02em',
+                marginBottom: 4,
+                textTransform: 'uppercase',
+              }}
+            >
+              We couldn&rsquo;t complete this
+            </div>
+            <div
+              style={{
+                fontSize: 13.5,
+                lineHeight: 1.55,
+                color: '#374151',
+                letterSpacing: '-0.005em',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {text || 'The action didn’t go through.'}
+            </div>
+            <div
+              style={{
+                marginTop: 12,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                flexWrap: 'wrap',
+              }}
+            >
+              {onRetry && failure.retryable && (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="agent-tappable"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '7px 12px',
+                    background: '#FFFFFF',
+                    border: '0.5px solid rgba(220,38,38,0.35)',
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: '#991B1B',
+                    cursor: 'pointer',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  <RefreshCw size={12} strokeWidth={2.25} />
+                  <span>Retry</span>
+                </button>
+              )}
+              {failure.correlationId && (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: '#9CA3AF',
+                    fontVariantNumeric: 'tabular-nums',
+                    letterSpacing: '0.02em',
+                  }}
+                >
+                  Error ref: {failure.correlationId}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function UserBubble({ text }: { text: string }) {

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -690,10 +690,11 @@ export async function POST(request: NextRequest) {
 
 RULES:
 - Every suggestion must be an ACTION the agent can take, not a question back to the agent.
-- Start each suggestion with a verb: "Draft...", "Check...", "Show...", "Create...", "Generate...", "Log..."
+- Start each suggestion with a verb: Draft, Check, Show, Create, Generate, Log.
 - Never ask the agent a clarifying question. Never use "Would you like..." or "Should I..."
 - Keep each suggestion under 8 words.
 - Make suggestions contextual to what was just discussed.
+- Each string is a clean suggestion. Do NOT wrap suggestions in quote characters, do not start them with a hyphen or bullet, do not add markdown.
 - Return ONLY a JSON array of strings, no explanation.`,
                 },
                 {

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -424,6 +424,57 @@ export async function POST(request: NextRequest) {
       });
     }
 
+    // Contact-resolver fallouts (BUG-03). When the email skill couldn't
+    // resolve the recipient name to a contact on file, the envelope
+    // carries `meta.needs_recipient` with either a candidate list or an
+    // empty list. Surface that to the model so the streamed reply names
+    // the candidates instead of asserting drafts went through.
+    type NeedsRecipientPayload = {
+      correlationId: string;
+      recipient_query: string;
+      candidates: Array<{
+        name: string;
+        email: string;
+        role: string;
+        scheme_name: string | null;
+        unit_label: string | null;
+      }>;
+      searched?: string[];
+    };
+    const needsRecipientPayloads: NeedsRecipientPayload[] = [];
+    for (const env of envelopes) {
+      const meta: any = env.meta || {};
+      if (meta.needs_recipient) {
+        needsRecipientPayloads.push(meta.needs_recipient as NeedsRecipientPayload);
+      }
+    }
+    if (needsRecipientPayloads.length > 0) {
+      const reasonsBlock = needsRecipientPayloads
+        .map((p) => {
+          if (p.candidates.length > 0) {
+            const lines = p.candidates.slice(0, 6).map((c, i) => {
+              const where = c.scheme_name
+                ? c.unit_label
+                  ? ` — ${c.unit_label}, ${c.scheme_name}`
+                  : ` — ${c.scheme_name}`
+                : c.unit_label
+                  ? ` — ${c.unit_label}`
+                  : '';
+              return `${i + 1}. ${c.name}${where} (${c.email})`;
+            });
+            return `Multiple matches for "${p.recipient_query}":\n${lines.join('\n')}\nAsk which one and offer to accept a pasted address.`;
+          }
+          return `No contact on file for "${p.recipient_query}". Ask the user to paste the email address.`;
+        })
+        .join('\n\n');
+      messages.push({
+        role: 'system',
+        content:
+          'IMPORTANT: The email tool needs a recipient that the system could not resolve. Tell the user we could not find an email on file and either ask them to choose from the candidate list verbatim or paste an address. Do NOT claim a draft was created. Do NOT invent an email address.\n\n' +
+          reasonsBlock,
+      });
+    }
+
     // Session 14 — yes/no disambiguation hook. Pick a single top_candidate
     // surfaced on any envelope's meta this turn. If two envelopes name
     // DIFFERENT candidates the prompt would be ambiguous — skip entirely.
@@ -642,30 +693,89 @@ export async function POST(request: NextRequest) {
           const HALLUCINATION_REGEX =
             /drafted|drafts?\s+(?:are|is)\s+ready|ready\s+for\s+your\s+review|in\s+the\s+drafts?\s+inbox|prepared\s+\d+\s+draft|i['’]ll\s+draft|i\s+(?:have\s+)?drafted/i;
           const claimsDrafts = HALLUCINATION_REGEX.test(fullContent);
-          if (claimsDrafts && totalDraftsPersisted === 0) {
-            const honestMessage = "I tried to draft those emails but the action didn’t actually go through — nothing landed in your inbox. Could you try asking again, or rephrase with the specific unit numbers / buyer names?";
+          // Decide whether this turn should render as a failure card.
+          //   - hallucinated_drafts: model claimed drafts but none persisted
+          //   - needs_recipient: contact resolver couldn't pin a recipient
+          //   - draft_blocked: persistence blocked every produced draft
+          // Each case carries a correlation id so support can trace.
+          let failureKind: 'hallucinated_drafts' | 'needs_recipient' | 'draft_blocked' | null = null;
+          let failureMessage: string | null = null;
+          let failureCorrelationId: string | null = null;
+          if (needsRecipientPayloads.length > 0) {
+            failureKind = 'needs_recipient';
+            failureCorrelationId = needsRecipientPayloads[0].correlationId;
+            const p = needsRecipientPayloads[0];
+            if (p.candidates.length > 0) {
+              const lines = p.candidates.slice(0, 6).map((c, i) => {
+                const where = c.scheme_name
+                  ? c.unit_label
+                    ? ` — ${c.unit_label}, ${c.scheme_name}`
+                    : ` — ${c.scheme_name}`
+                  : c.unit_label
+                    ? ` — ${c.unit_label}`
+                    : '';
+                return `${i + 1}. ${c.name}${where} (${c.email})`;
+              });
+              failureMessage = [
+                `We couldn't complete this — multiple contacts match "${p.recipient_query}".`,
+                ...lines,
+                'Reply with the number, the full name, or paste an email address.',
+              ].join('\n');
+            } else {
+              failureMessage = `We couldn't complete this — no email is on file for "${p.recipient_query}". Paste the address and I'll draft it.`;
+            }
+          } else if (claimsDrafts && totalDraftsPersisted === 0) {
+            failureKind = 'hallucinated_drafts';
+            failureCorrelationId = randomCorrelationId();
+            failureMessage =
+              "We couldn't complete this — the email action didn't go through and nothing landed in the drafts inbox. Tap Retry, or tell me the specific unit numbers / buyer names you meant.";
+          }
+
+          if (failureKind && failureMessage) {
             controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'override', content: honestMessage }) + '\n')
+              encoder.encode(
+                JSON.stringify({ type: 'override', content: failureMessage }) + '\n',
+              ),
             );
-            // Replace the recorded response so memory + analytics store the
-            // honest text, not the lie.
-            fullContent = honestMessage;
-            console.error('[hallucinated_drafts] overrode assistant response', {
-              kind: 'hallucinated_drafts',
+            controller.enqueue(
+              encoder.encode(
+                JSON.stringify({
+                  type: 'error',
+                  kind: failureKind,
+                  correlationId: failureCorrelationId,
+                  retryable: true,
+                  retryMessage: message,
+                  content: failureMessage,
+                }) + '\n',
+              ),
+            );
+            console.error('[intelligence_failure] surfaced to user', {
+              kind: failureKind,
+              correlationId: failureCorrelationId,
               user: agentContext.displayName,
               userId: agentContext.authUserId,
               originalMessage: message,
-              assistantClaimed: fullContent,
               toolsCalled: toolsCalled.map((t) => t.tool_name),
               draftToolCalled,
               totalDraftsPersisted,
+              needsRecipientPayloads: needsRecipientPayloads.map((p) => ({
+                correlationId: p.correlationId,
+                recipient_query: p.recipient_query,
+                candidate_count: p.candidates.length,
+                searched: p.searched,
+              })),
             });
+            // Replace the recorded response so memory + analytics store the
+            // honest text, not the lie.
+            fullContent = failureMessage;
           }
 
           // Store memory and log interaction (async, non-blocking)
           storeConversationMemory(supabase, agentContext, currentSessionId, message, fullContent, toolsCalled).catch(() => {});
           logInteraction(supabase, tenantId, authUserId, message, fullContent, toolsCalled, startTime, {
             hallucinatedDrafts: claimsDrafts && totalDraftsPersisted === 0,
+            failureKind: failureKind ?? undefined,
+            correlationId: failureCorrelationId ?? undefined,
           }, resolvedMode).catch(() => {});
 
           // Generate follow-up suggestions (non-blocking, appended after main response)
@@ -724,8 +834,29 @@ RULES:
           );
           controller.close();
         } catch (err) {
+          const correlationId = randomCorrelationId();
+          const errMessage = err instanceof Error ? err.message : 'Unknown error';
+          console.error('[intelligence_failure] stream crashed', {
+            kind: 'stream_failed',
+            correlationId,
+            user: agentContext.displayName,
+            userId: agentContext.authUserId,
+            originalMessage: message,
+            error: errMessage,
+          });
+          const userMessage =
+            "We couldn't complete this — the connection to Intelligence dropped before we got an answer. Tap Retry to try again.";
           controller.enqueue(
-            encoder.encode(JSON.stringify({ type: 'error', message: 'Stream failed' }) + '\n')
+            encoder.encode(
+              JSON.stringify({
+                type: 'error',
+                kind: 'stream_failed',
+                correlationId,
+                retryable: true,
+                retryMessage: message,
+                content: userMessage,
+              }) + '\n',
+            ),
           );
           controller.close();
         }
@@ -1084,6 +1215,16 @@ async function storeConversationMemory(
 /**
  * Log the intelligence interaction for analytics, audit, and learning.
  */
+/**
+ * Generate a short correlation id surfaced to the user as "error ref:
+ * abc12345" and logged with the same id on the server side. 8 hex chars
+ * is enough collision space for live debugging without being a UUID-
+ * sized string the user has to read out loud.
+ */
+function randomCorrelationId(): string {
+  return Math.random().toString(16).slice(2, 10);
+}
+
 async function logInteraction(
   supabase: ReturnType<typeof getSupabaseAdmin>,
   tenantId: string,
@@ -1092,7 +1233,7 @@ async function logInteraction(
   responseText: string,
   toolsCalled: Array<{ tool_name: string; params: any; result_summary: string }>,
   startTime: number,
-  flags: { hallucinatedDrafts?: boolean } = {},
+  flags: { hallucinatedDrafts?: boolean; failureKind?: string; correlationId?: string } = {},
   mode: 'sales' | 'lettings' = 'sales'
 ) {
   const latencyMs = Date.now() - startTime;
@@ -1103,13 +1244,15 @@ async function logInteraction(
     responseText.toLowerCase().includes('not in the system') ||
     responseText.toLowerCase().includes('no data available');
 
-  const responseType = flags.hallucinatedDrafts
-    ? 'hallucinated_drafts'
-    : toolsCalled.some(t => t.tool_name === 'draft_message' || t.tool_name === 'draft_buyer_followups')
-      ? 'draft'
-      : toolsCalled.some(t => t.tool_name === 'generate_developer_report') ? 'report'
-        : toolsCalled.some(t => t.tool_name === 'create_task') ? 'task_created'
-          : 'answer';
+  const responseType = flags.failureKind
+    ? flags.failureKind
+    : flags.hallucinatedDrafts
+      ? 'hallucinated_drafts'
+      : toolsCalled.some(t => t.tool_name === 'draft_message' || t.tool_name === 'draft_buyer_followups')
+        ? 'draft'
+        : toolsCalled.some(t => t.tool_name === 'generate_developer_report') ? 'report'
+          : toolsCalled.some(t => t.tool_name === 'create_task') ? 'task_created'
+            : 'answer';
 
   await supabase.from('intelligence_interactions').insert({
     tenant_id: tenantId,

--- a/apps/unified-portal/lib/agent-intelligence/contact-resolver.ts
+++ b/apps/unified-portal/lib/agent-intelligence/contact-resolver.ts
@@ -1,0 +1,316 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Contact resolution for the email-drafting tools. Replaces the previous
+ * fallback that wrote `recipient@tbc.invalid` whenever no email was on
+ * file: the agent now sees an inline prompt naming the candidates instead
+ * of a placeholder draft that fails at the persistence guard.
+ *
+ * Sources, in order:
+ *   1. Buyers / purchasers attached to the agent's assigned schemes
+ *      (units.purchaser_name + purchaser_email, plus the pipeline row).
+ *   2. Tenants in the agent's lettings portfolio
+ *      (agent_tenancies.tenant_name + tenant_email).
+ *   3. Developers attached to the agent's schemes
+ *      (developments.developer_user_id → auth.users.email).
+ *
+ * A query may be a free-text name ("Daniel Whelan") or a role keyword
+ * ("the developer", "the dev", "the manager"). Role keywords short-circuit
+ * the name-search and resolve via the active scheme(s).
+ */
+
+export type ContactRole = 'buyer' | 'tenant' | 'developer' | 'solicitor' | 'unknown';
+
+export interface ResolvedContact {
+  name: string;
+  email: string;
+  role: ContactRole;
+  source: string;
+  schemeName?: string;
+  unitLabel?: string;
+}
+
+export type ContactResolution =
+  | { status: 'one'; contact: ResolvedContact }
+  | { status: 'multiple'; candidates: ResolvedContact[] }
+  | { status: 'none'; searched: string[] };
+
+export interface ContactResolverContext {
+  agentProfileId: string;
+  /**
+   * If omitted, the resolver loads them from agent_scheme_assignments.
+   */
+  assignedDevelopmentIds?: string[];
+  activeDevelopmentId?: string | null;
+}
+
+async function loadAssignedDevelopmentIds(
+  supabase: SupabaseClient,
+  agentProfileId: string,
+): Promise<string[]> {
+  const { data } = await supabase
+    .from('agent_scheme_assignments')
+    .select('development_id')
+    .eq('agent_id', agentProfileId)
+    .eq('is_active', true);
+  return Array.from(
+    new Set((data || []).map((r: any) => r.development_id).filter(Boolean)),
+  );
+}
+
+const ROLE_KEYWORDS: Record<string, ContactRole> = {
+  'the developer': 'developer',
+  'developer': 'developer',
+  'the dev': 'developer',
+  'dev': 'developer',
+  'my developer': 'developer',
+  'the builder': 'developer',
+  'builder': 'developer',
+};
+
+export function detectRoleKeyword(query: string): ContactRole | null {
+  const normalised = (query || '').toLowerCase().trim().replace(/^(to|email)\s+/, '');
+  if (ROLE_KEYWORDS[normalised]) return ROLE_KEYWORDS[normalised];
+  // "the developer of Lakeside Manor" / "the developer for Lakeside" — match
+  // the leading words.
+  for (const key of Object.keys(ROLE_KEYWORDS)) {
+    if (normalised.startsWith(`${key} `)) return ROLE_KEYWORDS[key];
+  }
+  return null;
+}
+
+function dedupeByEmail(list: ResolvedContact[]): ResolvedContact[] {
+  const seen = new Map<string, ResolvedContact>();
+  for (const c of list) {
+    const key = `${(c.email || '').toLowerCase()}|${(c.name || '').toLowerCase()}`;
+    if (!seen.has(key)) seen.set(key, c);
+  }
+  return Array.from(seen.values());
+}
+
+function nameTokensMatch(haystack: string, needle: string): boolean {
+  const h = haystack.toLowerCase();
+  const n = needle.toLowerCase().trim();
+  if (!n) return false;
+  if (h === n || h.includes(n) || n.includes(h)) return true;
+  // Token overlap: every token in the shorter side must appear in the other.
+  const hTokens = new Set(h.split(/\s+/).filter(Boolean));
+  const nTokens = n.split(/\s+/).filter(Boolean);
+  if (nTokens.length === 0) return false;
+  return nTokens.every((t) => hTokens.has(t));
+}
+
+async function resolveBuyersByName(
+  supabase: SupabaseClient,
+  ctx: { assignedDevelopmentIds: string[] },
+  name: string,
+): Promise<ResolvedContact[]> {
+  if (!ctx.assignedDevelopmentIds.length) return [];
+  const { data: units } = await supabase
+    .from('units')
+    .select('id, unit_number, unit_uid, development_id, purchaser_name, purchaser_email')
+    .in('development_id', ctx.assignedDevelopmentIds);
+  const { data: pipeline } = await supabase
+    .from('unit_sales_pipeline')
+    .select('unit_id, development_id, purchaser_name, purchaser_email')
+    .in('development_id', ctx.assignedDevelopmentIds);
+  const { data: developments } = await supabase
+    .from('developments')
+    .select('id, name')
+    .in('id', ctx.assignedDevelopmentIds);
+  const devNameById = new Map<string, string>(
+    (developments || []).map((d: any) => [d.id, d.name]),
+  );
+
+  const out: ResolvedContact[] = [];
+  for (const u of units || []) {
+    const pname: string | null = u.purchaser_name;
+    const pemail: string | null = u.purchaser_email;
+    if (!pname || !pemail) continue;
+    if (!nameTokensMatch(pname, name)) continue;
+    const unitLabel = `Unit ${u.unit_number ?? u.unit_uid ?? '?'}`;
+    out.push({
+      name: pname,
+      email: pemail,
+      role: 'buyer',
+      source: 'units',
+      schemeName: devNameById.get(u.development_id) || undefined,
+      unitLabel,
+    });
+  }
+  for (const p of pipeline || []) {
+    const pname: string | null = p.purchaser_name;
+    const pemail: string | null = p.purchaser_email;
+    if (!pname || !pemail) continue;
+    if (!nameTokensMatch(pname, name)) continue;
+    out.push({
+      name: pname,
+      email: pemail,
+      role: 'buyer',
+      source: 'unit_sales_pipeline',
+      schemeName: devNameById.get(p.development_id) || undefined,
+    });
+  }
+  return out;
+}
+
+async function resolveTenantsByName(
+  supabase: SupabaseClient,
+  ctx: { agentProfileId: string },
+  name: string,
+): Promise<ResolvedContact[]> {
+  const { data, error } = await supabase
+    .from('agent_tenancies')
+    .select('tenant_name, tenant_email, status, agent_letting_properties!inner(address_line_1, address)')
+    .eq('agent_id', ctx.agentProfileId)
+    .eq('status', 'active');
+  if (error || !data) return [];
+  const out: ResolvedContact[] = [];
+  for (const t of data as any[]) {
+    if (!t.tenant_name || !t.tenant_email) continue;
+    if (!nameTokensMatch(t.tenant_name, name)) continue;
+    const property = t.agent_letting_properties;
+    out.push({
+      name: t.tenant_name,
+      email: t.tenant_email,
+      role: 'tenant',
+      source: 'agent_tenancies',
+      unitLabel: property?.address_line_1 || property?.address || undefined,
+    });
+  }
+  return out;
+}
+
+async function resolveDevelopersForSchemes(
+  supabase: SupabaseClient,
+  developmentIds: string[],
+): Promise<ResolvedContact[]> {
+  if (!developmentIds.length) return [];
+  const { data: developments } = await supabase
+    .from('developments')
+    .select('id, name, developer_user_id')
+    .in('id', developmentIds);
+  const userIds = Array.from(
+    new Set(
+      (developments || [])
+        .map((d: any) => d.developer_user_id)
+        .filter((id: string | null) => !!id),
+    ),
+  );
+  if (!userIds.length) return [];
+
+  // Try `admins` first (has email + role); fall back to a profiles view if
+  // the deployment exposes one.
+  const { data: admins } = await supabase
+    .from('admins')
+    .select('id, email')
+    .in('id', userIds);
+  const emailById = new Map<string, string>(
+    (admins || []).map((a: any) => [a.id, a.email]),
+  );
+
+  // If admins didn't cover every developer_user_id, fall through to a
+  // best-effort auth lookup. Wrapped in try/catch because some tenants
+  // restrict admin RPC access.
+  const missing = userIds.filter((id) => !emailById.has(id));
+  for (const userId of missing) {
+    try {
+      const res = await (supabase as any).auth.admin.getUserById(userId);
+      const email: string | undefined = res?.data?.user?.email;
+      if (email) emailById.set(userId, email);
+    } catch {
+      /* swallow — surfaces as "no email on file" downstream */
+    }
+  }
+
+  const out: ResolvedContact[] = [];
+  for (const d of developments || []) {
+    const email = emailById.get(d.developer_user_id);
+    if (!email) continue;
+    out.push({
+      name: `Developer (${d.name})`,
+      email,
+      role: 'developer',
+      source: 'developments.developer_user_id',
+      schemeName: d.name,
+    });
+  }
+  return out;
+}
+
+async function resolveDevelopersByName(
+  supabase: SupabaseClient,
+  ctx: { assignedDevelopmentIds: string[] },
+  name: string,
+): Promise<ResolvedContact[]> {
+  const all = await resolveDevelopersForSchemes(supabase, ctx.assignedDevelopmentIds);
+  // Match by scheme name (most realistic: "the Lakeside developer") or by
+  // email local-part when the user types a literal first name.
+  return all.filter((c) => {
+    if (c.schemeName && nameTokensMatch(c.schemeName, name)) return true;
+    const local = (c.email || '').split('@')[0] || '';
+    return nameTokensMatch(local.replace(/[._-]/g, ' '), name);
+  });
+}
+
+/**
+ * Public entry point. Resolve a free-text recipient query to one or more
+ * concrete contacts the agent can email. Returns a structured result so
+ * the caller can render an inline prompt for the disambiguation case.
+ */
+export async function resolveAgentContact(
+  supabase: SupabaseClient,
+  ctx: ContactResolverContext,
+  query: { name?: string; role?: ContactRole | null; schemeHint?: string | null },
+): Promise<ContactResolution> {
+  const searched: string[] = [];
+  const candidates: ResolvedContact[] = [];
+
+  // Role-keyword short-circuit. If the original query was "the developer",
+  // the model should have set role='developer' before calling, but we
+  // re-detect from the name string as a belt-and-braces.
+  const detectedRole = query.role || detectRoleKeyword(query.name || '');
+
+  const assignedDevelopmentIds = ctx.assignedDevelopmentIds
+    ?? (await loadAssignedDevelopmentIds(supabase, ctx.agentProfileId));
+  const fullCtx: Required<Pick<ContactResolverContext, 'agentProfileId' | 'assignedDevelopmentIds'>> &
+    Pick<ContactResolverContext, 'activeDevelopmentId'> = {
+    agentProfileId: ctx.agentProfileId,
+    assignedDevelopmentIds,
+    activeDevelopmentId: ctx.activeDevelopmentId,
+  };
+
+  if (detectedRole === 'developer') {
+    searched.push('developers');
+    let scope = fullCtx.assignedDevelopmentIds;
+    if (query.schemeHint) {
+      const lower = query.schemeHint.toLowerCase();
+      const { data: devs } = await supabase
+        .from('developments')
+        .select('id, name')
+        .in('id', fullCtx.assignedDevelopmentIds);
+      const matches = (devs || []).filter((d: any) =>
+        String(d.name).toLowerCase().includes(lower),
+      );
+      if (matches.length) scope = matches.map((d: any) => d.id);
+    } else if (fullCtx.activeDevelopmentId) {
+      scope = [fullCtx.activeDevelopmentId];
+    }
+    const resolved = await resolveDevelopersForSchemes(supabase, scope);
+    candidates.push(...resolved);
+  } else if (query.name && query.name.trim().length >= 2) {
+    const name = query.name.trim();
+    searched.push('buyers', 'tenants', 'developers');
+    const [buyers, tenants, developers] = await Promise.all([
+      resolveBuyersByName(supabase, fullCtx, name).catch(() => []),
+      resolveTenantsByName(supabase, fullCtx, name).catch(() => []),
+      resolveDevelopersByName(supabase, fullCtx, name).catch(() => []),
+    ]);
+    candidates.push(...buyers, ...tenants, ...developers);
+  }
+
+  const deduped = dedupeByEmail(candidates);
+  if (deduped.length === 0) return { status: 'none', searched };
+  if (deduped.length === 1) return { status: 'one', contact: deduped[0] };
+  return { status: 'multiple', candidates: deduped };
+}

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -91,6 +91,62 @@ function shouldBlockDraft(draft: AgenticSkillDraft): { block: boolean; reason: s
   return { block: false, reason: '' };
 }
 
+// Defence-in-depth scrub for assembled email bodies. The skill template is
+// the single source of truth for greeting + sign-off, so a body should
+// carry exactly one of each. If a regression slips greeting/sign-off into
+// the free-text fields the skill template wraps, we end up with two of
+// each. Strip a duplicated leading greeting and any duplicated trailing
+// sign-off block before persisting. Conservative — only fires when the
+// duplication is unambiguous (two adjacent greeting lines, or two sign-off
+// lines within four lines of the tail).
+const GREETING_LINE = /^\s*(hi|hello|hey|dear|good\s+(morning|afternoon|evening))\b[^\n]{0,60}[,!.]?\s*$/i;
+const SIGNOFF_LINE = /^\s*(thanks|thank you|thanks so much|many thanks|best|best regards|kind regards|warm regards|warmest regards|regards|sincerely|sincerely yours|yours|yours sincerely|yours faithfully|cheers|talk soon|speak soon)\b[^\n]{0,30}[,!.]?\s*$/i;
+
+export function dedupeBoilerplate(body: string | null | undefined): string {
+  if (!body) return '';
+  const lines = String(body).replace(/\r\n/g, '\n').split('\n');
+
+  // Leading: drop consecutive duplicate greeting lines, keep one.
+  let firstGreetingIdx = -1;
+  for (let i = 0; i < Math.min(lines.length, 5); i++) {
+    if (lines[i].trim() === '') continue;
+    if (GREETING_LINE.test(lines[i])) firstGreetingIdx = i;
+    break;
+  }
+  if (firstGreetingIdx >= 0) {
+    let j = firstGreetingIdx + 1;
+    // Skip blank lines after the first greeting.
+    while (j < lines.length && lines[j].trim() === '') j++;
+    while (j < lines.length && GREETING_LINE.test(lines[j])) {
+      // Remove this duplicated greeting line.
+      lines.splice(j, 1);
+      while (j < lines.length && lines[j].trim() === '') {
+        lines.splice(j, 1);
+      }
+    }
+  }
+
+  // Trailing: detect repeated sign-off blocks within the last 8 lines.
+  // A "sign-off block" is a sign-off line plus the 0–3 short lines that
+  // follow it (name, optional title, optional company). If we find two
+  // sign-off lines in the tail, drop the EARLIER one and the lines
+  // between it and the later sign-off (those are the duplicate signature
+  // tail of the first block).
+  const tailStart = Math.max(0, lines.length - 8);
+  const signoffIndices: number[] = [];
+  for (let i = tailStart; i < lines.length; i++) {
+    if (SIGNOFF_LINE.test(lines[i])) signoffIndices.push(i);
+  }
+  if (signoffIndices.length >= 2) {
+    const firstSignoff = signoffIndices[0];
+    const lastSignoff = signoffIndices[signoffIndices.length - 1];
+    // Remove from firstSignoff up to (but not including) lastSignoff.
+    lines.splice(firstSignoff, lastSignoff - firstSignoff);
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
 export async function persistDraftsForEnvelope(
   supabase: SupabaseClient,
   envelope: AgenticSkillEnvelope,
@@ -116,9 +172,12 @@ export async function persistDraftsForEnvelope(
     }
 
     const draftType = resolveDraftType(ctx.skill, draft);
+    // Final-mile dedupe: strips duplicate greeting / sign-off blocks if the
+    // template ever ends up wrapping a body that already had them.
+    const cleanBody = draft.type === 'email' ? dedupeBoilerplate(draft.body) : draft.body;
     const contentJson: Record<string, any> = {
       subject: draft.subject ?? null,
-      body: draft.body,
+      body: cleanBody,
       skill: ctx.skill,
       affected_record: draft.affected_record,
       reasoning: draft.reasoning,
@@ -149,11 +208,11 @@ export async function persistDraftsForEnvelope(
       // Log but preserve the original id so the drawer still opens. The
       // draft simply won't be send/discard-able via the inbox endpoints.
       console.error('[persistDraftsForEnvelope] insert failed', { skill: ctx.skill, error: error?.message });
-      rewritten.push(draft);
+      rewritten.push({ ...draft, body: cleanBody });
       continue;
     }
 
-    rewritten.push({ ...draft, id: data.id });
+    rewritten.push({ ...draft, id: data.id, body: cleanBody });
   }
 
   // Thread the blocked list through meta so the chat route can force

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -63,22 +63,24 @@ export interface SkillPersistContext {
 }
 
 /**
- * Session 13.2 — defence-in-depth guard.
+ * Defence-in-depth guard.
  *
- * Refuse to insert a draft whose recipient is the specific placeholder
- * `recipient@tbc.invalid`. That placeholder only appears on the
- * `draftMessageSkill` unresolved-scheme fall-through path — a pattern
- * that Session 13.2 also fixes at the skill level. If a future skill
- * regresses and produces a placeholder draft, this guard catches it
- * before it lands in `pending_drafts`.
+ * The catch-all "recipient" sentinel previously used by draftMessageSkill
+ * has been removed; the skill now returns a structured `needs_recipient`
+ * envelope instead of a placeholder draft, and the contact resolver fills
+ * in the email when it's on file. This set stays in place as a defensive
+ * net so any future regression that re-introduces the sentinel cannot
+ * land in `pending_drafts`.
  *
- * NOTE: `buyer@tbc.invalid` and `solicitor@tbc.invalid` are NOT blocked.
- * Those come from flows where the unit / solicitor is resolved but the
- * email isn't on file yet — legitimate "fill in before approving"
- * drafts. Only the catch-all `recipient@tbc.invalid` is the signal
- * that the whole target is a hallucination.
+ * NOTE: `buyer@tbc.invalid`, `tenant@tbc.invalid`, and
+ * `solicitor@tbc.invalid` are NOT blocked. Those come from flows where
+ * the unit / tenancy / solicitor is resolved but the email isn't on
+ * file yet — legitimate "fill in before approving" drafts.
  */
-const BLOCKED_PLACEHOLDER_EMAILS = new Set(['recipient@tbc.invalid']);
+const BLOCKED_PLACEHOLDER_EMAILS = new Set([
+  'recipient@tbc.invalid',
+  'placeholder@tbc.invalid',
+]);
 
 function shouldBlockDraft(draft: AgenticSkillDraft): { block: boolean; reason: string } {
   const email = draft.recipient?.email ?? '';

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -26,6 +26,7 @@ const AGENTIC_DRAFT_TYPE_BY_SKILL: Record<string, string> = {
   schedule_viewing_draft: 'schedule_viewing',
   draft_message: 'buyer_followup',
   draft_buyer_followups: 'buyer_followup',
+  create_viewing_schedule: 'viewing_proposal',
 };
 
 function resolveDraftType(skill: string, draft: AgenticSkillDraft): string {

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -540,9 +540,16 @@ ${independentContext || ''}
 ============================================================
 FOLLOW-UP SUGGESTIONS:
 ============================================================
-After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
-- After chase draft: "Approve chase email", "Show aged contracts by scheme", "Draft chase emails for other overdue buyers"
-- After briefing: "Approve briefing", "Draft chase emails for aged contracts", "Review units needing attention"
+Follow-up suggestions are surfaced by the UI as dedicated tappable chips that
+the platform generates separately. DO NOT embed a list of suggested next
+steps inside your response body — no bullet list, no numbered list, no
+inline "you might also want to..." prose. End your reply with the answer.
+Never wrap suggestions in quote characters of any kind.
+
+Examples of action-oriented chip copy (the platform generates these; do not
+write them yourself in the body): Approve chase email; Show aged contracts
+by scheme; Draft chase emails for other overdue buyers; Approve briefing;
+Review units needing attention.
 
 ============================================================
 PROACTIVE INTELLIGENCE:
@@ -689,10 +696,17 @@ ${viewingsSummary ? `LETTINGS VIEWINGS:\n${viewingsSummary}` : ''}
 ============================================================
 FOLLOW-UP SUGGESTIONS:
 ============================================================
-After every response, suggest 2-3 ACTION-ORIENTED next steps. Never clarifying questions.
-- After a draft to a tenant: "Send the draft now", "Edit the message", "Log maintenance ticket"
-- After a lease lookup: "Draft renewal offer", "Schedule check-in", "Show all leases ending in 30 days"
-- After a compliance gap: "Upload BER cert", "Mark RTB registered", "View property record"
+Follow-up suggestions are surfaced by the UI as dedicated tappable chips
+that the platform generates separately. DO NOT embed a list of suggested
+next steps inside your response body — no bullet list, no numbered list,
+no inline "you might also want to..." prose. End your reply with the
+answer. Never wrap suggestions in quote characters of any kind.
+
+Examples of action-oriented chip copy (the platform generates these; do
+not write them yourself in the body): Send the draft now; Edit the
+message; Log maintenance ticket; Draft renewal offer; Schedule check-in;
+Show all leases ending in 30 days; Upload BER cert; Mark RTB registered;
+View property record.
 
 ============================================================
 PROACTIVE INTELLIGENCE:

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -363,7 +363,8 @@ You have two classes of tools:
 
 (B) AGENTIC SKILL tools — produce draft work for the agent's approval. These are:
     chase_aged_contracts, draft_viewing_followup, weekly_monday_briefing,
-    draft_lease_renewal, natural_query, schedule_viewing_draft.
+    draft_lease_renewal, natural_query, schedule_viewing_draft,
+    create_viewing_schedule, rank_pipeline_buyers.
 
 Every agentic skill tool returns a structured envelope with
 \`status: "awaiting_approval"\` and zero-or-more drafts, each carrying a stable
@@ -383,7 +384,15 @@ ANYONE — ALWAYS call the appropriate draft-producing tool. Pick the tightest f
   - "chase all overdue contracts" → call chase_aged_contracts.
   - "follow up on viewings yesterday" → call draft_viewing_followup.
   - Lease renewals → draft_lease_renewal. Weekly briefing → weekly_monday_briefing.
-  - New viewing appointment → schedule_viewing_draft.
+  - New (single) viewing appointment → schedule_viewing_draft.
+  - Group viewing schedule across many buyers, "draft a viewing schedule for X
+    on Saturday from 9-2 and propose them to N active buyers" →
+    create_viewing_schedule. The skill builds the slots, ranks the buyers
+    via rank_pipeline_buyers, and emits one email + one viewing record per
+    buyer for approval.
+  - "Who is most likely to convert?" / "top buyers at scheme X" / "who
+    should I chase first" → call rank_pipeline_buyers and read the result;
+    do NOT guess or invent rankings.
 
 ALWAYS set draft_buyer_followups purpose:
   - "congratulate" / "welcome" / "keys" / "handed over" / "moved in"

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -2155,3 +2155,611 @@ export async function getCandidateUnitsSkill(
   }
 }
 
+// =====================================================================
+// Skill 10 — rank_pipeline_buyers (deterministic SQL ranking)
+// =====================================================================
+//
+// Phase 1 ranking helper for "who is most likely to convert" / "give me
+// the top N buyers" style asks, plus the input to create_viewing_schedule.
+// No LLM scoring layer — a transparent SQL rubric the agent can argue
+// with. Each ranked row carries a numeric score (0..100) and a short
+// `reason` string naming the top contributor ("contacted 3 days ago,
+// sale agreed, viewed twice").
+
+export interface RankedPipelineBuyer {
+  unit_id: string;
+  development_id: string;
+  unit_number: string;
+  scheme_name: string;
+  buyer_name: string;
+  buyer_email: string | null;
+  stage: string;
+  score: number;
+  reason: string;
+  last_contact_days: number | null;
+  pipeline_age_days: number | null;
+  viewing_count: number;
+}
+
+interface RankPipelineBuyersInput {
+  development_id?: string;
+  scheme_name?: string;
+  limit?: number;
+}
+
+function classifyStage(unitStatus: string | null, pipe: any | null): {
+  stage: string;
+  stagePoints: number;
+} {
+  // Pipeline-date-derived stage takes priority: a unit can be 'available'
+  // in `units.unit_status` while the pipeline row carries a deposit_date,
+  // because the column drift between the two tables is not always tight.
+  // We prefer the more progressed signal.
+  if (pipe?.handover_date) return { stage: 'handed_over', stagePoints: 100 };
+  if (pipe?.counter_signed_date) return { stage: 'counter_signed', stagePoints: 95 };
+  if (pipe?.signed_contracts_date) return { stage: 'signed', stagePoints: 90 };
+  if (pipe?.contracts_issued_date) return { stage: 'contracts_issued', stagePoints: 80 };
+  if (pipe?.deposit_date) return { stage: 'deposit_received', stagePoints: 70 };
+  if (pipe?.sale_agreed_date) return { stage: 'sale_agreed', stagePoints: 65 };
+  if (unitStatus === 'sale_agreed') return { stage: 'sale_agreed', stagePoints: 65 };
+  if (unitStatus === 'reserved') return { stage: 'reserved', stagePoints: 55 };
+  if (pipe?.release_date) return { stage: 'in_progress', stagePoints: 35 };
+  if (unitStatus === 'available') return { stage: 'for_sale', stagePoints: 15 };
+  return { stage: unitStatus || 'unknown', stagePoints: 10 };
+}
+
+function recencyPoints(daysSinceContact: number | null): number {
+  if (daysSinceContact === null) return 0;
+  if (daysSinceContact <= 3) return 100;
+  if (daysSinceContact <= 7) return 80;
+  if (daysSinceContact <= 14) return 50;
+  if (daysSinceContact <= 30) return 25;
+  return 5;
+}
+
+function agingPoints(daysInPipeline: number | null): number {
+  if (daysInPipeline === null) return 50; // unknown — neutral
+  if (daysInPipeline <= 14) return 100;
+  if (daysInPipeline <= 30) return 70;
+  if (daysInPipeline <= 60) return 40;
+  if (daysInPipeline <= 120) return 20;
+  return 5;
+}
+
+function viewingPoints(count: number): number {
+  if (count >= 2) return 100;
+  if (count === 1) return 70;
+  return 25;
+}
+
+function buildRankReason(
+  stage: string,
+  daysSinceContact: number | null,
+  daysInPipeline: number | null,
+  viewingCount: number,
+): string {
+  const parts: string[] = [];
+  // Always lead with the strongest signal.
+  if (daysSinceContact !== null && daysSinceContact <= 7) {
+    parts.push(`contacted ${daysSinceContact === 0 ? 'today' : `${daysSinceContact} day${daysSinceContact === 1 ? '' : 's'} ago`}`);
+  } else if (daysSinceContact !== null && daysSinceContact <= 30) {
+    parts.push(`last contact ${daysSinceContact} days ago`);
+  } else if (daysSinceContact === null) {
+    parts.push('no contact logged yet');
+  } else {
+    parts.push(`gone quiet (${daysSinceContact} days since contact)`);
+  }
+  if (stage && stage !== 'for_sale' && stage !== 'unknown') {
+    parts.push(stage.replace(/_/g, ' '));
+  }
+  if (viewingCount >= 1) {
+    parts.push(`viewed ${viewingCount === 1 ? 'once' : `${viewingCount} times`}`);
+  } else {
+    parts.push('no viewings yet');
+  }
+  if (daysInPipeline !== null && daysInPipeline > 60) {
+    parts.push(`in pipeline ${daysInPipeline} days`);
+  }
+  return parts.slice(0, 3).join(', ');
+}
+
+async function resolveRankingScope(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: RankPipelineBuyersInput,
+): Promise<
+  | { ok: true; developmentId: string; schemeName: string }
+  | { ok: false; reason: string }
+> {
+  const { data: asgs } = await supabase
+    .from('agent_scheme_assignments')
+    .select('development_id')
+    .eq('agent_id', agentContext.agentProfileId)
+    .eq('is_active', true);
+  const devIds = Array.from(
+    new Set((asgs || []).map((a: any) => a.development_id).filter(Boolean)),
+  );
+  if (!devIds.length) {
+    return { ok: false, reason: 'No assigned schemes for this agent.' };
+  }
+
+  if (inputs.development_id) {
+    if (!devIds.includes(inputs.development_id)) {
+      return { ok: false, reason: 'That development is not in your assigned schemes.' };
+    }
+    const { data: dev } = await supabase
+      .from('developments')
+      .select('id, name')
+      .eq('id', inputs.development_id)
+      .maybeSingle();
+    if (!dev) return { ok: false, reason: 'Development not found.' };
+    return { ok: true, developmentId: dev.id, schemeName: dev.name };
+  }
+
+  if (inputs.scheme_name) {
+    const { data: devs } = await supabase
+      .from('developments')
+      .select('id, name')
+      .in('id', devIds);
+    const devList = (devs || []) as Array<{ id: string; name: string }>;
+    const resolution = await resolveSchemeName(supabase, inputs.scheme_name, {
+      assignedDevelopmentIds: devList.map((d) => d.id),
+      assignedDevelopmentNames: devList.map((d) => d.name),
+    });
+    if (!resolution.ok) {
+      return {
+        ok: false,
+        reason:
+          resolution.reason === 'not_found'
+            ? `I couldn't find a scheme matching "${inputs.scheme_name}". Your assigned schemes are: ${resolution.candidates.join(', ')}.`
+            : resolution.reason === 'ambiguous'
+              ? `"${inputs.scheme_name}" matches multiple schemes (${resolution.candidates.join(', ')}). Please be specific.`
+              : `Scheme "${inputs.scheme_name}" is not in your assigned list.`,
+      };
+    }
+    return { ok: true, developmentId: resolution.developmentId, schemeName: resolution.canonicalName };
+  }
+
+  return {
+    ok: false,
+    reason: 'Provide either development_id or scheme_name.',
+  };
+}
+
+async function rankBuyersForDevelopment(
+  supabase: SupabaseClient,
+  developmentId: string,
+  schemeName: string,
+  limit: number,
+): Promise<RankedPipelineBuyer[]> {
+  // 1. Pipeline rows with stage dates + buyer contact info.
+  const { data: pipelineRows } = await supabase
+    .from('unit_sales_pipeline')
+    .select(
+      'unit_id, development_id, purchaser_name, purchaser_email, ' +
+        'release_date, sale_agreed_date, deposit_date, contracts_issued_date, ' +
+        'signed_contracts_date, counter_signed_date, handover_date, created_at',
+    )
+    .eq('development_id', developmentId);
+
+  const pipeRows = (pipelineRows || []) as any[];
+  if (!pipeRows.length) return [];
+
+  // 2. Unit rows for fallback purchaser name + status.
+  const unitIds = pipeRows.map((p) => p.unit_id).filter(Boolean);
+  const { data: unitRows } = await supabase
+    .from('units')
+    .select('id, unit_number, unit_uid, unit_status, purchaser_name, purchaser_email')
+    .in('id', unitIds);
+  const unitById = new Map<string, any>((unitRows || []).map((u: any) => [u.id, u]));
+
+  // 3. Communication recency per unit.
+  const { data: commsRows } = await supabase
+    .from('communication_events')
+    .select('unit_id, created_at')
+    .in('unit_id', unitIds)
+    .order('created_at', { ascending: false });
+  const lastCommByUnit = new Map<string, string>();
+  for (const c of (commsRows || []) as any[]) {
+    if (!c.unit_id) continue;
+    if (!lastCommByUnit.has(c.unit_id)) lastCommByUnit.set(c.unit_id, c.created_at);
+  }
+
+  // 4. Viewing counts. agent_viewings keys off a free-text unit_ref + a
+  //    nullable unit_id; we count by unit_id where available, and fall
+  //    back to unit_number string match for legacy rows.
+  const { data: viewingRows } = await supabase
+    .from('agent_viewings')
+    .select('unit_id, unit_ref, scheme_name, buyer_name')
+    .eq('scheme_name', schemeName);
+  const viewingsByUnitId = new Map<string, number>();
+  const viewingsByUnitRef = new Map<string, number>();
+  for (const v of (viewingRows || []) as any[]) {
+    if (v.unit_id) {
+      viewingsByUnitId.set(v.unit_id, (viewingsByUnitId.get(v.unit_id) || 0) + 1);
+    } else if (v.unit_ref) {
+      const k = String(v.unit_ref).toLowerCase();
+      viewingsByUnitRef.set(k, (viewingsByUnitRef.get(k) || 0) + 1);
+    }
+  }
+
+  const now = Date.now();
+  const ranked: RankedPipelineBuyer[] = [];
+
+  for (const p of pipeRows) {
+    const unit = unitById.get(p.unit_id);
+    const buyerName = (p.purchaser_name || unit?.purchaser_name || '').trim();
+    const buyerEmail = (p.purchaser_email || unit?.purchaser_email || null) as string | null;
+    if (!buyerName) continue; // No buyer in pipeline yet — skip, this is "who would convert", not "who could".
+
+    const unitNumber = unit?.unit_number || unit?.unit_uid || 'unknown';
+    const { stage, stagePoints } = classifyStage(unit?.unit_status || null, p);
+
+    const lastCommIso = lastCommByUnit.get(p.unit_id) || null;
+    const daysSinceContact = lastCommIso
+      ? Math.max(0, Math.floor((now - new Date(lastCommIso).getTime()) / 86400000))
+      : null;
+
+    const pipelineStartIso: string | null =
+      p.release_date || p.created_at || null;
+    const daysInPipeline = pipelineStartIso
+      ? Math.max(0, Math.floor((now - new Date(pipelineStartIso).getTime()) / 86400000))
+      : null;
+
+    let viewingCount = viewingsByUnitId.get(p.unit_id) || 0;
+    if (!viewingCount && unitNumber) {
+      viewingCount = viewingsByUnitRef.get(String(unitNumber).toLowerCase()) || 0;
+    }
+
+    const score =
+      0.4 * stagePoints +
+      0.3 * recencyPoints(daysSinceContact) +
+      0.2 * agingPoints(daysInPipeline) +
+      0.1 * viewingPoints(viewingCount);
+
+    ranked.push({
+      unit_id: p.unit_id,
+      development_id: p.development_id,
+      unit_number: String(unitNumber),
+      scheme_name: schemeName,
+      buyer_name: buyerName,
+      buyer_email: buyerEmail,
+      stage,
+      score: Math.round(score * 10) / 10,
+      reason: buildRankReason(stage, daysSinceContact, daysInPipeline, viewingCount),
+      last_contact_days: daysSinceContact,
+      pipeline_age_days: daysInPipeline,
+      viewing_count: viewingCount,
+    });
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked.slice(0, limit);
+}
+
+export async function rankPipelineBuyers(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: RankPipelineBuyersInput,
+): Promise<AgenticSkillEnvelope> {
+  const skill = 'rank_pipeline_buyers';
+  const limit = Math.max(1, Math.min(50, inputs.limit ?? 10));
+  const query = `rank_pipeline_buyers development=${inputs.development_id ?? inputs.scheme_name ?? ''} limit=${limit}`;
+
+  try {
+    const scope = await resolveRankingScope(supabase, agentContext, inputs);
+    if (!scope.ok) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: scope.reason,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    const ranked = await rankBuyersForDevelopment(
+      supabase,
+      scope.developmentId,
+      scope.schemeName,
+      limit,
+    );
+
+    if (!ranked.length) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: `No active buyers in the pipeline at ${scope.schemeName} yet.`,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    const summaryLines = [
+      `Top ${ranked.length} buyer${ranked.length === 1 ? '' : 's'} most likely to convert at ${scope.schemeName}:`,
+      ...ranked.map(
+        (r, i) =>
+          `${i + 1}. ${r.buyer_name} — Unit ${r.unit_number} (score ${r.score}) — ${r.reason}`,
+      ),
+    ];
+
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: summaryLines.join('\n'),
+      drafts: [],
+      meta: {
+        record_count: ranked.length,
+        generated_at: new Date().toISOString(),
+        query,
+        // @ts-ignore — diagnostic + consumed by create_viewing_schedule
+        ranked_buyers: ranked,
+        // @ts-ignore
+        development_id: scope.developmentId,
+        // @ts-ignore
+        scheme_name: scope.schemeName,
+      } as any,
+    };
+  } catch (err) {
+    return errorEnvelope(skill, query, err);
+  }
+}
+
+// =====================================================================
+// Skill 11 — create_viewing_schedule (timeslots + per-buyer proposals)
+// =====================================================================
+//
+// Phase 1 viewing scheduler. Builds N timeslots between start_time and
+// end_time at slot_duration_minutes spacing, ranks N buyers via the
+// existing rank_pipeline_buyers helper, and emits one viewing_record
+// draft and one email draft per buyer. The drafts go through the same
+// persistence / drawer pipeline every other agentic skill uses — no new
+// email pipeline.
+
+interface CreateViewingScheduleInput {
+  development_id?: string;
+  scheme_name?: string;
+  date: string; // ISO date "2026-05-09"
+  start_time: string; // "09:00"
+  end_time: string; // "14:00"
+  slot_duration_minutes?: number;
+  target_count?: number;
+}
+
+function parseClockTime(value: string): { hour: number; minute: number } | null {
+  if (!value) return null;
+  const trimmed = value.trim().toLowerCase();
+  // Accept "9", "9am", "9:00", "9:00am", "14:30", "2pm", "2:30pm".
+  const ampmMatch = trimmed.match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$/);
+  if (!ampmMatch) return null;
+  let hour = Number(ampmMatch[1]);
+  const minute = ampmMatch[2] ? Number(ampmMatch[2]) : 0;
+  const meridiem = ampmMatch[3];
+  if (meridiem === 'pm' && hour < 12) hour += 12;
+  if (meridiem === 'am' && hour === 12) hour = 0;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return { hour, minute };
+}
+
+function buildSlots(
+  date: string,
+  startTime: string,
+  endTime: string,
+  slotMinutes: number,
+  targetCount: number,
+): Array<{ start: string; end: string; iso: string }> | null {
+  const start = parseClockTime(startTime);
+  const end = parseClockTime(endTime);
+  if (!start || !end) return null;
+  const startMinutes = start.hour * 60 + start.minute;
+  const endMinutes = end.hour * 60 + end.minute;
+  if (endMinutes <= startMinutes) return null;
+  const slots: Array<{ start: string; end: string; iso: string }> = [];
+  let cursor = startMinutes;
+  while (cursor + slotMinutes <= endMinutes && slots.length < targetCount) {
+    const sH = Math.floor(cursor / 60);
+    const sM = cursor % 60;
+    const eMins = cursor + slotMinutes;
+    const eH = Math.floor(eMins / 60);
+    const eM = eMins % 60;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const startLabel = `${pad(sH)}:${pad(sM)}`;
+    const endLabel = `${pad(eH)}:${pad(eM)}`;
+    const iso = `${date}T${startLabel}:00`;
+    slots.push({ start: startLabel, end: endLabel, iso });
+    cursor += slotMinutes;
+  }
+  return slots;
+}
+
+function formatSlotForCopy(date: string, slotStart: string): string {
+  const d = new Date(`${date}T${slotStart}:00`);
+  if (Number.isNaN(d.getTime())) return `${date} ${slotStart}`;
+  const dayLabel = d.toLocaleDateString('en-IE', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  });
+  return `${dayLabel} at ${slotStart}`;
+}
+
+export async function createViewingSchedule(
+  supabase: SupabaseClient,
+  agentContext: SkillAgentContext,
+  inputs: CreateViewingScheduleInput,
+): Promise<AgenticSkillEnvelope> {
+  const skill = 'create_viewing_schedule';
+  const slotMinutes = Math.max(15, Math.min(120, inputs.slot_duration_minutes ?? 30));
+  const targetCount = Math.max(1, Math.min(20, inputs.target_count ?? 10));
+  const query = `create_viewing_schedule date=${inputs.date} ${inputs.start_time}-${inputs.end_time} slots=${targetCount}@${slotMinutes}m`;
+
+  try {
+    if (!inputs.date || !/^\d{4}-\d{2}-\d{2}$/.test(inputs.date)) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: 'Provide date as ISO YYYY-MM-DD (e.g. 2026-05-09).',
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    const scope = await resolveRankingScope(supabase, agentContext, inputs);
+    if (!scope.ok) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: scope.reason,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    const slots = buildSlots(
+      inputs.date,
+      inputs.start_time,
+      inputs.end_time,
+      slotMinutes,
+      targetCount,
+    );
+    if (!slots || slots.length === 0) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary:
+          'Could not build slots from the time range. Check start_time / end_time / slot_duration_minutes.',
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    // Use the same ranker the agent would call directly. We fetch one
+    // extra so we have headroom if a top-ranked buyer is missing an
+    // email and we need to skip them.
+    const ranked = await rankBuyersForDevelopment(
+      supabase,
+      scope.developmentId,
+      scope.schemeName,
+      targetCount + 5,
+    );
+
+    const eligible = ranked.filter((r) => r.buyer_email && r.buyer_name);
+    if (eligible.length === 0) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: `No buyers with email on file at ${scope.schemeName}. Update purchaser emails on the units before scheduling.`,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    const drafts: AgenticSkillEnvelope['drafts'] = [];
+    const usedSlots = Math.min(slots.length, eligible.length);
+
+    for (let i = 0; i < usedSlots; i++) {
+      const buyer = eligible[i];
+      const primarySlot = slots[i];
+      // Offer 2-3 specific slots: the primary plus the next two on either
+      // side, deduped, capped at the schedule's bounds. Phase 1 keeps it
+      // simple — let the agent edit later if needed.
+      const altSlots: typeof slots = [];
+      for (const offset of [1, -1, 2, -2]) {
+        const idx = i + offset;
+        if (idx >= 0 && idx < slots.length && altSlots.length < 2) {
+          altSlots.push(slots[idx]);
+        }
+      }
+      const slotLines = [primarySlot, ...altSlots]
+        .map((s) => `- ${formatSlotForCopy(inputs.date, s.start)}`)
+        .join('\n');
+
+      const buyerFirst = firstName(buyer.buyer_name);
+      const opener = `${buyer.reason}, so I wanted to put a slot in front of you.`;
+
+      const subject = `Viewing slot for Unit ${buyer.unit_number}, ${scope.schemeName}`;
+      const body = [
+        `Hi ${buyerFirst},`,
+        '',
+        opener,
+        '',
+        `I'm running viewings at ${scope.schemeName} on ${formatSlotForCopy(inputs.date, primarySlot.start).replace(' at ' + primarySlot.start, '')}. I've held a slot for you — pick whichever works:`,
+        slotLines,
+        '',
+        `Reply with the time and I'll lock it in. Happy to suggest another day if none of those land.`,
+        '',
+        'Thanks,',
+        signature(agentContext),
+      ].join('\n');
+
+      // Email draft.
+      drafts.push({
+        id: randomUUID(),
+        type: 'email' as const,
+        recipient: {
+          name: buyer.buyer_name,
+          email: buyer.buyer_email!,
+          role: 'buyer',
+        },
+        subject,
+        body,
+        affected_record: {
+          kind: 'sales_unit',
+          id: buyer.unit_id,
+          label: `Unit ${buyer.unit_number}, ${scope.schemeName}`,
+        },
+        reasoning: `Ranked #${i + 1} (score ${buyer.score}). ${buyer.reason}.`,
+      });
+
+      // Viewing-record draft. Mirrors scheduleViewingDraft so the same
+      // approval drawer creates a real agent_viewings row when the agent
+      // hits Approve.
+      const recordRow: Record<string, any> = {
+        agent_id: agentContext.agentProfileId,
+        buyer_name: buyer.buyer_name,
+        buyer_email: buyer.buyer_email,
+        viewing_date: inputs.date,
+        viewing_time: `${primarySlot.start}:00`,
+        status: 'pending',
+        source: 'intelligence',
+        unit_ref: buyer.unit_number,
+        development_id: scope.developmentId,
+        unit_id: buyer.unit_id,
+        scheme_name: scope.schemeName,
+      };
+      drafts.push({
+        id: randomUUID(),
+        type: 'viewing_record' as const,
+        body: JSON.stringify(recordRow, null, 2),
+        affected_record: {
+          kind: 'sales_unit',
+          id: buyer.unit_id,
+          label: `Unit ${buyer.unit_number}, ${scope.schemeName}`,
+        },
+        reasoning: `Holds ${formatSlotForCopy(inputs.date, primarySlot.start)} for ${buyer.buyer_name}. Created on approval.`,
+      });
+    }
+
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary: `Drafted a ${usedSlots}-slot viewing schedule for ${scope.schemeName} on ${inputs.date} (${inputs.start_time}–${inputs.end_time}). Each buyer has an email proposal and a held slot in the drawer for review.`,
+      drafts,
+      meta: {
+        record_count: drafts.length,
+        generated_at: new Date().toISOString(),
+        query,
+        // @ts-ignore — surfaced for diagnostics + analytics
+        development_id: scope.developmentId,
+        // @ts-ignore
+        scheme_name: scope.schemeName,
+        // @ts-ignore
+        slot_count: usedSlots,
+        // @ts-ignore
+        ranked_buyers: eligible.slice(0, usedSlots),
+      } as any,
+    };
+  } catch (err) {
+    return errorEnvelope(skill, query, err);
+  }
+}

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -54,6 +54,51 @@ function firstName(fullName: string | null | undefined): string {
   return fullName.trim().split(/\s+/)[0] ?? 'there';
 }
 
+// Defensive scrubber for the free-text body content the model passes via
+// `topic` / `context` / `custom_instruction`. The skill template already
+// supplies the greeting and the sign-off + signature block, so any greeting
+// or sign-off the model wrote into the body produces a duplicate. Strip a
+// leading greeting line (Hi/Hello/Dear/Hey ...,) and a trailing sign-off
+// block (Thanks/Best/Best regards/Kind regards/Sincerely/Yours/Cheers/
+// Warm regards/Many thanks ... followed by name(s) and an optional company
+// line) before assembly. Conservative on purpose — only strips when the
+// pattern clearly matches a salutation or closing block.
+export function stripGreetingAndSignoff(input: string | null | undefined): string {
+  if (!input) return '';
+  let text = String(input).replace(/\r\n/g, '\n').trim();
+  if (!text) return '';
+
+  const lines = text.split('\n');
+
+  // Leading greeting: Hi X,  /  Hello there,  /  Dear Eoin,  /  Hey,
+  const greetingRe = /^\s*(hi|hello|hey|dear|good\s+(morning|afternoon|evening))\b[^\n]{0,60}[,!.]?\s*$/i;
+  while (lines.length && greetingRe.test(lines[0])) {
+    lines.shift();
+    while (lines.length && lines[0].trim() === '') lines.shift();
+  }
+
+  // Trailing sign-off block. Sign-off line is something like "Thanks,",
+  // "Best regards,", "Kind regards,", "Sincerely,", "Yours,", "Cheers,",
+  // "Warm regards,", "Many thanks,". Followed by 0–3 short non-empty
+  // lines (the agent's name, optional title, optional company) before EOF.
+  const signoffRe = /^\s*(thanks|thank you|thanks so much|many thanks|best|best regards|kind regards|warm regards|warmest regards|regards|sincerely|sincerely yours|yours|yours sincerely|yours faithfully|cheers|talk soon|speak soon)\b[^\n]{0,30}[,!.]?\s*$/i;
+  // Walk backwards skipping trailing blanks.
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+  // Find a sign-off line within the last 5 lines.
+  for (let i = lines.length - 1; i >= Math.max(0, lines.length - 5); i--) {
+    if (signoffRe.test(lines[i])) {
+      // Drop everything from this index onward (sign-off + name/company tail).
+      lines.length = i;
+      break;
+    }
+  }
+
+  // Trim trailing blanks one more time in case the pop loop above didn't.
+  while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
+
+  return lines.join('\n').trim();
+}
+
 function errorEnvelope(skill: string, query: string, err: unknown): AgenticSkillEnvelope {
   const message = err instanceof Error ? err.message : String(err);
   return {
@@ -1100,7 +1145,9 @@ async function draftTenantMessage(
   const skill = 'draft_message';
   const recipientName = (inputs.recipient_name || '').trim();
   const propertyHint = (inputs.related_property || '').trim();
-  const context = (inputs.context || '').trim();
+  // Scrub greeting/sign-off the model may have included — the template
+  // below adds them once, which is the single source of truth.
+  const context = stripGreetingAndSignoff(inputs.context);
   const tone = (inputs.tone || 'warm').trim();
   const query = `draft_message recipient_type=tenant recipient="${recipientName}" property="${propertyHint}"`;
 
@@ -1242,7 +1289,9 @@ export async function draftMessageSkill(
   // resolved unit's purchaser_name. We carry recipientName as a let so the
   // unit-resolution stage below can fill it in when empty.
   let recipientName = (inputs.recipient_name || '').trim();
-  const context = (inputs.context || '').trim();
+  // Scrub greeting/sign-off the model may have included — the template
+  // below adds them once, which is the single source of truth.
+  const context = stripGreetingAndSignoff(inputs.context);
   const tone = (inputs.tone || (inputs.recipient_type === 'solicitor' ? 'formal' : 'warm')).trim();
   const query = `draft_message recipient="${recipientName}" unit="${inputs.related_unit || ''}" scheme="${inputs.related_scheme || ''}"`;
 
@@ -1599,9 +1648,13 @@ function buildFollowupContent(opts: {
   tone: string;
   ctx: SkillAgentContext;
 }): { subject: string; body: string } {
-  const { purpose, topic, customInstruction, unitLabel, greeting, tone, ctx } = opts;
+  const { purpose, topic: rawTopic, customInstruction: rawCustom, unitLabel, greeting, tone, ctx } = opts;
   const sign = toneSignOff(tone);
   const sig = signature(ctx);
+  // Defensive: scrub any greeting / sign-off the model may have included in
+  // the free-text fields, since the template already supplies both.
+  const topic = stripGreetingAndSignoff(rawTopic);
+  const customInstruction = stripGreetingAndSignoff(rawCustom);
 
   if (purpose === 'congratulate_handover') {
     return {
@@ -1645,7 +1698,7 @@ function buildFollowupContent(opts: {
   }
 
   if (purpose === 'custom') {
-    const instruction = customInstruction?.trim() || topic;
+    const instruction = customInstruction || topic;
     return {
       subject: unitLabel,
       body: [greeting, '', instruction, '', sign, sig].join('\n'),

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -9,6 +9,12 @@ import {
   type CandidateIntent,
 } from '../unit-resolver';
 import { resolveSchemeName } from '../scheme-resolver';
+import {
+  resolveAgentContact,
+  detectRoleKeyword,
+  type ContactResolution,
+  type ResolvedContact,
+} from '../contact-resolver';
 
 // Envelope returned by every agentic skill. Draft ids generated here are
 // temporary — the registry adapter funnels the envelope through
@@ -1309,13 +1315,9 @@ export async function draftMessageSkill(
   }
 
   try {
-    // Session 13.2 — strict scheme/unit resolution when the caller
-    // specified a unit context. Pre-13.2 the skill ran a naive ilike
-    // against developments.name; if the scheme didn't match it fell
-    // through to a placeholder-everything draft that got persisted
-    // into pending_drafts with recipient@tbc.invalid. Now: if
-    // related_scheme or related_unit is provided and either fails to
-    // resolve, return an envelope with zero drafts + a skipped reason,
+    // Strict scheme/unit resolution when the caller specified a unit
+    // context. If related_scheme or related_unit fails to resolve, we
+    // return an envelope with zero drafts plus a skipped reason —
     // matching the draftBuyerFollowups contract.
     let resolvedEmail: string | null = inputs.recipient_email || null;
     let resolvedUnitNumber: string | null = null;
@@ -1486,6 +1488,39 @@ export async function draftMessageSkill(
         ? `Unit ${resolvedUnitNumber}`
         : resolvedSchemeName || '';
 
+    // Contact resolution. If the model didn't pass recipient_email and the
+    // unit-resolution stage didn't pull one off the purchaser record, run
+    // the contact resolver against the recipient_name (or the role keyword
+    // it implies). Falls into one of three branches:
+    //   - one match: use that email
+    //   - multiple: return a structured needs_recipient envelope so the
+    //     chat route can surface an inline "which one?" prompt
+    //   - none: return needs_recipient with no candidates so the chat
+    //     route can ask the user to paste an address
+    if (!resolvedEmail && !affectedUnitId) {
+      const role = detectRoleKeyword(recipientName);
+      const resolution = await resolveAgentContact(
+        supabase,
+        { agentProfileId: agentContext.agentProfileId },
+        {
+          name: recipientName,
+          role: role,
+          schemeHint: inputs.related_scheme || resolvedSchemeName,
+        },
+      );
+      const ndsEnvelope = needsRecipientEnvelope(skill, query, recipientName, resolution);
+      if (ndsEnvelope) return ndsEnvelope;
+      if (resolution.status === 'one') {
+        resolvedEmail = resolution.contact.email;
+        // If the resolver disambiguated from a role keyword, use the
+        // resolved name as the recipient label too — "Developer (Lakeside
+        // Manor)" reads better than "the developer" on a draft card.
+        if (!recipientName || detectRoleKeyword(recipientName)) {
+          recipientName = resolution.contact.name;
+        }
+      }
+    }
+
     const subject = unitLabel
       ? `Following up — ${unitLabel}`
       : `Following up — ${context.slice(0, 60)}`;
@@ -1499,22 +1534,20 @@ export async function draftMessageSkill(
       signature(agentContext),
     ].filter((line) => line !== undefined).join('\n');
 
-    // Session 14.10 — placeholder semantics. The persistence-layer guard
-    // (draft-store.ts) refuses recipient@tbc.invalid because that
-    // placeholder originally signaled "the WHOLE target is a hallucination —
-    // we never resolved a unit, scheme, or buyer." But on this code path
-    // we DID resolve a real unit (affectedUnitId is set), we just don't
-    // have an email on file. That's the legitimate "fill-in-before-send"
-    // case — use buyer@tbc.invalid (which the guard explicitly allows)
-    // when we have an affected unit, falling back to the catch-all only
-    // when no unit was resolved.
-    const placeholderEmail = affectedUnitId ? 'buyer@tbc.invalid' : 'recipient@tbc.invalid';
+    // After resolver: when a unit is resolved but no email is on file we
+    // still produce a draft using the buyer@tbc.invalid sentinel (the
+    // persistence guard explicitly allows this — agent fills it in before
+    // approving). When no unit AND no resolved email, the resolver
+    // already returned a needs_recipient envelope above; we never reach
+    // the placeholder path here.
+    const placeholderEmail = 'buyer@tbc.invalid';
+    const finalEmail = resolvedEmail || placeholderEmail;
     const draft = {
       id: randomUUID(),
       type: 'email' as const,
       recipient: {
         name: recipientName,
-        email: resolvedEmail || placeholderEmail,
+        email: finalEmail,
         role: inputs.recipient_type || 'recipient',
       },
       subject,
@@ -1541,6 +1574,86 @@ export async function draftMessageSkill(
   } catch (err) {
     return errorEnvelope(skill, query, err);
   }
+}
+
+/**
+ * Build a structured "needs recipient" envelope when contact resolution
+ * comes back empty or ambiguous. Carries the candidate list (if any) on
+ * meta.needs_recipient so the chat route can render a disambiguation
+ * prompt that names each candidate plus the option to paste an address.
+ *
+ * Returns null when the resolution succeeded with exactly one match —
+ * the caller proceeds with the resolved email.
+ */
+function needsRecipientEnvelope(
+  skill: string,
+  query: string,
+  recipientQuery: string,
+  resolution: ContactResolution,
+): AgenticSkillEnvelope | null {
+  if (resolution.status === 'one') return null;
+  const correlationId = randomUUID().slice(0, 8);
+  const niceQuery = recipientQuery?.trim() || 'that recipient';
+  if (resolution.status === 'multiple') {
+    const lines = resolution.candidates.slice(0, 6).map((c, i) => {
+      const where = c.schemeName
+        ? c.unitLabel
+          ? ` — ${c.unitLabel}, ${c.schemeName}`
+          : ` — ${c.schemeName}`
+        : c.unitLabel
+          ? ` — ${c.unitLabel}`
+          : '';
+      return `${i + 1}. ${c.name}${where} (${c.email})`;
+    });
+    const summary = [
+      `I found ${resolution.candidates.length} contacts that match "${niceQuery}". Which one did you mean?`,
+      ...lines,
+      'Or paste an email address.',
+    ].join('\n');
+    return {
+      skill,
+      status: 'awaiting_approval',
+      summary,
+      drafts: [],
+      meta: {
+        record_count: 0,
+        generated_at: new Date().toISOString(),
+        query,
+        // @ts-ignore — chat route surfaces this
+        needs_recipient: {
+          correlationId,
+          recipient_query: niceQuery,
+          candidates: resolution.candidates.map((c) => ({
+            name: c.name,
+            email: c.email,
+            role: c.role,
+            scheme_name: c.schemeName ?? null,
+            unit_label: c.unitLabel ?? null,
+          })),
+        },
+      } as any,
+    };
+  }
+  // status === 'none'
+  const summary = `I couldn't find an email on file for "${niceQuery}". Reply with the address and I'll draft the email.`;
+  return {
+    skill,
+    status: 'awaiting_approval',
+    summary,
+    drafts: [],
+    meta: {
+      record_count: 0,
+      generated_at: new Date().toISOString(),
+      query,
+      // @ts-ignore
+      needs_recipient: {
+        correlationId,
+        recipient_query: niceQuery,
+        candidates: [],
+        searched: resolution.searched,
+      },
+    } as any,
+  };
 }
 
 // =====================================================================

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -35,6 +35,8 @@ import {
   draftMessageSkill,
   draftBuyerFollowups,
   getCandidateUnitsSkill,
+  rankPipelineBuyers,
+  createViewingSchedule,
   SkillAgentContext,
 } from './agentic-skills';
 import type { AgenticSkillEnvelope } from '../envelope';
@@ -299,6 +301,51 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
     },
     execute: ((supabase, _tenantId, agentContext, params) =>
       runAgenticSkill(getCandidateUnitsSkill, supabase, agentContext, params as any)) as ToolFunction,
+  },
+  {
+    name: 'rank_pipeline_buyers',
+    description: [
+      "Rank the buyers in the agent's sales pipeline at a given scheme by likelihood to convert.",
+      'Use this for "who is most likely to convert", "which buyers should I chase first", "top 10 active buyers" style questions, and as the input source when scheduling group viewings.',
+      'The score is deterministic: stage progress (sale_agreed > deposit_received > released > available), recency of last logged contact, days in pipeline, and viewing count.',
+      'Returns a list of ranked buyers with score and a one-line `reason` per buyer ("contacted 3 days ago, sale agreed, viewed twice").',
+      'Either development_id or scheme_name must be provided; scheme_name is resolved against the agent\'s assigned schemes.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        development_id: { type: 'string', description: 'UUID of the scheme. Preferred when known (avoids alias lookup).' },
+        scheme_name: { type: 'string', description: 'Scheme name (e.g. "Lakeside Manor"). Resolved against the agent\'s assigned schemes.' },
+        limit: { type: 'number', description: 'Max buyers to return (default 10, max 50).' },
+      },
+      required: [],
+    },
+    execute: ((supabase, _tenantId, agentContext, params) =>
+      runAgenticSkill(rankPipelineBuyers, supabase, agentContext, params as any)) as ToolFunction,
+  },
+  {
+    name: 'create_viewing_schedule',
+    description: [
+      'Build a viewing schedule for a scheme on a given date and propose specific timeslots to the top-ranked buyers in one batch.',
+      'Use this for "draft a viewing schedule for X this Saturday, 10 slots from 9–2, propose them to 10 active buyers" style requests.',
+      'Behaviour: builds N timeslots between start_time and end_time at slot_duration_minutes spacing, calls rank_pipeline_buyers internally to pick the buyers, then drafts one personalised email + one viewing_record per buyer. All drafts land in the approval drawer for review — nothing is sent or written to agent_viewings until the agent approves.',
+      'Each email opens with a one-line buyer-specific reasoning ("contacted 3 days ago, sale agreed, viewed twice — wanted to put a slot in front of you") and offers the assigned slot plus 2 alternatives.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        development_id: { type: 'string', description: 'UUID of the scheme. Preferred when known.' },
+        scheme_name: { type: 'string', description: 'Scheme name (e.g. "Lakeside Manor"). Resolved against the agent\'s assigned schemes.' },
+        date: { type: 'string', description: 'Viewing date as ISO YYYY-MM-DD (e.g. "2026-05-09" for Saturday).' },
+        start_time: { type: 'string', description: 'Schedule start time in 24-h or 12-h ("09:00", "9am").' },
+        end_time: { type: 'string', description: 'Schedule end time in 24-h or 12-h ("14:00", "2pm").' },
+        slot_duration_minutes: { type: 'number', description: 'Length of each slot in minutes (default 30, min 15, max 120).' },
+        target_count: { type: 'number', description: 'Number of buyers to invite / slots to fill (default 10, max 20).' },
+      },
+      required: ['date', 'start_time', 'end_time'],
+    },
+    execute: ((supabase, _tenantId, agentContext, params) =>
+      runAgenticSkill(createViewingSchedule, supabase, agentContext, params as any)) as ToolFunction,
   },
   {
     name: 'generate_developer_report',

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -229,7 +229,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       properties: {
         recipient_type: { type: 'string', description: 'Type of recipient', enum: ['buyer', 'developer', 'solicitor', 'tenant'] },
         recipient_name: { type: 'string', description: 'Name of the recipient. OPTIONAL when related_unit (sales) or related_property (lettings) is supplied — the skill resolves the buyer or tenant from the record on file.' },
-        context: { type: 'string', description: 'What the message should cover, in the agent\'s own words — this becomes the body.' },
+        context: { type: 'string', description: 'Body content only — what the message should cover, in the agent\'s own words. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         related_unit: { type: 'string', description: 'Related unit number (sales mode)' },
         related_scheme: { type: 'string', description: 'Related scheme name (sales mode)' },
@@ -267,7 +267,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
             required: ['unit_identifier'],
           },
         },
-        topic: { type: 'string', description: 'Shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent.' },
+        topic: { type: 'string', description: 'Body content only — the shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         purpose: {
           type: 'string',


### PR DESCRIPTION
## Summary

Three commits stacked for the promo build:

1. **`30fe78a` fix(agent): single-source greeting/signoff in drafts and clean markdown rendering in chat**
   - BUG-02: chat bubble now renders bullets / **bold** / *italic* via a small inline renderer (no `react-markdown` dep). FOLLOW-UP SUGGESTIONS prompt sections rewritten to be chips-only with no quote-wrapped examples.
   - BUG-01: tool descriptions for `draft_message.context` and `draft_buyer_followups.topic` now instruct the model to pass body content only. Added `stripGreetingAndSignoff()` in skill templates and a defence-in-depth `dedupeBoilerplate()` at persist time.

2. **`72514f7` fix(agent): contact resolver for email recipients and structured failure UX**
   - BUG-03: deleted the `recipient@tbc.invalid` placeholder branch from `draftMessageSkill`. New `lib/agent-intelligence/contact-resolver.ts` resolves recipient names through buyers, tenants, and the `developments.developer_user_id` → admins/auth chain. Role keywords ("the developer") short-circuit to scheme-relationship lookup. Returns structured `one` / `multiple` / `none` so the chat surfaces inline disambiguation prompts instead of failing drafts.
   - BUG-08: new `error` SSE frame carrying `kind`, `correlationId`, `retryable`, `retryMessage`. UI renders a red-bordered `FailureCard` with `AlertCircle`, "We couldn't complete this" framing, "Error ref: <id>" footer, and a one-tap Retry pill. Reworded copy across hallucinated-drafts, needs-recipient, and stream-failed paths so it never blames the user. Server logs every failure with the same correlation id.

3. **`1e4ce01` feat(agent): viewing scheduler and pipeline buyer ranking tools**
   - BUG-09: new `rank_pipeline_buyers` skill — deterministic SQL rubric (40% stage, 30% recency, 20% pipeline aging, 10% viewing count). Each ranked row carries a numeric score and a one-line `reason` ("contacted 3 days ago, sale agreed, viewed twice").
   - BUG-04: new `create_viewing_schedule` skill — builds slots, calls the ranker, emits one email + one viewing-record draft per buyer through the existing envelope pipeline. Each email opens with the buyer-specific reason and offers the assigned slot plus 2 alternates.
   - Both tools registered in `tools/registry.ts` with full JSON-schema. System prompt's APPROVAL-FIRST ACTION CONTRACT lists them with explicit picking cues so the model triggers them on "who is most likely to convert" and "draft a viewing schedule for X on Saturday from 9–2".

## Test plan

- [ ] Build passes: `npm run build` from repo root (verified locally on each commit).
- [ ] BUG-02: send a chat message that the model would reply to with a bullet list — confirm bullets render natively, no raw `- "..."` text.
- [ ] BUG-01: trigger a multi-draft batch on Lakeside Manor follow-ups using seeded agent Orla (`0f9210e0-342d-4f98-9be1-95decb6f507a`). Confirm one greeting and one sign-off per email.
- [ ] BUG-03 real contact: "Email Daniel Whelan the weekly tracker" with a seeded buyer named Daniel Whelan → draft lands.
- [ ] BUG-03 unknown name: same prompt with a name not on file → inline prompt asks for the address, no placeholder draft persisted.
- [ ] BUG-03 role-based: "Email the developer at Lakeside Manor" → resolver hits `developments.developer_user_id` and proceeds.
- [ ] BUG-08: simulate a failed draft (e.g. unknown scheme) → `FailureCard` renders with red border, AlertCircle, "Error ref: ..." footer, and Retry button that re-fires the original prompt.
- [ ] BUG-04 promo prompt: "Draft a viewing schedule for Lakeside Manor for this Saturday, 10 timeslots from 9am to 2pm, and propose them to 10 active buyers from the pipeline" → 10 viewing-record drafts + 10 email drafts in the drawer, each addressed to a real seeded buyer with the rank reason in the opener.
- [ ] BUG-09: "Who are my buyers most likely to convert at Lakeside Manor?" → numbered ranked list with `reason` strings, no hallucinated names.

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL

---
_Generated by [Claude Code](https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL)_