### PR TITLE
fix(care): bump tenant header logo to 91px so it's readable

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/page.tsx
+++ b/apps/unified-portal/app/care/[installationId]/page.tsx
@@ -109,29 +109,29 @@ export default function CareInstallationPage() {
         className="flex-shrink-0 bg-white z-50"
         style={{
           borderBottom: '1px solid #EEEEEE',
-          // Tenant logos are usually square brand marks, so we render them at
-          // 52px tall and tighten the vertical padding to keep the overall
-          // toolbar the same height as the SE Systems wordmark layout
-          // (8 + 52 + 8 = 68px ≡ 16 + 36 + 16).
+          // For tenant logos, push padding to zero so the brand mark can be
+          // ~75% larger than the SE Systems wordmark while keeping toolbar
+          // chrome to a minimum.
           paddingTop: tenantLogoUrl
-            ? 'calc(8px + env(safe-area-inset-top, 0px))'
+            ? 'calc(2px + env(safe-area-inset-top, 0px))'
             : 'calc(16px + env(safe-area-inset-top, 0px))',
-          paddingBottom: tenantLogoUrl ? 8 : 16,
+          paddingBottom: tenantLogoUrl ? 2 : 16,
           paddingLeft: 'calc(20px + env(safe-area-inset-left, 0px))',
           paddingRight: 'calc(20px + env(safe-area-inset-right, 0px))',
+          overflow: 'hidden',
         }}
       >
         <div className="flex items-center max-w-4xl mx-auto">
           <Image
             src={headerLogoSrc}
             alt={headerLogoAlt}
-            width={tenantLogoUrl ? 52 : 120}
-            height={tenantLogoUrl ? 52 : 36}
+            width={tenantLogoUrl ? 91 : 120}
+            height={tenantLogoUrl ? 91 : 36}
             priority
             style={{
-              height: tenantLogoUrl ? 52 : 36,
+              height: tenantLogoUrl ? 91 : 36,
               width: 'auto',
-              maxWidth: tenantLogoUrl ? 200 : 120,
+              maxWidth: tenantLogoUrl ? 360 : 120,
               objectFit: 'contain',
               // Only blacken the SE Systems wordmark fallback; render tenant logos in their natural colours.
               filter: tenantLogoUrl ? undefined : 'brightness(0)',


### PR DESCRIPTION
## Summary

Tail of #75/#77/#79. The 52px tenant logo from #79 was still too small to read. Bumping it to 91px (75% larger) and dropping vertical padding to 2+2 so the bar grows modestly (68 → 95px, +27px) instead of doubling.

SE Systems wordmark fallback unchanged.

## Test plan

- [ ] Hard-refresh `https://portal.openhouseai.ie/care/a17e8226-03e2-4417-982c-01308b92f65d` — Solas logo is clearly readable in the toolbar.
- [ ] SE Systems install — wordmark layout untouched.

https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2ADhjkmvdGD6kpVFtd9G5)_