### PR TITLE
fix(agent): compliance docs upsert against existing unique constraint

### DIFF
--- a/apps/unified-portal/app/api/compliance/[developmentId]/upload/route.ts
+++ b/apps/unified-portal/app/api/compliance/[developmentId]/upload/route.ts
@@ -98,54 +98,48 @@ export async function POST(
     }
 
     const uploadToUnit = async (targetUnitId: string) => {
-      const { data: existing } = await supabaseAdmin
+      // Read the prior row (if any) to bump the version counter.
+      // .maybeSingle() returns data:null on no rows rather than emitting
+      // a PostgREST PGRST116 error the way .single() does.
+      const { data: priorRow, error: priorErr } = await supabaseAdmin
         .from('compliance_documents')
         .select('id, version')
         .eq('unit_id', targetUnitId)
         .eq('document_type_id', documentTypeId)
-        .single();
+        .maybeSingle();
 
-      let documentId: string;
-      let version = 1;
+      if (priorErr) throw priorErr;
 
-      if (existing) {
-        version = (existing.version || 0) + 1;
-        const { data: updatedDoc, error: updateError } = await supabaseAdmin
-          .from('compliance_documents')
-          .update({
-            status: 'uploaded',
-            uploaded_by: session.email,
-            version,
-            expiry_date: expiryDate || null,
-            notes: notes || null,
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', existing.id)
-          .select()
-          .single();
+      const nextVersion = (priorRow?.version ?? 0) + 1;
 
-        if (updateError) throw updateError;
-        documentId = existing.id;
-      } else {
-        const { data: newDoc, error: insertError } = await supabaseAdmin
-          .from('compliance_documents')
-          .insert({
+      // Atomic upsert keyed on the (unit_id, document_type_id) unique
+      // constraint. Replaces in place when a row exists, inserts
+      // otherwise. Closes the race window the previous two-step
+      // select-then-insert pattern carried (two concurrent uploads
+      // could both see "no row" and both INSERT, hitting the constraint).
+      const { data: upsertedDoc, error: upsertError } = await supabaseAdmin
+        .from('compliance_documents')
+        .upsert(
+          {
             tenant_id: tenantId,
             development_id: actualDevelopmentId,
             unit_id: targetUnitId,
             document_type_id: documentTypeId,
             status: 'uploaded',
             uploaded_by: session.email,
-            version: 1,
+            version: nextVersion,
             expiry_date: expiryDate || null,
             notes: notes || null,
-          })
-          .select()
-          .single();
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'unit_id,document_type_id' },
+        )
+        .select('id')
+        .single();
 
-        if (insertError) throw insertError;
-        documentId = newDoc.id;
-      }
+      if (upsertError) throw upsertError;
+      const documentId = upsertedDoc.id;
+      const version = nextVersion;
 
       const { error: fileError } = await supabaseAdmin
         .from('compliance_files')
@@ -161,6 +155,12 @@ export async function POST(
         });
 
       if (fileError) {
+        console.error('[compliance_upload] failed to insert compliance_files row', {
+          documentId,
+          targetUnitId,
+          version,
+          message: fileError.message,
+        });
       }
 
       return documentId;


### PR DESCRIPTION
## Summary

BUG-10 fix, branched off `main` so it merges independently of the chat-formatting / contact-resolver / scheduler work in #76.

**Root cause:** `compliance_documents` already has a unique constraint on `(unit_id, document_type_id)`, and the sibling `compliance_files` table already records every uploaded file with a `version` column — the schema is set up for replace-in-place on the parent plus version history on the children. But the upload route was using a manual `SELECT.single() → INSERT-or-UPDATE` pattern that carried a race window: two concurrent uploads could both see "no row" and both INSERT, tripping the unique constraint. It also relied on `.single()` returning `data:null` for the no-row case alongside a PGRST116 error — fragile and noisy.

**Fix:** Switched to a real Supabase `.upsert(..., { onConflict: 'unit_id,document_type_id' })` and read the prior version with `.maybeSingle()`. Atomic on the database side; replaces in place when a row exists, inserts otherwise. Constraint shape unchanged, no migration. Also surfaced `compliance_files` insert failures via `console.error` instead of silently swallowing them.

**Schema confirmed via Supabase MCP** (project `mddxbilpjukwskeefakz` / OpenHouse Database V2):
- Unique: `compliance_documents_unit_id_document_type_id_key` on `(unit_id, document_type_id)`.
- `version` column already present on both `compliance_documents` and `compliance_files`.

## Test plan

- [ ] Upload a compliance doc to a unit/category that has no prior row → fresh row created, `version=1`, file recorded in `compliance_files`.
- [ ] Re-upload the same category for the same unit → existing row updated in place (status='uploaded', `version` bumped, `updated_at` refreshed); a second `compliance_files` row appears with the new version.
- [ ] Upload with `applyToAll=true` across all units in a development → no constraint violation even on subsequent applyToAll runs (which previously could race with each other).
- [ ] `npm run build` passes (verified locally).

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL

---
_Generated by [Claude Code](https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL)_