### PR TITLE
fix(agent-lettings): query_compliance_status correctness — dimension-aware filter, vacant exclusion, fill-rate score

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -768,13 +768,37 @@ COMMON INTENTS — what to do when you see these patterns:
   "Which tenancies are missing a BER cert?" OR "Show me overdue gas safety" OR
   "Which BER certs expire in the next 60 days?" OR "What's my compliance score?" OR
   "Which tenancies are missing an RTB registration?"
-  → Call query_compliance_status with the appropriate filter and document_type. Examples:
-       "missing BER" → filter="missing", document_type="ber"
-       "expiring within 60 days" → filter="expiring_soon", document_type="ber"
-       "compliance gaps for {tenant}" → filter="missing", document_type="all" (then narrow to that tenant's record from meta.records)
-       "compliance score" / "how's my portfolio doing" → filter="all" (the summary names the overall percentage)
-       "missing RTB" → filter="missing", document_type="rtb"
-     The skill returns a one-sentence summary suitable for the chat reply plus structured per-tenancy records on meta.records. The COMPLIANCE ATTENTION block in your live context already lists the most urgent items (BER expired, expiring within 60 days, missing RTB on active tenancies) so you can mention those proactively without a tool call when the user asks "what needs my attention".
+  → Call query_compliance_status with the appropriate filter and document_type.
+
+  CRITICAL — document_type MUST be set to a specific dimension when the user
+  names one ("BER", "gas safety", "electrical", "RTB", "signed lease"). The
+  default 'all' is reserved strictly for portfolio-wide queries that don't
+  name any one cert type. Passing document_type='all' when the user named
+  a specific dimension produces a wrong answer (returns every tenancy with
+  any outstanding item, not just the named cert).
+
+  Examples:
+       "Which tenancies are missing a BER cert?"
+         → filter='missing', document_type='ber'
+       "Show me overdue gas safety"
+         → filter='expired', document_type='gas_safety'
+       "Which BER certs expire in the next 60 days?"
+         → filter='expiring_soon', document_type='ber'
+       "Which tenancies are missing an RTB registration?"
+         → filter='missing', document_type='rtb'
+       "What's outstanding across the portfolio?" / "Show me everything outstanding"
+         → filter='missing', document_type='all'
+       "What's my compliance score?" / "How's my portfolio doing on compliance?"
+         → filter='all', document_type='all'
+       "Compliance gaps for {tenant}"
+         → filter='missing', document_type='all' (then narrow to that tenant's record from meta.records)
+
+  The skill returns a one-sentence summary suitable for the chat reply plus
+  structured per-tenancy records on meta.records. The COMPLIANCE ATTENTION
+  block in your live context already lists the most urgent items (BER
+  expired, expiring within 60 days, missing RTB on active tenancies) so you
+  can mention those proactively without a tool call when the user asks
+  "what needs my attention".
 
 ============================================================
 TOOL USE — LETTINGS MODE:

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -3408,6 +3408,18 @@ export async function queryComplianceStatus(
       };
     }
 
+    // Sub-bug 2 — asymmetric vacant handling.
+    //
+    // - filter='missing'     EXCLUDES vacant. Vacant properties are between
+    //                        tenancies; their missing certs are a re-letting
+    //                        prep concern, not an active compliance gap.
+    // - filter='expired'     KEEPS vacant. A vacant property with an expired
+    //                        BER blocks re-letting; the agent needs to know.
+    // - filter='expiring_soon' KEEPS vacant for the same reason.
+    //
+    // Do NOT "fix" this back to a uniform exclusion — the asymmetry is
+    // deliberate and tracks the agent's mental model: missing-on-vacant is
+    // less urgent than expiring-on-vacant.
     let filtered: LettingsComplianceRecord[];
     if (filter === 'expired') {
       // Only BER carries an expiry in this schema; other dimensions don't have
@@ -3416,17 +3428,149 @@ export async function queryComplianceStatus(
     } else if (filter === 'expiring_soon') {
       filtered = records.filter(r => r.ber.daysToExpiry !== null && r.ber.daysToExpiry >= 0 && r.ber.daysToExpiry <= 60);
     } else if (filter === 'missing') {
-      filtered = records.filter(r => !complianceDimensionOk(r, docType));
+      filtered = records.filter(r => !r.isVacant && !complianceDimensionOk(r, docType));
     } else {
       filtered = records;
     }
 
-    // Compliance score = fully-compliant non-vacant tenancies / total non-vacant.
     const nonVacant = records.filter(r => !r.isVacant);
-    const fullyCompliant = nonVacant.filter(r => r.outstandingCount === 0);
-    const compliancePct = nonVacant.length === 0
+
+    // Sub-bug 3 — fill-rate compliance score.
+    //
+    // Previous formula was "fully-compliant tenancies / non-vacant tenancies",
+    // which required EVERY dimension OK per tenancy. With 0 docs uploaded
+    // (which is the common state today), no tenancy is fully compliant, so
+    // the score collapsed to 0% even when ber_cert_number / RTB number ARE
+    // recorded on the row. The fill-rate metric is more honest: it reads
+    // "what fraction of applicable conditions are OK across all non-vacant
+    // tenancies?". For a portfolio with 4 BER + 11 RTB OK out of 12*5 = 60
+    // applicable conditions, that's 25% — recoverable, not catastrophic.
+    const okConditions = nonVacant.reduce((sum, r) => {
+      let n = 0;
+      if (r.ber.ok) n++;
+      if (r.gasSafety.ok) n++;
+      if (r.electrical.ok) n++;
+      if (r.rtb.applicable && r.rtb.ok) n++;
+      if (r.signedLease.ok) n++;
+      return sum + n;
+    }, 0);
+    const applicableConditions = nonVacant.reduce((sum, r) => {
+      // For non-vacant records: BER, gas, electrical, signed lease are always
+      // applicable (4); RTB is applicable when the tenancy is active (which
+      // it is for every record in nonVacant). So denominator is 5 per record.
+      // Kept explicit so a future schema change (e.g. doc applicability rules
+      // varying by property type) doesn't silently miscount.
+      return sum + 4 + (r.rtb.applicable ? 1 : 0);
+    }, 0);
+    const compliancePct = applicableConditions === 0
       ? null
-      : Math.round((fullyCompliant.length / nonVacant.length) * 100);
+      : Math.round((okConditions / applicableConditions) * 100);
+
+    // Per-dimension OK / total counts across non-vacant — used by both the
+    // missing+all breakdown (sub-bug 1b) and the score-summary tail.
+    const dimensionTotals = (() => {
+      const tally = {
+        ber: { ok: 0, total: nonVacant.length },
+        gasSafety: { ok: 0, total: nonVacant.length },
+        electrical: { ok: 0, total: nonVacant.length },
+        rtb: { ok: 0, total: 0 },
+        signedLease: { ok: 0, total: nonVacant.length },
+      };
+      for (const r of nonVacant) {
+        if (r.ber.ok) tally.ber.ok++;
+        if (r.gasSafety.ok) tally.gasSafety.ok++;
+        if (r.electrical.ok) tally.electrical.ok++;
+        if (r.rtb.applicable) {
+          tally.rtb.total++;
+          if (r.rtb.ok) tally.rtb.ok++;
+        }
+        if (r.signedLease.ok) tally.signedLease.ok++;
+      }
+      return tally;
+    })();
+
+    // Sub-bug 3b — dynamic strong/weak breakdown sentence. Picks the 1-2
+    // strongest dimensions (highest OK ratio) to highlight first, then names
+    // the weakest 1-3 as "not yet uploaded" / "need attention". One sentence
+    // only. Adapts to whatever the actual numerator distribution is — no
+    // hardcoded strong/weak assumptions.
+    const buildBreakdownSentence = (): string => {
+      const labelOf: Record<string, string> = {
+        ber: 'BER',
+        gasSafety: 'gas safety',
+        electrical: 'electrical',
+        rtb: 'RTB',
+        signedLease: 'signed lease',
+      };
+      const dims = (Object.entries(dimensionTotals) as Array<[keyof typeof dimensionTotals, { ok: number; total: number }]>)
+        .filter(([, v]) => v.total > 0)
+        .map(([k, v]) => ({ key: String(k), label: labelOf[String(k)], ok: v.ok, total: v.total, ratio: v.ok / v.total }));
+      if (!dims.length) return '';
+      const strong = dims.filter(d => d.ratio >= 0.7).sort((a, b) => b.ratio - a.ratio).slice(0, 2);
+      const partial = dims.filter(d => d.ratio > 0 && d.ratio < 0.7).sort((a, b) => b.ratio - a.ratio).slice(0, 2);
+      const weak = dims.filter(d => d.ratio === 0);
+      const parts: string[] = [];
+      if (strong.length) {
+        parts.push(`Strong on ${strong.map(d => `${d.label} (${d.ok}/${d.total})`).join(' and ')}`);
+      }
+      if (partial.length) {
+        const partialFragment = partial.map(d => `${d.label} (${d.ok}/${d.total})`).join(' and ');
+        parts.push(parts.length ? `partial on ${partialFragment}` : `Partial on ${partialFragment}`);
+      }
+      if (weak.length) {
+        const labels = weak.map(d => d.label);
+        const phrase = labels.length === 1
+          ? `${labels[0]} not yet uploaded`
+          : labels.length === 2
+            ? `${labels[0]} and ${labels[1]} not yet uploaded`
+            : `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]} not yet uploaded`;
+        parts.push(parts.length ? `with ${phrase}` : phrase.charAt(0).toUpperCase() + phrase.slice(1));
+      }
+      return parts.length ? `${parts.join(', ')}.` : '';
+    };
+
+    // Sub-bug 1b — when the user asks "what's outstanding across the
+    // portfolio?" the model passes filter='missing' + document_type='all'.
+    // Returning the union of all outstanding tenancies as a flat list is
+    // useless ("12 tenancies are outstanding") because almost every tenancy
+    // has SOME gap. Instead, return a per-dimension breakdown so the agent
+    // can see where the gaps actually are.
+    if (filter === 'missing' && docType === 'all') {
+      const breakdownLines = [
+        `- BER cert: ${nonVacant.length - dimensionTotals.ber.ok} active tenanc${nonVacant.length - dimensionTotals.ber.ok === 1 ? 'y' : 'ies'} (vacant excluded)`,
+        `- Gas safety: ${nonVacant.length - dimensionTotals.gasSafety.ok} active tenanc${nonVacant.length - dimensionTotals.gasSafety.ok === 1 ? 'y' : 'ies'}`,
+        `- Electrical: ${nonVacant.length - dimensionTotals.electrical.ok} active tenanc${nonVacant.length - dimensionTotals.electrical.ok === 1 ? 'y' : 'ies'}`,
+        `- RTB registration: ${dimensionTotals.rtb.total - dimensionTotals.rtb.ok} active tenanc${dimensionTotals.rtb.total - dimensionTotals.rtb.ok === 1 ? 'y' : 'ies'}`,
+        `- Signed lease: ${nonVacant.length - dimensionTotals.signedLease.ok} active tenanc${nonVacant.length - dimensionTotals.signedLease.ok === 1 ? 'y' : 'ies'}`,
+      ];
+      const breakdownTail = buildBreakdownSentence();
+      const summaryLines = [
+        compliancePct !== null
+          ? `Missing certificates across your portfolio (compliance ${compliancePct}%):`
+          : 'Missing certificates across your portfolio:',
+        ...breakdownLines,
+      ];
+      if (breakdownTail) summaryLines.push('', breakdownTail);
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: summaryLines.join('\n'),
+        drafts: [],
+        meta: {
+          record_count: nonVacant.length,
+          generated_at: new Date().toISOString(),
+          query,
+          // @ts-ignore — full per-tenancy records (active only) for downstream consumers
+          records: nonVacant.slice(0, COMPLIANCE_RECORD_CAP),
+          // @ts-ignore
+          truncated: nonVacant.length > COMPLIANCE_RECORD_CAP,
+          // @ts-ignore
+          compliance_pct: compliancePct,
+          // @ts-ignore
+          dimension_totals: dimensionTotals,
+        } as any,
+      };
+    }
 
     if (!filtered.length) {
       const noneSummary = (() => {
@@ -3434,24 +3578,28 @@ export async function queryComplianceStatus(
         if (filter === 'expiring_soon') return 'No BER certs expiring in the next 60 days.';
         if (filter === 'missing') {
           return docType === 'all'
-            ? 'No tenancies with outstanding compliance items.'
-            : `No tenancies missing ${docType.replace(/_/g, ' ')}.`;
+            ? 'No active tenancies with outstanding compliance items.'
+            : `No active tenancies missing ${docType.replace(/_/g, ' ')}.`;
         }
         return 'No tenancies match the requested compliance filter.';
       })();
+      const tail = buildBreakdownSentence();
+      const pctNote = compliancePct !== null
+        ? ` Portfolio compliance: ${compliancePct}%.${tail ? ' ' + tail : ''}`
+        : '';
       return {
         skill,
         status: 'awaiting_approval',
-        summary: compliancePct !== null
-          ? `${noneSummary} Portfolio compliance: ${compliancePct}% (${fullyCompliant.length} of ${nonVacant.length} tenancies fully compliant).`
-          : noneSummary,
+        summary: `${noneSummary}${pctNote}`,
         drafts: [],
         meta: {
           record_count: 0,
           generated_at: new Date().toISOString(),
           query,
-          // @ts-ignore — surfaced for the chat layer's response framing
+          // @ts-ignore
           compliance_pct: compliancePct,
+          // @ts-ignore
+          dimension_totals: dimensionTotals,
         } as any,
       };
     }
@@ -3488,8 +3636,9 @@ export async function queryComplianceStatus(
     const headline = (() => {
       const subject = describeFilterDocType(filter, docType);
       const truncationNote = truncated ? ` Showing ${COMPLIANCE_RECORD_CAP} of ${totalMatched}.` : '';
+      const tail = buildBreakdownSentence();
       const pctNote = compliancePct !== null
-        ? ` Portfolio compliance: ${compliancePct}%.`
+        ? ` Portfolio compliance: ${compliancePct}%.${tail ? ' ' + tail : ''}`
         : '';
       if (filter === 'expiring_soon') {
         return `${totalMatched} BER cert${totalMatched === 1 ? '' : 's'} expiring within 60 days.${truncationNote}${pctNote}`;
@@ -3498,7 +3647,7 @@ export async function queryComplianceStatus(
         return `${totalMatched} BER cert${totalMatched === 1 ? '' : 's'} already expired.${truncationNote}${pctNote}`;
       }
       if (filter === 'missing') {
-        return `${totalMatched} tenanc${totalMatched === 1 ? 'y' : 'ies'} with ${subject}.${truncationNote}${pctNote}`;
+        return `${totalMatched} active tenanc${totalMatched === 1 ? 'y' : 'ies'} with ${subject}.${truncationNote}${pctNote}`;
       }
       return `${totalMatched} tenanc${totalMatched === 1 ? 'y' : 'ies'} matched.${truncationNote}${pctNote}`;
     })();
@@ -3522,6 +3671,8 @@ export async function queryComplianceStatus(
         truncated,
         // @ts-ignore
         compliance_pct: compliancePct,
+        // @ts-ignore
+        dimension_totals: dimensionTotals,
       } as any,
     };
   } catch (err) {


### PR DESCRIPTION
## Why

Live-test of PR #91 came back 5 PASS / 1 FAIL. Test 1 (proactive intelligence), Test 3 (BER expiring soon), Test 4 (RTB missing), Test 5 (Documents tab hint), and the bonus Aoife renewal test all passed. **Test 2 (BER missing) failed** with three sub-bugs in `query_compliance_status` itself — the loader and live-context block from PR #91 were innocent.

This PR fixes the three. Stacked on top of PR #91 (`claude/lettings-compliance-intelligence`) — base targets that branch so the diff is just the skill correctness work. Once PR #91 lands on main, this PR's base can be retargeted.

## Sub-bug 1 — model defaulted `document_type='all'`

When the user asked *"Which tenancies are missing a BER cert?"*, the model called the skill without `document_type`, defaulting to `'all'`. Under `filter='missing'` + `document_type='all'`, `complianceDimensionOk` collapses to `record.outstandingCount === 0` — i.e. the filter returns every tenancy with ANY outstanding item. Aoife (whose BER is OK but who's missing gas/elec/lease docs) appeared in the "missing BER" results.

**Two-part fix:**

(a) **Prompt tightening** (`buildLettingsAgentSystemPrompt` COMMON INTENTS). New CRITICAL rule: *"document_type MUST be set to a specific dimension when the user names one ('BER', 'gas safety', 'electrical', 'RTB', 'signed lease'). The default 'all' is reserved strictly for portfolio-wide queries that don't name any one cert type."* Eight explicit example phrasings paired with the right `(filter, document_type)` tuple, including the legitimate `filter='missing'` + `document_type='all'` case for *"What's outstanding across the portfolio?"*

(b) **Code-side defensive fallback.** When the model passes `filter='missing'` + `document_type='all'` (legitimate for portfolio-wide queries), the skill returns a per-dimension breakdown instead of the union of all outstanding tenancies:

```
Missing certificates across your portfolio (compliance 25%):
- BER cert: 8 active tenancies (vacant excluded)
- Gas safety: 12 active tenancies
- Electrical: 12 active tenancies
- RTB registration: 1 active tenancy
- Signed lease: 12 active tenancies

Strong on RTB (11/12), partial on BER (4/12), with gas safety, electrical, and signed lease not yet uploaded.
```

Per-dimension counts respect the vacant exclusion from Sub-bug 2.

## Sub-bug 2 — vacant properties leaked into `filter='missing'`

6 of Sarah's 18 properties are vacant. They surfaced as missing BER alongside the 8 active-tenancy gaps, inflating the count to 14 when only 8 are actively-actionable.

**Asymmetric fix:**

| Filter | Vacant treatment | Rationale |
|---|---|---|
| `'missing'` | **Excluded** | Vacant properties are between-tenancies; missing certs are a re-letting prep concern, not an active compliance gap |
| `'expired'` | Kept | A vacant property with an expired BER blocks re-letting; agent needs to know |
| `'expiring_soon'` | Kept | Same re-letting urgency |

Inline comment in the skill explains the rationale so the next reader doesn't "fix" it back to a uniform exclusion.

## Sub-bug 3 — compliance score read 0%

Previous formula: *"fully-compliant tenancies / non-vacant tenancies"* — required EVERY dimension OK per tenancy. With 0 docs uploaded portfolio-wide (the common state today), no tenancy is fully compliant even when `ber_cert_number` / RTB number ARE recorded on the row. Score collapsed to 0% which read as *"everything broken"* instead of *"recoverable, partial"*.

**Two-part fix:**

(a) **Fill-rate metric.** New formula:

```
numerator   = sum of OK conditions across non-vacant records
              (ber.ok + gas.ok + elec.ok + (rtb.applicable ? rtb.ok : 0) + lease.ok)
denominator = sum of applicable conditions per record
              (5 per non-vacant record; RTB always applicable for non-vacant)
```

For Sarah Mitchell's portfolio post-PR-91-backfill:
- 4 BER + 0 gas + 0 elec + 11 RTB + 0 lease = **15 OK**
- 12 non-vacant × 5 = **60 conditions**
- **25%** — recoverable, demo-defensible, honest.

(b) **Dynamic strong/weak breakdown sentence** appended after the percentage. Picks dimensions with ratio ≥ 0.7 as "strong", 0 < ratio < 0.7 as "partial", ratio === 0 as "not yet uploaded". One sentence, no table. **Adapts to whatever the actual numerator distribution is — no hardcoded strong/weak assumptions.**

For Sarah today: *"Strong on RTB (11/12), partial on BER (4/12), with gas safety, electrical, and signed lease not yet uploaded."*

Rendered after the percentage in every relevant summary path (no-results, missing+all breakdown, headline summary).

## Test plan

- [ ] **Test 2-redo (per-dimension missing).** "Which tenancies are missing a BER cert?" → response lists ONLY the 8 active-tenancy properties without `ber_cert_number` set (NOT the 4 with cert numbers, NOT the 6 vacant). Aoife/Mark+Ciara/Maria/Kieran+Rachel absent from this list.
- [ ] **Test 2-redo (portfolio breakdown).** "What's outstanding across the portfolio?" → response shows the per-dimension breakdown with the 5 lines above + the strong/weak tail sentence. **Score is 25%, NOT 0%.**
- [ ] **Sub-bug 2 verify.** "Show me missing electrical certs" → response excludes the 6 vacant properties. "Which BER certs expire in the next 60 days?" → response still includes any vacant property with an expiring BER (none in current seed; verify the path doesn't filter them).
- [ ] **Sub-bug 3 verify.** "What's my compliance score?" → response reads as the fill-rate percentage with the dynamic strong/weak sentence. Verify the sentence adapts: if you upload one gas safety doc to one tenancy and re-run, the sentence should now mention gas safety as "partial" instead of "not yet uploaded".
- [ ] **Regressions.** Tests 1, 3, 4, 5 from PR #91 still pass. Aoife renewal flow (PR #90) still passes.

## Constraints respected

No schema changes. Loader (`getLettingsCompliance`) untouched — diagnostic confirmed it composes records correctly. COMPLIANCE ATTENTION live-context block (PR #91) untouched — verified clean by Test 1 PASS. Foundational code from prompts 6 and 7 untouched. Renewal window split (PR #85) untouched. `rank_pipeline_buyers` / `buildRankReason` (prompt 11 territory) untouched.

## Branch / commit

- **Branch:** `claude/compliance-skill-correctness` (off `claude/lettings-compliance-intelligence`)
- **Commit:** `c65c0bd`
- **Build:** passes
- **Not merged.** Awaiting live re-test.

https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk)_