### PR TITLE
chore(agent): demo polish — reset script, demo mode, batch ops, per-r…

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -96,8 +96,9 @@ function getContextEmoji(ctx: UserContext): string {
 export default function StatusBar({
   agentName = 'Sam',
 }: StatusBarProps) {
-  const { alerts, pipeline, workspaces, activeWorkspace, switchWorkspace } = useAgent();
+  const { agent, alerts, pipeline, workspaces, activeWorkspace, switchWorkspace } = useAgent();
   const { count: draftsCount, ready: draftsReady } = useDraftsCount();
+  const demoMode = Boolean(agent?.demoMode);
   const [panelOpen, setPanelOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
@@ -240,7 +241,9 @@ export default function StatusBar({
                 {activeWorkspace!.displayName}
               </span>
               <ModeBadge mode={activeWorkspace!.mode} />
-              <span style={{ color: '#A0A8B0', fontSize: 11, lineHeight: 1, flexShrink: 0 }}>&#9662;</span>
+              {/* TODO: restore chevron once agent_profile scheme resolver is fixed
+                  (returns empty for Orla despite 5 active assignments). Hidden
+                  for the promo build to avoid suggesting a working dropdown. */}
             </span>
           ) : (
             // Empty-state grace: agents without seeded workspace rows see a
@@ -341,7 +344,9 @@ export default function StatusBar({
             <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9" />
             <path d="M13.73 21a2 2 0 01-3.46 0" />
           </svg>
-          {unreadCount > 0 && (
+          {/* Demo mode (BUG-11) suppresses the unread badge so it doesn't
+              clutter the recording. Real users still see live counts. */}
+          {!demoMode && unreadCount > 0 && (
             <div
               style={{
                 position: 'absolute',

--- a/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
+++ b/apps/unified-portal/app/agent/_components/VoiceInputBar.tsx
@@ -121,7 +121,24 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
         </button>
 
         {recording ? (
-          <WaveformDisplay samples={voice.waveform} />
+          <>
+            {/* BUG-15 — persistent live-recording dot. Pulses on its own
+                rhythm independent of the waveform so the recording state
+                is unambiguous even in a quiet environment. */}
+            <span
+              data-testid="voice-recording-dot"
+              aria-label="Recording"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: 999,
+                background: '#DC2626',
+                flexShrink: 0,
+                animation: 'oh-voice-rec-dot 1.1s ease-in-out infinite',
+              }}
+            />
+            <WaveformDisplay samples={voice.waveform} />
+          </>
         ) : (
           <input
             ref={inputRef}
@@ -282,6 +299,10 @@ const VoiceInputBar = forwardRef<HTMLInputElement, VoiceInputBarProps>(function 
         @keyframes oh-voice-pulse {
           0%, 100% { box-shadow: 0 0 0 3px rgba(196,155,42,0.10), 0 1px 2px rgba(0,0,0,0.04) inset; }
           50% { box-shadow: 0 0 0 5px rgba(196,155,42,0.18), 0 1px 2px rgba(0,0,0,0.04) inset; }
+        }
+        @keyframes oh-voice-rec-dot {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50% { opacity: 0.45; transform: scale(0.8); }
         }
       `}</style>
     </div>

--- a/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
+++ b/apps/unified-portal/app/agent/_hooks/useVoiceCapture.ts
@@ -5,6 +5,7 @@ import {
   requestMicrophonePermission,
   openNativeSettings,
 } from '@/lib/capacitor-native';
+import { lightImpact } from '@/lib/agent/haptics';
 
 const OFFLINE_QUEUE_KEY = 'oh.agent.voice.offlineQueue.v1';
 const SILENCE_THRESHOLD = 0.012;
@@ -260,6 +261,9 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
       }
 
       setStatus('recording');
+      // BUG-15 — confirm mic-on with a light haptic so the agent
+      // doesn't have to read the screen to know recording started.
+      void lightImpact();
     } catch (err: any) {
       // iOS `NotAllowedError` (permission revoked mid-session) and
       // `NotFoundError` (no mic hardware) surface here. Mark as
@@ -278,6 +282,10 @@ export function useVoiceCapture({ onTranscriptReady }: UseVoiceCaptureArgs = {})
 
   const stop = useCallback(async (): Promise<string | null> => {
     if (status !== 'recording') return null;
+    // BUG-15 — confirm mic-off with a matching light haptic. Fired
+    // immediately so the cue lands on the user's tap, not after the
+    // transcription roundtrip.
+    void lightImpact();
 
     return new Promise<string | null>((resolve) => {
       stopResolveRef.current = resolve;

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/tweak-all/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/tweak-all/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import OpenAI from 'openai';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/agent/intelligence/drafts/tweak-all
+ *
+ * BUG-13 batch operations. Rewrites every draft in `draftIds` in a single
+ * LLM pass using `instruction` ("make these warmer", "add a viewing
+ * offer", etc). Returns the new subject + body for each draft id and
+ * persists the rewrite into `pending_drafts.content_json`.
+ *
+ * Body: { draftIds: string[]; instruction: string }
+ * Response: { rewrites: Array<{ id, subject, body }> }
+ *
+ * Single OpenAI call by design — iterating per-draft would multiply cost
+ * with little benefit when the instruction applies to the batch.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const draftIds: string[] = Array.isArray(body?.draftIds) ? body.draftIds : [];
+    const instruction: string = typeof body?.instruction === 'string' ? body.instruction.trim() : '';
+
+    if (!draftIds.length) {
+      return NextResponse.json({ error: 'draftIds is required' }, { status: 400 });
+    }
+    if (!instruction || instruction.length < 2) {
+      return NextResponse.json({ error: 'instruction is required' }, { status: 400 });
+    }
+
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { data: rows, error: fetchErr } = await supabase
+      .from('pending_drafts')
+      .select('id, content_json, user_id')
+      .in('id', draftIds)
+      .eq('user_id', user.id);
+
+    if (fetchErr) {
+      return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+    }
+    const drafts = (rows || []).filter((r: any) => r.content_json);
+    if (!drafts.length) {
+      return NextResponse.json({ error: 'No drafts found for that user' }, { status: 404 });
+    }
+
+    const llmInput = drafts.map((d: any, i: number) => ({
+      index: i,
+      id: d.id,
+      subject: d.content_json?.subject ?? '',
+      body: d.content_json?.body ?? '',
+    }));
+
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You rewrite a batch of draft emails for an Irish estate agent. Apply the user instruction to every draft. Keep the recipient name, the property reference, and any factual content (dates, addresses, prices) identical. Change tone, structure, and additions only as the instruction directs. Return ONLY a JSON object of shape { "rewrites": [{ "index": number, "subject": string, "body": string }] } — one entry per input, in the same order. No prose, no markdown, no commentary.',
+        },
+        {
+          role: 'user',
+          content: `Instruction: ${instruction}\n\nDrafts:\n${JSON.stringify(llmInput, null, 2)}`,
+        },
+      ],
+      temperature: 0.3,
+      max_tokens: 4000,
+      response_format: { type: 'json_object' },
+    });
+
+    const raw = completion.choices[0]?.message?.content?.trim();
+    if (!raw) {
+      return NextResponse.json({ error: 'Empty rewrite from model' }, { status: 502 });
+    }
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err: any) {
+      return NextResponse.json({ error: 'Could not parse rewrite JSON' }, { status: 502 });
+    }
+    const rewrites = Array.isArray(parsed?.rewrites) ? parsed.rewrites : [];
+
+    const out: Array<{ id: string; subject: string; body: string }> = [];
+    for (const r of rewrites) {
+      const idx = typeof r?.index === 'number' ? r.index : -1;
+      if (idx < 0 || idx >= drafts.length) continue;
+      const draft = drafts[idx];
+      const subject = typeof r?.subject === 'string' ? r.subject : (draft.content_json?.subject ?? '');
+      const draftBody = typeof r?.body === 'string' ? r.body : (draft.content_json?.body ?? '');
+      const nextContent = { ...(draft.content_json || {}), subject, body: draftBody };
+      const { error: updErr } = await supabase
+        .from('pending_drafts')
+        .update({
+          content_json: nextContent,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', draft.id)
+        .eq('user_id', user.id);
+      if (updErr) {
+        console.error('[tweak-all] update failed', { id: draft.id, message: updErr.message });
+        continue;
+      }
+      out.push({ id: draft.id, subject, body: draftBody });
+    }
+
+    return NextResponse.json({ rewrites: out });
+  } catch (error: any) {
+    console.error('[tweak-all] failed', { message: error?.message });
+    return NextResponse.json({ error: error?.message || 'Internal error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/components/agent/intelligence/ApprovalDrawer.tsx
+++ b/apps/unified-portal/components/agent/intelligence/ApprovalDrawer.tsx
@@ -16,6 +16,7 @@ import {
   Pencil,
   Send,
   Trash2,
+  Wand2,
   X,
   Loader2,
 } from 'lucide-react';
@@ -27,6 +28,9 @@ export default function ApprovalDrawer() {
   const [editing, setEditing] = useState(false);
   const [draftSubject, setDraftSubject] = useState('');
   const [draftBody, setDraftBody] = useState('');
+  // BUG-13 — inline tweak input.
+  const [tweakOpen, setTweakOpen] = useState(false);
+  const [tweakInstruction, setTweakInstruction] = useState('');
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -66,6 +70,8 @@ export default function ApprovalDrawer() {
     () => drawer.drafts.filter((d) => d.status === 'sent').length,
     [drawer.drafts],
   );
+  const selectedCount = drawer.selectedIds.length;
+  const isMultiDraft = drawer.drafts.length > 1;
 
   if (!drawer.envelope || !drawer.drafts.length) return null;
 
@@ -183,6 +189,172 @@ export default function ApprovalDrawer() {
               );
             })}
           </div>
+
+          {/* BUG-13 — batch operations row. Tweak all is always visible
+              when there are multiple drafts; the selection action bar
+              appears only when at least one draft is ticked. */}
+          {isMultiDraft && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => setTweakOpen((v) => !v)}
+                  data-testid="drawer-tweak-all-toggle"
+                  disabled={drawer.tweaking}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '7px 12px',
+                    background: tweakOpen ? '#FFF6D9' : '#FFFFFF',
+                    border: '0.5px solid rgba(196,155,42,0.35)',
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: '#8A6E1F',
+                    cursor: drawer.tweaking ? 'wait' : 'pointer',
+                    fontFamily: 'inherit',
+                    opacity: drawer.tweaking ? 0.6 : 1,
+                  }}
+                >
+                  {drawer.tweaking ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+                  <span>Tweak all</span>
+                </button>
+                {selectedCount > 0 && (
+                  <span style={{ fontSize: 11.5, color: '#6B7280' }}>
+                    {selectedCount} selected
+                  </span>
+                )}
+              </div>
+
+              {tweakOpen && (
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <input
+                    value={tweakInstruction}
+                    onChange={(e) => setTweakInstruction(e.target.value)}
+                    placeholder='e.g. "make these warmer", "add a viewing offer"'
+                    data-testid="drawer-tweak-input"
+                    disabled={drawer.tweaking}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && tweakInstruction.trim().length >= 2 && !drawer.tweaking) {
+                        drawer.tweakAll(tweakInstruction);
+                        setTweakOpen(false);
+                        setTweakInstruction('');
+                      }
+                    }}
+                    style={{
+                      flex: 1,
+                      border: '1px solid rgba(196,155,42,0.35)',
+                      borderRadius: 10,
+                      padding: '8px 10px',
+                      fontSize: 13,
+                      fontFamily: 'inherit',
+                      background: '#FFFFFF',
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      drawer.tweakAll(tweakInstruction);
+                      setTweakOpen(false);
+                      setTweakInstruction('');
+                    }}
+                    data-testid="drawer-tweak-submit"
+                    disabled={drawer.tweaking || tweakInstruction.trim().length < 2}
+                    style={{
+                      padding: '8px 12px',
+                      background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                      border: 'none',
+                      borderRadius: 10,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: '#FFFFFF',
+                      cursor: drawer.tweaking ? 'wait' : 'pointer',
+                      fontFamily: 'inherit',
+                      opacity: drawer.tweaking || tweakInstruction.trim().length < 2 ? 0.6 : 1,
+                    }}
+                  >
+                    Apply
+                  </button>
+                </div>
+              )}
+
+              {selectedCount > 0 && (
+                <div
+                  data-testid="drawer-selection-bar"
+                  style={{
+                    display: 'flex',
+                    gap: 8,
+                    padding: '8px 10px',
+                    background: 'rgba(15,17,24,0.04)',
+                    borderRadius: 10,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => drawer.discardSelected()}
+                    data-testid="drawer-discard-selected"
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      padding: '7px 12px',
+                      background: '#FFFFFF',
+                      border: '0.5px solid rgba(220,38,38,0.35)',
+                      borderRadius: 999,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: '#991B1B',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <Trash2 size={12} />
+                    <span>Discard selected</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => drawer.approveSelected()}
+                    data-testid="drawer-approve-selected"
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      padding: '7px 12px',
+                      background: 'linear-gradient(135deg, #C49B2A, #E8C84A)',
+                      border: 'none',
+                      borderRadius: 999,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: '#FFFFFF',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    <Check size={12} />
+                    <span>Approve selected</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => drawer.clearSelected()}
+                    data-testid="drawer-selection-clear"
+                    style={{
+                      marginLeft: 'auto',
+                      padding: '7px 8px',
+                      background: 'transparent',
+                      border: 'none',
+                      fontSize: 11.5,
+                      color: '#6B7280',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                    }}
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Body */}
@@ -194,6 +366,9 @@ export default function ApprovalDrawer() {
             body={draftBody}
             onSubjectChange={setDraftSubject}
             onBodyChange={setDraftBody}
+            selectable={isMultiDraft}
+            selected={drawer.selectedIds.includes(current.id)}
+            onToggleSelected={() => drawer.toggleSelected(current.id)}
           />}
         </div>
 
@@ -312,6 +487,9 @@ function DraftCard({
   body,
   onSubjectChange,
   onBodyChange,
+  selectable,
+  selected,
+  onToggleSelected,
 }: {
   draft: ReturnType<typeof useApprovalDrawer>['drafts'][number];
   editing: boolean;
@@ -319,6 +497,9 @@ function DraftCard({
   body: string;
   onSubjectChange: (v: string) => void;
   onBodyChange: (v: string) => void;
+  selectable: boolean;
+  selected: boolean;
+  onToggleSelected: () => void;
 }) {
   const statusChip =
     draft.status === 'sent'
@@ -334,6 +515,33 @@ function DraftCard({
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        {selectable && (
+          <label
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              cursor: 'pointer',
+              userSelect: 'none',
+              padding: '3px 8px',
+              borderRadius: 999,
+              background: selected ? 'rgba(196,155,42,0.12)' : 'transparent',
+              border: '0.5px solid rgba(15,17,24,0.12)',
+              fontSize: 11,
+              fontWeight: 600,
+              color: selected ? '#8A6E1F' : '#6B7280',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={onToggleSelected}
+              data-testid={`drawer-select-${draft.id}`}
+              style={{ margin: 0, accentColor: '#C49B2A' }}
+            />
+            <span>{selected ? 'Selected' : 'Select'}</span>
+          </label>
+        )}
         <span
           style={{
             fontSize: 10.5,

--- a/apps/unified-portal/lib/agent-intelligence/drawer-store.tsx
+++ b/apps/unified-portal/lib/agent-intelligence/drawer-store.tsx
@@ -42,6 +42,10 @@ export interface DrawerState {
   cursor: number;
   /** Approve-all progress — null when not active. */
   bulkProgress: { total: number; done: number; failed: number } | null;
+  /** BUG-13 batch ops: ids of drafts the agent has ticked. */
+  selectedIds: string[];
+  /** BUG-13: true while a tweak-all LLM pass is in flight. */
+  tweaking: boolean;
 }
 
 interface DrawerContextValue extends DrawerState {
@@ -52,6 +56,12 @@ interface DrawerContextValue extends DrawerState {
   discardDraft: (draftId: string) => Promise<void>;
   editDraft: (draftId: string, patch: { subject?: string; body?: string }) => Promise<void>;
   approveAll: () => Promise<void>;
+  // BUG-13 batch operations.
+  toggleSelected: (draftId: string) => void;
+  clearSelected: () => void;
+  approveSelected: () => Promise<void>;
+  discardSelected: () => Promise<void>;
+  tweakAll: (instruction: string) => Promise<void>;
 }
 
 const DrawerContext = createContext<DrawerContextValue | null>(null);
@@ -62,6 +72,8 @@ const INITIAL_STATE: DrawerState = {
   drafts: [],
   cursor: 0,
   bulkProgress: null,
+  selectedIds: [],
+  tweaking: false,
 };
 
 export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
@@ -86,6 +98,8 @@ export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
       drafts,
       cursor: 0,
       bulkProgress: null,
+      selectedIds: [],
+      tweaking: false,
     });
   }, []);
 
@@ -222,6 +236,100 @@ export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
     setState((s) => ({ ...s, bulkProgress: null }));
   }, [approveDraft]);
 
+  // BUG-13 — batch selection.
+  const toggleSelected = useCallback((draftId: string) => {
+    setState((s) => {
+      const has = s.selectedIds.includes(draftId);
+      return {
+        ...s,
+        selectedIds: has ? s.selectedIds.filter((id) => id !== draftId) : [...s.selectedIds, draftId],
+      };
+    });
+  }, []);
+
+  const clearSelected = useCallback(() => {
+    setState((s) => ({ ...s, selectedIds: [] }));
+  }, []);
+
+  const approveSelected = useCallback(async () => {
+    let queue: string[] = [];
+    setState((s) => {
+      const sendable = new Set(
+        s.drafts
+          .filter((d) => d.status === 'pending' || d.status === 'approved')
+          .map((d) => d.id),
+      );
+      queue = s.selectedIds.filter((id) => sendable.has(id));
+      return queue.length
+        ? { ...s, bulkProgress: { total: queue.length, done: 0, failed: 0 } }
+        : s;
+    });
+    if (!queue.length) return;
+    for (const id of queue) {
+      await approveDraft(id);
+      setState((s) => {
+        if (!s.bulkProgress) return s;
+        const draft = s.drafts.find((d) => d.id === id);
+        const done = s.bulkProgress.done + 1;
+        const failed = s.bulkProgress.failed + (draft?.status === 'failed' ? 1 : 0);
+        return { ...s, bulkProgress: { ...s.bulkProgress, done, failed } };
+      });
+    }
+    setState((s) => ({ ...s, bulkProgress: null, selectedIds: [] }));
+  }, [approveDraft]);
+
+  const discardSelected = useCallback(async () => {
+    let queue: string[] = [];
+    setState((s) => {
+      const discardable = new Set(
+        s.drafts
+          .filter((d) => d.status === 'pending' || d.status === 'approved' || d.status === 'failed')
+          .map((d) => d.id),
+      );
+      queue = s.selectedIds.filter((id) => discardable.has(id));
+      return s;
+    });
+    for (const id of queue) {
+      await discardDraft(id);
+    }
+    setState((s) => ({ ...s, selectedIds: [] }));
+  }, [discardDraft]);
+
+  const tweakAll = useCallback(async (instruction: string) => {
+    const trimmed = (instruction || '').trim();
+    if (!trimmed) return;
+    let draftIds: string[] = [];
+    setState((s) => {
+      draftIds = s.drafts
+        .filter((d) => d.status === 'pending' || d.status === 'approved')
+        .map((d) => d.id);
+      return draftIds.length ? { ...s, tweaking: true } : s;
+    });
+    if (!draftIds.length) return;
+    try {
+      const res = await fetch('/api/agent/intelligence/drafts/tweak-all', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draftIds, instruction: trimmed }),
+      });
+      if (!res.ok) throw new Error(`tweak-all failed (${res.status})`);
+      const data = (await res.json()) as { rewrites: Array<{ id: string; subject: string; body: string }> };
+      const byId = new Map(data.rewrites.map((r) => [r.id, r]));
+      setState((s) => ({
+        ...s,
+        drafts: s.drafts.map((d) => {
+          const r = byId.get(d.id);
+          if (!r) return d;
+          return { ...d, subject: r.subject, body: r.body };
+        }),
+        tweaking: false,
+      }));
+    } catch (err) {
+      console.error('[drawer-store] tweakAll failed', err);
+      setState((s) => ({ ...s, tweaking: false }));
+    }
+  }, []);
+
   const value = useMemo<DrawerContextValue>(
     () => ({
       ...state,
@@ -232,8 +340,27 @@ export function ApprovalDrawerProvider({ children }: { children: ReactNode }) {
       discardDraft,
       editDraft,
       approveAll,
+      toggleSelected,
+      clearSelected,
+      approveSelected,
+      discardSelected,
+      tweakAll,
     }),
-    [state, openApprovalDrawer, close, setCursor, approveDraft, discardDraft, editDraft, approveAll],
+    [
+      state,
+      openApprovalDrawer,
+      close,
+      setCursor,
+      approveDraft,
+      discardDraft,
+      editDraft,
+      approveAll,
+      toggleSelected,
+      clearSelected,
+      approveSelected,
+      discardSelected,
+      tweakAll,
+    ],
   );
 
   return <DrawerContext.Provider value={value}>{children}</DrawerContext.Provider>;

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -121,6 +121,177 @@ function errorEnvelope(skill: string, query: string, err: unknown): AgenticSkill
 }
 
 // =====================================================================
+// BUG-14 — Per-recipient "Why drafted" reasoning.
+// =====================================================================
+//
+// The draft envelopes used to carry a static `Drafted per agent request
+// (warm tone)` string for every recipient in a batch. The drawer surfaces
+// the reasoning chip prominently, so identical text across 10 drafts read
+// as canned. This helper builds a one-line, data-driven reason per
+// recipient using inputs already in scope when the batch is built:
+//   - daysSinceContact: from communication_events
+//   - pipelineStage: derived from unit_status / pipeline dates
+//   - mortgageExpiryDays: from unit_sales_pipeline.mortgage_expiry_date
+//   - viewingCount: from agent_viewings
+//
+// Priority (highest first; we pick exactly one signal):
+//   1. expiring mortgage approval (≤ 30 days) — urgent action signal
+//   2. stale contact (≥ 14 days since last logged interaction)
+//   3. pipeline stage (signed > sale_agreed > contracts_issued)
+//   4. viewing count (strong vs lukewarm interest)
+// Falls back to a generic line only when no signal applies.
+
+export interface PerRecipientReasonInput {
+  daysSinceContact: number | null;
+  pipelineStage: string | null;
+  mortgageExpiryDays: number | null;
+  viewingCount: number;
+  emailMissing: boolean;
+}
+
+export function buildPerRecipientReason(input: PerRecipientReasonInput): string {
+  const {
+    daysSinceContact,
+    pipelineStage,
+    mortgageExpiryDays,
+    viewingCount,
+    emailMissing,
+  } = input;
+
+  // 1. Expiring mortgage approval
+  if (mortgageExpiryDays !== null && mortgageExpiryDays <= 30) {
+    if (mortgageExpiryDays <= 0) {
+      return 'Mortgage approval expired — chase before contracts move.';
+    }
+    return `Mortgage approval expires in ${mortgageExpiryDays} day${mortgageExpiryDays === 1 ? '' : 's'}.`;
+  }
+
+  // 2. Stale contact
+  if (daysSinceContact !== null && daysSinceContact >= 14) {
+    const viewingPart =
+      viewingCount === 0
+        ? 'no viewings logged'
+        : viewingCount === 1
+          ? 'one viewing on record'
+          : `${viewingCount} viewings on record`;
+    return `No contact for ${daysSinceContact} days, ${viewingPart}.`;
+  }
+
+  // 3. Pipeline stage
+  if (pipelineStage === 'signed' || pipelineStage === 'counter_signed') {
+    return emailMissing
+      ? 'At signed stage but missing recipient email on file.'
+      : 'At signed stage, awaiting next milestone.';
+  }
+  if (pipelineStage === 'contracts_issued') {
+    return 'Contracts issued, awaiting signed return.';
+  }
+  if (pipelineStage === 'sale_agreed' || pipelineStage === 'agreed') {
+    return 'Sale agreed, contracts not yet issued.';
+  }
+  if (pipelineStage === 'deposit_received') {
+    return 'Deposit received, contracts pending.';
+  }
+  if (pipelineStage === 'reserved') {
+    return 'Unit reserved, no deposit logged yet.';
+  }
+
+  // 4. Viewing count
+  if (viewingCount >= 2) {
+    return `Strong interest, ${viewingCount} viewings logged.`;
+  }
+  if (viewingCount === 1) {
+    return 'One viewing logged, no follow-up yet.';
+  }
+
+  // Fallback — only when no signal applies (genuinely cold lead).
+  return 'No prior contact or viewings logged.';
+}
+
+/**
+ * Bulk enrichment loader for draftBuyerFollowups + draftMessageSkill.
+ * Pulls communication_events, agent_viewings, and pipeline mortgage
+ * expiry rows for every unit_id in `unitIds` in three batched queries —
+ * far cheaper than per-draft round-trips.
+ */
+export async function loadPerRecipientEnrichment(
+  supabase: SupabaseClient,
+  unitIds: string[],
+): Promise<{
+  daysSinceContactByUnit: Map<string, number>;
+  viewingCountByUnit: Map<string, number>;
+  mortgageExpiryDaysByUnit: Map<string, number>;
+}> {
+  const daysSinceContactByUnit = new Map<string, number>();
+  const viewingCountByUnit = new Map<string, number>();
+  const mortgageExpiryDaysByUnit = new Map<string, number>();
+  if (!unitIds.length) {
+    return { daysSinceContactByUnit, viewingCountByUnit, mortgageExpiryDaysByUnit };
+  }
+
+  const now = Date.now();
+
+  const [{ data: comms }, { data: viewings }, { data: pipeRows }] = await Promise.all([
+    supabase
+      .from('communication_events')
+      .select('unit_id, created_at')
+      .in('unit_id', unitIds)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('agent_viewings')
+      .select('unit_id')
+      .in('unit_id', unitIds),
+    supabase
+      .from('unit_sales_pipeline')
+      .select('unit_id, mortgage_expiry_date')
+      .in('unit_id', unitIds),
+  ]);
+
+  for (const c of (comms || []) as any[]) {
+    if (!c.unit_id || daysSinceContactByUnit.has(c.unit_id)) continue;
+    const ts = new Date(c.created_at).getTime();
+    if (Number.isNaN(ts)) continue;
+    daysSinceContactByUnit.set(c.unit_id, Math.max(0, Math.floor((now - ts) / 86_400_000)));
+  }
+
+  for (const v of (viewings || []) as any[]) {
+    if (!v.unit_id) continue;
+    viewingCountByUnit.set(v.unit_id, (viewingCountByUnit.get(v.unit_id) || 0) + 1);
+  }
+
+  for (const p of (pipeRows || []) as any[]) {
+    if (!p.unit_id || !p.mortgage_expiry_date) continue;
+    const ts = new Date(p.mortgage_expiry_date).getTime();
+    if (Number.isNaN(ts)) continue;
+    mortgageExpiryDaysByUnit.set(
+      p.unit_id,
+      Math.floor((ts - now) / 86_400_000),
+    );
+  }
+
+  return { daysSinceContactByUnit, viewingCountByUnit, mortgageExpiryDaysByUnit };
+}
+
+/**
+ * Map raw pipeline / unit-status signals onto the stage labels the reason
+ * helper switches on. Pipeline dates take priority — a unit may be
+ * `available` in `units.unit_status` while the pipeline row carries a
+ * deposit_date.
+ */
+export function classifyPipelineStage(unitStatus: string | null, pipe: any | null): string | null {
+  if (pipe?.handover_date) return 'handed_over';
+  if (pipe?.counter_signed_date) return 'counter_signed';
+  if (pipe?.signed_contracts_date) return 'signed';
+  if (pipe?.contracts_issued_date) return 'contracts_issued';
+  if (pipe?.deposit_date) return 'deposit_received';
+  if (pipe?.sale_agreed_date) return 'sale_agreed';
+  if (unitStatus === 'sale_agreed') return 'sale_agreed';
+  if (unitStatus === 'reserved') return 'reserved';
+  if (unitStatus === 'available') return null; // no signal yet
+  return unitStatus || null;
+}
+
+// =====================================================================
 // Skill 1 — chase_aged_contracts
 // =====================================================================
 export async function chaseAgedContracts(
@@ -1258,6 +1429,13 @@ async function draftTenantMessage(
       signature(agentContext),
     ].filter((line) => line !== undefined).join('\n');
 
+    // BUG-14 — per-recipient reason for tenant drafts. Lettings doesn't
+    // have the sales pipeline / mortgage signals; we surface lease-end
+    // proximity instead, which is the primary action signal in lettings.
+    const tenantReason = buildTenantRecipientReason({
+      tenancy,
+      tenantEmailOnFile: !!tenancy.tenant_email,
+    });
     return {
       skill,
       status: 'awaiting_approval',
@@ -1269,13 +1447,44 @@ async function draftTenantMessage(
         subject,
         body,
         affected_record: { kind: 'tenancy', id: tenancy.id, label: `${propertyAddress} — ${tenantFullName}` },
-        reasoning: `Drafted per agent request (${tone} tone). ${tenancy.tenant_email ? '' : 'Tenant email was not on file; placeholder used — please fill in before approving.'}`.trim(),
+        reasoning: tenantReason,
       }],
       meta: { record_count: 1, generated_at: new Date().toISOString(), query },
     };
   } catch (err) {
     return errorEnvelope(skill, query, err);
   }
+}
+
+/**
+ * BUG-14 — lettings recipient reason. Lease-end proximity, RTB
+ * registration gap, and email-on-file are the actionable signals here;
+ * we lift them out of the active tenancy row rather than reaching into
+ * communication_events / agent_viewings (lettings doesn't log either).
+ */
+function buildTenantRecipientReason(opts: {
+  tenancy: any;
+  tenantEmailOnFile: boolean;
+}): string {
+  const t = opts.tenancy;
+  const leaseEndIso = t?.lease_end as string | null | undefined;
+  if (leaseEndIso) {
+    const ms = new Date(leaseEndIso).getTime();
+    if (!Number.isNaN(ms)) {
+      const days = Math.floor((ms - Date.now()) / 86_400_000);
+      if (days < 0) return `Lease ended ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago.`;
+      if (days === 0) return 'Lease ends today.';
+      if (days <= 30) return `Lease ends in ${days} day${days === 1 ? '' : 's'}.`;
+      if (days <= 90) return `Lease ends in ${days} days, inside the 90-day notice window.`;
+    }
+  }
+  if (t?.rtb_registered === false) {
+    return 'RTB registration not on file for this tenancy.';
+  }
+  if (!opts.tenantEmailOnFile) {
+    return 'Tenant email not on file; please fill in before approving.';
+  }
+  return 'Routine tenant follow-up.';
 }
 
 export async function draftMessageSkill(
@@ -1542,6 +1751,43 @@ export async function draftMessageSkill(
     // the placeholder path here.
     const placeholderEmail = 'buyer@tbc.invalid';
     const finalEmail = resolvedEmail || placeholderEmail;
+
+    // BUG-14 — per-recipient reason. For the single-recipient path we
+    // do one targeted enrichment query; for cold contact rows (no
+    // affectedUnitId) we skip the lookup entirely and fall back to a
+    // generic line.
+    let perRecipientReason = 'Drafted per agent request.';
+    if (affectedUnitId) {
+      const enrichment = await loadPerRecipientEnrichment(supabase, [affectedUnitId]);
+      let pipelineRow: any = null;
+      let unitStatusVal: string | null = null;
+      try {
+        const { data: pipe } = await supabase
+          .from('unit_sales_pipeline')
+          .select('handover_date, counter_signed_date, signed_contracts_date, contracts_issued_date, deposit_date, sale_agreed_date')
+          .eq('unit_id', affectedUnitId)
+          .maybeSingle();
+        pipelineRow = pipe;
+        const { data: u } = await supabase
+          .from('units')
+          .select('unit_status')
+          .eq('id', affectedUnitId)
+          .maybeSingle();
+        unitStatusVal = u?.unit_status ?? null;
+      } catch {
+        /* enrichment is additive — fall back to default reason on failure */
+      }
+      perRecipientReason = buildPerRecipientReason({
+        daysSinceContact: enrichment.daysSinceContactByUnit.get(affectedUnitId) ?? null,
+        pipelineStage: classifyPipelineStage(unitStatusVal, pipelineRow),
+        mortgageExpiryDays: enrichment.mortgageExpiryDaysByUnit.get(affectedUnitId) ?? null,
+        viewingCount: enrichment.viewingCountByUnit.get(affectedUnitId) || 0,
+        emailMissing: !resolvedEmail,
+      });
+    }
+    const placeholderNote = resolvedEmail
+      ? ''
+      : ' Recipient email was not on file; placeholder used — please fill in before approving.';
     const draft = {
       id: randomUUID(),
       type: 'email' as const,
@@ -1555,7 +1801,7 @@ export async function draftMessageSkill(
       affected_record: affectedUnitId
         ? { kind: 'sales_unit', id: affectedUnitId, label: unitLabel || recipientName }
         : { kind: 'contact', id: recipientName, label: recipientName },
-      reasoning: `Drafted per agent request (${tone} tone). ${resolvedEmail ? '' : 'Recipient email was not on file; placeholder used — please fill in before approving.'}`.trim(),
+      reasoning: `${perRecipientReason}${placeholderNote}`.trim(),
     };
 
     return {
@@ -1870,6 +2116,17 @@ export async function draftBuyerFollowups(
 
   try {
     const drafts: AgenticSkillEnvelope['drafts'] = [];
+    // BUG-14 — collect resolved targets, defer draft creation until the
+    // bulk enrichment query has run.
+    const pending: Array<{
+      unit: any;
+      pipeline: any | null;
+      unitLabel: string;
+      parsed: ReturnType<typeof parseJointPurchaserNames>;
+      resolvedEmail: string;
+      subject: string;
+      body: string;
+    }> = [];
     const skipped: Array<{ ref: string; reason: string }> = [];
     const seenUnitIds = new Set<string>();
     // Session 13 — track which developments actually resolved this
@@ -2004,16 +2261,48 @@ export async function draftBuyerFollowups(
         ctx: agentContext,
       });
 
+      // BUG-14 — defer draft assembly so we can attach a per-recipient
+      // reason after the bulk enrichment query below.
+      pending.push({
+        unit,
+        pipeline,
+        unitLabel,
+        parsed,
+        resolvedEmail,
+        subject,
+        body,
+      });
+      if (unit.development_id) resolvedDevIds.add(unit.development_id);
+    }
+
+    // BUG-14 — single bulk enrichment for the whole batch. Pulls
+    // communication recency, viewing count, and mortgage expiry days for
+    // every resolved unit in three parallel batched queries. Cheaper
+    // than per-target round-trips and keeps the per-draft loop pure.
+    const enrichmentUnitIds = pending.map((p) => p.unit.id);
+    const enrichment = await loadPerRecipientEnrichment(supabase, enrichmentUnitIds);
+
+    for (const p of pending) {
+      const reason = buildPerRecipientReason({
+        daysSinceContact: enrichment.daysSinceContactByUnit.get(p.unit.id) ?? null,
+        pipelineStage: classifyPipelineStage(p.unit.unit_status, p.pipeline),
+        mortgageExpiryDays: enrichment.mortgageExpiryDaysByUnit.get(p.unit.id) ?? null,
+        viewingCount: enrichment.viewingCountByUnit.get(p.unit.id) || 0,
+        emailMissing: p.resolvedEmail === 'buyer@tbc.invalid',
+      });
+      const placeholderNote =
+        p.resolvedEmail === 'buyer@tbc.invalid'
+          ? ' Recipient email missing — placeholder used, please fill in before approving.'
+          : '';
       drafts.push({
         id: randomUUID(),
         type: 'email' as const,
-        recipient: { name: parsed.fullName, email: resolvedEmail, role: 'buyer' },
-        subject,
-        body,
-        affected_record: { kind: 'sales_unit', id: unit.id, label: unitLabel },
-        reasoning: `${purpose} email to ${parsed.fullName} at ${unitLabel}. Tone: ${tone}.${resolvedEmail === 'buyer@tbc.invalid' ? ' Recipient email missing — placeholder used, please fill in before approving.' : ''}`,
+        recipient: { name: p.parsed.fullName, email: p.resolvedEmail, role: 'buyer' },
+        subject: p.subject,
+        body: p.body,
+        affected_record: { kind: 'sales_unit', id: p.unit.id, label: p.unitLabel },
+        reasoning: `${reason}${placeholderNote}`,
       });
-      if (unit.development_id) resolvedDevIds.add(unit.development_id);
     }
 
     const summaryParts: string[] = [];

--- a/apps/unified-portal/lib/agent/agentPipelineService.ts
+++ b/apps/unified-portal/lib/agent/agentPipelineService.ts
@@ -97,6 +97,7 @@ export interface AgentProfile {
   bio: string | null;
   location: string | null;
   specialisations: string[] | null;
+  demoMode: boolean;
 }
 
 export interface DevelopmentSummary {
@@ -179,6 +180,7 @@ export async function getAgentProfile(preview?: string): Promise<AgentProfile | 
       bio: null,
       location: null,
       specialisations: null,
+      demoMode: false,
     };
   }
 
@@ -188,7 +190,7 @@ export async function getAgentProfile(preview?: string): Promise<AgentProfile | 
     if (user) {
       const { data } = await supabase
         .from('agent_profiles')
-        .select('id, display_name, agency_name, phone, email, tenant_id, agent_type, bio, location, specialisations')
+        .select('id, display_name, agency_name, phone, email, tenant_id, agent_type, bio, location, specialisations, demo_mode')
         .eq('user_id', user.id)
         .order('created_at', { ascending: true })
         .limit(1)
@@ -206,6 +208,7 @@ export async function getAgentProfile(preview?: string): Promise<AgentProfile | 
           bio: data.bio || null,
           location: data.location || null,
           specialisations: data.specialisations || null,
+          demoMode: Boolean(data.demo_mode),
         };
       }
     }
@@ -216,7 +219,7 @@ export async function getAgentProfile(preview?: string): Promise<AgentProfile | 
   // Fallback: load first agent profile (Sam Donworth for demo/preview)
   const { data } = await supabase
     .from('agent_profiles')
-    .select('id, display_name, agency_name, phone, email, tenant_id, agent_type, bio, location, specialisations')
+    .select('id, display_name, agency_name, phone, email, tenant_id, agent_type, bio, location, specialisations, demo_mode')
     .order('created_at', { ascending: true })
     .limit(1)
     .single();
@@ -233,6 +236,7 @@ export async function getAgentProfile(preview?: string): Promise<AgentProfile | 
     bio: data.bio || null,
     location: data.location || null,
     specialisations: data.specialisations || null,
+    demoMode: Boolean(data.demo_mode),
   };
 }
 

--- a/apps/unified-portal/lib/agent/haptics.ts
+++ b/apps/unified-portal/lib/agent/haptics.ts
@@ -1,0 +1,65 @@
+/**
+ * BUG-15 — voice input feedback. Cross-platform haptic helper for the
+ * mic press / release cycle. Voice-first surfaces depend on a clear
+ * tactile beat to confirm "I'm listening" / "I stopped"; without one,
+ * the user has to watch the screen to confirm the tap registered.
+ *
+ * Strategy:
+ *   1. Try Capacitor Haptics (native iOS + Android via the plugin) when
+ *      it's installed. Dynamic import so the web bundle never tries to
+ *      pull in the Capacitor runtime when the package isn't present.
+ *   2. Fall back to navigator.vibrate(15) — works on Android Chrome /
+ *      Firefox, silently no-ops on iOS Safari and desktop. Harmless.
+ *   3. Swallow any failure. Haptics are additive; the rest of the
+ *      mic flow must keep working.
+ *
+ * NOTE: at the time of writing, @capacitor/haptics is NOT in any
+ * package.json in this repo. The dynamic import returns null on the
+ * web bundle and the helper falls through to navigator.vibrate. When
+ * the Capacitor build adds the plugin later, this helper picks it up
+ * automatically — no call-site change needed.
+ */
+
+type ImpactStyle = 'LIGHT' | 'MEDIUM' | 'HEAVY';
+
+async function loadCapacitorHaptics(): Promise<{
+  Haptics: { impact: (opts: { style: any }) => Promise<void> };
+  ImpactStyle: Record<string, any>;
+} | null> {
+  try {
+    // Use a string variable so esbuild / webpack don't statically
+    // resolve the module path when the package isn't installed.
+    const moduleId = '@capacitor/haptics';
+    const mod = await import(/* @vite-ignore */ /* webpackIgnore: true */ moduleId);
+    if (!mod?.Haptics?.impact || !mod?.ImpactStyle) return null;
+    return mod as any;
+  } catch {
+    return null;
+  }
+}
+
+let cachedHaptics: Awaited<ReturnType<typeof loadCapacitorHaptics>> | undefined;
+
+export async function lightImpact(): Promise<void> {
+  if (typeof window === 'undefined') return;
+  if (cachedHaptics === undefined) {
+    cachedHaptics = await loadCapacitorHaptics();
+  }
+  if (cachedHaptics?.Haptics?.impact && cachedHaptics?.ImpactStyle) {
+    try {
+      await cachedHaptics.Haptics.impact({ style: cachedHaptics.ImpactStyle.Light });
+      return;
+    } catch {
+      /* fall through to web vibrate */
+    }
+  }
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(15);
+    }
+  } catch {
+    /* additive — never throw */
+  }
+}
+
+export type { ImpactStyle };

--- a/scripts/reset-demo-state.ts
+++ b/scripts/reset-demo-state.ts
@@ -1,0 +1,199 @@
+/**
+ * RESET DEMO STATE
+ *
+ * Wipes the chat history and pending drafts for one agent profile and
+ * reseeds a tiny synthetic demo conversation. Run before recording the
+ * promo so the screen is clean (BUG-06: stale pending_drafts residue;
+ * BUG-07: real names from earlier exploratory chats leaking in).
+ *
+ * USAGE:
+ *   npx tsx scripts/reset-demo-state.ts <agent_profile_id>
+ *
+ * Example:
+ *   npx tsx scripts/reset-demo-state.ts 0f9210e0-342d-4f98-9be1-95decb6f507a
+ *
+ * Required env vars:
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * WHAT IT DELETES (scoped to the supplied agent profile):
+ *   - pending_drafts WHERE user_id = <profile.user_id> AND skin LIKE 'agent%'
+ *   - intelligence_conversations WHERE agent_id = <profile.id>
+ *   - intelligence_interactions WHERE user_id = <profile.user_id> AND skin LIKE 'agent%'
+ *
+ * WHAT IT INSERTS:
+ *   A 4-turn synthetic demo conversation in intelligence_conversations
+ *   (2 user, 2 assistant) using existing seeded purchaser_name values
+ *   pulled from `units` rows tied to the agent's active scheme
+ *   assignments. Never invents new names; if no seeded names are
+ *   available the conversation is skipped and a warning is logged.
+ *
+ * WHAT IT DOES NOT TOUCH:
+ *   - units, developments, agent_profiles, agent_scheme_assignments
+ *   - any RLS or schema changes
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env.');
+  process.exit(1);
+}
+
+const agentProfileId = process.argv[2];
+if (!agentProfileId) {
+  console.error('Usage: npx tsx scripts/reset-demo-state.ts <agent_profile_id>');
+  process.exit(1);
+}
+
+const supabase: SupabaseClient = createClient(SUPABASE_URL, SERVICE_KEY);
+
+async function loadProfile() {
+  const { data, error } = await supabase
+    .from('agent_profiles')
+    .select('id, user_id, tenant_id, display_name')
+    .eq('id', agentProfileId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) throw new Error(`No agent_profiles row for id=${agentProfileId}`);
+  if (!data.user_id) throw new Error('agent_profiles.user_id is null — cannot scope auth-keyed deletes.');
+  return data as { id: string; user_id: string; tenant_id: string | null; display_name: string | null };
+}
+
+async function loadSeededBuyerNames(profile: {
+  id: string;
+  tenant_id: string | null;
+}): Promise<Array<{ name: string; scheme: string }>> {
+  const { data: assignments } = await supabase
+    .from('agent_scheme_assignments')
+    .select('development_id')
+    .eq('agent_id', profile.id)
+    .eq('is_active', true);
+  const devIds = Array.from(
+    new Set((assignments || []).map((a: any) => a.development_id).filter(Boolean)),
+  );
+  if (!devIds.length) return [];
+
+  const { data: devs } = await supabase
+    .from('developments')
+    .select('id, name')
+    .in('id', devIds);
+  const devNameById = new Map<string, string>(
+    (devs || []).map((d: any) => [d.id, d.name]),
+  );
+
+  const { data: rows } = await supabase
+    .from('units')
+    .select('purchaser_name, development_id')
+    .in('development_id', devIds)
+    .not('purchaser_name', 'is', null)
+    .neq('purchaser_name', '');
+
+  const seen = new Set<string>();
+  const out: Array<{ name: string; scheme: string }> = [];
+  for (const r of (rows || []) as any[]) {
+    const name = String(r.purchaser_name).trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push({ name, scheme: devNameById.get(r.development_id) || 'your scheme' });
+  }
+  return out;
+}
+
+async function deleteCount(table: string, filter: (q: any) => any): Promise<number> {
+  // Two-step: count first, then delete. Some PostgREST configs don't
+  // return affected row count on delete; the count() head request is
+  // reliable.
+  const countQ = filter(
+    supabase.from(table).select('id', { count: 'exact', head: true }),
+  );
+  const { count, error: countErr } = (await countQ) as any;
+  if (countErr) throw countErr;
+  if (!count) return 0;
+
+  const { error: delErr } = (await filter(supabase.from(table).delete())) as any;
+  if (delErr) throw delErr;
+  return count as number;
+}
+
+async function reseedConversation(
+  profile: { id: string; tenant_id: string | null; display_name: string | null },
+  buyers: Array<{ name: string; scheme: string }>,
+) {
+  if (buyers.length < 2) {
+    console.warn(`Not enough seeded buyer names for ${profile.id} — skipping reseed.`);
+    return;
+  }
+  const sessionId = `demo_${Date.now()}`;
+  const a = buyers[0];
+  const b = buyers[1];
+  const turns = [
+    { role: 'user', content: `Hey, give me a quick read on ${a.scheme} for the morning.` },
+    {
+      role: 'assistant',
+      content:
+        `${a.scheme} is steady. Two units worth chasing today: ${a.name} (contracts issued, no signed return) and ${b.name} (sale agreed, deposit clear). Want me to draft chase emails?`,
+    },
+    { role: 'user', content: `Yes, draft both. Keep it warm.` },
+    {
+      role: 'assistant',
+      content:
+        `Drafted two follow-ups. Have a flick through in the drawer and approve when you're happy.`,
+    },
+  ];
+  const rows = turns.map((t) => ({
+    agent_id: profile.id,
+    tenant_id: profile.tenant_id,
+    session_id: sessionId,
+    role: t.role,
+    content: t.content,
+    entities_mentioned: { buyers: [a.name, b.name].slice(0, 2), schemes: [a.scheme] },
+  }));
+  const { error } = await supabase.from('intelligence_conversations').insert(rows);
+  if (error) throw error;
+  console.log(`  inserted ${rows.length} demo conversation rows (session_id=${sessionId})`);
+}
+
+async function main() {
+  console.log('');
+  console.log('=== reset-demo-state ===');
+  console.log(`agent_profile_id: ${agentProfileId}`);
+  console.log('');
+
+  const profile = await loadProfile();
+  console.log(`profile resolved: ${profile.display_name || '(no name)'} (user_id=${profile.user_id})`);
+  console.log('');
+
+  console.log('Deleting…');
+  const draftsDeleted = await deleteCount('pending_drafts', (q) =>
+    q.eq('user_id', profile.user_id).like('skin', 'agent%'),
+  );
+  console.log(`  pending_drafts: ${draftsDeleted} row(s)`);
+
+  const convosDeleted = await deleteCount('intelligence_conversations', (q) =>
+    q.eq('agent_id', profile.id),
+  );
+  console.log(`  intelligence_conversations: ${convosDeleted} row(s)`);
+
+  const interactionsDeleted = await deleteCount('intelligence_interactions', (q) =>
+    q.eq('user_id', profile.user_id).like('skin', 'agent%'),
+  );
+  console.log(`  intelligence_interactions: ${interactionsDeleted} row(s)`);
+
+  console.log('');
+  console.log('Reseeding demo conversation…');
+  const buyers = await loadSeededBuyerNames({ id: profile.id, tenant_id: profile.tenant_id });
+  console.log(`  found ${buyers.length} seeded buyer name(s) in agent's schemes`);
+  await reseedConversation(profile, buyers);
+
+  console.log('');
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('reset-demo-state failed:', err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
…ecipient reasoning, voice feedback

Seven smaller demo-polish bugs bundled into one commit. Each is small on its own; together they make the difference between a clean recording and a janky one.

BUG-06 / BUG-07 — demo state reset script.
- Added scripts/reset-demo-state.ts. Takes an agent_profile_id CLI arg, no hardcoded id. Wipes pending_drafts (skin agent) for that profile, intelligence_conversations, and intelligence_interactions (skin agent). Reseeds a 4-turn synthetic conversation pulling buyer names from the existing units.purchaser_name pool tied to the agent's active scheme assignments — never invents new names, skips the reseed if no seeded names are available. Header comment documents how to run, what it deletes, what it inserts.
- Reset run against Orla (0f9210e0-342d-4f98-9be1-95decb6f507a) via the Supabase MCP: pending_drafts 56 -> 0, intelligence_conversations 356 -> 4 (reseeded), intelligence_interactions 124 -> 0.

BUG-11 — demo mode flag suppresses the red notification badge.
- agent_profiles.demo_mode boolean (default false) added via Supabase migration; no other column changes.
- Threaded demoMode through AgentProfile / AgentContext.
- StatusBar suppresses the unread-count badge when demoMode is true.
- Orla's profile set to demo_mode = true.

BUG-12 — non-functional Bridge Property scheme switcher chevron.
- Hid the chevron glyph next to the workspace label in StatusBar.
- TODO note left in place referencing the scheme resolver returning empty for Orla despite 5 active assignments. Resolver itself out of scope for this session.

BUG-13 — multi-draft batch operations in the approval drawer.
- drawer-store: added selectedIds + tweaking state, plus actions toggleSelected / clearSelected / approveSelected / discardSelected / tweakAll. approveSelected and discardSelected reuse the existing approveDraft / discardDraft endpoints. tweakAll posts to a single new endpoint and replaces drafts in place with the LLM rewrites.
- New endpoint POST /api/agent/intelligence/drafts/tweak-all takes { draftIds, instruction }, makes ONE OpenAI call (gpt-4o-mini, json_object response_format) to rewrite the whole batch, persists each rewrite into pending_drafts.content_json, returns { rewrites: [{ id, subject, body }] }. Single call by design — iterating per-draft would multiply cost.
- ApprovalDrawer.tsx UI: per-draft Select / Selected toggle in the card header; batch action row with Approve selected (Check) and Discard selected (Trash2) appearing only when at least one is ticked; Tweak all toggle (Wand2) and inline instruction input always visible when there are multiple drafts. Lucide icons only.

BUG-14 — per-recipient "Why drafted" reasoning.
- Added buildPerRecipientReason + loadPerRecipientEnrichment + classifyPipelineStage helpers in agentic-skills.ts.
- Priority order: expiring mortgage approval (<= 30d) > stale contact (>= 14d) > pipeline stage (signed > sale_agreed > contracts_issued > deposit_received > reserved) > viewing count. Picks one signal, never concatenates.
- draftBuyerFollowups now defers draft assembly into a `pending` array, runs ONE bulk enrichment query (communication_events, agent_viewings, unit_sales_pipeline.mortgage_expiry_date) keyed on the resolved unit_ids, then builds drafts with the per-recipient reason. No new per-draft round-trips.
- draftMessageSkill uses a smaller per-call enrichment lookup for the single-recipient path. draftTenantMessage uses a lettings- specific reason builder (lease-end proximity, RTB registration, email-on-file) since lettings doesn't log communication_events or agent_viewings.

BUG-15 — voice input feedback.
- Added a persistent red recording dot inside the input bar that pulses on its own rhythm next to the existing waveform. Visible even in a silent environment. CSS keyframe animation, no library.
- New helper lib/agent/haptics.ts: lightImpact() tries Capacitor @capacitor/haptics via dynamic import, falls back to navigator.vibrate(15) on web, no-ops on failure. The package is NOT in any package.json today; the helper picks it up automatically when the Capacitor build adds it.
- useVoiceCapture fires lightImpact() on start (after setStatus recording) and on stop (immediately, so the cue lands on the user's tap rather than after the transcription roundtrip).

https://claude.ai/code/session_0186V4RjscPx7BG3VsYt7qtL