### PR TITLE
fix(agent): launch-readiness batch 1 — 7 atomic fixes

### DIFF
--- a/apps/unified-portal/app/agent/lettings/properties/[id]/page.tsx
+++ b/apps/unified-portal/app/agent/lettings/properties/[id]/page.tsx
@@ -850,6 +850,11 @@ function NewTicketSheet({ propertyId, onClose, onSuccess }: { propertyId: string
   );
 }
 
+// Per-property compliance score (Issue 1.2 / Chrome ISSUE-006). Helper
+// lives in `lib/lettings/per-property-compliance.ts` so the regression
+// test can import it without pulling in a 'use client' page.
+import { computePerPropertyComplianceScore } from '../../../../../lib/lettings/per-property-compliance';
+
 function ComplianceTab({ property, activeTenancy, documents }: { property: PropertyFields; activeTenancy: Tenancy | null; documents: DocumentRow[] }) {
   const hasDoc = (t: string) => documents.some((d) => d.docType === t);
   const isVacant = !activeTenancy || activeTenancy.status !== 'active' || (property.status ?? '').toLowerCase() === 'vacant';
@@ -866,11 +871,12 @@ function ComplianceTab({ property, activeTenancy, documents }: { property: Prope
     { label: 'RTB registration', state: isVacant ? 'na' : rtbOk ? 'ok' : 'amber', status: isVacant ? 'Not applicable' : rtbOk ? 'Registered' : 'Outstanding' },
     { label: 'Signed lease on file', state: leaseOk ? 'ok' : 'amber', status: leaseOk ? 'Uploaded' : 'Outstanding' },
   ];
+  const scorePct = computePerPropertyComplianceScore(rows);
   return (
     <div className="bg-white border border-[#E5E7EB] rounded-xl p-4 mb-4">
       <div className="flex items-baseline justify-between mb-2">
         <span className="text-[11px] font-semibold tracking-wider uppercase text-[#9EA8B5]">Compliance status</span>
-        <span className="text-base font-semibold text-[#0D0D12]">{property.completenessScore}%</span>
+        <span className="text-base font-semibold text-[#0D0D12]">{scorePct === null ? '—' : `${scorePct}%`}</span>
       </div>
       {rows.map((r, i) => (
         <div key={r.label} className="flex items-center justify-between py-2.5" style={{ borderTop: i === 0 ? 'none' : '0.5px solid #F3F4F6' }}>

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -25,6 +25,7 @@ import { getToolDefinitionsForOpenAI, getToolByName } from '@/lib/agent-intellig
 import type { AgentContext } from '@/lib/agent-intelligence/types';
 import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import { captureInferredAlias, suggestClosestScheme, normaliseSchemeName } from '@/lib/agent-intelligence/scheme-resolver';
+import { redactEnvelopeForUser, redactSummaryForUser } from '@/lib/agent-intelligence/redact-scaffolding';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -606,7 +607,9 @@ export async function POST(request: NextRequest) {
             controller.enqueue(
               encoder.encode(JSON.stringify({
                 type: 'tools_used',
-                tools: toolsCalled.map(t => ({ name: t.tool_name, summary: t.result_summary })),
+                // Issue 1.1: strip internal model-facing scaffolding from
+                // the per-tool summaries surfaced in the user UI.
+                tools: toolsCalled.map(t => ({ name: t.tool_name, summary: redactSummaryForUser(t.result_summary) })),
               }) + '\n')
             );
           }
@@ -615,9 +618,17 @@ export async function POST(request: NextRequest) {
           // with the full set — approve / edit / discard targets real
           // `pending_drafts.id`s that were rewritten by
           // persistSkillEnvelope inside the registry adapter.
+          //
+          // Issue 1.1 / Chrome ISSUE-001: strip internal model-facing
+          // scaffolding ("Next: call draft_buyer_followups(...)") from
+          // user-visible envelope summaries before emitting the SSE
+          // frame. The original (un-redacted) summary is still pushed to
+          // `messages[]` as the tool-result, so the model's chain
+          // orchestration is unaffected.
           if (combinedEnvelope) {
+            const userVisibleEnvelope = redactEnvelopeForUser(combinedEnvelope);
             controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'envelope', envelope: combinedEnvelope }) + '\n')
+              encoder.encode(JSON.stringify({ type: 'envelope', envelope: userVisibleEnvelope }) + '\n')
             );
           }
 
@@ -676,14 +687,63 @@ export async function POST(request: NextRequest) {
             // beat before tokens start arriving.
             emitProgress('finalising', 'Almost there');
 
+            // Issue 1.5 / Chrome ISSUE-017 — stream-buffer dangling
+            // fragments. The user used to see mid-sentence truncation
+            // states like "Proposed rent: €1785 (" — the eventual full
+            // text was correct but the partial render was visible
+            // mid-stream. We buffer the trailing incomplete fragment
+            // server-side and only emit content up to the last safe
+            // boundary (newline, sentence terminator + space, or
+            // forced-flush after STREAM_FORCE_FLUSH_CHARS chars without
+            // a break). The remainder waits for the next delta. At
+            // stream end we flush whatever is left.
+            const STREAM_FORCE_FLUSH_CHARS = 80;
+            let pendingTail = '';
+            const findSafeEmitIndex = (buffer: string): number => {
+              // Prefer the last newline, then last sentence terminator
+              // followed by space (or end), then last comma + space, then
+              // a force-flush cutoff if the buffer is past the threshold.
+              const newlineIdx = buffer.lastIndexOf('\n');
+              if (newlineIdx >= 0) return newlineIdx + 1;
+              for (const re of [/[.!?](?=\s|$)/g, /[;:](?=\s|$)/g, /,(?=\s|$)/g]) {
+                let lastMatch = -1;
+                let m: RegExpExecArray | null;
+                while ((m = re.exec(buffer)) !== null) {
+                  lastMatch = m.index + m[0].length;
+                  if (m.index === re.lastIndex) re.lastIndex++;
+                }
+                if (lastMatch >= 0) return lastMatch;
+              }
+              if (buffer.length > STREAM_FORCE_FLUSH_CHARS) {
+                // Force-flush at the last whitespace position so we never
+                // emit a half-word; if there is no whitespace at all,
+                // hold and wait for more deltas.
+                const ws = buffer.lastIndexOf(' ');
+                if (ws > 0) return ws + 1;
+              }
+              return -1;
+            };
             for await (const chunk of stream) {
               const delta = chunk.choices[0]?.delta?.content;
               if (delta) {
                 fullContent += delta;
-                controller.enqueue(
-                  encoder.encode(JSON.stringify({ type: 'token', content: delta }) + '\n')
-                );
+                pendingTail += delta;
+                const idx = findSafeEmitIndex(pendingTail);
+                if (idx > 0) {
+                  const emit = pendingTail.slice(0, idx);
+                  pendingTail = pendingTail.slice(idx);
+                  controller.enqueue(
+                    encoder.encode(JSON.stringify({ type: 'token', content: emit }) + '\n')
+                  );
+                }
               }
+            }
+            // Flush any remaining buffered content at end of stream.
+            if (pendingTail) {
+              controller.enqueue(
+                encoder.encode(JSON.stringify({ type: 'token', content: pendingTail }) + '\n')
+              );
+              pendingTail = '';
             }
 
             if (!fullContent) {
@@ -766,9 +826,13 @@ export async function POST(request: NextRequest) {
             // is required.", etc) — far more useful than the generic
             // "rephrase your request" copy that used to be emitted.
             const emptyEnv = envelopes.find((e) => e.drafts.length === 0) || envelopes[0] || null;
+            // Issue 1.1: redact internal scaffolding from the user-facing
+            // failure message — the empty-result envelope summary may
+            // include the get_candidate_units chain nudge.
+            const redacted = redactSummaryForUser(emptyEnv?.summary).trim();
             const summary =
-              (emptyEnv?.summary && emptyEnv.summary.trim().length > 0)
-                ? emptyEnv.summary.trim()
+              redacted.length > 0
+                ? redacted
                 : "The draft action didn't go through.";
             failureKind = 'empty_draft_result';
             failureCorrelationId = randomCorrelationId();

--- a/apps/unified-portal/lib/agent-intelligence/format-helpers.ts
+++ b/apps/unified-portal/lib/agent-intelligence/format-helpers.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared formatting helpers for skill outputs.
+ *
+ * Two concerns:
+ *
+ *  1. Currency formatting (Issue 1.6 / CODE-ISSUE-005)
+ *     `€${rent}` interpolation lets a stored numeric like 1850.5 land in
+ *     tenant-facing legal copy as "€1850.5". `formatEuro` runs every
+ *     amount through `Intl.NumberFormat('en-IE', { currency: 'EUR' })`
+ *     so the user sees "€1,851" — rounded to whole euro, with a
+ *     thousands separator. This is the single source of truth for any
+ *     Euro string the agent renders.
+ *
+ *  2. Timezone-stable date parsing (Issue 1.7 / CODE-ISSUE-006)
+ *     `new Date('2026-05-08')` parses as UTC midnight. Formatting that
+ *     value with `toLocaleDateString` on a runtime west of UTC (or
+ *     even in BST when the wall-clock is past 01:00) can render as
+ *     "7 May" instead of "8 May". `parseIrishCalendarDate` parses
+ *     `YYYY-MM-DD` strings as LOCAL midnight via the (year, month, day)
+ *     constructor so the displayed day matches the stored day no matter
+ *     where the runtime is. Falls back to the standard `Date(string)`
+ *     parser when the input already carries a time component (ISO with
+ *     timezone) so existing call sites that pass full timestamps stay
+ *     correct.
+ */
+
+const EURO_FORMATTER = new Intl.NumberFormat('en-IE', {
+  style: 'currency',
+  currency: 'EUR',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Render a number as a Euro string in en-IE locale. Whole euro only —
+ * the renewal-cap math is rounded to multiples of €5 anyway, and tenant
+ * copy reads cleaner without ".00" everywhere.
+ *
+ * `null` / `undefined` / non-finite values render as "€0" rather than
+ * "€NaN" — the one place this matters (rent_pcm absent on a tenancy)
+ * was previously rendering "€0" via raw `Number(t.rent_pcm ?? 0)`, so
+ * this preserves the existing behaviour.
+ */
+export function formatEuro(amount: number | string | null | undefined): string {
+  const n = typeof amount === 'number' ? amount : Number(amount);
+  if (!Number.isFinite(n)) return EURO_FORMATTER.format(0);
+  return EURO_FORMATTER.format(n);
+}
+
+const YYYY_MM_DD_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a date string into a Date positioned at LOCAL midnight when the
+ * input is `YYYY-MM-DD`. For full ISO timestamps (containing a `T` or
+ * `Z`), defers to `new Date(input)` since those carry their own
+ * timezone information.
+ *
+ * Returns null when the input doesn't parse — callers fall back to
+ * displaying the raw string in that case.
+ */
+export function parseIrishCalendarDate(input: string | null | undefined): Date | null {
+  if (!input) return null;
+  const trimmed = String(input).trim();
+  if (!trimmed) return null;
+  const dateOnlyMatch = trimmed.match(YYYY_MM_DD_RE);
+  if (dateOnlyMatch) {
+    const [, y, m, d] = dateOnlyMatch;
+    const date = new Date(Number(y), Number(m) - 1, Number(d));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Day-of-month difference between `iso` and `now`, computed at midnight
+ * local time on both sides. Avoids the BST-evening-after-midnight-UTC
+ * off-by-one that bit `draftLeaseRenewal` (CODE-ISSUE-006): a renewal
+ * email used to read "lease ended 1 day ago" on the actual end date
+ * because `Date.now()` was a wall-clock instant while the parsed
+ * `lease_end` was UTC midnight.
+ */
+export function daysUntilCalendarDate(
+  iso: string | null | undefined,
+  now: Date = new Date(),
+): number | null {
+  const target = parseIrishCalendarDate(iso);
+  if (!target) return null;
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const ms = target.getTime() - today.getTime();
+  return Math.round(ms / 86_400_000);
+}
+
+/**
+ * Format an Irish calendar date as "8 May 2026". Stable across executor
+ * timezones for `YYYY-MM-DD` inputs.
+ */
+export function formatIrishDate(iso: string | null | undefined): string {
+  if (!iso) return 'unknown date';
+  const date = parseIrishCalendarDate(iso);
+  if (!date) return iso;
+  return date.toLocaleDateString('en-IE', { day: 'numeric', month: 'long', year: 'numeric' });
+}

--- a/apps/unified-portal/lib/agent-intelligence/redact-scaffolding.ts
+++ b/apps/unified-portal/lib/agent-intelligence/redact-scaffolding.ts
@@ -1,0 +1,100 @@
+/**
+ * Strip internal model-facing scaffolding from text shown to the user.
+ *
+ * Background (Issue 1.1 / Chrome ISSUE-001): PR #97 added a "Next:" hint
+ * inside the `get_candidate_units` envelope summary so the model would
+ * follow through with `draft_buyer_followups` in the same turn. That
+ * hint occasionally rendered to the user verbatim as a red error block
+ * — the user saw raw tool-call syntax like
+ *
+ *     Next: if the user asked for drafts, immediately call
+ *     draft_buyer_followups(targets=[the units above], purpose='chase',
+ *     topic='[full sentence describing the reason]') in the SAME turn.
+ *
+ * Solution: redact the summary at the boundary where it's emitted to
+ * the client (the `envelope` SSE frame). The model still sees the
+ * original via the tool-result message in its context, so chain
+ * orchestration is unaffected.
+ *
+ * Strategy:
+ *   - Drop any line that begins with a known scaffolding label
+ *     ("Next:", "Step 2:", "Then:") AND contains tool-call syntax.
+ *   - Drop any line that contains placeholder syntax like
+ *     "[full sentence describing X]".
+ *   - Drop any line that contains instruction-to-model phrases like
+ *     "in the SAME turn", "the input to step 2", "do not stop after",
+ *     "the final answer".
+ *   - Collapse multiple blank lines to one and trim trailing whitespace.
+ *
+ * Any line that doesn't match a redaction pattern passes through
+ * untouched, so legitimate skill summaries (e.g. "Drafted 3 follow-ups
+ * for buyers at Lakeside Manor") are preserved verbatim.
+ */
+
+const TOOL_CALL_RE = /\b(?:draft_buyer_followups|draft_message|draft_lease_renewal|surface_aged_contracts_for_solicitor|schedule_viewing_draft|create_viewing_schedule|get_candidate_units|rank_pipeline_buyers|query_compliance_status|natural_query|draft_viewing_followup|weekly_monday_briefing)\s*\(/i;
+
+const SCAFFOLD_LEAD_RE = /^\s*(?:next|step\s*\d+|then|now)\s*:\s*/i;
+
+const PLACEHOLDER_RE = /\[(?:full sentence|insert|describe|describing|placeholder|fill in)[^\]]*\]/i;
+
+const INSTRUCTION_TO_MODEL_RE =
+  /\b(?:in the same turn|input to step \d+|do not stop after|the final answer|call (?:get|draft|surface|schedule|create|rank|query)_[a-z_]+|immediately call)\b/i;
+
+const ARG_SYNTAX_RE = /\b(?:targets|purpose|topic|recipient_type|recipient|tone|filter|document_type|intent|window_hours|threshold_days|tenancy_id|tenant_name|scheme_name|development_id|date|start_time|end_time|slot_duration_minutes|target_count|preferred_datetime|buyer_email|buyer_phone|buyer_name|recipient_name|recipient_email|context|custom_instruction|related_unit|related_scheme|related_property|unit_or_property_ref|unit_identifier|limit)\s*=\s*['"\[]/;
+
+function isScaffoldingLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (SCAFFOLD_LEAD_RE.test(trimmed) && (TOOL_CALL_RE.test(trimmed) || ARG_SYNTAX_RE.test(trimmed))) return true;
+  if (PLACEHOLDER_RE.test(trimmed)) return true;
+  if (INSTRUCTION_TO_MODEL_RE.test(trimmed) && (TOOL_CALL_RE.test(trimmed) || ARG_SYNTAX_RE.test(trimmed))) return true;
+  // Multi-line scaffold: the "do not stop after this candidate list" phrase
+  // appears on its own follow-on line in the PR-97 nudge. Catch it standalone.
+  if (/^\s*do not stop after this candidate list\b/i.test(trimmed)) return true;
+  return false;
+}
+
+/**
+ * Redact internal scaffolding markers from a user-facing summary string.
+ * Pure function — does not mutate.
+ */
+export function redactSummaryForUser(summary: string | null | undefined): string {
+  if (!summary) return '';
+  const lines = String(summary).split('\n');
+  const kept = lines.filter((l) => !isScaffoldingLine(l));
+  // Collapse runs of blank lines into a single blank, then trim trailing
+  // whitespace. Preserves intentional paragraph breaks but drops the
+  // trailing "\n\n<scaffolding>" that the redaction leaves behind.
+  const collapsed: string[] = [];
+  for (const line of kept) {
+    const isBlank = line.trim() === '';
+    const lastIsBlank = collapsed.length > 0 && collapsed[collapsed.length - 1].trim() === '';
+    if (isBlank && lastIsBlank) continue;
+    collapsed.push(line);
+  }
+  while (collapsed.length && collapsed[collapsed.length - 1].trim() === '') collapsed.pop();
+  return collapsed.join('\n').trimEnd();
+}
+
+/**
+ * Apply `redactSummaryForUser` to every summary string inside an
+ * envelope, including the summary fields nested under each draft's
+ * `reasoning`. Returns a new envelope (does not mutate).
+ *
+ * The envelope shape lives in `lib/agent-intelligence/envelope.ts` but
+ * importing it here would create a circular dep with the test stub, so
+ * we use a structural type.
+ */
+export function redactEnvelopeForUser<T extends { summary?: string; drafts?: Array<{ reasoning?: string }> }>(
+  envelope: T,
+): T {
+  return {
+    ...envelope,
+    summary: redactSummaryForUser(envelope.summary),
+    drafts: (envelope.drafts || []).map((d) => ({
+      ...d,
+      // Reasoning surfaces in the drawer "Why" chip — same redaction applies.
+      reasoning: d.reasoning ? redactSummaryForUser(d.reasoning) : d.reasoning,
+    })) as any,
+  };
+}

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -26,10 +26,16 @@ export interface LiveContextBlocks {
   lettingsCompliance?: LettingsComplianceRecord[];
 }
 
+// Timezone-stable: parses YYYY-MM-DD strings as LOCAL midnight rather
+// than UTC midnight, so a date stored as 2026-05-08 always renders as
+// "8 May 2026" regardless of the runtime timezone (Issue 1.7 /
+// CODE-ISSUE-006).
+import { parseIrishCalendarDate } from './format-helpers';
+
 function fmtDate(iso: string | null | undefined): string {
   if (!iso) return 'unknown';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
+  const d = parseIrishCalendarDate(iso);
+  if (!d) return iso;
   return d.toLocaleDateString('en-IE', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
@@ -168,7 +174,21 @@ function renderComplianceAttention(records: LettingsComplianceRecord[] | undefin
     .sort((a, b) => a.ber.daysToExpiry! - b.ber.daysToExpiry!);
   const missingRtb = records.filter(r => r.rtb.applicable && !r.rtb.ok);
 
-  if (!expiredBer.length && !expiringBer.length && !missingRtb.length) return '';
+  // Issue 1.4 / Chrome ISSUE-008 — deterministic header line that uses
+  // the SAME ber.ok definition (`berCertNumber set OR ber_cert doc
+  // uploaded`) as `query_compliance_status`. Without this header the
+  // model used to infer the BER count from the EXPIRY items below
+  // (e.g. "1 expired → 11/12 OK") which contradicted the skill's
+  // cert-on-file count. Now both data sources surface the same
+  // numerator so the model can quote it identically whether it
+  // answers from live context or from the skill output.
+  const nonVacant = records.filter(r => !r.isVacant);
+  const berOnFileCount = nonVacant.filter(r => r.ber.ok).length;
+  const headerLine = `BER cert on file: ${berOnFileCount} of ${nonVacant.length} active tenanc${nonVacant.length === 1 ? 'y' : 'ies'} (cert number recorded OR ber_cert doc uploaded — this is the canonical "BER OK" count, do not derive it from the expiry items below)`;
+
+  if (!expiredBer.length && !expiringBer.length && !missingRtb.length) {
+    return `COMPLIANCE ATTENTION (action required):\n${headerLine}`;
+  }
 
   const truncate = <T,>(arr: T[], render: (item: T) => string, label: string): string => {
     const cap = 10;
@@ -202,7 +222,7 @@ function renderComplianceAttention(records: LettingsComplianceRecord[] | undefin
       'MISSING RTB REGISTRATION (active tenancies):',
     ));
   }
-  return `COMPLIANCE ATTENTION (action required):\n${sections.join('\n\n')}`;
+  return `COMPLIANCE ATTENTION (action required):\n${headerLine}\n\n${sections.join('\n\n')}`;
 }
 
 function renderSalesPipeline(s: SalesPipelineSummary | null): string {

--- a/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/agentic-skills.ts
@@ -50,11 +50,14 @@ export interface SkillAgentContext {
   isDemoMode?: boolean;
 }
 
+// Re-exported from format-helpers so existing callers in this file keep
+// working unchanged. The implementation lives there because (a) it's
+// shared with the route + system-prompt layers, and (b) we want one
+// place for the timezone-stable parser (Issue 1.7 / CODE-ISSUE-006).
+import { formatEuro, formatIrishDate as formatIrishDateImpl, daysUntilCalendarDate } from '../format-helpers';
+
 function formatIrishDate(iso: string | null | undefined): string {
-  if (!iso) return 'unknown date';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString('en-IE', { day: 'numeric', month: 'long', year: 'numeric' });
+  return formatIrishDateImpl(iso);
 }
 
 // Weekday + day + month, no year. Used by viewing-proposal openers so
@@ -922,8 +925,11 @@ export async function draftLeaseRenewal(
         ? `In line with RPZ rules, the maximum increase is ${(rpzUpliftCap() * 100).toFixed(1)}% per annum.`
         : 'Outside RPZ — rent held at current level for this renewal. Open to discussion.';
 
-      const leaseEnd = new Date(t.lease_end);
-      const daysToLeaseEnd = Math.floor((leaseEnd.getTime() - Date.now()) / 86400000);
+      // Issue 1.7 / CODE-ISSUE-006: parse lease_end at LOCAL midnight and
+      // compare against today's local midnight, not a wall-clock instant.
+      // Without this, the renewal email reads "ended 1 day ago" on the
+      // actual end date in BST after 01:00.
+      const daysToLeaseEnd = daysUntilCalendarDate(t.lease_end) ?? 0;
       const { greeting: tenantGreeting } = parseTenantName(t.tenant_name);
       const leaseEndLabel = formatIrishDate(t.lease_end);
       const expired = daysToLeaseEnd < 0;
@@ -944,7 +950,7 @@ export async function draftLeaseRenewal(
         `We'd like to offer a renewal on the following terms:`,
         ``,
         `- 12-month fixed term from ${leaseEndLabel}`,
-        `- Monthly rent: €${proposedRent} (current rent: €${currentRent})`,
+        `- Monthly rent: ${formatEuro(proposedRent)} (current rent: ${formatEuro(currentRent)})`,
         `- All other terms unchanged`,
         ``,
         rentNote,
@@ -972,7 +978,7 @@ export async function draftLeaseRenewal(
           id: t.id,
           label: `${prop.address} — ${t.tenant_name || 'Tenant'}`,
         },
-        reasoning: `${expired ? `Lease ended ${leaseEndLabel} (${daysAbs} day${daysAbs === 1 ? '' : 's'} ago, unrenewed).` : `Lease ends ${leaseEndLabel}.`} Property is ${inRPZ ? 'in RPZ' : 'outside RPZ'}. Proposed rent: €${proposedRent} (current €${currentRent}, ${inRPZ ? 'within RPZ cap' : 'no statutory cap'}).${t.tenant_email ? '' : ' Tenant email is missing on the tenancy record; recipient set to placeholder pending capture.'}`,
+        reasoning: `${expired ? `Lease ended ${leaseEndLabel} (${daysAbs} day${daysAbs === 1 ? '' : 's'} ago, unrenewed).` : `Lease ends ${leaseEndLabel}.`} Property is ${inRPZ ? 'in RPZ' : 'outside RPZ'}. Proposed rent: ${formatEuro(proposedRent)} (current ${formatEuro(currentRent)}, ${inRPZ ? 'within RPZ cap' : 'no statutory cap'}).${t.tenant_email ? '' : ' Tenant email is missing on the tenancy record; recipient set to placeholder pending capture.'}`,
       };
     });
 
@@ -993,7 +999,7 @@ export async function draftLeaseRenewal(
         const rpzNote = inRPZ
           ? `${prop.city ?? 'this area'} is in a Rent Pressure Zone, so the increase is capped at ${(rpzUpliftCap() * 100).toFixed(0)}%`
           : 'this property is outside RPZ — no statutory rent cap applies';
-        return `Drafted renewal for ${t.tenant_name || 'tenant'} at ${prop.address} — ${rpzNote}. Proposed €${proposedRent}/m (current €${currentRent}/m).`;
+        return `Drafted renewal for ${t.tenant_name || 'tenant'} at ${prop.address} — ${rpzNote}. Proposed ${formatEuro(proposedRent)}/m (current ${formatEuro(currentRent)}/m).`;
       }
       // Multi-draft: split RPZ vs non-RPZ counts so the headline is honest.
       const rpzCount = rows.filter((t: any) => {
@@ -1122,7 +1128,7 @@ export async function naturalQuery(
         const rows = data || [];
         const total = rows.reduce((sum: number, r: any) => sum + (Number(r.rent_pcm) || 0), 0);
         recordIds = rows.map((r: any) => r.id);
-        answer = `Your current monthly rent roll is €${total.toLocaleString('en-IE')} across ${rows.length} active tenanc${rows.length === 1 ? 'y' : 'ies'}.`;
+        answer = `Your current monthly rent roll is ${formatEuro(total)} across ${rows.length} active tenanc${rows.length === 1 ? 'y' : 'ies'}.`;
       }
     } else if (intent === 'lease_end') {
       if (mode !== 'lettings') {
@@ -1659,11 +1665,48 @@ async function draftTenantMessage(
     const tenantFullName = tenancy.tenant_name || 'Tenant';
     const tenantFirst = firstName(tenantFullName);
     const propertyAddress = property?.address_line_1 || property?.address || 'your property';
-    const tenantEmail = tenancy.tenant_email || 'tenant@tbc.invalid';
 
-    const subject = context
-      ? `Re: ${context.slice(0, 60)}`
-      : `Quick note from ${agentContext.agencyName || 'your letting agent'}`;
+    // Issue 1.3(a): refuse with a clear envelope when the tenant has no
+    // email on file. Falling through to `tenant@tbc.invalid` produced a
+    // draft that looked sendable in the drawer but couldn't actually go
+    // out — the agent would only learn after clicking Approve.
+    if (!tenancy.tenant_email) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: `I don't have an email on file for ${tenantFullName} at ${propertyAddress}. Add their email to the tenancy record and I'll draft this for you.`,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+    const tenantEmail: string = tenancy.tenant_email;
+
+    // Issue 1.3(c): landlord-side compliance duties (RTB registration,
+    // BER cert, gas/electrical certs, deposit protection scheme) are
+    // the agent/landlord's legal responsibility — not the tenant's.
+    // The model has been mis-routing "remind me about the missing X"
+    // into a tenant email asking the tenant to supply X. Refuse with a
+    // suggestion to convert into an agent-side task. This is a
+    // conservative guard scoped to error paths; imperative-command
+    // flows (the tenant rephrases their actual ask) are handled in
+    // Batch 2.
+    const LANDLORD_DUTY_RE =
+      /\b(?:rtb(?:\s+(?:registration|number|cert(?:ificate)?))?|ber\s+cert(?:ificate)?|ber\s+number|gas\s+safety\s+cert|electrical\s+cert|deposit\s+protection|landlord\s+(?:registration|certificate|insurance))\b/i;
+    if (LANDLORD_DUTY_RE.test(context)) {
+      return {
+        skill,
+        status: 'awaiting_approval',
+        summary: `That looks like a landlord/agent compliance step, not something to ask ${tenantFullName} for. Want me to (a) add this as a task on your list to register/upload, or (b) send ${tenantFullName} a status update saying it's in progress?`,
+        drafts: [],
+        meta: { record_count: 0, generated_at: new Date().toISOString(), query },
+      };
+    }
+
+    // Issue 1.3(b): subject was `Re: ${context.slice(0, 60)}` — produced
+    // mid-word truncation like "Re: This is a reminder regarding the
+    // missing RTB registration nu". Use a stable subject derived from
+    // the property address; it never truncates and is always readable.
+    const subject = `Quick note about ${propertyAddress}`;
 
     const body = [
       toneGreeting(tenantFirst),
@@ -1715,15 +1758,14 @@ function buildTenantRecipientReason(opts: {
 }): string {
   const t = opts.tenancy;
   const leaseEndIso = t?.lease_end as string | null | undefined;
-  if (leaseEndIso) {
-    const ms = new Date(leaseEndIso).getTime();
-    if (!Number.isNaN(ms)) {
-      const days = Math.floor((ms - Date.now()) / 86_400_000);
-      if (days < 0) return `Lease ended ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago.`;
-      if (days === 0) return 'Lease ends today.';
-      if (days <= 30) return `Lease ends in ${days} day${days === 1 ? '' : 's'}.`;
-      if (days <= 90) return `Lease ends in ${days} days, inside the 90-day notice window.`;
-    }
+  // Issue 1.7 / CODE-ISSUE-006 — local-midnight parse so a YYYY-MM-DD
+  // lease_end doesn't read as "1 day ago" in BST evening.
+  const days = daysUntilCalendarDate(leaseEndIso);
+  if (days !== null) {
+    if (days < 0) return `Lease ended ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'} ago.`;
+    if (days === 0) return 'Lease ends today.';
+    if (days <= 30) return `Lease ends in ${days} day${days === 1 ? '' : 's'}.`;
+    if (days <= 90) return `Lease ends in ${days} days, inside the 90-day notice window.`;
   }
   if (t?.rtb_registered === false) {
     return 'RTB registration not on file for this tenancy.';

--- a/apps/unified-portal/lib/lettings/per-property-compliance.ts
+++ b/apps/unified-portal/lib/lettings/per-property-compliance.ts
@@ -1,0 +1,21 @@
+/**
+ * Per-property compliance score arithmetic (Issue 1.2 / Chrome ISSUE-006).
+ *
+ * The Compliance tab on the per-property page used to render
+ * `property.completenessScore` — a stored column updated by an
+ * unrelated pipeline — so a property with every dimension Outstanding
+ * still showed 80%. The portfolio-level fix from PR #95 used a fill-
+ * rate formula correctly; the per-property page was using a different
+ * (broken) source. This helper consolidates the formula in one place
+ * so the per-property page and the regression test agree.
+ *
+ * Rule: numerator = #OK dimensions, denominator = #applicable
+ * dimensions (excludes 'na', e.g. RTB on a vacant property).
+ */
+
+export function computePerPropertyComplianceScore(rows: Array<{ state: 'ok' | 'amber' | 'na' }>): number | null {
+  const applicable = rows.filter((r) => r.state !== 'na');
+  if (applicable.length === 0) return null;
+  const ok = applicable.filter((r) => r.state === 'ok').length;
+  return Math.round((ok / applicable.length) * 100);
+}

--- a/apps/unified-portal/tests/agent-intelligence/format-helpers.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/format-helpers.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression guards for the shared formatting helpers.
+ *
+ * Issue 1.6 / CODE-ISSUE-005 — `formatEuro` covers the rent-formatting
+ * bug where `€${1850.5}` ended up in tenant-facing renewal copy.
+ *
+ * Issue 1.7 / CODE-ISSUE-006 — `formatIrishDate` covers the BST evening
+ * off-by-one where `new Date('2026-05-08')` parsed as UTC midnight and
+ * formatted as "7 May" on runtimes west of UTC.
+ *
+ * Hermetic — pure functions, no Supabase, no network.
+ */
+
+import {
+  formatEuro,
+  formatIrishDate,
+  parseIrishCalendarDate,
+  daysUntilCalendarDate,
+} from '../../lib/agent-intelligence/format-helpers';
+
+describe('formatEuro (Issue 1.6)', () => {
+  it('formats a whole-euro integer with locale separator', () => {
+    expect(formatEuro(1850)).toBe('€1,850');
+  });
+
+  it('rounds a fractional value to whole euro', () => {
+    expect(formatEuro(1850.5)).toBe('€1,851');
+    expect(formatEuro(1850.49)).toBe('€1,850');
+  });
+
+  it('formats zero as €0', () => {
+    expect(formatEuro(0)).toBe('€0');
+  });
+
+  it('treats null / undefined / NaN as €0', () => {
+    expect(formatEuro(null)).toBe('€0');
+    expect(formatEuro(undefined)).toBe('€0');
+    expect(formatEuro(Number.NaN)).toBe('€0');
+  });
+
+  it('coerces a numeric-string input', () => {
+    expect(formatEuro('2000')).toBe('€2,000');
+    expect(formatEuro('1850.5')).toBe('€1,851');
+  });
+
+  it('formats large amounts with thousands separator', () => {
+    expect(formatEuro(1234567)).toBe('€1,234,567');
+  });
+});
+
+describe('parseIrishCalendarDate (Issue 1.7)', () => {
+  it('parses YYYY-MM-DD at LOCAL midnight (not UTC midnight)', () => {
+    const d = parseIrishCalendarDate('2026-05-08');
+    expect(d).not.toBeNull();
+    expect(d!.getFullYear()).toBe(2026);
+    // May = 4 (0-indexed)
+    expect(d!.getMonth()).toBe(4);
+    expect(d!.getDate()).toBe(8);
+    // Stable: midnight in local time, so the hours portion is 0 regardless
+    // of which TZ Node is running in.
+    expect(d!.getHours()).toBe(0);
+    expect(d!.getMinutes()).toBe(0);
+  });
+
+  it('returns null on invalid input', () => {
+    expect(parseIrishCalendarDate(null)).toBeNull();
+    expect(parseIrishCalendarDate('')).toBeNull();
+    expect(parseIrishCalendarDate('not-a-date')).toBeNull();
+  });
+
+  it('falls back to standard Date parser for full ISO timestamps', () => {
+    const d = parseIrishCalendarDate('2026-05-08T12:34:56Z');
+    expect(d).not.toBeNull();
+    expect(d!.getFullYear()).toBe(2026);
+  });
+});
+
+describe('formatIrishDate (Issue 1.7)', () => {
+  it('renders 8 May 2026 for the YYYY-MM-DD input regardless of TZ', () => {
+    // Because parseIrishCalendarDate returns a Date constructed at LOCAL
+    // midnight on the given calendar day, toLocaleDateString shows the
+    // same day component in any timezone — the previous bug was that
+    // new Date('2026-05-08') was UTC midnight, which formatted as "7 May"
+    // in any TZ west of UTC.
+    expect(formatIrishDate('2026-05-08')).toMatch(/\b8 May 2026\b/);
+  });
+
+  it('returns "unknown date" on null/empty', () => {
+    expect(formatIrishDate(null)).toBe('unknown date');
+    expect(formatIrishDate(undefined)).toBe('unknown date');
+    expect(formatIrishDate('')).toBe('unknown date');
+  });
+
+  it('passes through unparseable strings unchanged', () => {
+    expect(formatIrishDate('not-a-date')).toBe('not-a-date');
+  });
+
+  // TZ-switch sanity check: we can't fully simulate a different timezone
+  // without restarting Node (TZ env var is read at startup on most
+  // platforms), but we can at least demonstrate that the parsed Date's
+  // day-of-month is preserved across simulated wall-clock instants.
+  it('preserves day-of-month across an early-morning evaluation window', () => {
+    // Simulate "now is 2026-05-09 00:30 local" and ask for 2026-05-09.
+    // Output must read "9 May 2026" — the bug was that toLocaleDateString
+    // saw UTC midnight = local 23:00 the previous day in BST and rendered
+    // "8 May".
+    const d = parseIrishCalendarDate('2026-05-09');
+    expect(d!.getDate()).toBe(9);
+    expect(formatIrishDate('2026-05-09')).toMatch(/\b9 May 2026\b/);
+  });
+});
+
+describe('daysUntilCalendarDate (Issue 1.7)', () => {
+  it('returns 0 when target equals today', () => {
+    const today = new Date();
+    const iso = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    expect(daysUntilCalendarDate(iso, today)).toBe(0);
+  });
+
+  it('returns -1 for yesterday, +1 for tomorrow', () => {
+    const t = new Date(2026, 4, 8); // 8 May 2026 local
+    expect(daysUntilCalendarDate('2026-05-07', t)).toBe(-1);
+    expect(daysUntilCalendarDate('2026-05-09', t)).toBe(1);
+  });
+
+  it('does not flip to -1 when wall-clock is past local midnight', () => {
+    // The bug: the previous helper computed daysToLeaseEnd as
+    //   floor((leaseEnd_UTC - now_local) / 86_400_000)
+    // which on the actual end date in BST after 01:00 returned -1.
+    // The new helper anchors both sides at LOCAL midnight, so it returns
+    // 0 for the actual end date even at noon local time.
+    const noonOfEndDate = new Date(2026, 4, 8, 12, 0, 0); // 8 May 2026 12:00 local
+    expect(daysUntilCalendarDate('2026-05-08', noonOfEndDate)).toBe(0);
+  });
+
+  it('returns null on invalid input', () => {
+    expect(daysUntilCalendarDate(null)).toBeNull();
+    expect(daysUntilCalendarDate('not-a-date')).toBeNull();
+  });
+});

--- a/apps/unified-portal/tests/agent-intelligence/lettings-compliance-determinism.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/lettings-compliance-determinism.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression guard for Issue 1.4 / Chrome ISSUE-008.
+ *
+ * Within the same session the agent answered "BER (4/12)" then
+ * "BER (11/12)" for the same portfolio. The numbers were drawn from
+ * different definitions: 4/12 = `ber.ok` from the compliance loader
+ * (cert number on file OR ber_cert doc uploaded) vs. 11/12 = "not
+ * expired" inferred by the model from the COMPLIANCE ATTENTION block.
+ *
+ * Two contracts under test:
+ *   1. `getLettingsCompliance` returns the SAME `ber.ok` flag on
+ *      consecutive calls with the same data — no caching, no clock
+ *      coupling, no randomness.
+ *   2. The `ber.ok` definition is exactly `berCertNumber set OR
+ *      ber_cert doc uploaded` — the canonical one — and does not
+ *      consult `ber_expiry_date`.
+ *
+ * Hermetic — stubbed Supabase, no network.
+ */
+
+import { getLettingsCompliance } from '../../lib/agent-intelligence/context';
+
+type Row = Record<string, any>;
+
+function buildSupabaseStub(byTable: Record<string, Row[]>) {
+  const make = (rows: Row[]) => {
+    const builder: any = {
+      _rows: rows,
+      _filters: [] as Array<(r: Row) => boolean>,
+      select() { return builder; },
+      eq(col: string, val: any) { builder._filters.push((r: Row) => r[col] === val); return builder; },
+      then(resolve: (v: any) => any) {
+        const filtered = builder._rows.filter((r: Row) => builder._filters.every((f: any) => f(r)));
+        return Promise.resolve({ data: filtered, error: null }).then(resolve);
+      },
+    };
+    return builder;
+  };
+  return {
+    from(name: string) {
+      return make(byTable[name] || []);
+    },
+  } as any;
+}
+
+const AGENT_ID = '0f9210e0-342d-4f98-9be1-95decb6f507a';
+
+// 12 properties of which 4 have ber_cert_number on file. None have
+// ber_cert in lettings_documents. Mirrors the production data shape
+// that produced "4/12" vs "11/12" in the bug report.
+const PROPERTIES: Row[] = Array.from({ length: 12 }).map((_, i) => ({
+  id: `prop-${i + 1}`,
+  agent_id: AGENT_ID,
+  address: `${i + 1} Demo Street`,
+  city: 'Dublin',
+  status: 'let',
+  ber_cert_number: i < 4 ? `B${100000 + i}` : null,
+  ber_expiry_date: i < 11 ? '2027-01-01' : '2024-01-01',
+}));
+
+const TENANCIES: Row[] = PROPERTIES.map((p, i) => ({
+  id: `t-${i + 1}`,
+  letting_property_id: p.id,
+  tenant_name: `Tenant ${i + 1}`,
+  agent_id: AGENT_ID,
+  status: 'active',
+  rtb_registration_number: i % 3 === 0 ? `RTB-${i}` : null,
+  rtb_registered: i % 3 === 0,
+}));
+
+const DOCUMENTS: Row[] = []; // No ber_cert docs uploaded.
+
+describe('getLettingsCompliance ber.ok determinism (Issue 1.4)', () => {
+  it('returns the same ber.ok per-property across two consecutive calls', async () => {
+    const supabase = buildSupabaseStub({
+      agent_letting_properties: PROPERTIES,
+      agent_tenancies: TENANCIES,
+      lettings_documents: DOCUMENTS,
+    });
+    const first = await getLettingsCompliance(supabase, AGENT_ID);
+    const second = await getLettingsCompliance(supabase, AGENT_ID);
+    expect(first.length).toBe(second.length);
+    for (let i = 0; i < first.length; i++) {
+      expect(second[i].propertyId).toBe(first[i].propertyId);
+      expect(second[i].ber.ok).toBe(first[i].ber.ok);
+    }
+  });
+
+  it('counts ber.ok as cert-on-file (4 of 12), NOT not-expired (11 of 12)', async () => {
+    const supabase = buildSupabaseStub({
+      agent_letting_properties: PROPERTIES,
+      agent_tenancies: TENANCIES,
+      lettings_documents: DOCUMENTS,
+    });
+    const records = await getLettingsCompliance(supabase, AGENT_ID);
+    const okCount = records.filter((r) => r.ber.ok).length;
+    expect(okCount).toBe(4); // matches the canonical definition
+    expect(okCount).not.toBe(11); // would be wrong (uses ber_expiry_date)
+  });
+
+  it('does not consult ber_expiry_date when computing ber.ok', async () => {
+    // A property with a fresh expiry date but NO cert number and NO uploaded
+    // doc is still ber.ok=false. (And vice versa — cert number set but
+    // expired stays ber.ok=true; expiry is a separate dimension.)
+    const props: Row[] = [
+      { id: 'p1', agent_id: AGENT_ID, address: '1 Demo', city: 'Dublin', status: 'let', ber_cert_number: null, ber_expiry_date: '2099-01-01' },
+      { id: 'p2', agent_id: AGENT_ID, address: '2 Demo', city: 'Dublin', status: 'let', ber_cert_number: 'B999', ber_expiry_date: '2000-01-01' },
+    ];
+    const tens: Row[] = [
+      { id: 't1', letting_property_id: 'p1', tenant_name: 'A', agent_id: AGENT_ID, status: 'active', rtb_registration_number: null },
+      { id: 't2', letting_property_id: 'p2', tenant_name: 'B', agent_id: AGENT_ID, status: 'active', rtb_registration_number: 'X' },
+    ];
+    const supabase = buildSupabaseStub({
+      agent_letting_properties: props,
+      agent_tenancies: tens,
+      lettings_documents: [],
+    });
+    const records = await getLettingsCompliance(supabase, AGENT_ID);
+    const byId = new Map(records.map((r) => [r.propertyId, r]));
+    expect(byId.get('p1')!.ber.ok).toBe(false); // future expiry but no cert
+    expect(byId.get('p2')!.ber.ok).toBe(true);  // cert on file even if expired
+  });
+});

--- a/apps/unified-portal/tests/agent-intelligence/per-property-compliance.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/per-property-compliance.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression guard for Issue 1.2 / Chrome ISSUE-006.
+ *
+ * The per-property Compliance tab used to render
+ * `property.completenessScore` — a stored column updated by an unrelated
+ * pipeline — so a property with every dimension Outstanding still showed
+ * 80%. The fill-rate formula from PR #95 is the right answer; this
+ * guard pins the formula so future refactors can't silently revert.
+ */
+
+import { computePerPropertyComplianceScore } from '../../lib/lettings/per-property-compliance';
+
+describe('computePerPropertyComplianceScore (Issue 1.2)', () => {
+  it('returns 0 when every applicable dimension is Outstanding (the 1 Rose Hill case)', () => {
+    const rows = [
+      { state: 'amber' as const }, // BER
+      { state: 'amber' as const }, // Gas
+      { state: 'amber' as const }, // Electrical
+      { state: 'na' as const },    // RTB — vacant, N/A
+      { state: 'amber' as const }, // Lease
+    ];
+    expect(computePerPropertyComplianceScore(rows)).toBe(0);
+  });
+
+  it('returns 100 when every applicable dimension is OK', () => {
+    const rows = [
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+    ];
+    expect(computePerPropertyComplianceScore(rows)).toBe(100);
+  });
+
+  it('excludes N/A dimensions from the denominator', () => {
+    // 2 OK out of 4 applicable (RTB is N/A on a vacant property) = 50%.
+    const rows = [
+      { state: 'ok' as const },    // BER
+      { state: 'ok' as const },    // Gas
+      { state: 'amber' as const }, // Electrical
+      { state: 'na' as const },    // RTB — vacant, N/A
+      { state: 'amber' as const }, // Lease
+    ];
+    expect(computePerPropertyComplianceScore(rows)).toBe(50);
+  });
+
+  it('rounds to nearest integer percent', () => {
+    // 1 of 3 applicable = 33.33% → 33%
+    expect(
+      computePerPropertyComplianceScore([
+        { state: 'ok' as const },
+        { state: 'amber' as const },
+        { state: 'amber' as const },
+      ]),
+    ).toBe(33);
+  });
+
+  it('returns null when no dimensions are applicable', () => {
+    expect(computePerPropertyComplianceScore([])).toBeNull();
+    expect(
+      computePerPropertyComplianceScore([{ state: 'na' as const }, { state: 'na' as const }]),
+    ).toBeNull();
+  });
+
+  it('matches the PR #95 portfolio formula on a four-of-five OK record', () => {
+    // Same arithmetic as the lettings portfolio fill-rate. 4 OK / 5
+    // applicable = 80% — the rounding boundary stays consistent.
+    const rows = [
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'ok' as const },
+      { state: 'amber' as const },
+    ];
+    expect(computePerPropertyComplianceScore(rows)).toBe(80);
+  });
+});

--- a/apps/unified-portal/tests/agent-intelligence/redact-scaffolding.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/redact-scaffolding.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression guard for Issue 1.1 / Chrome ISSUE-001.
+ *
+ * The "Next:" hint inside `getCandidateUnitsSkill`'s envelope summary
+ * was reaching the user verbatim as a red error block. Redacting it on
+ * the way out — but keeping it in the model's tool-result context for
+ * chain orchestration — is the contract under test.
+ */
+
+import { redactSummaryForUser, redactEnvelopeForUser } from '../../lib/agent-intelligence/redact-scaffolding';
+
+describe('redactSummaryForUser (Issue 1.1)', () => {
+  it('strips the PR-97 "Next:" scaffolding line verbatim', () => {
+    const input = [
+      'Found 3 candidate units (mortgage_expiring):',
+      '- Lakeside Manor Unit 12 — Aoife Carey (sale agreed)',
+      '- Lakeside Manor Unit 14 — Lucy Reid (signed)',
+      '- Lakeside Manor Unit 19 — Cian Murphy (sale agreed)',
+      '',
+      "Next: if the user asked for drafts, immediately call draft_buyer_followups(targets=[the units above], purpose='chase', topic='[full sentence describing the reason]') in the SAME turn. Do not stop after this candidate list — it is the input to step 2, not the final answer.",
+    ].join('\n');
+    const out = redactSummaryForUser(input);
+    expect(out).toContain('Found 3 candidate units');
+    expect(out).toContain('Lakeside Manor Unit 12');
+    expect(out).not.toContain('Next:');
+    expect(out).not.toContain('draft_buyer_followups');
+    expect(out).not.toContain('targets=');
+    expect(out).not.toContain('full sentence describing');
+    expect(out).not.toContain('SAME turn');
+    expect(out).not.toContain('input to step 2');
+    expect(out).not.toContain('the final answer');
+  });
+
+  it('preserves a legitimate skill summary verbatim', () => {
+    const input = [
+      'Drafted 3 follow-ups for buyers at Lakeside Manor.',
+      '- Lucy Reid — Unit 14',
+      '- Cian Murphy — Unit 19',
+      '- Aoife Carey — Unit 12',
+    ].join('\n');
+    expect(redactSummaryForUser(input)).toBe(input);
+  });
+
+  it('strips a "Step 2:" variant carrying the same scaffolding', () => {
+    const input =
+      'Step 2: call draft_buyer_followups(targets=[...], purpose=\'chase\') in the SAME turn.';
+    expect(redactSummaryForUser(input)).toBe('');
+  });
+
+  it('strips a placeholder marker even without a Next: prefix', () => {
+    const input = 'Compose body using [full sentence describing the reason] then send.';
+    expect(redactSummaryForUser(input)).toBe('');
+  });
+
+  it('handles null / undefined / empty', () => {
+    expect(redactSummaryForUser(null)).toBe('');
+    expect(redactSummaryForUser(undefined)).toBe('');
+    expect(redactSummaryForUser('')).toBe('');
+  });
+
+  it('collapses double-blank lines left behind after redaction', () => {
+    const input = [
+      'Found 1 candidate unit (handover):',
+      '- Westfield Heights Unit 25 — Mark Sweeney',
+      '',
+      '',
+      "Next: call draft_buyer_followups(targets=[...], purpose='congratulate_handover', topic='[full sentence describing]') in the SAME turn.",
+    ].join('\n');
+    const out = redactSummaryForUser(input);
+    expect(out).not.toMatch(/\n{3,}/);
+    expect(out.endsWith('\n')).toBe(false);
+  });
+
+  it('does not strip a sentence that mentions a tool name in prose', () => {
+    // "I'll need a recipient address" is legitimate user-facing copy that
+    // happens to contain words like "recipient" — it doesn't carry the
+    // tool-call argument syntax, so it must pass through.
+    const input = "I need a recipient address for 'Aoife O'Brien'. Paste the address and I'll draft it.";
+    expect(redactSummaryForUser(input)).toBe(input);
+  });
+});
+
+describe('redactEnvelopeForUser (Issue 1.1)', () => {
+  it('redacts the envelope summary AND each draft.reasoning', () => {
+    const env = {
+      skill: 'get_candidate_units',
+      status: 'awaiting_approval',
+      summary: 'Found 1 candidate.\n\nNext: call draft_buyer_followups(targets=[...]) in the SAME turn.',
+      drafts: [
+        {
+          id: 'draft-1',
+          // Multi-line reasoning where one line is scaffolding and the
+          // others are legit data — the legit lines must survive.
+          reasoning: 'Lease ends 12 May 2026.\nNext: call draft_lease_renewal(tenancy_id=...) in the SAME turn.\nProperty in RPZ.',
+        },
+      ],
+    };
+    const out = redactEnvelopeForUser(env);
+    expect(out.summary).toBe('Found 1 candidate.');
+    expect(out.drafts[0].reasoning).toBe('Lease ends 12 May 2026.\nProperty in RPZ.');
+    // Original is not mutated.
+    expect(env.summary).toContain('Next:');
+    expect(env.drafts[0].reasoning).toContain('Next:');
+  });
+});


### PR DESCRIPTION
## Summary

Single commit covering **7 atomic, individually-testable launch-readiness fixes**. Imperative-command flow changes are reserved for Batch 2.

| # | Issue | Source | What changed |
|---|---|---|---|
| 1.1 | Scaffolding redaction | Chrome ISSUE-001 | New `redactSummaryForUser` helper strips internal model-facing scaffolding (`Next: call draft_buyer_followups(...)`) from envelope summaries at the SSE-emit boundary. Model still sees the original in its tool-result context, so chain orchestration is unaffected. |
| 1.2 | Per-property compliance score | Chrome ISSUE-006 | Score now derived from the rows array via fill-rate (`#OK / #applicable`, excludes 'na'), matching the PR #95 portfolio formula. 1 Rose Hill (0 OK out of 4 applicable) now correctly shows 0%. |
| 1.3 | Tenant draft RTB | Chrome ISSUE-007 | Three sub-fixes: (a) refuse with a clear envelope when tenant has no email rather than `tenant@tbc.invalid`; (b) replace truncating `Re: ${context.slice(0, 60)}` subject with stable `Quick note about ${propertyAddress}`; (c) detect landlord-side compliance keywords (RTB, BER, gas, electrical, deposit protection) and refuse to produce a tenant email asking for landlord-duty data. |
| 1.4 | BER session inconsistency | Chrome ISSUE-008 | Added a deterministic "BER cert on file: X of Y active tenancies" header line to the lettings COMPLIANCE ATTENTION block. Uses the same `ber.ok` definition (`berCertNumber set OR ber_cert doc uploaded`) as `query_compliance_status`. Eliminates the "4/12 then 11/12" inconsistency. |
| 1.5 | Mid-stream truncation | Chrome ISSUE-017 | Server-side stream buffer holds incomplete fragments until a safe boundary (newline, sentence terminator + space, or 80-char force-flush at last whitespace). User no longer sees mid-sentence states like `€1785 (`. |
| 1.6 | Currency formatting | CODE-ISSUE-005 | New `formatEuro` helper using `Intl.NumberFormat('en-IE', { currency: 'EUR' })` applied across the agent-intelligence skills. `1850.5` now renders as `€1,851` in tenant-facing legal copy. |
| 1.7 | Lease-end timezone off-by-one | CODE-ISSUE-006 | New `parseIrishCalendarDate` parses YYYY-MM-DD as LOCAL midnight; new `daysUntilCalendarDate` anchors both sides at local midnight. Renewal email no longer reads "lease ended 1 day ago" on the actual end date in BST after 01:00. Applied to `formatIrishDate`, `draft_lease_renewal`, `buildTenantRecipientReason`, and the live-context `fmtDate`. |

### Files

- New: `lib/agent-intelligence/format-helpers.ts`, `lib/agent-intelligence/redact-scaffolding.ts`, `lib/lettings/per-property-compliance.ts`
- Modified: `app/agent/lettings/properties/[id]/page.tsx`, `app/api/agent-intelligence/chat/route.ts`, `lib/agent-intelligence/system-prompt.ts`, `lib/agent-intelligence/tools/agentic-skills.ts`
- New tests: `format-helpers.test.ts`, `redact-scaffolding.test.ts`, `per-property-compliance.test.ts`, `lettings-compliance-determinism.test.ts`

### Build

`npm run build` passes. Tests are excluded from the build/typecheck per existing `tsconfig.json` (same convention as the other tests under `tests/agent-intelligence/`).

## Test plan (live, on preview)

- [ ] Re-run mortgage-expiring chase query — confirm no scaffolding text appears even if the chain orchestration from PR #98 fails to fire.
- [ ] Open the 1 Rose Hill compliance tab — confirm score reads 0% (or whatever the rows array supports), not the stored `completenessScore`.
- [ ] Ask "Draft a reminder email to John Murphy about the missing RTB number" — confirm: no `tenant@tbc.invalid` placeholder, no truncated `Re:` subject, no body asking the tenant to supply RTB data; instead a refusal envelope offering to (a) add an agent task or (b) send a status update.
- [ ] Ask "What's my compliance score?" then ask "Wat my compleance scor" in the same session — confirm the BER count is identical across both replies.
- [ ] Watch a long streaming reply — confirm no `€NNN (` partial states are visible.
- [ ] Generate a renewal draft for a tenant with `rent_pcm = 1850.5` — confirm the email body reads `€1,851`, not `€1850.5`.
- [ ] Generate a renewal draft for a tenancy whose `lease_end` is today — confirm the body reads "lease ends today", not "ended 1 day ago".

**Do not merge until live tests pass.**

https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF)_