### PR TITLE
fix(agent): expand RPZ zone list to include Dublin and other designated areas

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/rpz-zones.ts
+++ b/apps/unified-portal/lib/agent-intelligence/rpz-zones.ts
@@ -1,14 +1,65 @@
 // Rent Pressure Zone (RPZ) lookup for Irish lettings.
 //
 // Source of truth: https://www.rtb.ie/ — the RTB publishes the authoritative
-// list of Rent Pressure Zones and their boundaries. The hardcoded list below
-// covers the Cork-area LEAs and towns where this agent's letting portfolio
-// sits; it is NOT a national list. Review this table periodically (at minimum
-// once per year, or whenever the RTB updates designations) to keep it in sync
-// with rtb.ie. When adding support for a new letting region, extend this list
-// rather than branching at the call site.
+// list of Rent Pressure Zones and their designations
+// (residentialtenancies.ie/rent-pressure-zones). Review this table
+// periodically (at minimum once per year, or whenever the RTB updates
+// designations) to keep it in sync. When adding support for a new letting
+// region, extend this list rather than branching at the call site.
+//
+// Coverage as of the latest RTB designations:
+//   - Dublin (all four LAs: Dublin City Council, Fingal, South Dublin,
+//     Dún Laoghaire–Rathdown) plus every Dublin postal district.
+//   - Cork City and the named Cork suburbs / LEAs.
+//   - Galway City, Limerick City, Waterford City.
+//   - Wicklow commuter LEAs: Bray, Greystones, Wicklow, Arklow.
+//   - Kildare LEAs: Naas, Newbridge, Maynooth, Celbridge, Leixlip,
+//     Kildare town, Athy.
+//   - Meath commuter LEAs: Navan, Ashbourne, Ratoath, Trim, Kells,
+//     Laytown–Bettystown, Duleek, Slane.
+//   - Louth: Drogheda, Dundalk.
+//
+// The Set is keyed on lowercase, whitespace-trimmed names. Callers go
+// through normaliseCity() so trailing postcode tokens ("Dublin 4",
+// "Dublin 18") match the bare city entry, and so common spelling
+// variants of Dún Laoghaire collapse to a single key.
 
 const RPZ_AREAS = new Set<string>([
+  // Dublin — all four local authority areas + the postal districts.
+  // Postal districts vary in how they're written into the `city` field
+  // (e.g. "Dublin", "Dublin 4", "D04"), so we list both forms.
+  'dublin',
+  'dublin city',
+  'dublin city council',
+  'fingal',
+  'south dublin',
+  'dun laoghaire',
+  'dun laoghaire-rathdown',
+  'dun laoghaire rathdown',
+  'dublin 1',
+  'dublin 2',
+  'dublin 3',
+  'dublin 4',
+  'dublin 5',
+  'dublin 6',
+  'dublin 6w',
+  'dublin 7',
+  'dublin 8',
+  'dublin 9',
+  'dublin 10',
+  'dublin 11',
+  'dublin 12',
+  'dublin 13',
+  'dublin 14',
+  'dublin 15',
+  'dublin 16',
+  'dublin 17',
+  'dublin 18',
+  'dublin 20',
+  'dublin 22',
+  'dublin 24',
+  // Cork City + suburbs (pre-existing list, retained verbatim).
+  'cork',
   'cork city',
   'ballincollig',
   'bishopstown',
@@ -17,11 +68,68 @@ const RPZ_AREAS = new Set<string>([
   'glanmire',
   'ballyvolane',
   'mayfield',
+  // Other major regional cities under RPZ designation.
+  'galway',
+  'galway city',
+  'limerick',
+  'limerick city',
+  'waterford',
+  'waterford city',
+  // Wicklow commuter LEAs.
+  'bray',
+  'greystones',
+  'wicklow',
+  'arklow',
+  // Kildare LEAs.
+  'naas',
+  'newbridge',
+  'maynooth',
+  'celbridge',
+  'leixlip',
+  'kildare',
+  'athy',
+  // Meath commuter LEAs.
+  'navan',
+  'ashbourne',
+  'ratoath',
+  'trim',
+  'kells',
+  'laytown',
+  'bettystown',
+  'laytown-bettystown',
+  'duleek',
+  'slane',
+  // Louth.
+  'drogheda',
+  'dundalk',
 ]);
+
+/**
+ * Lowercased, whitespace-collapsed compare key. Strips Irish-language
+ * fadás so "Dún Laoghaire" matches "Dun Laoghaire", and strips trailing
+ * postcode digits so "Dublin 4" / "Dublin 18" match the bare "dublin"
+ * entry. Conservative — only collapses well-known patterns.
+ */
+function normaliseCity(raw: string): string {
+  let s = raw.trim().toLowerCase();
+  // Strip diacritics (Dún → Dun) by decomposing then dropping
+  // combining marks U+0300..U+036F.
+  s = s.normalize('NFD').replace(/[̀-ͯ]/g, '');
+  // Collapse multiple spaces.
+  s = s.replace(/\s+/g, ' ');
+  return s;
+}
 
 export function isInRPZ(city: string | null | undefined): boolean {
   if (!city) return false;
-  return RPZ_AREAS.has(city.trim().toLowerCase());
+  const normalised = normaliseCity(city);
+  if (RPZ_AREAS.has(normalised)) return true;
+  // Postcode tail strip: "dublin 4" / "dublin 6w" → "dublin". Only
+  // collapse when the prefix on its own is a known RPZ entry, so we
+  // don't accidentally match arbitrary "<word> <number>" cities.
+  const postcodeStripped = normalised.replace(/\s+(?:\d{1,2}[a-z]?|d\d{1,2}[a-z]?)$/, '');
+  if (postcodeStripped !== normalised && RPZ_AREAS.has(postcodeStripped)) return true;
+  return false;
 }
 
 export function rpzUpliftCap(): number {


### PR DESCRIPTION
## Summary

`isInRPZ('Dublin')` returned **false** because `apps/unified-portal/lib/agent-intelligence/rpz-zones.ts` only contained Cork-area names. Every Dublin tenancy was therefore classified as non-RPZ, and `draftLeaseRenewal` would slot in the wrong copy:

> Outside RPZ — rent held at current level for this renewal. Open to discussion.

…instead of the RPZ-cap copy:

> In line with RPZ rules, the maximum increase is 2.0% per annum.

A renewal offer drafted for a Dublin tenant could legitimately have proposed a rent uplift above the statutory 2% cap, in violation of the RTB rent-pressure-zone rules. Same risk for any other RPZ-designated area outside Cork.

## Discovery context

Surfaced while auditing **BUG-05** (renewal offer drafting failure). The two issues are **independent** — the RPZ correctness bug affects email **body content** for renewals that succeed, not the draft-generation pipeline that BUG-05 deals with. Shipping this separately so it can land independently of the route + prompt fixes still pending PR #76.

## Coverage now

Source: [residentialtenancies.ie/rent-pressure-zones](https://www.residentialtenancies.ie/rent-pressure-zones)

- **Dublin** — all four local authorities (Dublin City Council, Fingal, South Dublin, Dún Laoghaire–Rathdown) plus every Dublin postal district 1–24 (including 6w).
- **Cork City** + the named Cork suburbs / LEAs (retained verbatim from the previous list).
- **Galway City, Limerick City, Waterford City.**
- **Wicklow LEAs:** Bray, Greystones, Wicklow, Arklow.
- **Kildare LEAs:** Naas, Newbridge, Maynooth, Celbridge, Leixlip, Kildare town, Athy.
- **Meath LEAs:** Navan, Ashbourne, Ratoath, Trim, Kells, Laytown, Bettystown, Duleek, Slane.
- **Louth:** Drogheda, Dundalk.

## Robustness

Added a `normaliseCity()` helper so the lookup tolerates real-world variation in the `city` field on `agent_letting_properties`:

- **Trailing postcode tokens** — `"Dublin 4"`, `"Dublin 18"`, `"Dublin 6w"` collapse to `"dublin"` and match. Confirmed via `node -e` eval: `"Dublin 4"` → `"dublin"`.
- **Diacritics** — `"Dún Laoghaire"` decomposes via `String.prototype.normalize('NFD')` and the combining-mark range U+0300..U+036F is stripped. Confirmed: `"Dún Laoghaire"` → `"dun laoghaire"`.
- **Whitespace** — multi-space collapse via `\s+ → ' '`.

Postcode strip is conservative: it only fires when the prefix on its own is in the RPZ set, so we don't accidentally match arbitrary `"<word> <number>"` city values.

## API

`isInRPZ(city: string | null | undefined): boolean` and `rpzUpliftCap(): number` signatures unchanged. Call sites in `draftLeaseRenewal` (`agentic-skills.ts:572`) and the lettings live-context loader (`getRenewalWindow` in `context.ts:523`) pick up the new coverage transparently.

## Test plan

- [x] `npm run build` passes.
- [x] `node -e` eval confirms `"Dublin 4"` → `"dublin"` (matches), `"Dún Laoghaire"` → `"dun laoghaire"` (matches).
- [ ] Optional: spot-check `isInRPZ` against a few production property rows in the lettings portfolio.

No live testing required — pure data correctness in a constants file. Ready to merge once reviewed.

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL

---
_Generated by [Claude Code](https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL)_