### PR TITLE
fix(security): move _demo_backup_*_20260502 tables out of public schema

### DIFF
--- a/apps/unified-portal/migrations/057_move_demo_backups_out_of_public.sql
+++ b/apps/unified-portal/migrations/057_move_demo_backups_out_of_public.sql
@@ -1,0 +1,32 @@
+-- Move 10 _demo_backup_*_20260502 tables out of the public schema.
+--
+-- These tables were created on 2026-05-02 as a safety snapshot during demo
+-- data work. They have RLS disabled, which means anyone holding the public
+-- anon key (which ships in the client bundle) can read every row of the
+-- snapshotted tenant, agent, sales pipeline, units, compliance documents
+-- and tenancy data. The Supabase advisor flagged this as critical.
+--
+-- Fix: relocate them to a non-public `demo_backups` schema. The Supabase
+-- anon and authenticated roles only get table access in `public` by
+-- default, so moving the schema is sufficient to revoke their reach
+-- without losing the snapshots themselves.
+--
+-- No application code references these tables (verified by grep). Safe to
+-- move without code changes.
+
+CREATE SCHEMA IF NOT EXISTS demo_backups;
+
+ALTER TABLE public._demo_backup_agent_letting_properties_20260502 SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_agent_profiles_20260502           SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_agent_tenancies_20260502          SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_agent_workspaces_20260502         SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_authuser_developer_20260502       SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_compliance_documents_20260502     SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_developments_20260502             SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_tenants_20260502                  SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_unit_sales_pipeline_20260502      SET SCHEMA demo_backups;
+ALTER TABLE public._demo_backup_units_20260502                    SET SCHEMA demo_backups;
+
+REVOKE ALL ON SCHEMA demo_backups FROM PUBLIC;
+REVOKE ALL ON SCHEMA demo_backups FROM anon, authenticated;
+REVOKE ALL ON ALL TABLES IN SCHEMA demo_backups FROM anon, authenticated;


### PR DESCRIPTION
## Summary

The 10 `_demo_backup_*_20260502` tables created on 2026-05-02 had RLS disabled and were exposed in the `public` schema, meaning anyone holding the public anon key (which ships in the client bundle) could read every row. Snapshotted content included `tenants`, `agent_profiles`, `agent_workspaces`, `developments`, `unit_sales_pipeline`, `units`, `compliance_documents`, `agent_tenancies`, `agent_letting_properties`, and `authuser_developer`.

This PR relocates the tables to a new non-public `demo_backups` schema. Anon and authenticated roles only have table access in `public` by default, so moving the schema is sufficient to revoke their reach without dropping the snapshots themselves. Privileges on `demo_backups` are explicitly revoked from `PUBLIC`, `anon`, and `authenticated` for defence-in-depth.

The migration was applied to the production Supabase project (`mddxbilpjukwskeefakz`) via Supabase MCP `apply_migration` and verified:

- All 10 tables now in `demo_backups`, **0 remaining in `public`**.
- Supabase advisor `rls_disabled` warning has cleared.
- No application code references these tables (verified via grep across `*.ts`, `*.tsx`, `*.js`, `*.sql`, `*.json`).

Found during the code-level QA audit (CODE-ISSUE-015).

## Test plan

- [x] `apply_migration` succeeded against production project
- [x] `SELECT schemaname, COUNT(*) FROM pg_tables WHERE tablename LIKE '\\_demo\\_backup\\_%' GROUP BY schemaname` returns `demo_backups | 10` and nothing for `public`
- [x] `mcp__supabase__list_tables(schemas=["public"])` no longer surfaces the `rls_disabled` advisory
- [x] grep across the repo shows zero references to `_demo_backup`
- [ ] Smoke-test production after deploy: dashboards, agent intelligence chat, lettings compliance, sales pipeline list

https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF)_