### PR TITLE
fix(agent-sales): server-side chain orchestration after get_candidate_units

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -25,6 +25,9 @@ import { getToolDefinitionsForOpenAI, getToolByName } from '@/lib/agent-intellig
 import type { AgentContext } from '@/lib/agent-intelligence/types';
 import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import { captureInferredAlias, suggestClosestScheme, normaliseSchemeName } from '@/lib/agent-intelligence/scheme-resolver';
+import { shouldChainAfterCandidateUnits } from '@/lib/agent-intelligence/chain-orchestration';
+import type { CandidateIntent, UnitCandidate } from '@/lib/agent-intelligence/unit-resolver';
+import { randomUUID } from 'node:crypto';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -329,10 +332,16 @@ export async function POST(request: NextRequest) {
       for (const toolCall of responseMessage.tool_calls) {
         const toolDef = getToolByName(toolCall.function.name);
         let toolResult: string;
+        // Track the parsed params + envelope of the original call so we can
+        // optionally server-side chain into draft_buyer_followups after
+        // get_candidate_units (Issue D).
+        let originalParams: Record<string, any> = {};
+        let originalEnvelope: AgenticSkillEnvelope | null = null;
 
         if (toolDef) {
           try {
             const params = JSON.parse(toolCall.function.arguments);
+            originalParams = params;
             const result = await toolDef.execute(supabase, tenantId, agentContext, params);
             toolResult = JSON.stringify(result);
             toolsCalled.push({
@@ -344,7 +353,10 @@ export async function POST(request: NextRequest) {
             // AgenticSkillEnvelope. Collect them so we can stream an
             // `envelope` SSE frame once the tool-calling rounds finish.
             const envelope = extractEnvelope(result);
-            if (envelope) envelopes.push(envelope);
+            if (envelope) {
+              envelopes.push(envelope);
+              originalEnvelope = envelope;
+            }
           } catch (err: unknown) {
             const errMessage = err instanceof Error ? err.message : 'Unknown error';
             toolResult = JSON.stringify({ error: errMessage, summary: `Tool execution failed: ${errMessage}` });
@@ -358,6 +370,111 @@ export async function POST(request: NextRequest) {
           tool_call_id: toolCall.id,
           content: toolResult,
         });
+
+        // Issue D — server-side two-step chain.
+        //
+        // After get_candidate_units returns, if the user's original
+        // message carries draft-intent language and the candidate set
+        // is non-empty, fire draft_buyer_followups in the same turn
+        // with hard-coded per-intent purpose + topic. The model never
+        // has to decide to chain — it just summarises both tool
+        // results in its final reply.
+        //
+        // We synthesize the second call as a follow-up assistant
+        // message + tool result pair so the conversation history
+        // OpenAI sees stays consistent (every tool message references
+        // an assistant tool_call). The model in its NEXT round sees
+        // both results and writes a coherent summary.
+        if (toolDef && toolCall.function.name === 'get_candidate_units' && originalEnvelope) {
+          const candidates = (originalEnvelope.meta as any)?.candidates as
+            | UnitCandidate[]
+            | undefined;
+          const intent = (originalParams.intent ?? null) as CandidateIntent | null;
+          const chain = shouldChainAfterCandidateUnits({
+            toolName: toolCall.function.name,
+            intent,
+            candidates: candidates ?? [],
+            userMessage: message,
+          });
+          if (chain) {
+            const chainedToolDef = getToolByName('draft_buyer_followups');
+            if (chainedToolDef) {
+              const chainedParams = {
+                targets: chain.targets,
+                purpose: chain.plan.purpose,
+                topic: chain.plan.topic,
+                tone: 'gentle_chase',
+              };
+              const chainedToolCallId = `chain-${randomUUID()}`;
+              // Synthetic assistant message — opaque to the model in
+              // this round; it's only there so OpenAI's tool-result
+              // wiring stays consistent for the NEXT round's call.
+              messages.push({
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: chainedToolCallId,
+                    type: 'function',
+                    function: {
+                      name: 'draft_buyer_followups',
+                      arguments: JSON.stringify(chainedParams),
+                    },
+                  },
+                ],
+              } as any);
+              try {
+                const chainedResult = await chainedToolDef.execute(
+                  supabase,
+                  tenantId,
+                  agentContext,
+                  chainedParams,
+                );
+                const chainedToolResult = JSON.stringify(chainedResult);
+                toolsCalled.push({
+                  tool_name: 'draft_buyer_followups',
+                  params: chainedParams,
+                  result_summary: chainedResult.summary,
+                });
+                const chainedEnvelope = extractEnvelope(chainedResult);
+                if (chainedEnvelope) envelopes.push(chainedEnvelope);
+                messages.push({
+                  role: 'tool',
+                  tool_call_id: chainedToolCallId,
+                  content: chainedToolResult,
+                });
+                // Tell the model the chain already fired. Stops it
+                // from re-calling draft_buyer_followups in the NEXT
+                // round (which would duplicate drafts).
+                messages.push({
+                  role: 'system',
+                  content:
+                    'AUTO-CHAINED: server-side invoked draft_buyer_followups against the candidate units. Drafts already produced. Do NOT call draft_buyer_followups again this turn — summarise the result instead.',
+                });
+              } catch (chainErr: unknown) {
+                // Defensive: chain failures must not blow up the
+                // user's original turn. Emit a tool-result for the
+                // synthetic call so the conversation stays valid,
+                // and let the model continue.
+                const chainErrMsg =
+                  chainErr instanceof Error ? chainErr.message : 'Unknown error';
+                messages.push({
+                  role: 'tool',
+                  tool_call_id: chainedToolCallId,
+                  content: JSON.stringify({
+                    error: chainErrMsg,
+                    summary: `Auto-chain into draft_buyer_followups failed: ${chainErrMsg}`,
+                  }),
+                });
+                console.error('[chat/route] auto-chain failed', {
+                  intent,
+                  candidatesCount: chain.targets.length,
+                  error: chainErrMsg,
+                });
+              }
+            }
+          }
+        }
       }
     }
 
@@ -775,10 +892,36 @@ export async function POST(request: NextRequest) {
             failureMessage = summary;
             failureQuery = emptyEnv?.meta?.query ?? null;
           } else if (claimsDrafts && totalDraftsPersisted === 0) {
-            failureKind = 'hallucinated_drafts';
-            failureCorrelationId = randomCorrelationId();
-            failureMessage =
-              "We couldn't complete this — the email action didn't go through and nothing landed in the drafts inbox. Tap Retry, or tell me the specific unit numbers / buyer names you meant.";
+            // Issue E (PR follow-up to #97). Suppress the red
+            // hallucinated_drafts card when the only tools called this
+            // turn were read-only — never-draft-producing tools like
+            // get_candidate_units, get_unit_status, etc. The model may
+            // still emit "I'll draft them" prose without firing any
+            // draft skill, but in that case there's nothing to lie
+            // ABOUT — no drafts were ever expected to land. Letting
+            // the response render as a normal AIResponseCard surfaces
+            // the candidate list / read-only result the user actually
+            // got, instead of a misleading red error envelope.
+            //
+            // The hallucination guard still fires the moment ANY
+            // draft-producing tool gets called and produces zero — that's
+            // the regression class we keep blocking.
+            const anyDraftToolFired = toolsCalled.some((t) =>
+              DRAFT_PRODUCING_TOOLS.has(t.tool_name),
+            );
+            if (anyDraftToolFired) {
+              failureKind = 'hallucinated_drafts';
+              failureCorrelationId = randomCorrelationId();
+              failureMessage =
+                "We couldn't complete this — the email action didn't go through and nothing landed in the drafts inbox. Tap Retry, or tell me the specific unit numbers / buyer names you meant.";
+            } else {
+              console.warn('[chat/route] model emitted draft-claim language without firing any draft tool', {
+                userId: agentContext.authUserId,
+                originalMessage: message,
+                toolsCalled: toolsCalled.map((t) => t.tool_name),
+                contentSnippet: fullContent.slice(0, 200),
+              });
+            }
           }
 
           if (failureKind && failureMessage) {

--- a/apps/unified-portal/lib/agent-intelligence/chain-orchestration.ts
+++ b/apps/unified-portal/lib/agent-intelligence/chain-orchestration.ts
@@ -1,0 +1,140 @@
+/**
+ * Server-side two-step chain for buyer-chase requests.
+ *
+ * PR #97's live test showed that soft prompt directives (the SALES
+ * TWO-STEP CHAIN block + the getCandidateUnitsSkill "Next: …" nudge in
+ * the envelope summary) are unreliable: the model received the
+ * candidate list with explicit "next call draft_buyer_followups"
+ * instructions and stopped, treating the hint as text to display
+ * rather than instruction to execute. Same lesson as cross-scheme
+ * ranking — soft directives don't move the model; the chain has to
+ * happen in code.
+ *
+ * This module is the deterministic chain. When the model calls
+ * `get_candidate_units` AND the original user message carries
+ * draft-intent language (draft / send / chase / follow up / email /
+ * reach out / message / write to / mail / ping / contact / let X
+ * know), the chat route invokes `draft_buyer_followups` in the same
+ * turn with:
+ *   - targets derived from the candidate list
+ *   - purpose + topic derived from the candidate intent (hard-coded
+ *     templates; deterministic, consistent voice)
+ *
+ * The model never decides whether to chain; it just summarises both
+ * tool results in its final reply.
+ */
+
+import type { CandidateIntent, UnitCandidate } from './unit-resolver';
+import type { DraftBuyerFollowupPurpose } from './tools/agentic-skills';
+
+/**
+ * Words and phrases in the user's message that signal "the user wants
+ * drafts produced for the cohort the model is about to fetch". Errs
+ * on the inclusive side — better to chain a draft the user wanted
+ * than to leave a candidate-list dangling. The cost of an extra
+ * chain when the user wanted only a list is low (drafts land in the
+ * approval drawer, agent doesn't have to send them); the cost of a
+ * missed chain is the bug we just hit in production.
+ *
+ * Whole-word matches only — avoids false positives on substring
+ * overlaps (e.g. "discharge" shouldn't match "chase").
+ */
+const DRAFT_INTENT_RE =
+  /\b(draft|drafts?|drafted|drafting|send|sends?|sending|sent|chase|chases|chasing|chased|follow[-\s]?up|following[-\s]?up|reach[-\s]?out|reaching[-\s]?out|email|emails?|emailing|message|messages?|messaging|write\s+to|writing\s+to|contact|contacts?|contacting|let\s+\S+\s+know|mail|mails?|mailing|ping|pings?|pinging)\b/i;
+
+export function messageHasDraftIntent(message: string | null | undefined): boolean {
+  if (!message) return false;
+  return DRAFT_INTENT_RE.test(message);
+}
+
+/**
+ * Map a candidate-units intent onto the draft_buyer_followups inputs
+ * the server-side chain should fire with. Hard-coded sentence-form
+ * topics (option (i) from the task brief) — deterministic, agent-voice
+ * consistent, and always satisfies the registry parameter description's
+ * "must be a complete sentence" rule.
+ *
+ * Returns null when the intent is too generic for an auto-chain
+ * (intent='all') — in that case the model has to decide what to do.
+ */
+export interface ChainPlan {
+  purpose: DraftBuyerFollowupPurpose;
+  topic: string;
+}
+
+export function planChainFromIntent(intent: CandidateIntent): ChainPlan | null {
+  switch (intent) {
+    case 'mortgage_expiring':
+      return {
+        purpose: 'chase',
+        topic:
+          'I noticed your mortgage approval is coming up for expiry — happy to help arrange anything needed before it lapses.',
+      };
+    case 'overdue_contracts':
+      return {
+        purpose: 'chase',
+        topic:
+          'I wanted to check in on your contract signing — could you let me know where things stand?',
+      };
+    case 'sale_agreed':
+      return {
+        purpose: 'chase',
+        topic:
+          'Just checking in on the next steps from your sale agreement — happy to help move things along whenever you\'re ready.',
+      };
+    case 'handover':
+      return {
+        // congratulate_handover ignores topic and uses its own template body.
+        purpose: 'congratulate_handover',
+        topic: '',
+      };
+    case 'all':
+    default:
+      // Too generic — the user probably asked for something specific
+      // that the model resolved to 'all' as a fallback. Don't auto-chain
+      // because we can't pick a sensible topic.
+      return null;
+  }
+}
+
+/**
+ * Build the targets array that goes into draft_buyer_followups from a
+ * candidate-units result. One entry per unit; joint purchasers at one
+ * unit collapse to a single target inside draft_buyer_followups.
+ */
+export function buildChainTargets(
+  candidates: UnitCandidate[],
+): Array<{ unit_identifier: string; scheme_name: string }> {
+  return candidates.map((c) => ({
+    unit_identifier: c.unit_number,
+    scheme_name: c.scheme_name,
+  }));
+}
+
+/**
+ * Decide whether the chain should fire for this turn.
+ *
+ * Conditions (all must hold):
+ *   1. The model just called `get_candidate_units` and it returned
+ *      a non-empty candidates array.
+ *   2. The intent is one we have a chain plan for (handover,
+ *      overdue_contracts, mortgage_expiring, sale_agreed).
+ *   3. The user's original message contains draft-intent language.
+ *
+ * Returns the chain plan + targets when all three hold; null
+ * otherwise (model + chat layer fall through to normal rendering).
+ */
+export function shouldChainAfterCandidateUnits(args: {
+  toolName: string;
+  intent: CandidateIntent | null;
+  candidates: UnitCandidate[];
+  userMessage: string;
+}): { plan: ChainPlan; targets: Array<{ unit_identifier: string; scheme_name: string }> } | null {
+  if (args.toolName !== 'get_candidate_units') return null;
+  if (!args.candidates.length) return null;
+  if (!args.intent) return null;
+  if (!messageHasDraftIntent(args.userMessage)) return null;
+  const plan = planChainFromIntent(args.intent);
+  if (!plan) return null;
+  return { plan, targets: buildChainTargets(args.candidates) };
+}

--- a/apps/unified-portal/tests/agent-intelligence/chain-orchestration.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/chain-orchestration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Server-side two-step chain regression guards.
+ *
+ * Background: PR #97's live test showed the model treated the soft
+ * "Next: …" envelope nudge as text to display rather than instruction
+ * to execute. This module locks down the deterministic chain helpers
+ * the chat route uses to fire draft_buyer_followups in the same turn
+ * as get_candidate_units.
+ *
+ * Hermetic — pure functions, no Supabase / no network.
+ */
+
+import {
+  messageHasDraftIntent,
+  planChainFromIntent,
+  buildChainTargets,
+  shouldChainAfterCandidateUnits,
+} from '../../lib/agent-intelligence/chain-orchestration';
+import type { UnitCandidate } from '../../lib/agent-intelligence/unit-resolver';
+
+describe('messageHasDraftIntent', () => {
+  it.each([
+    'Show me the buyers at lakeside manor whose mortgage is expiring in the next 30 days and draft chase emails for all of them',
+    'Send chase emails to buyers who haven\'t signed contracts yet',
+    'Find anyone whose mortgage is expiring AND email them',
+    'List the unsigned contracts and chase them',
+    'Reach out to anyone who hasn\'t signed',
+    'Follow up with the overdue buyers',
+    'follow-up with everyone in the cohort',
+    'mail the unsigned cohort',
+    'ping the buyers about their mortgage',
+    'message everyone whose deposit is in',
+    'write to the unsigned buyers',
+    'let me know who hasn\'t signed and contact them',
+  ])('matches "%s"', (msg) => {
+    expect(messageHasDraftIntent(msg)).toBe(true);
+  });
+
+  it.each([
+    'show me overdue contracts',
+    'list the unsigned contracts',
+    'who hasn\'t signed yet',
+    'how many buyers are in the pipeline',
+    'tell me about Lakeside Manor',
+    'what\'s the status of unit 12',
+  ])('does NOT match read-only "%s"', (msg) => {
+    expect(messageHasDraftIntent(msg)).toBe(false);
+  });
+
+  it('handles null and empty input', () => {
+    expect(messageHasDraftIntent(null)).toBe(false);
+    expect(messageHasDraftIntent(undefined)).toBe(false);
+    expect(messageHasDraftIntent('')).toBe(false);
+  });
+});
+
+describe('planChainFromIntent', () => {
+  it('mortgage_expiring → chase + sentence-form topic mentioning mortgage', () => {
+    const plan = planChainFromIntent('mortgage_expiring');
+    expect(plan).not.toBeNull();
+    expect(plan!.purpose).toBe('chase');
+    expect(plan!.topic).toMatch(/mortgage/i);
+    // Must read as a complete sentence (registry contract — Issue C of #96).
+    expect(plan!.topic.trim()).toMatch(/[.!?]$/);
+  });
+
+  it('overdue_contracts → chase + sentence about contract signing', () => {
+    const plan = planChainFromIntent('overdue_contracts');
+    expect(plan).not.toBeNull();
+    expect(plan!.purpose).toBe('chase');
+    expect(plan!.topic).toMatch(/contract/i);
+    expect(plan!.topic.trim()).toMatch(/[.!?]$/);
+  });
+
+  it('sale_agreed → chase + sentence about next steps', () => {
+    const plan = planChainFromIntent('sale_agreed');
+    expect(plan).not.toBeNull();
+    expect(plan!.purpose).toBe('chase');
+    expect(plan!.topic.trim()).toMatch(/[.!?]$/);
+  });
+
+  it('handover → congratulate_handover (topic ignored by template)', () => {
+    const plan = planChainFromIntent('handover');
+    expect(plan).not.toBeNull();
+    expect(plan!.purpose).toBe('congratulate_handover');
+  });
+
+  it('all → null (too generic to auto-chain)', () => {
+    expect(planChainFromIntent('all')).toBeNull();
+  });
+});
+
+describe('buildChainTargets', () => {
+  it('one target per candidate, scheme + unit number passed through', () => {
+    const candidates: UnitCandidate[] = [
+      { id: 'u-1', development_id: 'dev-1', scheme_name: 'Lakeside Manor', unit_number: '12', purchaser_name: 'Aoife Byrne', status_hint: 'mortgage approval expires 2026-05-10 (3d)' },
+      { id: 'u-2', development_id: 'dev-1', scheme_name: 'Lakeside Manor', unit_number: '15', purchaser_name: 'Rónán McCarthy', status_hint: 'mortgage approval expires 2026-05-25 (18d)' },
+    ];
+    expect(buildChainTargets(candidates)).toEqual([
+      { unit_identifier: '12', scheme_name: 'Lakeside Manor' },
+      { unit_identifier: '15', scheme_name: 'Lakeside Manor' },
+    ]);
+  });
+
+  it('empty candidate list → empty targets', () => {
+    expect(buildChainTargets([])).toEqual([]);
+  });
+});
+
+describe('shouldChainAfterCandidateUnits — full gate', () => {
+  const cohort: UnitCandidate[] = [
+    { id: 'u-1', development_id: 'dev-1', scheme_name: 'Lakeside Manor', unit_number: '12', purchaser_name: 'Aoife', status_hint: 'mortgage approval expires 2026-05-10 (3d)' },
+  ];
+
+  it('all conditions met → returns chain plan + targets', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: 'mortgage_expiring',
+      candidates: cohort,
+      userMessage:
+        'Show me the buyers at lakeside manor whose mortgage is expiring in the next 30 days and draft chase emails for all of them',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.plan.purpose).toBe('chase');
+    expect(result!.plan.topic).toMatch(/mortgage/i);
+    expect(result!.targets).toEqual([
+      { unit_identifier: '12', scheme_name: 'Lakeside Manor' },
+    ]);
+  });
+
+  it('wrong tool → no chain', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_buyer_details',
+      intent: 'mortgage_expiring',
+      candidates: cohort,
+      userMessage: 'show me Aoife\'s details and email her',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('zero candidates → no chain', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: 'mortgage_expiring',
+      candidates: [],
+      userMessage: 'show me whose mortgage is expiring and email them',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('null intent → no chain', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: null,
+      candidates: cohort,
+      userMessage: 'show me the candidates and email them',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('intent="all" → no chain (too generic)', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: 'all',
+      candidates: cohort,
+      userMessage: 'show me everyone and email them',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('user message has no draft intent → no chain (pure show-me)', () => {
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: 'mortgage_expiring',
+      candidates: cohort,
+      userMessage: 'show me whose mortgage is expiring at lakeside manor',
+    });
+    expect(result).toBeNull();
+  });
+
+  // Worked example from the live-test failure that motivated this PR.
+  it('production failure repro — Test 2 retry chains correctly', () => {
+    const candidates: UnitCandidate[] = [
+      { id: 'u-9', development_id: 'dev-1', scheme_name: 'Lakeside Manor', unit_number: '9', purchaser_name: 'Ailbhe Tierney', status_hint: 'mortgage approval expires 2026-05-10 (3d)' },
+    ];
+    const result = shouldChainAfterCandidateUnits({
+      toolName: 'get_candidate_units',
+      intent: 'mortgage_expiring',
+      candidates,
+      userMessage:
+        'Show me the buyers at lakeside manor whose mortgage is expiring in the next 30 days and draft chase emails for all of them',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.targets).toEqual([
+      { unit_identifier: '9', scheme_name: 'Lakeside Manor' },
+    ]);
+    expect(result!.plan.purpose).toBe('chase');
+    // Topic must be a complete sentence in the agent's voice — not the
+    // "[full sentence describing the reason]" placeholder hint.
+    expect(result!.plan.topic).not.toMatch(/\[/);
+    expect(result!.plan.topic.trim()).toMatch(/[.!?]$/);
+  });
+});


### PR DESCRIPTION
## Summary

PR #97 live test confirmed: even with the SALES `TWO-STEP CHAIN` prompt block AND the explicit "Next: call draft_buyer_followups" hint inside the candidate-units envelope summary, the model called `get_candidate_units` and stopped, treating the hint as text to display rather than instruction to execute. Same lesson as cross-scheme ranking — when reliability matters, the chain has to happen in code.

This PR moves the chain server-side. One commit, two issues, plus tests.

### Issue D — Server-side chain orchestration

New `lib/agent-intelligence/chain-orchestration.ts` decides whether the chat route should auto-fire `draft_buyer_followups` immediately after `get_candidate_units` returns. Three gates, all required:

1. The completed tool call was `get_candidate_units` and returned non-empty candidates.
2. The intent has a chain plan (`handover` / `overdue_contracts` / `mortgage_expiring` / `sale_agreed`). `'all'` is excluded — too generic.
3. The user's original message contains draft-intent language: `draft / send / chase / follow up / email / reach out / message / write to / mail / contact / let X know / ping`. Whole-word match.

When all three hold, the chat route synthesizes a follow-up assistant `tool_call` + tool result pair (keeps OpenAI conversation history consistent) and invokes `draft_buyer_followups` with:
- **targets[]** — one entry per candidate (unit_number + scheme_name)
- **purpose** — derived from intent (`chase` for cohort intents, `congratulate_handover` for handover)
- **topic** — hard-coded sentence-form template per intent (option (i) from the brief). Deterministic, agent-voice consistent, satisfies PR #96 Change C's "must be a complete sentence" rule.

A trailing system message tells the model the chain already fired so it just summarises both tool results in its final reply.

### Issue E — Suppress red failure card when no draft tool actually ran

The pre-Issue-D failure mode: model calls `get_candidate_units`, writes "I'll draft them" without firing `draft_buyer_followups`, chat route flags it as `hallucinated_drafts` → red error envelope on top of valid candidate-list data.

With Issue D's chain in place, drafts now land in this exact path so the regex no longer trips. But for safety: when `claimsDrafts && totalDraftsPersisted === 0` AND the only tools called this turn were read-only, suppress the red card and let the candidate list render as a normal `AIResponseCard`. The hallucination guard still fires the moment ANY draft-producing tool gets called and produces zero — that's the regression class we keep blocking.

## Test plan

- [x] `npm run build` — `✓ Compiled successfully`. Build exit 0.
- [x] New `tests/agent-intelligence/chain-orchestration.test.ts` covers:
  - `messageHasDraftIntent` — 12 positive cases (draft / chase / send / follow up / mail / ping / reach out / message / write to / contact / let X know / email) and 6 negative read-only cases (show me / list / who hasn't signed / how many / tell me / what's the status); null + empty input.
  - `planChainFromIntent` — each intent maps to the right purpose + a sentence-terminated topic; `'all'` returns null.
  - `buildChainTargets` — candidate → target shape; empty list passthrough.
  - `shouldChainAfterCandidateUnits` — every gate independently (wrong tool / zero candidates / null intent / `'all'` intent / pure show-me) plus a worked example for the Test 2 retry — Ailbhe Tierney at Lakeside Manor Unit 9, mortgage expiring — verifying the chain fires with the right targets and a real sentence topic (no placeholder `[full sentence …]` text).
- [ ] **Live verification** before merge:
  1. Test 2 retry: "Show me the buyers at lakeside manor whose mortgage is expiring in the next 30 days and draft chase emails for all of them" → expect `get_candidate_units(intent='mortgage_expiring')` IMMEDIATELY followed by `draft_buyer_followups(purpose='chase', topic='I noticed your mortgage approval is coming up for expiry — happy to help arrange anything needed before it lapses.')`. Drafts land in the inbox.
  2. Pure show-me: "Show me the overdue contracts at Lakeside Manor" → `get_candidate_units` only, candidate list renders as a normal `AIResponseCard` (no red error envelope), even if the model says "I could draft chase emails for them" in its summary text.
  3. Buyer-chase: "Send chase emails to anyone who hasn't signed contracts at Lakeside Manor" → chain fires for `overdue_contracts` intent.
  4. Handover: "Welcome the latest handovers at Árdan View" → chain fires with `purpose='congratulate_handover'`.

## Stack note for review

- Branched off `origin/main` (currently `c1b2359` — PR #96 only). PR #97 (`claude/sales-chase-email-completion`) is still open.
- The draft-intent regex + topic templates here are independent of PR #97. The server-side chain becomes the SOURCE OF TRUTH; PR #97's "Next:" hint becomes belt-and-braces (still useful when the model picks up a chain that wasn't gated by message-level draft intent).
- When PR #97 lands first, this PR rebases cleanly — no overlap with #97's chat-route edits (#97 modifies the failure-message copy + adds `recipientQuery`; this PR adds a chain block in the tool loop and an `anyDraftToolFired` gate around the hallucination check).

DO NOT merge until live test passes — Issue D is the regression we just hit, so verify the chain fires in production before shipping.

https://claude.ai/code/session_0196N1JWkBwqqKJRNVMpsVNp

---
_Generated by [Claude Code](https://claude.ai/code/session_0196N1JWkBwqqKJRNVMpsVNp)_