### PR TITLE
fix(agent-sales): chase-email path — wrong-skill, missing intent, topic-bleed

### DIFF
--- a/apps/unified-portal/app/agent/_components/StatModal.tsx
+++ b/apps/unified-portal/app/agent/_components/StatModal.tsx
@@ -356,7 +356,7 @@ function ActiveContent({
 /* ─── Urgent / needs attention drill-down ─── */
 
 // Session 14d — build a dynamic Intelligence prompt from the urgent
-// items. Sales-side draft tools (chase_aged_contracts, draft_message)
+// items. Sales-side draft tools (surface_aged_contracts_for_solicitor, draft_message)
 // understand "Draft contract chase emails to: …" and "Draft mortgage
 // approval extension follow-ups to: …" intents per Session 14's
 // TOOL-USE MANDATE; the Intelligence page auto-fires on ?prompt=… so

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -37,7 +37,7 @@ function labelForTool(toolName: string): string {
     case 'draft_buyer_followups': return 'Drafting messages';
     case 'draft_lease_renewal': return 'Drafting renewal offer';
     case 'draft_viewing_followup': return 'Drafting viewing follow-up';
-    case 'chase_aged_contracts': return 'Drafting chase emails';
+    case 'surface_aged_contracts_for_solicitor': return 'Surfacing aged contracts for solicitor';
     case 'weekly_monday_briefing': return 'Building briefing';
     case 'schedule_viewing_draft': return 'Drafting viewing schedule';
     case 'natural_query': return 'Looking up details';
@@ -287,7 +287,7 @@ export async function POST(request: NextRequest) {
     const DRAFT_PRODUCING_TOOLS = new Set<string>([
       'draft_message',
       'draft_buyer_followups',
-      'chase_aged_contracts',
+      'surface_aged_contracts_for_solicitor',
       'draft_viewing_followup',
       'draft_lease_renewal',
       'weekly_monday_briefing',

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -18,7 +18,7 @@ import type { AgentContext } from './types';
  */
 
 const AGENTIC_DRAFT_TYPE_BY_SKILL: Record<string, string> = {
-  chase_aged_contracts: 'solicitor_chase',
+  surface_aged_contracts_for_solicitor: 'solicitor_chase',
   draft_viewing_followup: 'viewing_followup',
   draft_lease_renewal: 'lease_renewal',
   weekly_monday_briefing: 'weekly_briefing',
@@ -89,7 +89,7 @@ export interface SkillPersistContext {
  * regressions that re-introduce a placeholder.
  *
  * `solicitor@tbc.invalid` was added after the audit found 45 ghost
- * solicitor_chase drafts in production — chaseAgedContracts now surfaces
+ * solicitor_chase drafts in production — surfaceAgedContractsForSolicitor now surfaces
  * the aged contracts via a needs_recipient envelope and never produces a
  * placeholder draft. Blocking the literal closes the regression class.
  *

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -486,7 +486,7 @@ You have two classes of tools:
 (A) READ tools — retrieve information. You may call these freely.
 
 (B) AGENTIC SKILL tools — produce draft work for the agent's approval. These are:
-    chase_aged_contracts, draft_viewing_followup, weekly_monday_briefing,
+    surface_aged_contracts_for_solicitor, draft_viewing_followup, weekly_monday_briefing,
     draft_lease_renewal, natural_query, schedule_viewing_draft,
     create_viewing_schedule, rank_pipeline_buyers.
 
@@ -505,7 +505,55 @@ ANYONE — ALWAYS call the appropriate draft-producing tool. Pick the tightest f
     per unit) and the matching purpose.
   - "draft an email to [one person]" → call draft_message with that single
     recipient.
-  - "chase all overdue contracts" → call chase_aged_contracts.
+  - "surface aged contracts for solicitor follow-up" → call
+    surface_aged_contracts_for_solicitor. The skill returns a needs_recipient
+    envelope; the agent pastes the solicitor address before any draft is
+    generated. NEVER call this skill when the user wants to chase the
+    BUYERS — use the buyer-chase routing below.
+
+  EXPLICIT BUYER-CHASE ROUTING — never conflate solicitor surfacing with
+  buyer chase. When the user wants to chase BUYERS based on a stage or
+  date criterion, the call is always TWO STEPS: a get_candidate_units
+  filter that produces the cohort, then a draft_buyer_followups against
+  the returned units. Concrete patterns:
+
+    - "Send chase emails to buyers who haven't signed contracts yet" /
+      "Email anyone who hasn't signed in [scheme]" / "Chase the unsigned
+      buyers at [scheme]"
+        1. get_candidate_units(intent='overdue_contracts', scheme_name='[scheme]')
+        2. draft_buyer_followups(
+             targets=[returned units],
+             purpose='chase',
+             topic='Following up on contract signing — could you let me
+                    know where things stand?'
+           )
+
+    - "Chase buyers whose mortgage is expiring soon" / "Email anyone whose
+      mortgage approval is running out" / "Buyers with mortgage expiry in
+      the next 30 days at [scheme] — draft chase emails"
+        1. get_candidate_units(intent='mortgage_expiring', scheme_name='[scheme]')
+        2. draft_buyer_followups(
+             targets=[returned units],
+             purpose='chase',
+             topic='I wanted to flag that your mortgage approval is
+                    coming up for expiry — happy to help arrange anything
+                    needed before it lapses.'
+           )
+
+    - "Surface aged contracts for solicitor chase" / "Show me contracts
+      issued >6 weeks ago that haven't been signed and chase the
+      solicitors" → surface_aged_contracts_for_solicitor (returns
+      needs_recipient; agent pastes the solicitor address).
+
+  NEVER invent intermediate recipients. If the user asks to chase "them",
+  "the buyers", "anyone matching X", or "everyone whose Y" — the recipient
+  is each BUYER individually via draft_buyer_followups. Do NOT route
+  through surface_aged_contracts_for_solicitor unless the user explicitly
+  named the solicitor as the recipient. Do NOT pick units silently from
+  prior turns when a stage criterion is given — call get_candidate_units
+  with the intent that matches the criterion and pass the returned units
+  through to draft_buyer_followups.
+
   - "follow up on viewings yesterday" → call draft_viewing_followup.
   - Lease renewals → draft_lease_renewal. Weekly briefing → weekly_monday_briefing.
   - New (single) viewing appointment → schedule_viewing_draft.
@@ -542,8 +590,9 @@ When the user specifies a count but not specific unit identifiers (e.g. "draft
 email to 3 Ardan view and congratulate them on their keys"), you MUST:
   1. Call get_candidate_units FIRST with the intent that matches the request:
        - "congratulate / welcome / keys" → intent="handover"
-       - "chase / overdue" → intent="overdue_contracts"
+       - "chase / overdue / haven't signed" → intent="overdue_contracts"
        - "sale agreed" → intent="sale_agreed"
+       - "mortgage expiring / mortgage approval running out / mortgage expiry" → intent="mortgage_expiring"
        - otherwise → intent="all"
      Pass scheme_name when the user named one.
   2. Branch on what comes back:
@@ -597,7 +646,10 @@ drawer and the inbox surface all of that visually.
 
 CORRECT:
   User: "Draft follow-up emails to overdue buyers"
-  You: [call chase_aged_contracts]
+  You: [call get_candidate_units(intent='overdue_contracts')]
+  You: [call draft_buyer_followups(targets=[returned units], purpose='chase',
+       topic='Following up on contract signing — could you let me know where
+       things stand?')]
   You: "Drafted 15 follow-ups — have a flick through in the drawer and hit
   Approve when you're happy."
 
@@ -608,6 +660,12 @@ INCORRECT:
     2. Rebecca Burke — contract follow-up
     ..."
   [no tool call — nothing reaches the inbox]
+
+INCORRECT:
+  User: "Draft follow-up emails to overdue buyers"
+  You: [call surface_aged_contracts_for_solicitor]
+  [Wrong skill — that one chases solicitors, not buyers, and returns a
+  needs_recipient envelope rather than buyer drafts.]
 
 CORRECT:
   User: "Send the lease renewals for next month"

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -326,9 +326,9 @@ export function classifyPipelineStage(unitStatus: string | null, pipe: any | nul
 }
 
 // =====================================================================
-// Skill 1 — chase_aged_contracts
+// Skill 1 — surface_aged_contracts_for_solicitor
 // =====================================================================
-export async function chaseAgedContracts(
+export async function surfaceAgedContractsForSolicitor(
   supabase: SupabaseClient,
   agentContext: SkillAgentContext,
   inputs: { threshold_days?: number; scheme_filter?: string },
@@ -337,7 +337,7 @@ export async function chaseAgedContracts(
     ? Math.max(1, Number(inputs.threshold_days))
     : 42;
   const schemeFilter = (inputs.scheme_filter || '').trim().toLowerCase();
-  const skill = 'chase_aged_contracts';
+  const skill = 'surface_aged_contracts_for_solicitor';
   const cutoffIso = new Date(Date.now() - thresholdDays * 86400000).toISOString();
   const query = `unit_sales_pipeline WHERE signed_contracts_date IS NULL AND contracts_issued_date < now() - interval '${thresholdDays} days'${schemeFilter ? ` AND scheme ILIKE '%${schemeFilter}%'` : ''}`;
 
@@ -543,7 +543,7 @@ export async function draftViewingFollowup(
 // helper in ../context requires a full AgentContext (with assignedSchemes and
 // tenantId) which the skill call-site does not have. Rather than widen
 // SkillAgentContext, we replicate the same query pattern used by
-// chaseAgedContracts above — scheme assignments → pipeline → dev + unit
+// surfaceAgedContractsForSolicitor above — scheme assignments → pipeline → dev + unit
 // lookups. Kept private to this module.
 async function loadAgedForBriefing(
   supabase: SupabaseClient,
@@ -2172,6 +2172,19 @@ const PURPOSE_PRECONDITIONS: Record<
   custom: { check: () => true, rejectionReason: () => '' },
 };
 
+// Safety-net for topic-bleed bug: when the model passes a fragment ("update
+// on signing their contracts") rather than a sentence, the body composer
+// drops it in verbatim and the email reads as a stub. We can't rewrite the
+// fragment into prose from this layer, but we CAN guarantee the line at
+// least ends with a sentence terminator so it reads less like a missing
+// placeholder. The primary fix lives in the registry parameter description
+// + the system prompt's chase examples; this is the last-line defence.
+export function ensureSentenceTerminator(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
 function buildFollowupContent(opts: {
   purpose: DraftBuyerFollowupPurpose;
   topic: string;
@@ -2186,8 +2199,9 @@ function buildFollowupContent(opts: {
   const sig = signature(ctx);
   // Defensive: scrub any greeting / sign-off the model may have included in
   // the free-text fields, since the template already supplies both.
-  const topic = stripGreetingAndSignoff(rawTopic);
-  const customInstruction = stripGreetingAndSignoff(rawCustom);
+  // Then append a sentence terminator if the model passed a fragment.
+  const topic = ensureSentenceTerminator(stripGreetingAndSignoff(rawTopic));
+  const customInstruction = ensureSentenceTerminator(stripGreetingAndSignoff(rawCustom));
 
   if (purpose === 'congratulate_handover') {
     return {

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -26,7 +26,7 @@ import {
 // ready without anything landing in pending_drafts. Session 6D replaced
 // it with draftMessageSkill() in agentic-skills.ts.
 import {
-  chaseAgedContracts,
+  surfaceAgedContractsForSolicitor,
   draftViewingFollowup,
   weeklyMondayBriefing,
   draftLeaseRenewal,
@@ -270,7 +270,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
             required: ['unit_identifier'],
           },
         },
-        topic: { type: 'string', description: 'Body content only — the shared topic / reason for the email. For chase: what to chase on. For custom: the free-text intent. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
+        topic: { type: 'string', description: 'Full sentence describing the reason for the email, written in the agent\'s voice. Will appear as-is in the email body between the greeting and the closing line, so it MUST read as a complete sentence the agent would actually write. Example for chase: "I noticed your contracts haven\'t been signed yet — could you let me know where things stand?". Example for custom: "Wanted to flag that the kitchen selection deadline has been pushed to next Friday." NEVER pass a noun phrase, a verb phrase, or a fragment lifted from the user\'s prompt (e.g. "update on signing their contracts", "chase signing", "mortgage expiry"); rewrite the user\'s intent into a proper sentence the recipient could read back. DO NOT include a greeting (no "Hi X,", "Hello,", "Dear X,") and DO NOT include a sign-off, signature, or company name. The skill template adds the greeting and the agent\'s own sign-off block automatically; passing them here causes duplicates in the final email.' },
         tone: { type: 'string', description: 'Message tone', enum: ['warm', 'formal', 'urgent', 'gentle_chase'] },
         purpose: {
           type: 'string',
@@ -286,14 +286,14 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: 'get_candidate_units',
-    description: 'Return units from the agent\'s assigned schemes filtered by INTENT, for use as clarification candidates when the user specified a count but no specific unit identifiers. Read-only — returns an envelope with zero drafts and the candidate list in the summary. ALWAYS call this BEFORE asking the user "which N units?" so the example set reflects the actual eligible pool.',
+    description: 'Return units from the agent\'s assigned schemes filtered by INTENT, for use as clarification candidates when the user specified a count but no specific unit identifiers — and as the input source for criterion-based buyer chases ("buyers whose mortgage is expiring soon", "buyers who haven\'t signed yet"). Read-only — returns an envelope with zero drafts and the candidate list in the summary. ALWAYS call this BEFORE asking the user "which N units?" so the example set reflects the actual eligible pool.',
     parameters: {
       type: 'object',
       properties: {
         intent: {
           type: 'string',
-          description: 'Filter criterion. "handover" = units with handover_date (congratulate on keys). "overdue_contracts" = contracts issued >28d ago and unsigned. "sale_agreed" = sale_agreed but not yet signed/handed-over. "all" = every unit.',
-          enum: ['handover', 'overdue_contracts', 'sale_agreed', 'all'],
+          description: 'Filter criterion. "handover" = units with handover_date (congratulate on keys). "overdue_contracts" = contracts issued >28d ago and unsigned. "sale_agreed" = sale_agreed but not yet signed/handed-over. "mortgage_expiring" = pipeline rows whose mortgage_expiry_date falls within the next 60 days and have not yet handed over. "all" = every unit.',
+          enum: ['handover', 'overdue_contracts', 'sale_agreed', 'mortgage_expiring', 'all'],
         },
         scheme_name: { type: 'string', description: 'Optional — narrow the candidates to one scheme.' },
         limit: { type: 'number', description: 'Max candidates to return (default 6, max 20).' },
@@ -396,8 +396,8 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   // land until the /confirm endpoint approves the drafts.
   // -------------------------------------------------------------------
   {
-    name: 'chase_aged_contracts',
-    description: "Find contracts issued over 6 weeks ago that haven't been signed, and draft solicitor chase emails for each. Returns drafts for agent approval before any email is sent.",
+    name: 'surface_aged_contracts_for_solicitor',
+    description: "Surface aged unsigned contracts (>6 weeks since contracts_issued_date) for solicitor follow-up. Returns a needs_recipient envelope listing the affected units; the agent must paste the solicitor's email address before any draft is generated. NOT for buyer chase emails — use draft_buyer_followups (with get_candidate_units first when no specific units are named) for that.",
     parameters: {
       type: 'object',
       properties: {
@@ -407,7 +407,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       required: [],
     },
     execute: ((supabase, _tenantId, agentContext, params) =>
-      runAgenticSkill(chaseAgedContracts, supabase, agentContext, params as any)) as ToolFunction,
+      runAgenticSkill(surfaceAgedContractsForSolicitor, supabase, agentContext, params as any)) as ToolFunction,
   },
   {
     name: 'draft_viewing_followup',

--- a/apps/unified-portal/lib/agent-intelligence/unit-resolver.ts
+++ b/apps/unified-portal/lib/agent-intelligence/unit-resolver.ts
@@ -172,7 +172,22 @@ export async function resolveUnitIdentifier(
  *   "sale agreed" / "reserved"                        → 'sale_agreed'
  *   anything else                                     → 'all'
  */
-export type CandidateIntent = 'handover' | 'sale_agreed' | 'overdue_contracts' | 'all';
+export type CandidateIntent =
+  | 'handover'
+  | 'sale_agreed'
+  | 'overdue_contracts'
+  | 'mortgage_expiring'
+  | 'all';
+
+/**
+ * Default lookahead window for the `mortgage_expiring` intent. Mirrors the
+ * lettings BER `expiring_soon` window so the two cohort filters feel
+ * consistent. 60 days is wide enough to give the agent a real planning
+ * horizon (mortgage approvals routinely lapse 6 months after issue and
+ * solicitors want 30+ days to react) but not so wide that the cohort
+ * collapses into "every active buyer".
+ */
+export const MORTGAGE_EXPIRY_WINDOW_DAYS = 60;
 
 export interface UnitCandidate {
   id: string;
@@ -314,6 +329,58 @@ export async function getCandidateUnits(
       purchaser_name: r.purchaser_name ?? unitById.get(r.unit_id)?.purchaser_name ?? null,
       status_hint: `sale agreed ${r.sale_agreed_date.slice(0, 10)}`,
     }));
+  }
+
+  if (intent === 'mortgage_expiring') {
+    const now = new Date();
+    const windowEnd = new Date(now.getTime() + MORTGAGE_EXPIRY_WINDOW_DAYS * 86400000);
+    const nowIso = now.toISOString().split('T')[0];
+    const windowEndIso = windowEnd.toISOString().split('T')[0];
+    // Cohort: pipeline rows with mortgage_expiry_date set, within the
+    // lookahead window, and NOT yet handed over (handover_date IS NULL).
+    // Ordered soonest-first so the most urgent expiries surface at the top.
+    const { data: rows } = await supabase
+      .from('unit_sales_pipeline')
+      .select('unit_id, development_id, mortgage_expiry_date, handover_date, purchaser_name')
+      .in('development_id', scope)
+      .not('mortgage_expiry_date', 'is', null)
+      .is('handover_date', null)
+      .gte('mortgage_expiry_date', nowIso)
+      .lte('mortgage_expiry_date', windowEndIso)
+      .order('mortgage_expiry_date', { ascending: true })
+      .limit(limit);
+    const pipelineRows = (rows || []) as Array<{
+      unit_id: string;
+      development_id: string;
+      mortgage_expiry_date: string;
+      handover_date: string | null;
+      purchaser_name: string | null;
+    }>;
+    if (!pipelineRows.length) return [];
+    const unitIds = pipelineRows.map((r) => r.unit_id).filter(Boolean);
+    const { data: units } = unitIds.length
+      ? await supabase
+          .from('units')
+          .select('id, unit_number, purchaser_name')
+          .in('id', unitIds)
+      : { data: [] };
+    const unitById = new Map<string, { unit_number: string | null; purchaser_name: string | null }>(
+      (units || []).map((u: any) => [u.id, { unit_number: u.unit_number, purchaser_name: u.purchaser_name }]),
+    );
+    return pipelineRows.map((r) => {
+      const daysToExpiry = Math.max(
+        0,
+        Math.round((new Date(r.mortgage_expiry_date).getTime() - now.getTime()) / 86400000),
+      );
+      return {
+        id: r.unit_id,
+        development_id: r.development_id,
+        scheme_name: schemeNameById.get(r.development_id) ?? 'Unknown scheme',
+        unit_number: unitById.get(r.unit_id)?.unit_number ?? '?',
+        purchaser_name: r.purchaser_name ?? unitById.get(r.unit_id)?.purchaser_name ?? null,
+        status_hint: `mortgage approval expires ${r.mortgage_expiry_date.slice(0, 10)} (${daysToExpiry}d)`,
+      };
+    });
   }
 
   // 'all' — every unit in scope.

--- a/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
@@ -305,7 +305,7 @@ describe('Tool registry invariant (Session 6D)', () => {
     const DRAFT_PRODUCERS = new Set([
       'draft_message',
       'draft_buyer_followups',
-      'chase_aged_contracts',
+      'surface_aged_contracts_for_solicitor',
       'draft_viewing_followup',
       'draft_lease_renewal',
       'weekly_monday_briefing',

--- a/apps/unified-portal/tests/agent-intelligence/sales-chase-fixes.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/sales-chase-fixes.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Sales chase-email path regression guards.
+ *
+ * Three production failures (audit 2026-05-06) drove these tests:
+ *   1. chase_aged_contracts mis-picked for buyer chases (rename guard via
+ *      drafts-pipeline.test.ts already covers the registry side).
+ *   2. mortgage_expiry_date had no candidate-unit exposure — the audit
+ *      flagged it as a missing intent. Test below drives the new
+ *      'mortgage_expiring' branch end-to-end.
+ *   3. Verbatim topic-bleed: model passed a fragment ("update on signing
+ *      their contracts") and the chase body composer dropped it in
+ *      unchanged. Test below asserts the safety-net appends a sentence
+ *      terminator so the body never reads as a missing placeholder.
+ *
+ * Hermetic — stubbed Supabase, no network.
+ */
+
+import {
+  getCandidateUnits,
+  MORTGAGE_EXPIRY_WINDOW_DAYS,
+} from '../../lib/agent-intelligence/unit-resolver';
+import {
+  draftBuyerFollowups,
+  ensureSentenceTerminator,
+} from '../../lib/agent-intelligence/tools/agentic-skills';
+
+const SKILL_CTX = {
+  agentProfileId: 'profile-1' as any,
+  authUserId: 'user-1' as any,
+  displayName: 'Orla Hennessy',
+  agencyName: 'Hennessy Property',
+};
+
+type Row = Record<string, any>;
+
+// Mock supabase that supports the operators used by the
+// 'mortgage_expiring' branch: gte, lte, not, is, order, limit. Same
+// general shape as session-9.test.ts's mock with the date-range methods
+// added.
+function mockSupabase(state: {
+  developments?: Row[];
+  units?: Row[];
+  agent_scheme_assignments?: Row[];
+  unit_sales_pipeline?: Row[];
+}) {
+  const data: Record<string, Row[]> = {
+    developments: state.developments ?? [],
+    units: state.units ?? [],
+    agent_scheme_assignments: state.agent_scheme_assignments ?? [],
+    unit_sales_pipeline: state.unit_sales_pipeline ?? [],
+  };
+
+  function qb(table: string) {
+    const predicates: Array<(r: Row) => boolean> = [];
+    let orderKey: string | null = null;
+    let orderAsc = true;
+    let limitVal: number | null = null;
+
+    const builder: any = {
+      select() { return builder; },
+      eq(col: string, val: any) {
+        predicates.push((r) => r[col] === val);
+        return builder;
+      },
+      in(col: string, vals: any[]) {
+        const set = new Set(vals);
+        predicates.push((r) => set.has(r[col]));
+        return builder;
+      },
+      not(col: string, _op: string, val: any) {
+        if (val === null) predicates.push((r) => r[col] != null);
+        else predicates.push((r) => r[col] !== val);
+        return builder;
+      },
+      is(col: string, val: any) {
+        predicates.push((r) => r[col] === val);
+        return builder;
+      },
+      lt(col: string, val: any) {
+        predicates.push((r) => r[col] != null && r[col] < val);
+        return builder;
+      },
+      gte(col: string, val: any) {
+        predicates.push((r) => r[col] != null && r[col] >= val);
+        return builder;
+      },
+      lte(col: string, val: any) {
+        predicates.push((r) => r[col] != null && r[col] <= val);
+        return builder;
+      },
+      ilike(col: string, pattern: string) {
+        const p = pattern.toLowerCase();
+        if (p.startsWith('%') && p.endsWith('%') && p.length > 2) {
+          const needle = p.slice(1, -1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().includes(needle));
+        } else if (p.startsWith('%')) {
+          const needle = p.slice(1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().endsWith(needle));
+        } else if (p.endsWith('%')) {
+          const needle = p.slice(0, -1);
+          predicates.push((r) => String(r[col] ?? '').toLowerCase().startsWith(needle));
+        } else {
+          predicates.push((r) => String(r[col] ?? '').toLowerCase() === p);
+        }
+        return builder;
+      },
+      or() { return builder; },
+      order(col: string, opts?: { ascending?: boolean }) {
+        orderKey = col;
+        orderAsc = opts?.ascending !== false;
+        return builder;
+      },
+      limit(n: number) { limitVal = n; return builder; },
+      async single() {
+        const rows = resolve();
+        return { data: rows[0] ?? null, error: rows.length ? null : new Error('no rows') };
+      },
+      async maybeSingle() {
+        const rows = resolve();
+        return { data: rows[0] ?? null, error: null };
+      },
+      then(onResolve: any) {
+        return Promise.resolve({ data: resolve(), error: null }).then(onResolve);
+      },
+    };
+
+    function resolve(): Row[] {
+      let rows = data[table].filter((r) => predicates.every((p) => p(r)));
+      if (orderKey) {
+        const key = orderKey;
+        rows = rows.slice().sort((a, b) => {
+          const av = a[key], bv = b[key];
+          if (av === bv) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          return (av < bv ? -1 : 1) * (orderAsc ? 1 : -1);
+        });
+      }
+      if (limitVal != null) rows = rows.slice(0, limitVal);
+      return rows;
+    }
+
+    return builder;
+  }
+
+  return { from: (table: string) => qb(table) } as any;
+}
+
+// Helpers — produce ISO date strings relative to NOW.
+function isoInDays(days: number): string {
+  return new Date(Date.now() + days * 86400000).toISOString().split('T')[0];
+}
+
+describe('Change B — getCandidateUnits intent="mortgage_expiring"', () => {
+  // Three buyers at one scheme, two of them inside the 60-day window.
+  // Unit 5 (10 days out), Unit 12 (45 days out) → in cohort.
+  // Unit 20 (120 days out) → outside the window.
+  // Unit 30 (handed over already) → excluded even though mortgage date set.
+  // Unit 40 (no mortgage_expiry_date) → excluded.
+  const state = {
+    developments: [{ id: 'dev-1', name: 'Lakeside Manor' }],
+    units: [
+      { id: 'u-5', development_id: 'dev-1', unit_number: '5', purchaser_name: 'Aoife Byrne' },
+      { id: 'u-12', development_id: 'dev-1', unit_number: '12', purchaser_name: 'Rónán McCarthy' },
+      { id: 'u-20', development_id: 'dev-1', unit_number: '20', purchaser_name: 'Mark Donnelly' },
+      { id: 'u-30', development_id: 'dev-1', unit_number: '30', purchaser_name: 'Niamh O\'Brien' },
+      { id: 'u-40', development_id: 'dev-1', unit_number: '40', purchaser_name: 'Cillian Walsh' },
+    ],
+    unit_sales_pipeline: [
+      { unit_id: 'u-5', development_id: 'dev-1', mortgage_expiry_date: isoInDays(10), handover_date: null, purchaser_name: 'Aoife Byrne' },
+      { unit_id: 'u-12', development_id: 'dev-1', mortgage_expiry_date: isoInDays(45), handover_date: null, purchaser_name: 'Rónán McCarthy' },
+      { unit_id: 'u-20', development_id: 'dev-1', mortgage_expiry_date: isoInDays(120), handover_date: null, purchaser_name: 'Mark Donnelly' },
+      { unit_id: 'u-30', development_id: 'dev-1', mortgage_expiry_date: isoInDays(15), handover_date: isoInDays(-5), purchaser_name: 'Niamh O\'Brien' },
+      { unit_id: 'u-40', development_id: 'dev-1', mortgage_expiry_date: null, handover_date: null, purchaser_name: 'Cillian Walsh' },
+    ],
+  };
+
+  it('default 60-day window includes the two in-window buyers and excludes the rest', async () => {
+    const supabase = mockSupabase(state);
+    const cands = await getCandidateUnits(supabase, 'mortgage_expiring', { developmentIds: ['dev-1'] });
+    expect(cands).toHaveLength(2);
+    // Soonest expiry first.
+    expect(cands[0].unit_number).toBe('5');
+    expect(cands[1].unit_number).toBe('12');
+    // Status hint surfaces the days-to-expiry signal.
+    expect(cands[0].status_hint).toMatch(/mortgage approval expires/i);
+    expect(cands[0].status_hint).toMatch(/\d+d\)/);
+    // Out-of-window / handed-over / null buyers must NOT appear.
+    expect(cands.find((c) => c.unit_number === '20')).toBeUndefined();
+    expect(cands.find((c) => c.unit_number === '30')).toBeUndefined();
+    expect(cands.find((c) => c.unit_number === '40')).toBeUndefined();
+  });
+
+  it('every returned candidate has a mortgage_expiry_date within MORTGAGE_EXPIRY_WINDOW_DAYS', async () => {
+    const supabase = mockSupabase(state);
+    const cands = await getCandidateUnits(supabase, 'mortgage_expiring', { developmentIds: ['dev-1'] });
+    const now = Date.now();
+    const windowMs = MORTGAGE_EXPIRY_WINDOW_DAYS * 86400000;
+    for (const c of cands) {
+      const days = parseInt(c.status_hint.match(/\((\d+)d\)/)?.[1] ?? '-1', 10);
+      expect(days).toBeGreaterThanOrEqual(0);
+      expect(days).toBeLessThanOrEqual(MORTGAGE_EXPIRY_WINDOW_DAYS);
+      // Cross-check: days converts back to a timestamp inside the window.
+      expect(days * 86400000).toBeLessThanOrEqual(windowMs);
+      // Suppress unused-var warning when transpiled.
+      void now;
+    }
+  });
+});
+
+describe('Change C — buildFollowupContent topic-fragment safety net', () => {
+  it('ensureSentenceTerminator appends a period to a fragment', () => {
+    expect(ensureSentenceTerminator('update on signing their contracts')).toBe(
+      'update on signing their contracts.',
+    );
+  });
+
+  it('ensureSentenceTerminator preserves an existing terminator', () => {
+    expect(ensureSentenceTerminator('Where do things stand?')).toBe('Where do things stand?');
+    expect(ensureSentenceTerminator('Just checking in.')).toBe('Just checking in.');
+    expect(ensureSentenceTerminator('Sign the contracts now!')).toBe(
+      'Sign the contracts now!',
+    );
+  });
+
+  it('ensureSentenceTerminator returns empty for empty / whitespace input', () => {
+    expect(ensureSentenceTerminator('')).toBe('');
+    expect(ensureSentenceTerminator('   ')).toBe('');
+  });
+
+  // End-to-end via draftBuyerFollowups: even when the model passes a
+  // bare fragment, the rendered body never reads as a stub line missing
+  // its terminator. This is the production regression the audit caught.
+  it('draftBuyerFollowups + fragment topic → body line ends with sentence terminator', async () => {
+    const supabase = mockSupabase({
+      developments: [{ id: 'dev-1', name: 'Lakeside Manor' }],
+      units: [
+        {
+          id: 'u-12',
+          development_id: 'dev-1',
+          unit_number: '12',
+          unit_uid: 'LM-12',
+          purchaser_name: 'Rónán McCarthy',
+          purchaser_email: 'ronan@example.com',
+          unit_status: 'contracts_issued',
+        },
+      ],
+      agent_scheme_assignments: [
+        { agent_id: 'profile-1', development_id: 'dev-1', is_active: true },
+      ],
+      unit_sales_pipeline: [
+        {
+          unit_id: 'u-12',
+          development_id: 'dev-1',
+          handover_date: null,
+          contracts_issued_date: isoInDays(-50),
+          signed_contracts_date: null,
+          counter_signed_date: null,
+          purchaser_name: 'Rónán McCarthy',
+          purchaser_email: 'ronan@example.com',
+        },
+      ],
+    });
+
+    const envelope = await draftBuyerFollowups(supabase, SKILL_CTX as any, {
+      targets: [{ unit_identifier: '12', scheme_name: 'Lakeside Manor' }],
+      topic: 'update on signing their contracts',
+      purpose: 'chase',
+    });
+
+    expect(envelope.drafts).toHaveLength(1);
+    const body = envelope.drafts[0].body;
+    // Find the topic line in the body and assert it ends with a terminator.
+    const topicLine = body
+      .split('\n')
+      .find((line) => line.toLowerCase().includes('update on signing their contracts'));
+    expect(topicLine).toBeDefined();
+    expect(topicLine!.trim()).toMatch(/[.!?]$/);
+    // The fragment must NOT appear without its terminator.
+    expect(body).not.toMatch(/update on signing their contracts\n/);
+  });
+});


### PR DESCRIPTION
## Summary

Three production failures observed in the sales chase-email flow on 2026-05-06 (Bridge Property — Sales workspace, agent_test). Audit traced them to three independent root causes; this PR is the minimum viable fix in one commit, four atomic changes.

### Failures fixed
1. **Wrong-skill match.** "Send chase emails to anyone who hasn't signed contracts at Lakeside Manor" → model picked `chase_aged_contracts`, which is solicitor-only and surfaces a `needs_recipient` envelope hard-coded with the literal `"solicitor for aged contracts"`. User saw `We couldn't complete this — no email is on file for "solicitor for aged contracts"`.
2. **Missing criterion.** "Buyers whose mortgage is expiring in 30 days" → no candidate-unit intent existed for mortgage expiry. Model fell back to silent unit selection from the previous turn (the Session 9 rule explicitly forbids this) and produced 6 chase-emails about CONTRACT SIGNING when the user asked about MORTGAGE EXPIRY.
3. **Verbatim topic-bleed.** Email body contained the user's prompt fragment `"update on signing their contracts"` dropped in unchanged. `buildFollowupContent` for `purpose='chase'` puts the model's `topic` value into the body verbatim; the model passed a noun-phrase rather than a sentence.

### Changes (one commit, A–D)

**A — Rename `chase_aged_contracts` → `surface_aged_contracts_for_solicitor`**
The skill never produces drafts and is solicitor-scoped. The new name + tightened description make this obvious. Touches the registry, the skill itself, the draft-store skill→type map, the chat route's `labelForTool` and `DRAFT_PRODUCING_TOOLS` set, the system-prompt tool list + worked examples, and the registry-invariant test.

**B — Add `mortgage_expiring` to `CandidateIntent`**
New branch in `getCandidateUnits`: pipeline rows where `mortgage_expiry_date` falls within `MORTGAGE_EXPIRY_WINDOW_DAYS` (60) and `handover_date IS NULL`, ordered soonest-first. Exposed via the `get_candidate_units` enum + description. Lookahead window mirrors the lettings BER `expiring_soon` window.

**C — Tighten `draft_buyer_followups` topic contract**
- Registry parameter description for `topic` now demands a full sentence with concrete examples and explicitly forbids fragments lifted from the user's prompt.
- New exported `ensureSentenceTerminator()` safety net in `buildFollowupContent`: if `topic` doesn't end with `.`, `!`, or `?`, append `.`. Last-line defence against the bleed.

**D — Update SALES system prompt with explicit chase routing**
Adds two buyer-chase recipes (overdue contracts → `get_candidate_units(intent='overdue_contracts')` + `draft_buyer_followups`; mortgage expiring → `get_candidate_units(intent='mortgage_expiring')` + `draft_buyer_followups`) and a solicitor-only entry. Adds a NEVER directive forbidding invented intermediate recipients and silent unit selection when a stage criterion is given. Extends the get_candidate_units intent map with the new `mortgage_expiring` mapping.

## Test plan

- [x] `npm run build` — TypeScript and JS compilation pass (`✓ Compiled successfully`). The post-build `collect-build-traces` MODULE_NOT_FOUND fires identically on a clean main checkout — pre-existing environment issue, unrelated to this PR.
- [x] `tests/agent-intelligence/drafts-pipeline.test.ts` — registry-invariant updated for the rename.
- [x] `tests/agent-intelligence/sales-chase-fixes.test.ts` (new) — covers Change B (mortgage_expiring intent: in-window inclusion, out-of-window exclusion, handed-over exclusion, null-date exclusion, ordering, status_hint shape) and Change C (`ensureSentenceTerminator` unit cases + `draftBuyerFollowups` end-to-end with a fragment topic asserting body line ends with a sentence terminator).
- [ ] **Live verification (3 runs)** — required before merge:
  1. Sales mode, agent with Lakeside Manor: "Can you send an email to anyone who has not signed their contract in Lakeside Manor and ask them for an update on when they will be signing" → expect `get_candidate_units(intent='overdue_contracts', scheme_name='Lakeside Manor')` then `draft_buyer_followups(purpose='chase', …)`. NOT `surface_aged_contracts_for_solicitor`.
  2. Same agent: "Show me the buyers at lakeside manor whose mortgage is expiring in the next 30 days and draft chase emails for all of them" → expect `get_candidate_units(intent='mortgage_expiring', scheme_name='Lakeside Manor')` then `draft_buyer_followups(purpose='chase', …)` with a sentence-style topic about mortgage expiry. NOT 6 contract-signing emails.
  3. Inspect any draft body — the line between greeting and closing must be a complete sentence ending with `.`, `!`, or `?`. No fragments like "update on signing their contracts" without punctuation.

DO NOT merge until all three live runs pass — three failures need three live verifications.

https://claude.ai/code/session_0196N1JWkBwqqKJRNVMpsVNp

---
_Generated by [Claude Code](https://claude.ai/code/session_0196N1JWkBwqqKJRNVMpsVNp)_