### PR TITLE
fix(agent): viewing-schedule drawer header date — natural-language Irish English, parity with body copy

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -3429,7 +3429,7 @@ export async function createViewingSchedule(
     return {
       skill,
       status: 'awaiting_approval',
-      summary: `Drafted a ${usedSlots}-slot viewing schedule for ${scope.primaryLabel} on ${inputs.date} (${inputs.start_time}–${inputs.end_time}). ${usedSlots} proposal email${usedSlots === 1 ? '' : 's'} ready for review; matching slots pre-held in your viewings list as PENDING until each buyer confirms.`,
+      summary: `Drafted a ${usedSlots}-slot viewing schedule for ${scope.primaryLabel} on ${new Date(`${inputs.date}T00:00:00`).toLocaleDateString('en-IE', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' })} (${inputs.start_time}–${inputs.end_time}). ${usedSlots} proposal email${usedSlots === 1 ? '' : 's'} ready for review; matching slots pre-held in your viewings list as PENDING until each buyer confirms.`,
       drafts,
       meta: {
         record_count: drafts.length,


### PR DESCRIPTION
## Why

The drafts-drawer carousel header for `create_viewing_schedule` was reading:

> Drafted a 10-slot viewing schedule for Lakeside Manor on **2026-05-09** (09:00–14:00). 10 proposal emails ready for review; matching slots pre-held in your viewings list as PENDING until each buyer confirms.

The ISO `2026-05-09` clashes with the natural-language formatting throughout the email bodies (`"Saturday, 9 May"`) and slot lists (`"Saturday, 9 May at 09:00"`) right below it in the same drawer.

## What this changes

`agentic-skills.ts:3432` — `${inputs.date}` replaced with an inline `en-IE` locale call:

```ts
new Date(`${inputs.date}T00:00:00`).toLocaleDateString('en-IE', {
  weekday: 'long',
  day: 'numeric',
  month: 'long',
  year: 'numeric',
})
```

Result: `"Saturday, 9 May 2026"`. Slight extra formality (year included) fits the header's system-metadata feel while staying in the same natural-language register as the body. The body's `formatScheduleDayLabel` (no year) is unchanged — the year on the header gives the agent unambiguous context without adding noise to the recipient-facing email copy.

No new helper introduced — added a fourth date helper for one caller wasn't worth the abstraction. Used the same locale options as the existing `formatScheduleDayLabel` plus `year: 'numeric'` inline.

`scheduleViewingDraft` (single-viewing flow) already uses `formatIrishDate` (`"9 May 2026"`) in its summary — natural language, no ISO leak. Left untouched per spec.

## Test plan

- [ ] Run `create_viewing_schedule` for Lakeside Manor on a future Saturday. Drawer carousel header should read `Drafted a N-slot viewing schedule for Lakeside Manor on Saturday, 9 May 2026 (09:00–14:00). …` — natural-language date, year included, no ISO leak.
- [ ] Email bodies and slot lists unchanged from PR #93 — `"Saturday, 9 May"` (no year) in body, `"Saturday, 9 May at 09:00"` in slot list.
- [ ] `scheduleViewingDraft` (single-viewing) unchanged — summary still reads `"… on 9 May 2026 at 14:00."` per `formatIrishDate`.

## Constraints respected

No schema changes. No new helper. PR #89's email-body fix (`formatScheduleDayLabel`) untouched. PR #93's ranker fixes untouched. Only the one summary line in `createViewingSchedule` changes.

## Branch / commit

- **Branch:** `claude/carousel-header-date-format` (off `origin/main`)
- **Commit:** `a89b782`
- **Build:** passes
- **Not merged.** Holding for live test.

https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk)_