### PR TITLE
fix(agent): foundational bugs — date awareness in lettings and workspace mode bleed across product surfaces

### DIFF
--- a/apps/unified-portal/app/agent/_components/BottomNav.tsx
+++ b/apps/unified-portal/app/agent/_components/BottomNav.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
 import { useApplicantsCount } from '../_hooks/useApplicantsCount';
 import { useAgent } from '@/lib/agent/AgentContext';
+import { deriveEffectiveMode } from '@/lib/agent/effective-mode';
 
 // Tab ids cover both nav surfaces. Sales: home | pipeline | applicants |
 // viewings. Lettings: home | properties | viewings | maintenance. 'home' and
@@ -107,11 +108,14 @@ export default function BottomNav() {
   const { count: draftsCount } = useDraftsCount();
   const { count: applicantsCount } = useApplicantsCount();
 
-  // Workspace-aware nav. Lettings mode swaps in the lettings tab set; every
-  // other state (sales mode, no-workspace legacy users) keeps the original
-  // sales tabs. The Intelligence FAB is shared and unchanged.
+  // Workspace-aware nav. The displayed tab set is derived from the URL when
+  // it unambiguously belongs to one workspace; otherwise we fall back to the
+  // persisted active workspace. Without this, pipeline pages (sales URLs)
+  // showed lettings tabs whenever the persisted workspace was lettings, and
+  // vice versa.
   const { activeWorkspace } = useAgent();
-  const tabs = activeWorkspace?.mode === 'lettings' ? LETTINGS_TABS : SALES_TABS;
+  const effectiveMode = deriveEffectiveMode(pathname, activeWorkspace?.mode);
+  const tabs = effectiveMode === 'lettings' ? LETTINGS_TABS : SALES_TABS;
   const leftTabs = tabs.slice(0, 2);
   const rightTabs = tabs.slice(2);
 

--- a/apps/unified-portal/app/agent/_components/StatusBar.tsx
+++ b/apps/unified-portal/app/agent/_components/StatusBar.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import NotificationPanel from './NotificationPanel';
 import type { Notification } from './NotificationPanel';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { type Alert, type PipelineUnit, getInitials } from '@/lib/agent/agentPipelineService';
 import { useDraftsCount } from '../_hooks/useDraftsCount';
+import { deriveEffectiveMode } from '@/lib/agent/effective-mode';
 
 interface UserContext {
   id: string;
@@ -110,8 +111,20 @@ export default function StatusBar({
   const [showSwitcher, setShowSwitcher] = useState(false);
   const [showWorkspaceSwitcher, setShowWorkspaceSwitcher] = useState(false);
   const router = useRouter();
+  const pathname = usePathname();
 
-  const hasWorkspaces = workspaces.length > 0 && activeWorkspace !== null;
+  // Header pill follows the URL when it unambiguously belongs to one
+  // workspace, falling back to the persisted active workspace on
+  // mode-neutral routes (intelligence, drafts, settings). Prevents the
+  // pill / badge from displaying lettings on a sales URL and vice versa.
+  const effectiveMode = deriveEffectiveMode(pathname, activeWorkspace?.mode);
+  const displayedWorkspace = (() => {
+    if (!activeWorkspace) return null;
+    if (activeWorkspace.mode === effectiveMode) return activeWorkspace;
+    return workspaces.find((w) => w.mode === effectiveMode) ?? activeWorkspace;
+  })();
+
+  const hasWorkspaces = workspaces.length > 0 && displayedWorkspace !== null;
 
   const handleSwitchWorkspace = useCallback(
     async (workspaceId: string) => {
@@ -238,9 +251,9 @@ export default function StatusBar({
                   minWidth: 0,
                 }}
               >
-                {activeWorkspace!.displayName}
+                {displayedWorkspace!.displayName}
               </span>
-              <ModeBadge mode={activeWorkspace!.mode} />
+              <ModeBadge mode={displayedWorkspace!.mode} />
               {/* TODO: restore chevron once agent_profile scheme resolver is fixed
                   (returns empty for Orla despite 5 active assignments). Hidden
                   for the promo build to avoid suggesting a working dropdown. */}

--- a/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
+++ b/apps/unified-portal/app/agent/_hooks/useDraftsCount.ts
@@ -1,6 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { useAgent } from '@/lib/agent/AgentContext';
+import { deriveEffectiveMode } from '@/lib/agent/effective-mode';
 
 const REFRESH_EVENT = 'oh.agent.drafts.refresh';
 const POLL_INTERVAL_MS = 30_000;
@@ -11,6 +14,11 @@ const POLL_INTERVAL_MS = 30_000;
  * the endpoint themselves. Other parts of the app (review screen, approve
  * action, send flow) can dispatch `oh.agent.drafts.refresh` to force an
  * immediate refresh instead of waiting for the next poll tick.
+ *
+ * The count is workspace-scoped: lettings drafts don't inflate the sales
+ * inbox badge and vice versa. The effective mode is derived from the URL
+ * (sales/lettings page → that workspace; mode-neutral page → fall back to
+ * the persisted active workspace).
  */
 export function useDraftsCount(): {
   count: number;
@@ -21,10 +29,13 @@ export function useDraftsCount(): {
 } {
   const [count, setCount] = useState(0);
   const [ready, setReady] = useState(false);
+  const pathname = usePathname();
+  const { activeWorkspace } = useAgent();
+  const mode = deriveEffectiveMode(pathname, activeWorkspace?.mode);
 
   const refresh = useCallback(async () => {
     try {
-      const res = await fetch('/api/agent/intelligence/drafts', { cache: 'no-store' });
+      const res = await fetch(`/api/agent/intelligence/drafts?mode=${mode}`, { cache: 'no-store' });
       if (!res.ok) return;
       const data = await res.json();
       if (typeof data.count === 'number') setCount(data.count);
@@ -33,7 +44,7 @@ export function useDraftsCount(): {
     } finally {
       setReady(true);
     }
-  }, []);
+  }, [mode]);
 
   useEffect(() => {
     refresh();

--- a/apps/unified-portal/app/agent/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/drafts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { MailCheck, Settings2 } from 'lucide-react';
 import AgentShell from '../_components/AgentShell';
 import DraftsListRow from '../_components/DraftsListRow';
@@ -12,6 +13,7 @@ import {
 } from '@/lib/agent-intelligence/autonomy';
 import UndoPill from '../_components/UndoPill';
 import { useAgent } from '@/lib/agent/AgentContext';
+import { deriveEffectiveMode } from '@/lib/agent/effective-mode';
 import { notifyDraftsChanged } from '../_hooks/useDraftsCount';
 import type { DraftRecord } from '@/lib/agent-intelligence/drafts';
 
@@ -24,7 +26,12 @@ interface UndoBatch {
 }
 
 export default function AgentDraftsPage() {
-  const { agent, alerts } = useAgent();
+  const { agent, alerts, activeWorkspace } = useAgent();
+  const pathname = usePathname();
+  // /agent/drafts is mode-neutral, so this falls back to the persisted
+  // active workspace and shows the inbox for whichever side the agent has
+  // currently selected via the header switcher.
+  const mode = deriveEffectiveMode(pathname, activeWorkspace?.mode);
   const [drafts, setDrafts] = useState<DraftRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -51,7 +58,7 @@ export default function AgentDraftsPage() {
 
   const loadDrafts = useCallback(async () => {
     try {
-      const res = await fetch('/api/agent/intelligence/drafts', { cache: 'no-store' });
+      const res = await fetch(`/api/agent/intelligence/drafts?mode=${mode}`, { cache: 'no-store' });
       if (!res.ok) return;
       const data = await res.json();
       setDrafts(data.drafts || []);
@@ -59,7 +66,7 @@ export default function AgentDraftsPage() {
       setLoading(false);
       setRefreshing(false);
     }
-  }, []);
+  }, [mode]);
 
   useEffect(() => { loadDrafts(); }, [loadDrafts]);
 

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
@@ -5,6 +5,7 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 import {
   resolveRecipient,
   toDraftRecord,
+  draftTypesForMode,
   type DraftRecord,
 } from '@/lib/agent-intelligence/drafts';
 
@@ -17,7 +18,7 @@ export const dynamic = 'force-dynamic';
  * Also returns a `count` field so the bottom nav / sidebar badge can stay
  * live without a second round trip.
  */
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
   try {
     const supabase = getSupabaseAdmin();
     const cookieStore = cookies();
@@ -29,12 +30,26 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ drafts: [], count: 0 }, { status: 200 });
     }
 
-    const { data: rows, error } = await supabase
+    // Workspace partition. `?mode=sales|lettings` restricts the list to draft
+    // types belonging to that workspace plus the shared `buyer_followup`
+    // type (used by both sales and lettings flows). Without `mode`, return
+    // every draft so legacy / non-workspace consumers behave as before.
+    const modeParam = request.nextUrl.searchParams.get('mode');
+    const mode: 'sales' | 'lettings' | null =
+      modeParam === 'sales' || modeParam === 'lettings' ? modeParam : null;
+
+    let query = supabase
       .from('pending_drafts')
       .select('*')
       .eq('user_id', userId)
       .eq('status', 'pending_review')
       .order('created_at', { ascending: false });
+
+    if (mode) {
+      query = query.in('draft_type', draftTypesForMode(mode));
+    }
+
+    const { data: rows, error } = await query;
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/apps/unified-portal/lib/agent-intelligence/context.ts
+++ b/apps/unified-portal/lib/agent-intelligence/context.ts
@@ -27,6 +27,12 @@ export interface SalesPipelineSummary {
   totalContractsIssued: number;
   totalSaleAgreed: number;
   totalAvailable: number;
+  overdueClosings: Array<{
+    schemeName: string;
+    purchaserName: string | null;
+    estimatedCloseDate: string;
+    daysOverdue: number;
+  }>;
 }
 
 export interface LettingsSummary {
@@ -367,12 +373,12 @@ export async function getSalesPipelineSummary(
 ): Promise<SalesPipelineSummary> {
   const devIds = agentContext.assignedSchemes.map(s => s.developmentId);
   if (!devIds.length) {
-    return { perScheme: [], totalUnits: 0, totalSold: 0, totalContractsIssued: 0, totalSaleAgreed: 0, totalAvailable: 0 };
+    return { perScheme: [], totalUnits: 0, totalSold: 0, totalContractsIssued: 0, totalSaleAgreed: 0, totalAvailable: 0, overdueClosings: [] };
   }
 
   const { data: pipeline } = await supabase
     .from('unit_sales_pipeline')
-    .select('development_id, status, sale_agreed_date, contracts_issued_date, signed_contracts_date, counter_signed_date, handover_date')
+    .select('development_id, status, sale_agreed_date, contracts_issued_date, signed_contracts_date, counter_signed_date, handover_date, estimated_close_date, purchaser_name')
     .eq('tenant_id', tenantId)
     .in('development_id', devIds);
 
@@ -412,7 +418,32 @@ export async function getSalesPipelineSummary(
   const totalSaleAgreed = perScheme.reduce((a, s) => a + s.counts.sale_agreed, 0);
   const totalAvailable = perScheme.reduce((a, s) => a + s.counts.available, 0);
 
-  return { perScheme, totalUnits, totalSold, totalContractsIssued, totalSaleAgreed, totalAvailable };
+  // Surface units whose estimated_close_date is already in the past and that
+  // haven't been handed over yet. The model otherwise sees "Est. Closing 1 Feb"
+  // alongside no urgency signal and treats it as a future date.
+  const schemeNameById = new Map<string, string>(
+    agentContext.assignedSchemes.map(s => [s.developmentId, s.schemeName]),
+  );
+  const overdueClosings = (pipeline || [])
+    .map((p: any) => {
+      if (!p.estimated_close_date) return null;
+      if (p.handover_date) return null;
+      const ms = new Date(p.estimated_close_date).getTime();
+      if (!Number.isFinite(ms)) return null;
+      const daysOverdue = Math.floor((Date.now() - ms) / 86400000);
+      if (daysOverdue <= 0) return null;
+      return {
+        schemeName: schemeNameById.get(p.development_id) || 'Unknown scheme',
+        purchaserName: p.purchaser_name || null,
+        estimatedCloseDate: p.estimated_close_date,
+        daysOverdue,
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+    .sort((a, b) => b.daysOverdue - a.daysOverdue)
+    .slice(0, 12);
+
+  return { perScheme, totalUnits, totalSold, totalContractsIssued, totalSaleAgreed, totalAvailable, overdueClosings };
 }
 
 export async function getLettingsSummary(
@@ -484,7 +515,10 @@ export async function getRenewalWindow(
   agentId: string
 ): Promise<RenewalWindowTenancy[]> {
   const today = new Date();
-  const todayIso = today.toISOString().split('T')[0];
+  // Widen backwards by 14 days so recently-expired-and-unrenewed leases surface
+  // as urgent next to upcoming renewals — without them the prose layer was
+  // blind to expired tenancies and the model invented "lease ends tomorrow".
+  const fourteenAgoIso = new Date(today.getTime() - 14 * 86400000).toISOString().split('T')[0];
   const ninetyIso = new Date(today.getTime() + 90 * 86400000).toISOString().split('T')[0];
 
   const { data, error } = await supabase
@@ -492,7 +526,7 @@ export async function getRenewalWindow(
     .select('id, agent_id, letting_property_id, tenant_name, tenant_email, lease_end, status, rent_pcm, notes')
     .eq('agent_id', agentId)
     .eq('status', 'active')
-    .gte('lease_end', todayIso)
+    .gte('lease_end', fourteenAgoIso)
     .lte('lease_end', ninetyIso);
 
   if (error || !data?.length) return [];
@@ -510,7 +544,9 @@ export async function getRenewalWindow(
   return data
     .map((t: any) => {
       const leaseEnd = new Date(t.lease_end);
-      const daysOut = Math.ceil((leaseEnd.getTime() - today.getTime()) / 86400000);
+      // Match the per-recipient helper exactly: floor against wall-clock so
+      // both layers agree at the day boundary.
+      const daysOut = Math.floor((leaseEnd.getTime() - Date.now()) / 86400000);
       const prop = propertyById.get(t.letting_property_id);
       return {
         tenancyId: t.id,

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -73,6 +73,45 @@ const BUYER_DRAFT_TYPES: readonly string[] = [
   'chain_update_to_buyer',
 ];
 
+// Workspace-mode partition for the drafts list filter. `buyer_followup` is
+// produced by both `draft_message` and `draft_buyer_followups`, both of
+// which are reachable from sales AND lettings flows (the lettings system
+// prompt at system-prompt.ts:645 and the registry's lettings recipient_type
+// branch). Keep it visible in BOTH modes — the alternative is hiding real
+// lettings drafts from the lettings inbox, which is worse than minor
+// cross-pollination.
+export const SALES_DRAFT_TYPES: readonly string[] = [
+  'solicitor_chase',
+  'viewing_followup',
+  'viewing_proposal',
+  'viewing_record',
+  'weekly_briefing',
+  'intelligence_report',
+  'intelligence_answer',
+  'intelligence_draft',
+  'schedule_viewing',
+  'vendor_update',
+  'offer_response',
+  'price_reduction_notice',
+  'chain_update_to_buyer',
+];
+
+export const LETTINGS_DRAFT_TYPES: readonly string[] = [
+  'lease_renewal',
+  'application_invitation',
+  'landlord_statement',
+];
+
+export const SHARED_DRAFT_TYPES: readonly string[] = [
+  'buyer_followup',
+];
+
+export function draftTypesForMode(mode: 'sales' | 'lettings'): string[] {
+  return mode === 'lettings'
+    ? [...LETTINGS_DRAFT_TYPES, ...SHARED_DRAFT_TYPES]
+    : [...SALES_DRAFT_TYPES, ...SHARED_DRAFT_TYPES];
+}
+
 export async function resolveRecipient(
   supabase: SupabaseClient,
   draftType: string,

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -100,13 +100,20 @@ function renderAgedContracts(rows: AgedContract[]): string {
 }
 
 function renderRenewalWindow(rows: RenewalWindowTenancy[]): string {
-  if (!rows.length) return 'RENEWAL WINDOW (next 90 days):\n- None.';
+  if (!rows.length) return 'RENEWAL WINDOW (expired ≤14d or upcoming ≤90d):\n- None.';
   const lines = rows.map(r => {
     const rpz = r.isRpz ? 'RPZ' : 'non-RPZ';
     const rent = r.currentRent ? ` @ ${fmtEuro(r.currentRent)}/mo` : '';
+    if (r.daysOut < 0) {
+      const n = Math.abs(r.daysOut);
+      return `- ${r.tenantName} — ${r.propertyAddress}${rent} — lease ENDED ${fmtDate(r.leaseEnd)} — ${n} day${n === 1 ? '' : 's'} ago, EXPIRED (${rpz})`;
+    }
+    if (r.daysOut === 0) {
+      return `- ${r.tenantName} — ${r.propertyAddress}${rent} — lease ends TODAY (${fmtDate(r.leaseEnd)}, ${rpz})`;
+    }
     return `- ${r.tenantName} — ${r.propertyAddress}${rent} — lease ends ${fmtDate(r.leaseEnd)} (${r.daysOut}d out, ${rpz})`;
   });
-  return `RENEWAL WINDOW (next 90 days):\n${lines.join('\n')}`;
+  return `RENEWAL WINDOW (expired ≤14d or upcoming ≤90d):\n${lines.join('\n')}`;
 }
 
 function renderRentArrears(rows: RentArrearsRecord[]): string {
@@ -122,7 +129,16 @@ function renderSalesPipeline(s: SalesPipelineSummary | null): string {
     return `- ${p.schemeName}: ${p.total} units — sold ${c.sold}, signed ${c.signed}, contracts issued ${c.contracts_issued}, sale agreed ${c.sale_agreed}, available ${c.available}`;
   });
   const totals = `  TOTALS: ${s.totalUnits} units — sold ${s.totalSold}, contracts issued ${s.totalContractsIssued}, sale agreed ${s.totalSaleAgreed}, available ${s.totalAvailable}`;
-  return `SALES PIPELINE (per scheme):\n${lines.join('\n')}\n${totals}`;
+  // Mirror the lettings expired-lease wording: capitalised "OVERDUE Nd" so the
+  // model treats past-due closing dates as urgent rather than future.
+  const overdueLines = (s.overdueClosings || []).map(o => {
+    const buyer = o.purchaserName ? ` — ${o.purchaserName}` : '';
+    return `- ${o.schemeName}${buyer} — Est. Closing ${fmtDate(o.estimatedCloseDate)} — OVERDUE ${o.daysOverdue}d`;
+  });
+  const overdueBlock = overdueLines.length
+    ? `\n\nOVERDUE CLOSINGS (estimated_close_date in the past, not yet handed over):\n${overdueLines.join('\n')}`
+    : '';
+  return `SALES PIPELINE (per scheme):\n${lines.join('\n')}\n${totals}${overdueBlock}`;
 }
 
 function renderLettingsSummary(l: LettingsSummary | null): string {
@@ -137,8 +153,6 @@ function renderLettingsSummary(l: LettingsSummary | null): string {
 // when a tenancy is active; "VACANT" otherwise. Capped at 30 lines.
 function renderLettingsPortfolio(l: LettingsSummary | null): string {
   if (!l || !l.total) return 'LETTINGS PORTFOLIO:\n- (no properties yet)';
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
   const lines = l.properties.slice(0, 30).map((p) => {
     const cityPart = p.city ? `, ${p.city}` : '';
     if (p.activeTenant) {
@@ -147,11 +161,23 @@ function renderLettingsPortfolio(l: LettingsSummary | null): string {
       let leasePart = '';
       if (t.leaseEnd) {
         const end = new Date(t.leaseEnd);
-        const days = Math.round((end.getTime() - today.getTime()) / 86_400_000);
-        const daysPart = Number.isFinite(days)
-          ? days < 0 ? `${Math.abs(days)}d ago` : days === 0 ? 'today' : `${days}d`
-          : '';
-        leasePart = `, lease ends ${fmtDate(t.leaseEnd)}${daysPart ? ` (${daysPart})` : ''}`;
+        // Floor against wall-clock time, identical to the per-recipient
+        // reasoning helper. Capitalised tense ("ENDED ... EXPIRED") gives the
+        // model an unambiguous past-tense anchor so it stops generating
+        // "lease ends tomorrow" prose for already-expired tenancies.
+        const days = Math.floor((end.getTime() - Date.now()) / 86_400_000);
+        if (Number.isFinite(days)) {
+          if (days < 0) {
+            const n = Math.abs(days);
+            leasePart = `, lease ENDED ${fmtDate(t.leaseEnd)} — ${n} day${n === 1 ? '' : 's'} ago, EXPIRED`;
+          } else if (days === 0) {
+            leasePart = `, lease ends TODAY (${fmtDate(t.leaseEnd)})`;
+          } else {
+            leasePart = `, lease ends ${fmtDate(t.leaseEnd)} (${days}d)`;
+          }
+        } else {
+          leasePart = `, lease ends ${fmtDate(t.leaseEnd)}`;
+        }
       }
       return `- ${p.address}${cityPart} — ${t.name} (${rentPart}${leasePart})`;
     }

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -696,10 +696,12 @@ export async function draftLeaseRenewal(
 ): Promise<AgenticSkillEnvelope> {
   const skill = 'draft_lease_renewal';
   const today = new Date();
-  const todayIso = today.toISOString().split('T')[0];
+  // Mirror getRenewalWindow: include leases that ended in the last 14 days so
+  // expired-but-unrenewed tenancies still get a renewal draft generated.
+  const fourteenAgoIso = new Date(today.getTime() - 14 * 86400000).toISOString().split('T')[0];
   const ninetyIso = new Date(today.getTime() + 90 * 86400000).toISOString().split('T')[0];
   const tenancyFilter = inputs.tenancy_id ? ` AND id = '${inputs.tenancy_id}'` : '';
-  const query = `agent_tenancies WHERE agent_id = '${agentContext.agentProfileId}' AND status = 'active' AND lease_end BETWEEN ${todayIso} AND ${ninetyIso}${tenancyFilter}`;
+  const query = `agent_tenancies WHERE agent_id = '${agentContext.agentProfileId}' AND status = 'active' AND lease_end BETWEEN ${fourteenAgoIso} AND ${ninetyIso}${tenancyFilter}`;
 
   try {
     let tenancyQ = supabase
@@ -707,7 +709,7 @@ export async function draftLeaseRenewal(
       .select('id, letting_property_id, tenant_name, tenant_email, lease_end, status, rent_pcm')
       .eq('agent_id', agentContext.agentProfileId)
       .eq('status', 'active')
-      .gte('lease_end', todayIso)
+      .gte('lease_end', fourteenAgoIso)
       .lte('lease_end', ninetyIso);
 
     if (inputs.tenancy_id) tenancyQ = tenancyQ.eq('id', inputs.tenancy_id);
@@ -721,8 +723,8 @@ export async function draftLeaseRenewal(
         skill,
         status: 'awaiting_approval',
         summary: inputs.tenancy_id
-          ? 'No matching active tenancy found in the 90-day renewal window.'
-          : 'No tenancies in the 90-day renewal window — nothing to draft.',
+          ? 'No matching active tenancy found in the renewal window (14 days expired through 90 days ahead).'
+          : 'No tenancies in the renewal window (14 days expired through 90 days ahead) — nothing to draft.',
         drafts: [],
         meta: { record_count: 0, generated_at: new Date().toISOString(), query },
       };
@@ -750,14 +752,21 @@ export async function draftLeaseRenewal(
         : 'Outside RPZ — rent held at current level for this renewal. Open to discussion.';
 
       const leaseEnd = new Date(t.lease_end);
-      const daysToLeaseEnd = Math.max(0, Math.round((leaseEnd.getTime() - today.getTime()) / 86400000));
+      const daysToLeaseEnd = Math.floor((leaseEnd.getTime() - Date.now()) / 86400000);
       const { firstName: tenantFirst } = parseTenantName(t.tenant_name);
       const leaseEndLabel = formatIrishDate(t.lease_end);
+      const expired = daysToLeaseEnd < 0;
+      const daysAbs = Math.abs(daysToLeaseEnd);
+      const leaseLine = expired
+        ? `Your lease at ${prop.address} ended on ${leaseEndLabel} (${daysAbs} day${daysAbs === 1 ? '' : 's'} ago) and hasn't been renewed yet.`
+        : daysToLeaseEnd === 0
+          ? `Your current lease at ${prop.address} ends today (${leaseEndLabel}).`
+          : `Your current lease at ${prop.address} is due to end on ${leaseEndLabel} (in ${daysToLeaseEnd} day${daysToLeaseEnd === 1 ? '' : 's'}).`;
 
       const body = [
         `Hi ${tenantFirst},`,
         ``,
-        `Your current lease at ${prop.address} is due to end on ${leaseEndLabel} (in ${daysToLeaseEnd} days).`,
+        leaseLine,
         ``,
         `We'd like to offer a renewal on the following terms:`,
         ``,
@@ -790,7 +799,7 @@ export async function draftLeaseRenewal(
           id: t.id,
           label: `${prop.address} — ${t.tenant_name || 'Tenant'}`,
         },
-        reasoning: `Lease ends ${leaseEndLabel}. Property is ${inRPZ ? 'in RPZ' : 'outside RPZ'}. Proposed rent: €${proposedRent} (current €${currentRent}, ${inRPZ ? 'within RPZ cap' : 'no statutory cap'}).${t.tenant_email ? '' : ' Tenant email is missing on the tenancy record; recipient set to placeholder pending capture.'}`,
+        reasoning: `${expired ? `Lease ended ${leaseEndLabel} (${daysAbs} day${daysAbs === 1 ? '' : 's'} ago, unrenewed).` : `Lease ends ${leaseEndLabel}.`} Property is ${inRPZ ? 'in RPZ' : 'outside RPZ'}. Proposed rent: €${proposedRent} (current €${currentRent}, ${inRPZ ? 'within RPZ cap' : 'no statutory cap'}).${t.tenant_email ? '' : ' Tenant email is missing on the tenancy record; recipient set to placeholder pending capture.'}`,
       };
     });
 

--- a/apps/unified-portal/lib/agent/effective-mode.ts
+++ b/apps/unified-portal/lib/agent/effective-mode.ts
@@ -1,0 +1,34 @@
+// Workspace mode resolution for the agent shell.
+//
+// `activeWorkspace.mode` (from AgentContext) is sticky — it reads from
+// `agent_profiles.last_active_workspace_id` and only changes when the header
+// switcher writes through `switchWorkspace()`. That left URL navigation out
+// of sync: visiting /agent/pipeline/... while the persisted workspace was
+// 'lettings' showed lettings tabs and the lettings header pill.
+//
+// `deriveEffectiveMode` resolves the mode the UI should display: the URL
+// pathname wins when it unambiguously belongs to one workspace, and we fall
+// back to the persisted workspace state for mode-neutral routes (intelligence,
+// drafts, settings, dashboard, profile).
+
+export type WorkspaceMode = 'sales' | 'lettings';
+
+const SALES_PREFIXES = [
+  '/agent/pipeline',
+  '/agent/applicants',
+  '/agent/viewings',
+  '/agent/home',
+  '/agent/enquiries',
+  '/agent/contacts',
+  '/agent/solicitors',
+];
+
+export function deriveEffectiveMode(
+  pathname: string | null | undefined,
+  fallback: WorkspaceMode | null | undefined,
+): WorkspaceMode {
+  const p = pathname || '';
+  if (p.startsWith('/agent/lettings')) return 'lettings';
+  if (SALES_PREFIXES.some((prefix) => p.startsWith(prefix))) return 'sales';
+  return fallback ?? 'sales';
+}


### PR DESCRIPTION
## Background

Two audits run against production commit `b2e1453` surfaced two foundational bugs that were poisoning every downstream feature in the OpenHouse Agent app. First, the lettings Intelligence layer was telling the agent that an already-expired lease was "ending tomorrow" — the date math in the lettings system prompt used a different formula from the per-recipient reasoning helper, and the 90-day "expiring leases" query was forward-only so already-expired leases never reached the LLM. Second, the BottomNav and header pill rendered the persisted workspace mode regardless of which page the user was on, so navigating directly to a sales URL while the persisted workspace was lettings showed lettings tabs and the lettings pill on a sales page; the drafts list was also unfiltered by mode, so sales and lettings drafts mingled in the same inbox.

## Root causes

These are the parts future-you will care about — both audits initially proposed glamorous causes that turned out to be wrong, and the real causes are smaller and more specific.

**Date awareness — NOT a `Date()` caching bug at module load.** I searched `lib/agent-intelligence/` and `app/api/agent-intelligence/` for top-level `const now = new Date()` patterns; none exist. Every date computation runs at request, render, or skill time. Two real causes:

1. `renderLettingsPortfolio` in `system-prompt.ts` computed days as `Math.round((leaseEnd - today) / 86_400_000)` after mutating `today` with `setHours(0, 0, 0, 0)`, while the per-recipient reasoning helper computed days as `Math.floor((leaseEnd - Date.now()) / 86_400_000)` against full wall-clock time. The two layers could disagree by a day at the boundary, and the parenthetical `(1d ago)` annotation was too weak a signal — the LLM would re-derive its own answer and emit "lease ends tomorrow, 4 May 2026".
2. `getRenewalWindow` in `context.ts` filtered `lease_end >= today AND lease_end <= today + 90d`, forward-only. Already-expired leases were dropped at the SQL layer, never reached the system prompt's RENEWAL WINDOW block, never made it into `draftLeaseRenewal`'s candidate set. The model was free to hallucinate from the LETTINGS PORTFOLIO line alone, and that's exactly what it did.

**Workspace bleed — NOT a URL-driven state writer.** I searched every layout and page under `app/agent/` for code that writes active-workspace state based on URL; none exists. The actual mechanism is the inverse: workspace state is sticky in `agent_profiles.last_active_workspace_id`, `BottomNav` and `StatusBar` read it verbatim, and the `/api/agent/intelligence/drafts` route applies no mode filter. So a sales URL viewed while the persisted workspace was lettings showed lettings UI, the drafts inbox showed everything regardless of mode, and the user perceived this as "the URL switched my workspace" when it really just exposed the sticky-state mismatch.

## Fix summary

Ten surgical changes across nine files, plus one new helper module. No schema changes, no routing changes, per-recipient reasoning helpers untouched.

1. `getRenewalWindow` widens the SQL window to `today - 14d ... today + 90d` so recently-expired-and-unrenewed leases surface alongside upcoming renewals.
2. `daysOut` in `getRenewalWindow` switches to `Math.floor((leaseEnd - Date.now()) / 86_400_000)` to match the per-recipient helper exactly.
3. `renderLettingsPortfolio` adopts the same floor math and switches to capitalised past-tense wording for expired leases (`lease ENDED <date> — N days ago, EXPIRED`) so the model has an unambiguous past-tense anchor.
4. `renderRenewalWindow` mirrors the same wording for negative `daysOut` rows now that the window can include them.
5. `draftLeaseRenewal` in `agentic-skills.ts` mirrors the widened window and rewrites the email body and reasoning string for expired leases (`Your lease at X ended on Y (N days ago) and hasn't been renewed yet`).
6. `SalesPipelineSummary.overdueClosings` is added as a top-12 list of units whose `estimated_close_date` is in the past and that haven't been handed over. `renderSalesPipeline` appends an `OVERDUE CLOSINGS` block with `OVERDUE Nd` wording, mirroring the lettings expired-lease style.
7. New helper `lib/agent/effective-mode.ts` exports `deriveEffectiveMode(pathname, fallback)` — pathname wins when it unambiguously belongs to one workspace, persisted workspace wins on mode-neutral routes (`intelligence`, `drafts`, `settings`, `dashboard`, `profile`).
8. `BottomNav` and `StatusBar` consume `deriveEffectiveMode` so the tab set, header pill, and ModeBadge match the URL the user is on.
9. `/api/agent/intelligence/drafts` accepts `?mode=sales|lettings` and filters by `draft_type` partition exported from `drafts.ts` (`SALES_DRAFT_TYPES`, `LETTINGS_DRAFT_TYPES`, `SHARED_DRAFT_TYPES`).
10. `/agent/drafts` and `useDraftsCount` derive the effective mode and pass it through, so the inbox list and badge are workspace-scoped.

**A3 (move `Today: <date>` to the top of the lettings live context block) is intentionally deferred.** The audit rated it MEDIUM-confidence reinforcing-only. Ship A2 alone first; if the live test against Aoife's renewal flow still shows date confusion, A3 is the obvious follow-up. **A5 (sales overdue annotation)** was included in this commit despite technically being a separate ticket, because it's the same rendering-an-urgency-annotation pattern in the same file — doing it now is cheaper than touching `system-prompt.ts` twice.

## buyer_followup caveat

The `buyer_followup` draft type is reachable from BOTH sales and lettings flows. Three independent call sites confirmed this:

- `lib/agent-intelligence/draft-store.ts:27-28` maps both `draft_message` and `draft_buyer_followups` skills to `buyer_followup`.
- `lib/agent-intelligence/system-prompt.ts:645` (lettings system prompt) explicitly tells the lettings model to use those skills for tenants.
- `lib/agent-intelligence/tools/registry.ts:228` (`draft_message` registry entry) has a dedicated `recipient_type='tenant'` lettings branch.

Rather than hide real lettings drafts from the lettings inbox, `buyer_followup` lives in `SHARED_DRAFT_TYPES` and is included in both `draftTypesForMode('sales')` and `draftTypesForMode('lettings')`. Cross-pollination of one type beats hiding real work. The clean fix is a `workspace_mode` column on `pending_drafts`, but that's a schema change and out of scope for this commit.

## Test plan

- [ ] Test 1 — Aoife renewal copy. Send to Intelligence: "Help me with Aoife O'Brien's lease renewal." Expect past-tense wording ("ended" / "expired") with a day count. Fail if the response says "tomorrow" or "due to expire".
- [ ] Test 2 — Renewal window query. Send: "Which tenancies have leases expiring in the next 90 days?" Expect Aoife O'Brien to appear marked EXPIRED with a negative day count or "ended X days ago". Fail if she's absent.
- [ ] Test 3 — Direct URL workspace bleed. While in lettings mode, type `/agent/pipeline` directly into the URL bar. Expect SALES tabs and SALES pill. Then navigate to `/agent/intelligence` and expect the BottomNav to reflect the persisted workspace (sticky on neutral routes is intentional).
- [ ] Test 4 — Drafts segregation. In SALES mode, open `/agent/drafts` and expect only sales draft types plus shared `buyer_followup`. Switch to LETTINGS mode, reload, and expect only lettings draft types plus shared `buyer_followup`.

## Out of scope

The following are queued as separate prompts and intentionally not addressed here: viewing scheduler raw JSON, RPZ math precision, drafts queue cleanup, ranker scoping.

https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk)_