### PR TITLE
fix(care): cap Care header logo to 36px to match SE Systems toolbar height

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/page.tsx
+++ b/apps/unified-portal/app/care/[installationId]/page.tsx
@@ -123,6 +123,9 @@ export default function CareInstallationPage() {
             height={36}
             priority
             style={{
+              height: 36,
+              width: 'auto',
+              maxWidth: 120,
               objectFit: 'contain',
               // Only blacken the SE Systems wordmark fallback; render tenant logos in their natural colours.
               filter: tenantLogoUrl ? undefined : 'brightness(0)',


### PR DESCRIPTION
## Summary

PR #75 was merged before the header-logo height fix landed, so production currently shows the Solas logo at its natural square aspect ratio in the top toolbar — making the header about 2× as tall as the SE Systems wordmark version.

This is the tail of that PR: a 3-line CSS clamp on the Care portal header `<Image>` to force the rendered logo to 36px tall regardless of source aspect ratio, matching the SE Systems toolbar height.

## Test plan

- [ ] After deploy, hard-refresh `https://portal.openhouseai.ie/care/a17e8226-03e2-4417-982c-01308b92f65d` (Solas install) — header height matches the SE Systems install.
- [ ] Check an SE Systems install — wordmark logo unchanged.

https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5)_