### PR TITLE
security: harden draft auth, chat-route exception handling, demo-backup RLS

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -302,6 +302,23 @@ export async function POST(request: NextRequest) {
     const MAX_TOOL_ROUNDS = 3;
     const envelopes: AgenticSkillEnvelope[] = [];
 
+    // Task 2 — track whether any skill threw inside the tool loop. The
+    // legacy catch path JSON-stringified the raw exception into the
+    // model's tool-result, which (a) leaked stack/argument detail to the
+    // model context, (b) never set `failureKind`, and (c) let the model
+    // hallucinate "Drafted X follow-ups" because the post-stream guard
+    // had no signal that the underlying tool actually failed. We now
+    // record a single flag + correlation id; the failure-decision
+    // cascade at the end of this route reads the flag and emits a
+    // sanitised user-facing message.
+    let skillExceptionOccurred = false;
+    let skillExceptionCorrelationId: string | null = null;
+    // Sanitised message the model sees as the tool result. Identical to
+    // the user-facing message — the model has no need for the raw
+    // exception text and a clean string keeps it from echoing internals.
+    const SKILL_EXCEPTION_USER_MESSAGE =
+      "I hit an error while running that. Try again, or rephrase the request.";
+
     while (rounds <= MAX_TOOL_ROUNDS) {
       const completion = await openai.chat.completions.create({
         model: 'gpt-4o-mini',
@@ -332,13 +349,14 @@ export async function POST(request: NextRequest) {
         let toolResult: string;
 
         if (toolDef) {
+          let parsedParams: any = null;
           try {
-            const params = JSON.parse(toolCall.function.arguments);
-            const result = await toolDef.execute(supabase, tenantId, agentContext, params);
+            parsedParams = JSON.parse(toolCall.function.arguments);
+            const result = await toolDef.execute(supabase, tenantId, agentContext, parsedParams);
             toolResult = JSON.stringify(result);
             toolsCalled.push({
               tool_name: toolCall.function.name,
-              params,
+              params: parsedParams,
               result_summary: result.summary,
             });
             // Agentic skills return a ToolResult whose `data` is an
@@ -347,8 +365,40 @@ export async function POST(request: NextRequest) {
             const envelope = extractEnvelope(result);
             if (envelope) envelopes.push(envelope);
           } catch (err: unknown) {
-            const errMessage = err instanceof Error ? err.message : 'Unknown error';
-            toolResult = JSON.stringify({ error: errMessage, summary: `Tool execution failed: ${errMessage}` });
+            // Task 2 — sanitised tool-failure path.
+            //
+            // Previously: `JSON.stringify({ error: errMessage, summary:
+            // 'Tool execution failed: ${errMessage}' })` was pushed
+            // verbatim to the model context, leaking the raw exception
+            // string and bypassing the `draftToolCalled &&
+            // totalDraftsPersisted === 0` guard (which never saw a
+            // failureKind set). Result: the model could still write
+            // "Drafted X follow-ups" with nothing persisted.
+            //
+            // New behaviour:
+            //   - log the FULL exception (tool name, args, message,
+            //     stack) to console.error with a `[skill_exception]`
+            //     prefix and a correlation id;
+            //   - feed the model only the sanitised summary;
+            //   - flip a flag the post-stream guard reads, so the
+            //     user-visible reply is overridden with a clear
+            //     "I couldn't complete that" message.
+            const errObj = err instanceof Error ? err : new Error(String(err));
+            const correlationId = randomCorrelationId();
+            skillExceptionOccurred = true;
+            skillExceptionCorrelationId = skillExceptionCorrelationId ?? correlationId;
+            console.error('[skill_exception]', {
+              correlationId,
+              tool: toolCall.function.name,
+              params: parsedParams,
+              message: errObj.message,
+              stack: errObj.stack,
+            });
+            toolResult = JSON.stringify({
+              error: 'skill_exception',
+              correlation_id: correlationId,
+              summary: SKILL_EXCEPTION_USER_MESSAGE,
+            });
           }
         } else {
           toolResult = JSON.stringify({ error: `Unknown tool: ${toolCall.function.name}` });
@@ -779,11 +829,25 @@ export async function POST(request: NextRequest) {
             | 'needs_recipient'
             | 'draft_blocked'
             | 'empty_draft_result'
+            | 'skill_exception'
             | null = null;
           let failureMessage: string | null = null;
           let failureCorrelationId: string | null = null;
           let failureQuery: unknown = null;
-          if (needsRecipientPayloads.length > 0) {
+          if (skillExceptionOccurred) {
+            // Task 2 — a skill threw inside the tool loop. The model has
+            // been fed only a sanitised summary, but it may still have
+            // composed a confident-sounding reply around it. Override
+            // the user-facing text with a clear failure message so the
+            // user doesn't see "Drafted X" when nothing happened. The
+            // correlation id is the FIRST exception's id; subsequent
+            // exceptions in the same turn are still logged but rolled
+            // up under that id for support.
+            failureKind = 'skill_exception';
+            failureCorrelationId = skillExceptionCorrelationId;
+            failureMessage =
+              "I couldn't complete that — no drafts were created. Try again, or rephrase the request.";
+          } else if (needsRecipientPayloads.length > 0) {
             // needs_recipient is a CLARIFICATION request, not a system
             // failure. The chat layer used to wrap it in
             // "We couldn't complete this — …" copy and ship it as

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   resolveRecipient,
   toDraftRecord,
 } from '@/lib/agent-intelligence/drafts';
+import { authorizeDraftMutation } from '@/lib/agent-intelligence/draft-auth';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -56,9 +57,12 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
     if (getErr) return NextResponse.json({ error: getErr.message }, { status: 500 });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-    if (user && existing.user_id !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
+
+    // Auth + tenant guard. See `lib/agent-intelligence/draft-auth.ts` —
+    // closes the falsy-bypass that let unauthenticated PATCH requests
+    // slip through to the service-role admin client.
+    const authResult = await authorizeDraftMutation(supabase, user, existing);
+    if (!authResult.ok) return authResult.response;
 
     const nextContent = { ...(existing.content_json || {}) };
     if (typeof body.subject === 'string') nextContent.subject = body.subject;
@@ -109,14 +113,17 @@ export async function DELETE(_request: NextRequest, { params }: { params: { id: 
 
     const { data: existing } = await supabase
       .from('pending_drafts')
-      .select('user_id')
+      .select('user_id, tenant_id')
       .eq('id', params.id)
       .maybeSingle();
 
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-    if (user && existing.user_id !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
+
+    // Auth + tenant guard. See `lib/agent-intelligence/draft-auth.ts` —
+    // closes the falsy-bypass that let unauthenticated DELETE requests
+    // slip through to the service-role admin client.
+    const authResult = await authorizeDraftMutation(supabase, user, existing);
+    if (!authResult.ok) return authResult.response;
 
     await supabase
       .from('recent_actions')

--- a/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
@@ -6,6 +6,7 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { getResendClient } from '@/lib/resend';
 import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
 import { isStatutoryDraftType } from '@/lib/agent-intelligence/autonomy';
+import { authorizeDraftMutation } from '@/lib/agent-intelligence/draft-auth';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -54,9 +55,13 @@ export async function POST(request: NextRequest) {
 
     if (fetchErr) return NextResponse.json({ error: fetchErr.message }, { status: 500 });
     if (!draft) return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
-    if (user && draft.user_id !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
+
+    // Auth + tenant guard. Replaces the old `if (user && draft.user_id !==
+    // user.id)` pattern which short-circuited to ALLOW when no auth
+    // cookie was present, letting an unauthenticated POST with a known
+    // draft id slip through to the service-role admin client.
+    const authResult = await authorizeDraftMutation(supabase, user, draft);
+    if (!authResult.ok) return authResult.response;
     console.log('[send-draft] entry', {
       draftId,
       userId: draft.user_id,

--- a/apps/unified-portal/lib/agent-intelligence/draft-auth.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-auth.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared auth + tenant guard for the draft mutation endpoints.
+ *
+ * Three routes write to `pending_drafts`:
+ *   - POST   /api/agent/intelligence/send-draft
+ *   - PATCH  /api/agent/intelligence/drafts/[id]
+ *   - DELETE /api/agent/intelligence/drafts/[id]
+ *
+ * Before this helper, each route used the pattern:
+ *
+ *     const { data: { user } } = await supabaseAuth.auth.getUser();
+ *     if (user && draft.user_id !== user.id) return 403;
+ *
+ * which short-circuited to ALLOW when `user` was falsy (no auth cookie).
+ * The routes then proceeded with `getSupabaseAdmin()` (service role,
+ * bypasses RLS), so an unauthenticated POST with a known `draft.id`
+ * could send / patch / delete any tenant's draft.
+ *
+ * This helper enforces three checks in order:
+ *   1. an authenticated user must be present (return 401 otherwise);
+ *   2. `draft.user_id` must match `user.id` (return 403 otherwise);
+ *   3. `draft.tenant_id` must match the user's `agent_profiles.tenant_id`
+ *      (return 403 otherwise) — defence-in-depth so a bug in (2) can't
+ *      cross tenants.
+ *
+ * The caller passes the draft row it has already fetched (and, optionally,
+ * the supabase admin client for the tenant lookup). The helper either
+ * returns `{ ok: true, user, tenantId }` or returns `{ ok: false,
+ * response: NextResponse }` carrying the right error status. Callers
+ * then either continue with confidence or short-circuit by returning
+ * `result.response` directly.
+ */
+
+import { NextResponse } from 'next/server';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+
+export type DraftAuthSuccess = {
+  ok: true;
+  user: User;
+  tenantId: string;
+};
+
+export type DraftAuthFailure = {
+  ok: false;
+  response: NextResponse;
+};
+
+export type DraftAuthResult = DraftAuthSuccess | DraftAuthFailure;
+
+interface DraftLike {
+  user_id?: string | null;
+  tenant_id?: string | null;
+}
+
+/**
+ * Resolve and verify the authenticated user can mutate this draft.
+ *
+ * @param supabaseAdmin   Service-role client, used to look up the user's
+ *                        tenant via `agent_profiles.tenant_id` keyed off
+ *                        `user_id`.
+ * @param authUser        Result of `supabaseAuth.auth.getUser()` —
+ *                        `null` when no cookie was sent.
+ * @param draft           The `pending_drafts` row the caller already
+ *                        loaded. Carries `user_id` and `tenant_id`.
+ */
+export async function authorizeDraftMutation(
+  supabaseAdmin: SupabaseClient,
+  authUser: User | null | undefined,
+  draft: DraftLike,
+): Promise<DraftAuthResult> {
+  if (!authUser) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 },
+      ),
+    };
+  }
+
+  if (draft.user_id !== authUser.id) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    };
+  }
+
+  // Tenant-scoped check. agent_profiles.user_id matches auth.users.id;
+  // we read tenant_id from the agent profile and compare it against the
+  // draft's stored tenant_id. A mismatch can only happen via a bug
+  // upstream (and is exactly the class of bug this guard exists to
+  // catch), so we treat it as a 403 rather than papering over it.
+  const { data: profile, error: profileErr } = await supabaseAdmin
+    .from('agent_profiles')
+    .select('tenant_id')
+    .eq('user_id', authUser.id)
+    .maybeSingle();
+
+  if (profileErr) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Failed to verify tenant' },
+        { status: 500 },
+      ),
+    };
+  }
+  const tenantId = (profile as any)?.tenant_id as string | undefined;
+  if (!tenantId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'No agent profile on file for this user' },
+        { status: 403 },
+      ),
+    };
+  }
+  if (draft.tenant_id && draft.tenant_id !== tenantId) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, user: authUser, tenantId };
+}

--- a/apps/unified-portal/migrations/058_enable_rls_demo_backups.sql
+++ b/apps/unified-portal/migrations/058_enable_rls_demo_backups.sql
@@ -1,0 +1,25 @@
+-- Defence-in-depth: enable RLS on every _demo_backup_*_20260502 table
+-- in the `demo_backups` schema.
+--
+-- Migration 057 moved these tables out of `public` so PostgREST no
+-- longer exposes them via the anon/authenticated roles. RLS is
+-- therefore not strictly required for confidentiality today — but
+-- enabling it locks the tables down even if the schema is ever added
+-- to PostgREST's `db.schemas` list, or if a future migration grants
+-- direct table access. No policies are added: the intent is "no
+-- access by default" until an explicit policy is written.
+--
+-- One ALTER per table per the team's "split DDL" convention; each was
+-- applied via Supabase MCP `apply_migration` so the migration history
+-- in the Supabase dashboard mirrors this file. Listed alphabetically.
+
+ALTER TABLE demo_backups._demo_backup_agent_letting_properties_20260502 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_agent_profiles_20260502           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_agent_tenancies_20260502          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_agent_workspaces_20260502         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_authuser_developer_20260502       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_compliance_documents_20260502     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_developments_20260502             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_tenants_20260502                  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_unit_sales_pipeline_20260502      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE demo_backups._demo_backup_units_20260502                    ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

Three independent server-side hardening fixes in one commit. None change happy-path behaviour.

### 1. Auth bypass on draft mutation endpoints
`send-draft`, `drafts/[id]` PATCH and `drafts/[id]` DELETE all used the pattern `if (user && draft.user_id !== user.id) return 403`, which short-circuits to ALLOW when no auth cookie is present. The routes then proceed with `getSupabaseAdmin()` (service role, bypasses RLS), so an unauthenticated POST with a known draft.id could send/edit/delete any tenant's draft.

New shared helper `lib/agent-intelligence/draft-auth.ts` (`authorizeDraftMutation`) enforces three checks per handler:
- **401** if no authenticated user
- **403** if `draft.user_id !== user.id`
- **403** if `draft.tenant_id !== agent_profiles.tenant_id` (defence-in-depth — looked up via `agent_profiles.user_id = auth.users.id`)

### 2. Tool exception silent feedback in chat route
The catch block around the tool-calling loop used to push `JSON.stringify({ error, summary: 'Tool execution failed: ...' })` straight into the model's tool-result message. The downstream draft-persistence guard never fired because `failureKind` was never set, so the model could still write "Drafted X follow-ups" with nothing persisted.

Catch path now:
- Logs the FULL exception (tool name, args, message, stack) to `console.error` with a `[skill_exception]` prefix and a correlation id.
- Feeds only a sanitised `"I hit an error while running that. Try again, or rephrase the request."` summary back to the model.
- Flips `skillExceptionOccurred` so the post-stream failure cascade hits a new `skill_exception` branch first, overriding the user-visible reply with `"I couldn't complete that — no drafts were created. Try again, or rephrase the request."`. The `failureKind` union was extended to include `'skill_exception'`.

### 3. `_demo_backup_*_20260502` RLS
PR #99 already moved the 10 backup tables out of `public` into `demo_backups`, so PostgREST no longer exposes them. This commit adds defence-in-depth by enabling RLS on every backup table (no policies — no access by default if the schema is ever added to PostgREST's exposure list).

Applied via Supabase MCP `apply_migration`, one ALTER per call (no DDL batching); mirrored in `migrations/058_enable_rls_demo_backups.sql`. The 10 actual tables in `demo_backups` are: `agent_letting_properties`, `agent_profiles`, `agent_tenancies`, `agent_workspaces`, `authuser_developer`, `compliance_documents`, `developments`, `tenants`, `unit_sales_pipeline`, `units`. Three names from the original brief (`agent_viewings`, `pending_drafts`, `buyer_communications`) don't exist — skipped per the brief's instruction.

## Test plan

- [x] `npm run build` passes
- [x] All 10 demo_backups tables verified `rowsecurity = true` via `pg_tables`
- [ ] Verify on preview: unauthenticated POST to `/api/agent/intelligence/send-draft` with a known UUID returns 401, not 200/403 with placeholder.
- [ ] Verify on preview: unauthenticated PATCH/DELETE to `/api/agent/intelligence/drafts/<id>` returns 401.
- [ ] Verify on preview: PATCH/DELETE/POST from a different tenant's user (with valid auth) returns 403.
- [ ] Verify on preview: when a skill is forced to throw, response reads "I couldn't complete that — no drafts were created" and console logs carry `[skill_exception]` with correlation id.

No test files added in this session; Batch 6 covers test backfill.

https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8WddKpTGKsXbghMUZahhF)_