### PR TITLE
fix(agent): surface envelope summary on draft failure + lettings prompt nudge for renewals

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -368,10 +368,14 @@ export async function POST(request: NextRequest) {
     const totalDraftsPersisted = envelopesWithDrafts.reduce((n, e) => n + e.drafts.length, 0);
 
     if (draftToolCalled && totalDraftsPersisted === 0) {
+      // Minimal note: tell the model not to claim success. The actual
+      // user-facing reply is replaced post-stream with the envelope's
+      // own summary string (see the empty_draft_result branch below),
+      // so the model's text here is essentially a placeholder.
       messages.push({
         role: 'system',
         content:
-          'IMPORTANT: The draft tool(s) you just called returned zero drafts. Do NOT tell the user their drafts are ready, or that anything is in the drafts inbox, or that you prepared anything to review. Tell them the action did not go through, and ask them to rephrase or try a more specific request.',
+          'IMPORTANT: The draft tool(s) returned zero drafts. Do NOT claim a draft was created. Keep your reply short — the platform will surface the reason to the user.',
       });
     }
 
@@ -694,13 +698,24 @@ export async function POST(request: NextRequest) {
             /drafted|drafts?\s+(?:are|is)\s+ready|ready\s+for\s+your\s+review|in\s+the\s+drafts?\s+inbox|prepared\s+\d+\s+draft|i['’]ll\s+draft|i\s+(?:have\s+)?drafted/i;
           const claimsDrafts = HALLUCINATION_REGEX.test(fullContent);
           // Decide whether this turn should render as a failure card.
-          //   - hallucinated_drafts: model claimed drafts but none persisted
           //   - needs_recipient: contact resolver couldn't pin a recipient
+          //   - empty_draft_result: a draft tool fired but produced zero
+          //     drafts (BUG-05). Causes converge — wrong tenancy_id,
+          //     no rows in window, RLS error, etc. The skill itself
+          //     writes a user-readable summary; we trust it.
+          //   - hallucinated_drafts: model claimed drafts but no tool
+          //     fired and nothing persisted. Catches text-only lies.
           //   - draft_blocked: persistence blocked every produced draft
           // Each case carries a correlation id so support can trace.
-          let failureKind: 'hallucinated_drafts' | 'needs_recipient' | 'draft_blocked' | null = null;
+          let failureKind:
+            | 'hallucinated_drafts'
+            | 'needs_recipient'
+            | 'draft_blocked'
+            | 'empty_draft_result'
+            | null = null;
           let failureMessage: string | null = null;
           let failureCorrelationId: string | null = null;
+          let failureQuery: unknown = null;
           if (needsRecipientPayloads.length > 0) {
             failureKind = 'needs_recipient';
             failureCorrelationId = needsRecipientPayloads[0].correlationId;
@@ -724,6 +739,23 @@ export async function POST(request: NextRequest) {
             } else {
               failureMessage = `We couldn't complete this — no email is on file for "${p.recipient_query}". Paste the address and I'll draft it.`;
             }
+          } else if (draftToolCalled && totalDraftsPersisted === 0) {
+            // BUG-05. Pick the first envelope with empty drafts and
+            // surface its summary verbatim. Skills already write
+            // user-readable summaries ("No matching active tenancy
+            // found in the 90-day renewal window.", "I couldn't find
+            // a scheme matching X.", "Tenant name or property address
+            // is required.", etc) — far more useful than the generic
+            // "rephrase your request" copy that used to be emitted.
+            const emptyEnv = envelopes.find((e) => e.drafts.length === 0) || envelopes[0] || null;
+            const summary =
+              (emptyEnv?.summary && emptyEnv.summary.trim().length > 0)
+                ? emptyEnv.summary.trim()
+                : "The draft action didn't go through.";
+            failureKind = 'empty_draft_result';
+            failureCorrelationId = randomCorrelationId();
+            failureMessage = summary;
+            failureQuery = emptyEnv?.meta?.query ?? null;
           } else if (claimsDrafts && totalDraftsPersisted === 0) {
             failureKind = 'hallucinated_drafts';
             failureCorrelationId = randomCorrelationId();
@@ -746,6 +778,7 @@ export async function POST(request: NextRequest) {
                   retryable: true,
                   retryMessage: message,
                   content: failureMessage,
+                  ...(failureQuery !== null ? { query: failureQuery } : {}),
                 }) + '\n',
               ),
             );
@@ -758,6 +791,7 @@ export async function POST(request: NextRequest) {
               toolsCalled: toolsCalled.map((t) => t.tool_name),
               draftToolCalled,
               totalDraftsPersisted,
+              query: failureQuery,
               needsRecipientPayloads: needsRecipientPayloads.map((p) => ({
                 correlationId: p.correlationId,
                 recipient_query: p.recipient_query,

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -646,6 +646,9 @@ You may call the draft and message tools the platform already provides (draft_me
 
 When the user asks you to draft, write, send, follow up with, chase, or message a tenant — ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent — nothing leaves the system until the agent explicitly approves.
 
+DRAFT_LEASE_RENEWAL — IMPORTANT:
+When the user says "renewal", "renew the lease", "draft renewal offer", or taps a renewal suggestion chip without naming a specific tenancy id, call draft_lease_renewal with NO arguments. The live context lists tenancies by tenant name + address only — it does NOT expose tenancy IDs, and you must NEVER invent a UUID-shaped string for tenancy_id. The skill, when called with no arguments, returns drafts for every active tenancy in the 90-day renewal window. Only pass tenancy_id if a previous tool result in this conversation surfaced a real tenancy id.
+
 Your text reply after a draft tool fires is a ONE-SENTENCE summary only. Do NOT paste the message body inline. The drawer renders the draft visually.
 
 ============================================================


### PR DESCRIPTION
## Summary

BUG-05 follow-up. The chat route's zero-drafts override used to inject a system message instructing the model to write _"the action did not go through, ask them to rephrase"_ — burying the actual reason the skill emitted (e.g. _"No matching active tenancy found in the 90-day renewal window"_) behind generic copy that read as user error.

Two changes, both small, both reuse PR #76's failure-frame machinery:

### `apps/unified-portal/app/api/agent-intelligence/chat/route.ts` (+37 / −3)

1. **Replaced the verbose override system message with a minimal one.** It now just tells the model not to claim success and keep its reply short — the user-facing copy is replaced post-stream anyway, so the model's text on this path is a placeholder.

2. **Added a new `empty_draft_result` branch** in the post-stream override block, sitting alongside the existing `needs_recipient` / `hallucinated_drafts` / `draft_blocked` kinds added by PR #76. When `draftToolCalled && totalDraftsPersisted === 0` (and no `needs_recipient` payload took precedence), the route picks the first empty-draft envelope and emits a structured `error` SSE frame:
   - `kind: 'empty_draft_result'`
   - `content`: `envelope.summary` verbatim (e.g. _"No matching active tenancy found in the 90-day renewal window."_, _"I couldn't find a scheme matching X."_, _"Tenant name or property address is required."_)
   - `query`: `envelope.meta.query` — the diagnostic string the skill writes (e.g. the WHERE clause + bogus tenancy_id if the model invented one)
   - `correlationId`, `retryable`, `retryMessage` — same shape as the other kinds
   - The `FailureCard` reads `content`, so the user now sees the actual reason in plain English with an Error ref and a Retry button.
3. **Threaded `query` into the structured `console.error` log line** so support can correlate the SSE frame's correlation id with the server-side log.

### `apps/unified-portal/lib/agent-intelligence/system-prompt.ts` (+3 / −0)

Added a `DRAFT_LEASE_RENEWAL — IMPORTANT` block in the lettings tool-use section. When the user says "renewal" or taps a renewal suggestion chip without naming a specific tenancy id, the model is now told to call `draft_lease_renewal` with **no arguments**. The live context lists tenancies by tenant name + address only — it does NOT expose tenancy IDs, and the model must NEVER invent a UUID-shaped string for `tenancy_id`. This pre-empts the audit's most-likely failure mode (model invents a `tenancy_id`, skill `eq('id', ...)` returns 0 rows, override fires).

## Background

Surfaced via the BUG-05 audit. Three plausible failure modes converged on the same generic "rephrase" copy in production:
1. Model invents `tenancy_id` (most likely — live context exposes name+address but no UUID).
2. Model picks `draft_message` with empty recipient.
3. DB error inside the skill's SELECT.

All three now produce the actual envelope summary in the FailureCard plus a correlation id, so the next reproduction will tell us which mode was the real one without needing the Vercel log buffer.

## How it lands today

- This branch was originally parked at `origin/pending/bug-05-renewal-failure-surface` while PR #76's failure-frame machinery was still in review. It cherry-picked cleanly onto current `main` once PR #76 merged at `82e2a43f`.
- Once this PR merges, the parked branch can be deleted: `git push origin --delete pending/bug-05-renewal-failure-surface`.

## Test plan

- [x] `npm run build` passes (verified from repo root).
- [ ] Re-trigger the renewal chip on the lettings test agent against Aoife O'Brien's tenancy at 1 Lakeside Drive. Confirm the `FailureCard` body shows the envelope's summary verbatim, an `Error ref:` with a correlation id is rendered, and Retry re-fires the original message. The displayed reason will identify the actual failure mode.
- [ ] Confirm the lettings prompt nudge takes effect: `draft_lease_renewal` should be called with `{}` rather than an invented `tenancy_id`.

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL

---
_Generated by [Claude Code](https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL)_