### PR TITLE
fix(care): make tenant header logo readable while keeping toolbar height

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/page.tsx
+++ b/apps/unified-portal/app/care/[installationId]/page.tsx
@@ -109,8 +109,14 @@ export default function CareInstallationPage() {
         className="flex-shrink-0 bg-white z-50"
         style={{
           borderBottom: '1px solid #EEEEEE',
-          paddingTop: 'calc(16px + env(safe-area-inset-top, 0px))',
-          paddingBottom: 16,
+          // Tenant logos are usually square brand marks, so we render them at
+          // 52px tall and tighten the vertical padding to keep the overall
+          // toolbar the same height as the SE Systems wordmark layout
+          // (8 + 52 + 8 = 68px ≡ 16 + 36 + 16).
+          paddingTop: tenantLogoUrl
+            ? 'calc(8px + env(safe-area-inset-top, 0px))'
+            : 'calc(16px + env(safe-area-inset-top, 0px))',
+          paddingBottom: tenantLogoUrl ? 8 : 16,
           paddingLeft: 'calc(20px + env(safe-area-inset-left, 0px))',
           paddingRight: 'calc(20px + env(safe-area-inset-right, 0px))',
         }}
@@ -119,13 +125,13 @@ export default function CareInstallationPage() {
           <Image
             src={headerLogoSrc}
             alt={headerLogoAlt}
-            width={120}
-            height={36}
+            width={tenantLogoUrl ? 52 : 120}
+            height={tenantLogoUrl ? 52 : 36}
             priority
             style={{
-              height: 36,
+              height: tenantLogoUrl ? 52 : 36,
               width: 'auto',
-              maxWidth: 120,
+              maxWidth: tenantLogoUrl ? 200 : 120,
               objectFit: 'contain',
               // Only blacken the SE Systems wordmark fallback; render tenant logos in their natural colours.
               filter: tenantLogoUrl ? undefined : 'brightness(0)',


### PR DESCRIPTION
## Summary

Tail of #75/#77. The 36px height clamp from #77 made square tenant logos render at 36×36, far too small to read. This makes tenant logos render at 52px tall while tightening header vertical padding from 16+16 to 8+8 — total toolbar height stays at 68px (matches the SE Systems wordmark layout) but the tenant brand mark is ~44% larger and clearly legible.

SE Systems fallback (wordmark) is unchanged: 36px tall logo, 16px padding, same 68px header.

## Test plan

- [ ] Hard-refresh `https://portal.openhouseai.ie/care/a17e8226-03e2-4417-982c-01308b92f65d` (Solas install) — Solas logo readable in the header, header height unchanged.
- [ ] Open an SE Systems install — wordmark logo and header unchanged from before.

https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5)_