### PR TITLE
fix(agent): split renewal block, fix send-draft for agentic-skill drafts, batch failure visibility

### DIFF
--- a/apps/unified-portal/app/agent/drafts/page.tsx
+++ b/apps/unified-portal/app/agent/drafts/page.tsx
@@ -310,8 +310,9 @@ export default function AgentDraftsPage() {
 
   const batchSend = useCallback(async () => {
     if (!selectedDrafts.length) return;
+    const total = selectedDrafts.length;
     const confirmed = typeof window !== 'undefined'
-      ? window.confirm(`Send ${selectedDrafts.length} draft${selectedDrafts.length === 1 ? '' : 's'} now?`)
+      ? window.confirm(`Send ${total} draft${total === 1 ? '' : 's'} now?`)
       : true;
     if (!confirmed) return;
     setBatchBusy('send');
@@ -336,6 +337,16 @@ export default function AgentDraftsPage() {
         });
         notifyDraftsChanged();
       }
+      const failed = total - sentIds.length;
+      if (typeof window !== 'undefined') {
+        if (sentIds.length === 0) {
+          window.alert(`None of the ${total} drafts could be sent — check the list for failures.`);
+        } else if (failed > 0) {
+          window.alert(`Sent ${sentIds.length} of ${total} drafts. The remaining ${failed} could not be sent — check the list for failures.`);
+        } else {
+          window.alert(`Sent ${sentIds.length} of ${total} drafts.`);
+        }
+      }
     } finally {
       setBatchBusy(null);
     }
@@ -343,8 +354,9 @@ export default function AgentDraftsPage() {
 
   const batchDiscard = useCallback(async () => {
     if (!selectedDrafts.length) return;
+    const total = selectedDrafts.length;
     const confirmed = typeof window !== 'undefined'
-      ? window.confirm(`Discard ${selectedDrafts.length} draft${selectedDrafts.length === 1 ? '' : 's'}? This can't be undone.`)
+      ? window.confirm(`Discard ${total} draft${total === 1 ? '' : 's'}? This can't be undone.`)
       : true;
     if (!confirmed) return;
     setBatchBusy('discard');
@@ -369,6 +381,14 @@ export default function AgentDraftsPage() {
         }
         notifyDraftsChanged();
       }
+      const failed = total - deletedIds.length;
+      if (failed > 0 && typeof window !== 'undefined') {
+        window.alert(
+          deletedIds.length === 0
+            ? `None of the ${total} drafts could be discarded — check the list for failures.`
+            : `Discarded ${deletedIds.length} of ${total} drafts. The remaining ${failed} could not be discarded — check the list for failures.`,
+        );
+      }
     } finally {
       setBatchBusy(null);
     }
@@ -380,6 +400,7 @@ export default function AgentDraftsPage() {
       ? window.prompt(`Tweak instruction for ${selectedDrafts.length} draft${selectedDrafts.length === 1 ? '' : 's'} (e.g. "make these warmer", "add a viewing offer"):`)
       : null;
     if (!instruction || instruction.trim().length < 2) return;
+    const total = selectedDrafts.length;
     setBatchBusy('tweak');
     try {
       const res = await fetch('/api/agent/intelligence/drafts/tweak-all', {
@@ -391,12 +412,15 @@ export default function AgentDraftsPage() {
         }),
       });
       if (!res.ok) {
-        alert('Could not tweak those drafts.');
+        if (typeof window !== 'undefined') {
+          window.alert(`Could not tweak those drafts. None of the ${total} were rewritten.`);
+        }
         return;
       }
       const data = await res.json();
+      const rewrites = (data.rewrites || []) as Array<{ id: string; subject: string; body: string }>;
       const byId = new Map<string, { id: string; subject: string; body: string }>(
-        (data.rewrites || []).map((r: any) => [r.id, r]),
+        rewrites.map((r) => [r.id, r]),
       );
       setDrafts((prev) => prev.map((d) => {
         const r = byId.get(d.id);
@@ -406,6 +430,11 @@ export default function AgentDraftsPage() {
       // Selection persists after a tweak — the same drafts are still in the
       // list, just with rewritten content, so the agent can immediately
       // batch-send if happy with the new copy.
+      const tweaked = rewrites.length;
+      const failed = total - tweaked;
+      if (failed > 0 && typeof window !== 'undefined') {
+        window.alert(`Tweaked ${tweaked} of ${total} drafts. The remaining ${failed} could not be rewritten — check the list for failures.`);
+      }
     } finally {
       setBatchBusy(null);
     }

--- a/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
@@ -57,7 +57,16 @@ export async function POST(request: NextRequest) {
     if (user && draft.user_id !== user.id) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
+    console.log('[send-draft] entry', {
+      draftId,
+      userId: draft.user_id,
+      draftType: draft.draft_type,
+      status: draft.status,
+      sendMode,
+    });
+
     if (draft.status !== 'pending_review' && draft.status !== 'auto_sending') {
+      console.warn('[send-draft] rejected: wrong status', { draftId, status: draft.status });
       return NextResponse.json(
         { error: `Draft is already in status "${draft.status}"` },
         { status: 409 }
@@ -81,6 +90,13 @@ export async function POST(request: NextRequest) {
     }
 
     const recipient = await resolveRecipient(supabase, draft.draft_type, draft.recipient_id);
+    console.log('[send-draft] recipient resolved', {
+      draftId,
+      draftType: draft.draft_type,
+      source: recipient.source,
+      hasEmail: !!recipient.email,
+      hasPhone: !!recipient.phone,
+    });
     const sendMethod = draft.send_method || 'email';
     const batchId = randomUUID();
     const sentAt = new Date().toISOString();
@@ -97,6 +113,13 @@ export async function POST(request: NextRequest) {
 
     if (sendMethod === 'email') {
       if (!recipient.email) {
+        console.warn('[send-draft] rejected: no recipient email', {
+          draftId,
+          draftType: draft.draft_type,
+          recipientIdShape: typeof draft.recipient_id === 'string'
+            ? (draft.recipient_id.includes('@') ? 'email-like' : 'non-email')
+            : 'null',
+        });
         return NextResponse.json(
           {
             error:
@@ -116,7 +139,16 @@ export async function POST(request: NextRequest) {
         });
         provider = 'resend';
         providerMessageId = (result as any)?.data?.id ?? (result as any)?.id ?? null;
+        console.log('[send-draft] email sent', {
+          draftId,
+          provider,
+          providerMessageId,
+        });
       } catch (err: any) {
+        console.error('[send-draft] resend rejected', {
+          draftId,
+          message: err?.message || 'unknown',
+        });
         return NextResponse.json(
           {
             error: 'Email provider rejected the send',

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -163,11 +163,21 @@ export async function resolveRecipient(
     }
   }
 
-  // Fallback — display the raw reference so the user sees what the voice heard.
+  // Fallback. Agentic-skill drafts (lease_renewal, viewing_proposal,
+  // weekly_briefing, intelligence_*, etc.) are persisted by draft-store.ts
+  // with `recipient_id` set to the literal email string — see
+  // draft-store.ts:212-214. resolveRecipient never had a handler for those
+  // draft types, so it always returned email=null and the send-draft route
+  // bailed at "No email on file" for every agentic-skill-typed draft. Detect
+  // the email-shaped recipient_id here and surface it as the email so single
+  // and batch send work for those drafts. recipient.name still falls back to
+  // the email string itself; the drafts list typically renders subject /
+  // body rather than recipient.name as the primary identifier.
+  const isEmailShaped = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipientId);
   return {
     id: recipientId,
     name: recipientId,
-    email: null,
+    email: isEmailShaped ? recipientId : null,
     phone: null,
     source: 'unknown',
   };

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -100,8 +100,25 @@ function renderAgedContracts(rows: AgedContract[]): string {
 }
 
 function renderRenewalWindow(rows: RenewalWindowTenancy[]): string {
-  if (!rows.length) return 'RENEWAL WINDOW (expired ≤14d or upcoming ≤90d):\n- None.';
-  const lines = rows.map(r => {
+  if (!rows.length) return 'RENEWAL ATTENTION (recently expired OR ending within 90 days — both are urgent):\n- None.';
+
+  // Structural split. EXPIRED entries live in their own section so the model
+  // can't filter them out by question phrasing ("expiring in 90 days" reads
+  // forward-tense; before this split the model treated the EXPIRED rows as
+  // out-of-scope). The two sections are sorted independently:
+  //   - RECENTLY EXPIRED: most-recent expiry first (smallest |daysOut|).
+  //   - UPCOMING RENEWALS: nearest lease-end first (smallest daysOut).
+  // Empty sections are omitted entirely so the prompt stays compact.
+  const expired = rows
+    .filter((r) => r.daysOut < 0)
+    .slice()
+    .sort((a, b) => Math.abs(a.daysOut) - Math.abs(b.daysOut));
+  const upcoming = rows
+    .filter((r) => r.daysOut >= 0)
+    .slice()
+    .sort((a, b) => a.daysOut - b.daysOut);
+
+  const renderRow = (r: RenewalWindowTenancy): string => {
     const rpz = r.isRpz ? 'RPZ' : 'non-RPZ';
     const rent = r.currentRent ? ` @ ${fmtEuro(r.currentRent)}/mo` : '';
     if (r.daysOut < 0) {
@@ -112,8 +129,16 @@ function renderRenewalWindow(rows: RenewalWindowTenancy[]): string {
       return `- ${r.tenantName} — ${r.propertyAddress}${rent} — lease ends TODAY (${fmtDate(r.leaseEnd)}, ${rpz})`;
     }
     return `- ${r.tenantName} — ${r.propertyAddress}${rent} — lease ends ${fmtDate(r.leaseEnd)} (${r.daysOut}d out, ${rpz})`;
-  });
-  return `RENEWAL WINDOW (expired ≤14d or upcoming ≤90d):\n${lines.join('\n')}`;
+  };
+
+  const sections: string[] = [];
+  if (expired.length) {
+    sections.push(`RECENTLY EXPIRED (urgent — already overdue, action required):\n${expired.map(renderRow).join('\n')}`);
+  }
+  if (upcoming.length) {
+    sections.push(`UPCOMING RENEWALS (ending within 90 days):\n${upcoming.map(renderRow).join('\n')}`);
+  }
+  return sections.join('\n\n');
 }
 
 function renderRentArrears(rows: RentArrearsRecord[]): string {
@@ -757,7 +782,21 @@ PROACTIVE INTELLIGENCE:
 ============================================================
 - Flag related issues the agent might not have thought of, but only when supported by the live context.
 - Call out RPZ implications on renewals (2% cap), upcoming lease ends inside the 90-day notice window, and missing RTB registrations on active tenancies.
-- Never invent patterns or communication history.`;
+- Never invent patterns or communication history.
+
+============================================================
+RENEWAL ATTENTION — HOW TO ANSWER "WHICH LEASES ARE EXPIRING":
+============================================================
+The live context above splits renewal-attention tenancies into TWO blocks:
+
+  RECENTLY EXPIRED (urgent — already overdue, action required)
+  UPCOMING RENEWALS (ending within 90 days)
+
+When the user asks about leases "expiring", "ending", "due", "in the next N days", "in the renewal window", or anything that touches lease end timing, the response MUST surface the RECENTLY EXPIRED section FIRST as the most urgent items, then the UPCOMING RENEWALS section. Recently expired leases require MORE urgent action than upcoming ones — the tenancy is already past its end date and the agent is overdue on the renewal conversation.
+
+Do NOT filter out the RECENTLY EXPIRED block based on the user's question phrasing. "Expiring in the next 90 days" is forward-tense English but the agent's operational concern is the renewal window — past-due tenancies are the most pressing items in that window, not out-of-scope.
+
+If RECENTLY EXPIRED is empty, omit it from the response and answer with the UPCOMING RENEWALS list. If both blocks are empty, say "No tenancies in the renewal window — nothing pending."`;
 
   return `${identityBlock}\n\n${scopeBlock}\n\n${basePrompt}`;
 }

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -611,10 +611,22 @@ export async function weeklyMondayBriefing(
     if (!renewals.length) {
       lettingsLines.push('No renewals due in the window.');
     } else {
-      lettingsLines.push(`Renewal windows opening: ${renewals.length} tenanc${renewals.length === 1 ? 'y' : 'ies'} in next 90 days.`);
+      const expiredCount = renewals.filter((r) => r.daysOut < 0).length;
+      const upcomingCount = renewals.length - expiredCount;
+      const summary = expiredCount && upcomingCount
+        ? `${expiredCount} recently expired, ${upcomingCount} ending within 90 days.`
+        : expiredCount
+          ? `${expiredCount} recently expired (urgent — already overdue).`
+          : `${upcomingCount} ending within 90 days.`;
+      lettingsLines.push(`Renewal attention: ${renewals.length} tenanc${renewals.length === 1 ? 'y' : 'ies'} — ${summary}`);
       lettingsLines.push('');
       for (const r of renewals) {
-        lettingsLines.push(`- ${r.propertyAddress} — ${r.tenantName} — ${r.daysOut} days to lease end`);
+        if (r.daysOut < 0) {
+          const n = Math.abs(r.daysOut);
+          lettingsLines.push(`- ${r.propertyAddress} — ${r.tenantName} — EXPIRED ${n} day${n === 1 ? '' : 's'} ago`);
+        } else {
+          lettingsLines.push(`- ${r.propertyAddress} — ${r.tenantName} — ${r.daysOut} days to lease end`);
+        }
       }
     }
 


### PR DESCRIPTION
## Background

Two real failures from the eight-test verification of PR #86 (commit `75b9de88`):
- **Test 2 (FAIL):** "Which tenancies have leases expiring in the next 90 days?" — Aoife O'Brien (lease ended yesterday) was absent from the response despite being in the data.
- **Test 8 (FAIL):** Selecting two drafts and tapping Send — the button cycled "Sending…" then reverted to "Send 2", both rows remained, no error surfaced.

A third observation (sales drafts page briefly flipping to lettings then redirecting to /agent/intelligence) is parked — the audit found no redirect logic in the code and the symptom needs a clean reproduction.

## Root causes

**Test 2 — model-side filtering driven by question phrasing, not a data bug.** PR #85 widened `getRenewalWindow` to `today-14d → today+90d` so Aoife's just-expired tenancy IS in the live context with `daysOut = -1` and EXPIRED tagging. DB confirms her record is `status='active'`, `lease_end='2026-05-04'`. The renderer emits her correctly. The model still excluded her because the user's question used forward-tense "expiring in the next 90 days" English — and the system prompt did not explicitly tell the model that EXPIRED rows in the renewal block must surface for that class of question. The single section header was easy for the LLM to reinterpret as forward-only.

**Test 8 — `resolveRecipient` had no handler for agentic-skill draft types.** Every agentic-skill draft (lease_renewal, viewing_proposal, viewing_followup, weekly_briefing, intelligence_*, schedule_viewing) is persisted by `draft-store.ts:212-214` with `recipient_id` set to the literal email string. `resolveRecipient` in `drafts.ts:115-174` had handlers for `vendor_update`, `BUYER_DRAFT_TYPES`, and `application_invitation`, then a fallback that returned `email: null`. The send-draft route at `route.ts:99` checks `recipient.email` and bails 400 "No email on file…" for any draft whose type wasn't explicitly handled. Production DB confirms: no draft for Sarah Mitchell has ever reached `status='sent'`. Single-quick-send (swipe-right) and review-panel-send had the exact same failure mode; the audits never tested them. Batch-send was the one that surfaced the bug because it failed multiple times in a row visibly.

The batch handler also swallowed per-row failures silently — `sentIds` stayed empty, the button reverted, no signal to the user. Equivalent silent-failure pattern in `batchDiscard` and `batchTweak`.

## What this PR ships

**A. Renewal block splits into two structurally-distinct sections.** `renderRenewalWindow` in `system-prompt.ts:102` now emits up to two blocks:

- `RECENTLY EXPIRED (urgent — already overdue, action required)` — sorted most-recent-first
- `UPCOMING RENEWALS (ending within 90 days)` — sorted nearest-first

Empty sections are omitted entirely. The structural separation makes it impossible for the model to filter EXPIRED rows out by question phrasing — they're in their own labelled block.

The lettings system prompt (`buildLettingsAgentSystemPrompt`) gains a `RENEWAL ATTENTION` block at the bottom that explicitly references both sections and instructs the model: "When the user asks about leases expiring, ending, due, or in the next N days, the response MUST surface the RECENTLY EXPIRED section first as the most urgent items, then UPCOMING RENEWALS. Recently expired leases require MORE urgent action than upcoming ones."

`weeklyMondayBriefing` summary wording in `agentic-skills.ts:609-619` reflects the split — counts expired and upcoming separately, renders expired rows as "EXPIRED N days ago" rather than negative-day-count.

**B. Send fix + visibility.**

1. `resolveRecipient` fallback (`drafts.ts:166-178`) now detects email-shaped `recipient_id` and returns it as the email. Single-line guard around the existing fallback. Fixes single-quick-send, review-panel-send, AND batch-send for every agentic-skill draft type. The `recipient.name` continues to fall back to the recipient_id string; the drafts list typically renders subject/body rather than recipient.name as the primary identifier.
2. Batch handlers on `/agent/drafts` (`page.tsx`) now surface partial failures via `window.alert`. Wording for batchSend: "Sent N of M drafts. The remaining N could not be sent — check the list for failures." Equivalents for batchDiscard / batchTweak. Total-success path is silent for batchDiscard/Tweak; batchSend always confirms a successful all-OK send.
3. `send-draft` route gains structured logs at entry, after `resolveRecipient`, at the resend success/failure, and at the no-email rejection. Mirrors the tweak-all instrumentation from PR #86. Captures the data we need to diagnose silently-failing send attempts in production logs going forward.

**C. Sales-drafts redirect — parked.** No code in the drafts page or its consumers redirects to `/agent/intelligence`. The "briefly flipped to LETTINGS" is the documented async-fallback behaviour for mode-neutral routes (PR #85). Needs a clean reproduction with screen recording before any further investigation.

## Test plan (run after preview Ready — DO NOT MERGE before)

- [ ] **T2-redo.** Lettings → Intelligence: "Which tenancies have leases expiring in the next 90 days?" PASS = Aoife O'Brien surfaces FIRST under a "recently expired" / "urgent" framing, then the four future-dated tenancies. FAIL = Aoife absent OR not surfaced as more urgent.
- [ ] **T8-redo.** /agent/drafts in either mode → select 2 drafts → Send. PASS = both rows disappear, counter drops by 2, alert says "Sent 2 of 2 drafts." (or no alert if you prefer silent-success). PARTIAL = some succeed and an alert surfaces correctly with N of M wording. FAIL = "Sending…" reverts to "Send 2", rows remain, no alert.
- [ ] **Smoke-test single-send.** Any draft row → swipe right → Send. PASS = row disappears, counter drops by 1. Confirms B's resolver fix benefits both batch and single paths.

## Constraints respected

No schema changes. No routing refactor. Per-recipient reasoning helpers (PR #84), workspace-mode filtering (PR #85), drafts-queue scope filter (PR #86) untouched.

https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk)_