### PR TITLE
fix(agent-lettings): preserve compliance-score breakdown verbatim

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -802,10 +802,15 @@ COMMON INTENTS — what to do when you see these patterns:
        "Compliance gaps for {tenant}"
          → filter='missing', document_type='all' (then narrow to that tenant's record from meta.records)
 
-  The skill returns a one-sentence summary suitable for the chat reply plus
-  structured per-tenancy records on meta.records. The COMPLIANCE ATTENTION
-  block in your live context already lists the most urgent items (BER
-  expired, expiring within 60 days, missing RTB on active tenancies) so you
+  The skill returns a structured summary that you MUST relay verbatim to the
+  agent — do not paraphrase, do not summarise into one sentence, do not
+  collapse the per-dimension breakdown into generic copy. The summary
+  contains the percentage AND the breakdown sentence (shape: "Strong on
+  [DIMENSION] (X/Y), partial on [DIMENSION] (X/Y), with [DIMENSIONS] not
+  yet uploaded") — preserve both word-for-word so the agent sees exactly
+  which dimensions are strong vs partial vs missing. The COMPLIANCE
+  ATTENTION block in your live context lists the most urgent items (BER
+  expired, expiring within 60 days, missing RTB on active tenancies); you
   can mention those proactively without a tool call when the user asks
   "what needs my attention".
 


### PR DESCRIPTION
## Why

When the user asks *"What's my compliance score?"*, the chat reply returns the percentage correctly but paraphrases the per-dimension breakdown sentence into generic copy. Backlog item from prompt 10's live test (filed during PR #92's merge):

> Expected: *"Strong on RTB (11/12), partial on BER (4/12), with gas safety, electrical, and signed lease not yet uploaded."*
>
> Actual: *"based on outstanding compliance items, including missing RTB registration and upcoming BER expirations"*

## Audit findings

**Skill-side is correct.** `agentic-skills.ts:3606` (`buildBreakdownSentence`) composes the dynamic strong/partial/weak sentence; `:3745-3762` (`headline` builder) appends it via `pctNote`. For `filter='all' + document_type='all'`, the full summary returned to the chat layer is multi-sentence + multi-line:

```
18 tenancies matched. Portfolio compliance: 25%. Strong on RTB (11/12), partial on BER (4/12), with gas safety, electrical, and signed lease not yet uploaded.

- 1 Lakeside Drive — Aoife O'Brien — outstanding: gas safety, electrical, signed lease
- 14 Beechwood Park — Mark Donnelly and Ciara O'Leary — outstanding: …
- (+13 more in records)
```

The breakdown sentence IS in the summary.

**Prompt-side root cause.** `system-prompt.ts:805` told the model:
> *"The skill returns a one-sentence summary suitable for the chat reply plus structured per-tenancy records on meta.records."*

This biased the model to pick ONE sentence and paraphrase the rest. The compliance-score summary is genuinely multi-sentence by design.

## Fix

Single-line file change in `system-prompt.ts:805-810`. Replace the one-sentence framing with explicit verbatim-relay language. Mirrors the pattern at line 832 (*"relay that to the agent verbatim"*) which already works for renewal disambiguation envelopes.

Worked-example shape uses placeholders (`[DIMENSION]`, `X/Y`) instead of hardcoded numbers so the model can't latch onto "11/12" or "4/12" as canonical values when the actual data shifts.

```
The skill returns a structured summary that you MUST relay verbatim to the
agent — do not paraphrase, do not summarise into one sentence, do not
collapse the per-dimension breakdown into generic copy. The summary
contains the percentage AND the breakdown sentence (shape: "Strong on
[DIMENSION] (X/Y), partial on [DIMENSION] (X/Y), with [DIMENSIONS] not
yet uploaded") — preserve both word-for-word so the agent sees exactly
which dimensions are strong vs partial vs missing. The COMPLIANCE
ATTENTION block in your live context lists the most urgent items (BER
expired, expiring within 60 days, missing RTB on active tenancies); you
can mention those proactively without a tool call when the user asks
"what needs my attention".
```

## What is NOT changed

- Skill (`queryComplianceStatus`) — the summary string already contains the breakdown.
- Loader (`getLettingsCompliance`) — verified clean in PR #91.
- Other compliance paths (`missing` / `expired` / `expiring_soon`) — current prose-paraphrase behaviour produces sharp natural-language replies, scoped out per spec.
- COMPLIANCE ATTENTION proactive-mention guidance — preserved.
- No new helpers, no schema changes, no skill-side changes.

## Test plan

- [ ] **Live test the score path.** Lettings mode → "What's my compliance score?" → reply must include both `"25%"` AND the breakdown sentence verbatim (`"Strong on RTB (11/12), partial on BER (4/12), with gas safety, electrical, and signed lease not yet uploaded."`).
- [ ] **Regression on other compliance paths.** Run "Which tenancies are missing a BER cert?" — should still return the per-dimension list with no regression to the existing prose. Same for "Which BER certs expire in the next 60 days?" and "Which tenancies are missing an RTB registration?"
- [ ] **Regression on other lettings flows.** Aoife renewal (PR #90) and the COMPLIANCE ATTENTION proactive surface (PR #91 Test 1) unchanged.

## Branch / commit

- **Branch:** `claude/compliance-score-breakdown` (off `origin/main`)
- **Commit:** `6ca80bf`
- **Build:** passes
- **Not merged.** Holding for live test PASS before merge.

https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDC4wpRVot6CEW83z2Xbk)_