### PR TITLE
feat(agent): create viewing from intelligence chat with device calendar sync

### DIFF
--- a/apps/unified-portal/android/app/src/main/AndroidManifest.xml
+++ b/apps/unified-portal/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
+
+        <activity
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:name=".MainActivity"
+            android:label="@string/title_activity_main"
+            android:theme="@style/AppTheme.NoActionBarLaunch"
+            android:launchMode="singleTask"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+        </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"></meta-data>
+        </provider>
+    </application>
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+</manifest>

--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -19,6 +19,7 @@ import { notifyDraftsChanged, useDraftsCount } from '../_hooks/useDraftsCount';
 import { ApprovalDrawerProvider, useApprovalDrawer } from '@/lib/agent-intelligence/drawer-store';
 import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import ApprovalDrawer from '@/components/agent/intelligence/ApprovalDrawer';
+import ViewingCard, { type ViewingDraftPayload } from '@/components/agent/intelligence/ViewingCard';
 
 // Session 7 — the landing-screen action-button grid and the SCHEME_PILLS /
 // INDEPENDENT_PILLS 2×2 grid are gone. Capability surfacing is now the
@@ -84,6 +85,11 @@ interface Message {
   // frame; renders as a red-bordered card with AlertCircle, the failure
   // copy, an "error ref: <id>" footer, and a Retry button.
   failure?: FailurePayload;
+  // create_viewing draft surfacing. The chat route emits one
+  // `viewing_draft` SSE frame per draft; we stash them on the
+  // assistant message so the card renders inline and persists in
+  // history. The card mutates in place to a receipt on confirm.
+  viewingDrafts?: ViewingDraftPayload[];
 }
 
 interface UndoBatch {
@@ -136,7 +142,7 @@ export default function IntelligencePage() {
 }
 
 function IntelligencePageInner() {
-  const { agent, alerts, developmentIds, activeWorkspace } = useAgent();
+  const { agent, alerts, developmentIds, developments, activeWorkspace } = useAgent();
   const { openApprovalDrawer } = useApprovalDrawer();
   const { count: pendingDraftsCount, ready: draftsReady } = useDraftsCount();
   const searchParams = useSearchParams();
@@ -354,6 +360,24 @@ function IntelligencePageInner() {
                   }];
                 });
               }
+            } else if (data.type === 'viewing_draft' && data.draft) {
+              const draft = data.draft as ViewingDraftPayload;
+              setMessages(prev => {
+                const existing = prev.find(m => m.id === streamingMsgId);
+                if (existing) {
+                  return prev.map(m =>
+                    m.id === streamingMsgId
+                      ? { ...m, viewingDrafts: [...(m.viewingDrafts ?? []), draft] }
+                      : m,
+                  );
+                }
+                return [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: '',
+                  viewingDrafts: [draft],
+                }];
+              });
             } else if (data.type === 'override') {
               // Server detected the model hallucinated drafts. Replace
               // whatever tokens have streamed so far with the honest
@@ -1063,15 +1087,25 @@ function IntelligencePageInner() {
                 );
               }
               return (
-                <AIResponseCard
-                  key={msg.id}
-                  text={msg.content}
-                  emails={msg.emails}
-                  followups={msg.followups}
-                  onFollowup={handleSend}
-                  envelope={msg.envelope}
-                  onReopen={(env) => openApprovalDrawer(env)}
-                />
+                <div key={msg.id} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  {(msg.content || msg.emails || msg.followups || msg.envelope) && (
+                    <AIResponseCard
+                      text={msg.content}
+                      emails={msg.emails}
+                      followups={msg.followups}
+                      onFollowup={handleSend}
+                      envelope={msg.envelope}
+                      onReopen={(env) => openApprovalDrawer(env)}
+                    />
+                  )}
+                  {msg.viewingDrafts && msg.viewingDrafts.map((draft, idx) => (
+                    <ViewingCard
+                      key={`${msg.id}-viewing-${idx}`}
+                      draft={draft}
+                      developments={developments?.map((d) => ({ id: d.id, name: d.name }))}
+                    />
+                  ))}
+                </div>
               );
             })}
             {isTyping && <TypingIndicator />}

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -301,6 +301,13 @@ export async function POST(request: NextRequest) {
     let rounds = 0;
     const MAX_TOOL_ROUNDS = 3;
     const envelopes: AgenticSkillEnvelope[] = [];
+    // create_viewing returns either { status: 'draft', draft } or
+    // { status: 'needs_clarification', ... }. The draft payload is surfaced
+    // to the chat surface as a `viewing_draft` SSE frame so the assistant
+    // message can render a persistent ViewingCard. Most of the time only
+    // one viewing draft fires per turn; on the off chance two come back we
+    // emit both.
+    const viewingDrafts: Array<Record<string, unknown>> = [];
 
     // Task 2 — track whether any skill threw inside the tool loop. The
     // legacy catch path JSON-stringified the raw exception into the
@@ -364,6 +371,17 @@ export async function POST(request: NextRequest) {
             // `envelope` SSE frame once the tool-calling rounds finish.
             const envelope = extractEnvelope(result);
             if (envelope) envelopes.push(envelope);
+            // create_viewing draft surfacing — picked up by the
+            // ViewingCard renderer in the assistant message stream.
+            if (
+              toolCall.function.name === 'create_viewing' &&
+              result?.data &&
+              typeof result.data === 'object' &&
+              (result.data as any).status === 'draft' &&
+              (result.data as any).draft
+            ) {
+              viewingDrafts.push((result.data as any).draft as Record<string, unknown>);
+            }
           } catch (err: unknown) {
             // Task 2 — sanitised tool-failure path.
             //
@@ -679,6 +697,16 @@ export async function POST(request: NextRequest) {
             const userVisibleEnvelope = redactEnvelopeForUser(combinedEnvelope);
             controller.enqueue(
               encoder.encode(JSON.stringify({ type: 'envelope', envelope: userVisibleEnvelope }) + '\n')
+            );
+          }
+
+          // Emit one viewing_draft frame per draft the create_viewing tool
+          // returned this turn. The IntelligencePage stashes them on the
+          // assistant message and renders a persistent ViewingCard the
+          // agent confirms / edits / cancels.
+          for (const draft of viewingDrafts) {
+            controller.enqueue(
+              encoder.encode(JSON.stringify({ type: 'viewing_draft', draft }) + '\n'),
             );
           }
 

--- a/apps/unified-portal/app/api/agent-intelligence/confirm-viewing/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/confirm-viewing/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+import { confirmViewing, type ViewingDraft } from '@/lib/agent-intelligence/tools/viewing-tools';
+import type { AgentContext } from '@/lib/agent-intelligence/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isViewingDraft(value: unknown): value is ViewingDraft {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.applicant_id === 'string' &&
+    typeof v.applicant_name === 'string' &&
+    typeof v.development_id === 'string' &&
+    typeof v.development_name === 'string' &&
+    typeof v.scheduled_at === 'string' &&
+    typeof v.duration_minutes === 'number'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    if (!isViewingDraft(body?.draft)) {
+      return NextResponse.json({ error: 'Invalid draft payload' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const v2 = await resolveAgentContextV2(supabase, user.id);
+    const resolved = v2.context;
+    if (!resolved) {
+      return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
+    }
+
+    const agentContext: AgentContext = {
+      agentProfileId: resolved.agentProfileId,
+      authUserId: resolved.authUserId,
+      tenantId: resolved.tenantId ?? '',
+      displayName: resolved.displayName,
+      agencyName: resolved.agencyName,
+      agentType: resolved.agentType,
+      assignedSchemes: resolved.assignedSchemes,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      activeDevelopmentId: null,
+      isDemoMode: resolved.isDemoMode,
+    };
+
+    if (!agentContext.tenantId) {
+      return NextResponse.json({ error: 'Agent has no tenant assignment' }, { status: 403 });
+    }
+    if (!agentContext.assignedDevelopmentIds.includes(body.draft.development_id)) {
+      return NextResponse.json({ error: 'Development not in your assigned schemes' }, { status: 403 });
+    }
+
+    const created = await confirmViewing(supabase, agentContext, { draft: body.draft });
+
+    return NextResponse.json({
+      viewing: {
+        id: created.id,
+        scheduled_at: created.scheduled_at,
+        status: created.status,
+        applicant_name: body.draft.applicant_name,
+        development_name: body.draft.development_name,
+        duration_minutes: body.draft.duration_minutes,
+        location: body.draft.location ?? null,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent-intelligence/viewings/[id]/calendar/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/viewings/[id]/calendar/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json();
+    const eventId: unknown = body?.device_calendar_event_id;
+    if (typeof eventId !== 'string' || eventId.length === 0) {
+      return NextResponse.json({ error: 'device_calendar_event_id required' }, { status: 400 });
+    }
+
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from('viewings')
+      .update({ device_calendar_event_id: eventId, updated_at: new Date().toISOString() })
+      .eq('id', params.id)
+      .eq('agent_id', user.id)
+      .select('id, device_calendar_event_id')
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: error?.message || 'Viewing not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ viewing: data });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/viewings/[id]/page.tsx
+++ b/apps/unified-portal/app/viewings/[id]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function ViewingByIdRedirect({ params }: { params: { id: string } }) {
+  redirect(`/agent/viewings?focus=${encodeURIComponent(params.id)}`);
+}

--- a/apps/unified-portal/components/agent/intelligence/ViewingCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/ViewingCard.tsx
@@ -1,0 +1,534 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Calendar, Check, Pencil, X, ArrowRight, AlertTriangle, Loader2 } from 'lucide-react';
+import { addEventToDeviceCalendar } from '@/lib/capacitor-calendar';
+
+export interface ViewingDraftPayload {
+  applicant_id: string;
+  applicant_name: string;
+  development_id: string;
+  development_name: string;
+  scheduled_at: string;
+  duration_minutes: number;
+  location: string | null;
+  notes: string | null;
+}
+
+export interface CreatedViewing {
+  id: string;
+  scheduled_at: string;
+  status: string;
+  applicant_name: string;
+  development_name: string;
+  duration_minutes: number;
+  location: string | null;
+}
+
+export type CalendarOutcome =
+  | { kind: 'added' }
+  | { kind: 'unavailable' }
+  | { kind: 'denied' }
+  | { kind: 'error'; message: string }
+  | { kind: 'pending' };
+
+interface DevelopmentOption {
+  id: string;
+  name: string;
+}
+
+interface ViewingCardProps {
+  draft: ViewingDraftPayload;
+  developments?: DevelopmentOption[];
+  onConfirmed?: (viewing: CreatedViewing) => void;
+  onCancelled?: () => void;
+}
+
+const cardSurface: React.CSSProperties = {
+  background: '#FFFFFF',
+  borderRadius: 18,
+  padding: 16,
+  width: '100%',
+  maxWidth: '90%',
+  boxShadow:
+    '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const labelText: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#6B7280',
+  letterSpacing: 0,
+  textTransform: 'none',
+};
+
+const valueText: React.CSSProperties = {
+  fontSize: 13.5,
+  color: '#0D0D12',
+  letterSpacing: '-0.005em',
+  fontWeight: 500,
+};
+
+const primaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)',
+  border: 'none',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#FFFFFF',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const secondaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: '#F4F4F5',
+  border: '0.5px solid rgba(0,0,0,0.08)',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#374151',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const tertiaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'transparent',
+  border: 'none',
+  fontSize: 13,
+  fontWeight: 500,
+  color: '#6B7280',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+function formatScheduled(iso: string): { date: string; time: string } {
+  const dt = new Date(iso);
+  const date = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  }).format(dt);
+  const time = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(dt);
+  return { date, time };
+}
+
+function isoToLocalInputValue(iso: string): string {
+  const dt = new Date(iso);
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(dt)) {
+    if (p.type !== 'literal') parts[p.type] = p.value;
+  }
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`;
+}
+
+function localInputValueToIso(value: string): string {
+  // Treat the input as Europe/Dublin local time.
+  const [datePart, timePart] = value.split('T');
+  if (!datePart || !timePart) return new Date(value).toISOString();
+  const [y, m, d] = datePart.split('-').map((n) => parseInt(n, 10));
+  const [hh, mm] = timePart.split(':').map((n) => parseInt(n, 10));
+  // Build UTC by reverse-projecting from Europe/Dublin.
+  const utcGuess = Date.UTC(y, m - 1, d, hh, mm);
+  const probe = new Date(utcGuess);
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(probe)) {
+    if (p.type !== 'literal') parts[p.type] = p.value;
+  }
+  const projected = Date.UTC(
+    parseInt(parts.year, 10),
+    parseInt(parts.month, 10) - 1,
+    parseInt(parts.day, 10),
+    parseInt(parts.hour, 10),
+    parseInt(parts.minute, 10),
+  );
+  const offset = utcGuess - projected;
+  return new Date(utcGuess + offset).toISOString();
+}
+
+export default function ViewingCard({
+  draft: initialDraft,
+  developments,
+  onConfirmed,
+  onCancelled,
+}: ViewingCardProps) {
+  type Phase = 'draft' | 'editing' | 'confirming' | 'receipt' | 'cancelled' | 'error';
+
+  const [draft, setDraft] = useState<ViewingDraftPayload>(initialDraft);
+  const [phase, setPhase] = useState<Phase>('draft');
+  const [created, setCreated] = useState<CreatedViewing | null>(null);
+  const [calendar, setCalendar] = useState<CalendarOutcome>({ kind: 'pending' });
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [retryingCalendar, setRetryingCalendar] = useState(false);
+
+  const formatted = useMemo(() => formatScheduled(draft.scheduled_at), [draft.scheduled_at]);
+  const editFormatted = useMemo(
+    () => (created ? formatScheduled(created.scheduled_at) : formatted),
+    [created, formatted],
+  );
+
+  async function writeToDeviceCalendar(viewing: CreatedViewing): Promise<CalendarOutcome> {
+    const start = new Date(viewing.scheduled_at).getTime();
+    const end = start + viewing.duration_minutes * 60 * 1000;
+    const result = await addEventToDeviceCalendar({
+      title: `Viewing — ${viewing.applicant_name} at ${viewing.development_name}`,
+      startMs: start,
+      endMs: end,
+      location: viewing.location ?? viewing.development_name,
+      notes: draft.notes ?? undefined,
+    });
+
+    if (result.status === 'created') {
+      try {
+        await fetch(`/api/agent-intelligence/viewings/${viewing.id}/calendar`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ device_calendar_event_id: result.eventId }),
+        });
+      } catch {
+        // Non-blocking: the row exists, the device event exists; the
+        // back-link is a nice-to-have.
+      }
+      return { kind: 'added' };
+    }
+    if (result.status === 'denied') return { kind: 'denied' };
+    if (result.status === 'unavailable') return { kind: 'unavailable' };
+    return { kind: 'error', message: result.message };
+  }
+
+  async function handleConfirm() {
+    setPhase('confirming');
+    setErrorText(null);
+    try {
+      const res = await fetch('/api/agent-intelligence/confirm-viewing', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ draft }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || 'Could not create viewing');
+      }
+      const data = await res.json();
+      const viewing = data.viewing as CreatedViewing;
+      setCreated(viewing);
+      setPhase('receipt');
+      const outcome = await writeToDeviceCalendar(viewing);
+      setCalendar(outcome);
+      onConfirmed?.(viewing);
+    } catch (err) {
+      setErrorText(err instanceof Error ? err.message : 'Could not create viewing');
+      setPhase('error');
+    }
+  }
+
+  async function handleRetryCalendar() {
+    if (!created) return;
+    setRetryingCalendar(true);
+    const outcome = await writeToDeviceCalendar(created);
+    setCalendar(outcome);
+    setRetryingCalendar(false);
+  }
+
+  function handleCancel() {
+    setPhase('cancelled');
+    onCancelled?.();
+  }
+
+  if (phase === 'cancelled') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={{ ...cardSurface, gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <X size={16} strokeWidth={2} style={{ color: '#9CA3AF' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#6B7280' }}>Viewing not created</span>
+          </div>
+          <span style={{ fontSize: 12.5, color: '#6B7280' }}>
+            Cancelled before save. Ask Intelligence again when you want to schedule it.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'receipt' && created) {
+    const calendarLine = (() => {
+      if (calendar.kind === 'added') {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#10703C' }}>
+            <Check size={14} strokeWidth={2.25} />
+            <span style={{ fontSize: 12.5, fontWeight: 500 }}>Added to your calendar</span>
+          </div>
+        );
+      }
+      if (calendar.kind === 'pending') {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#6B7280' }}>
+            <Loader2 size={14} className="animate-spin" />
+            <span style={{ fontSize: 12.5, fontWeight: 500 }}>Adding to your calendar</span>
+          </div>
+        );
+      }
+      if (calendar.kind === 'unavailable') {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#6B7280' }}>
+            <Calendar size={14} strokeWidth={2} />
+            <span style={{ fontSize: 12.5, fontWeight: 500 }}>Calendar sync only on the iOS / Android app</span>
+          </div>
+        );
+      }
+      return (
+        <button
+          type="button"
+          onClick={handleRetryCalendar}
+          className="agent-tappable"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 10px',
+            background: 'rgba(245, 184, 0, 0.10)',
+            border: '0.5px solid rgba(245, 184, 0, 0.32)',
+            borderRadius: 999,
+            fontSize: 12.5,
+            fontWeight: 600,
+            color: '#8A6A00',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+          disabled={retryingCalendar}
+        >
+          {retryingCalendar ? <Loader2 size={13} className="animate-spin" /> : <AlertTriangle size={13} strokeWidth={2.25} />}
+          <span>Not added to calendar — tap to retry</span>
+        </button>
+      );
+    })();
+
+    const r = formatScheduled(created.scheduled_at);
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={cardSurface}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Check size={16} strokeWidth={2.25} style={{ color: '#10703C' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>Viewing scheduled</span>
+          </div>
+          <ReceiptRow label="Applicant" value={created.applicant_name} />
+          <ReceiptRow label="Property" value={created.development_name} />
+          <ReceiptRow label="When" value={`${r.date} at ${r.time}`} />
+          <ReceiptRow label="Length" value={`${created.duration_minutes} min`} />
+          {calendarLine}
+          <Link
+            href={`/viewings/${created.id}`}
+            className="agent-tappable"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '8px 12px',
+              background: '#F4F4F5',
+              border: '0.5px solid rgba(0,0,0,0.08)',
+              borderRadius: 999,
+              fontSize: 12.5,
+              fontWeight: 600,
+              color: '#0D0D12',
+              textDecoration: 'none',
+              alignSelf: 'flex-start',
+            }}
+          >
+            <span>Open in Viewings</span>
+            <ArrowRight size={13} strokeWidth={2.25} />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'editing') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={cardSurface}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Pencil size={16} strokeWidth={2} style={{ color: '#0D0D12' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>Edit viewing</span>
+          </div>
+          <ReceiptRow label="Applicant" value={draft.applicant_name} />
+          <EditField
+            label="Property"
+            type="select"
+            value={draft.development_id}
+            options={developments && developments.length > 0
+              ? developments
+              : [{ id: draft.development_id, name: draft.development_name }]}
+            onChange={(v) => {
+              const opt = (developments || [{ id: draft.development_id, name: draft.development_name }]).find((o) => o.id === v);
+              setDraft((d) => ({
+                ...d,
+                development_id: v,
+                development_name: opt?.name ?? d.development_name,
+                location: opt?.name ?? d.location,
+              }));
+            }}
+          />
+          <EditField
+            label="When"
+            type="datetime-local"
+            value={isoToLocalInputValue(draft.scheduled_at)}
+            onChange={(v) => setDraft((d) => ({ ...d, scheduled_at: localInputValueToIso(v) }))}
+          />
+          <EditField
+            label="Length (min)"
+            type="number"
+            value={String(draft.duration_minutes)}
+            onChange={(v) => setDraft((d) => ({ ...d, duration_minutes: Math.max(5, Math.min(240, parseInt(v || '30', 10) || 30)) }))}
+          />
+          <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+            <button type="button" style={primaryButton} onClick={() => setPhase('draft')} className="agent-tappable">
+              <Check size={14} strokeWidth={2.25} />
+              Done
+            </button>
+            <button type="button" style={tertiaryButton} onClick={() => { setDraft(initialDraft); setPhase('draft'); }} className="agent-tappable">
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div style={cardSurface}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Calendar size={16} strokeWidth={2} style={{ color: '#0D0D12' }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>New viewing</span>
+        </div>
+
+        <ReceiptRow label="Applicant" value={draft.applicant_name} />
+        <ReceiptRow label="Property" value={draft.development_name} />
+        <ReceiptRow label="When" value={`${formatted.date} at ${formatted.time}`} />
+        <ReceiptRow label="Length" value={`${draft.duration_minutes} min`} />
+        {draft.notes && <ReceiptRow label="Notes" value={draft.notes} />}
+
+        {phase === 'error' && errorText && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#B91C1C' }}>
+            <AlertTriangle size={14} strokeWidth={2.25} />
+            <span style={{ fontSize: 12.5, fontWeight: 500 }}>{errorText}</span>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 4 }}>
+          <button
+            type="button"
+            style={primaryButton}
+            onClick={handleConfirm}
+            disabled={phase === 'confirming'}
+            className="agent-tappable"
+          >
+            {phase === 'confirming' ? (
+              <>
+                <Loader2 size={14} className="animate-spin" />
+                Creating
+              </>
+            ) : (
+              <>
+                <Check size={14} strokeWidth={2.25} />
+                {phase === 'error' ? 'Try again' : 'Create viewing'}
+              </>
+            )}
+          </button>
+          <button type="button" style={secondaryButton} onClick={() => setPhase('editing')} className="agent-tappable" disabled={phase === 'confirming'}>
+            <Pencil size={14} strokeWidth={2.25} />
+            Edit
+          </button>
+          <button type="button" style={tertiaryButton} onClick={handleCancel} className="agent-tappable" disabled={phase === 'confirming'}>
+            Cancel
+          </button>
+        </div>
+              </div>
+    </div>
+  );
+}
+
+function ReceiptRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={labelText}>{label}</span>
+      <span style={valueText}>{value}</span>
+    </div>
+  );
+}
+
+function EditField(props: {
+  label: string;
+  type: 'datetime-local' | 'number' | 'select';
+  value: string;
+  options?: DevelopmentOption[];
+  onChange: (v: string) => void;
+}) {
+  const inputStyle: React.CSSProperties = {
+    padding: '8px 10px',
+    fontSize: 13,
+    border: '0.5px solid rgba(0,0,0,0.16)',
+    borderRadius: 8,
+    background: '#FFFFFF',
+    color: '#0D0D12',
+    fontFamily: 'inherit',
+  };
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <span style={labelText}>{props.label}</span>
+      {props.type === 'select' ? (
+        <select style={inputStyle} value={props.value} onChange={(e) => props.onChange(e.target.value)}>
+          {(props.options ?? []).map((opt) => (
+            <option key={opt.id} value={opt.id}>{opt.name}</option>
+          ))}
+        </select>
+      ) : (
+        <input
+          style={inputStyle}
+          type={props.type}
+          value={props.value}
+          onChange={(e) => props.onChange(e.target.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/unified-portal/ios/App/App/Info.plist
+++ b/apps/unified-portal/ios/App/App/Info.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenHouse</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>OpenHouse uses the microphone for voice commands to your assistant.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>OpenHouse needs calendar access to add property viewings to your schedule.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>OpenHouse needs calendar access to add property viewings to your schedule.</string>
+</dict>
+</plist>

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -597,7 +597,34 @@ You have two classes of tools:
 (B) AGENTIC SKILL tools — produce draft work for the agent's approval. These are:
     surface_aged_contracts_for_solicitor, draft_viewing_followup, weekly_monday_briefing,
     draft_lease_renewal, natural_query, schedule_viewing_draft,
-    create_viewing_schedule, rank_pipeline_buyers.
+    create_viewing_schedule, rank_pipeline_buyers, create_viewing.
+
+============================================================
+CREATE_VIEWING — RESOLVE THEN CONFIRM:
+============================================================
+For voice-first viewing capture ("schedule a viewing with Jack Murphy Tuesday 6pm"), call create_viewing. Pass:
+  - applicant_name: exactly what the user said.
+  - scheduled_at_natural: the user's date/time phrase verbatim ("Tuesday 6pm", "tomorrow at 11").
+  - property_hint: only when the user named a scheme.
+  - duration_minutes / notes: only when the user said them.
+
+NEVER invent applicant or property data. The resolver runs against the agent's own applicants and their active enquiries.
+
+The tool returns one of two shapes:
+
+  status: "draft" — fully resolved. The chat surface renders a viewing card from the draft.
+    Your reply MUST be a single short sentence (<= 12 words) confirming you've prepared it.
+    DO NOT echo the applicant, the property, the date or the time in your reply — the card already shows them.
+
+  status: "needs_clarification" — the resolver could not finish. The result carries a \`reason\`
+    and a user-friendly \`message\`. Ask the agent the SINGLE targeted question implied by the reason:
+      - applicant_not_found  → "I don't have an applicant matching X. Add them first?"
+      - applicant_ambiguous  → "Which Jack — the one on Rathárd Park or the one on Longview Park?"
+      - property_not_found   → "Which development is this viewing for?"
+      - property_ambiguous   → "Lakeside Manor or Westfield Heights?"
+      - missing_time         → "What time on Tuesday?"
+      - date_unparseable     → "When? Try 'Tuesday 6pm' or 'tomorrow at 11'."
+    One question, max. No multi-step wizards. When the user answers, call create_viewing again with the clarification rolled in.
 
 Every agentic skill tool returns a structured envelope with
 \`status: "awaiting_approval"\` and zero-or-more drafts, each carrying a stable
@@ -1209,6 +1236,13 @@ TOOL USE — LETTINGS MODE:
 You may call the draft and message tools the platform already provides (draft_message, draft_buyer_followups when used for a tenant, etc.). The sales-side read tools (get_unit_status, get_scheme_overview, get_buyer_details, get_outstanding_items, get_candidate_units, etc.) do NOT apply here — the data lives in agent_letting_properties and agent_tenancies, which is already loaded into your live context. Read from the LETTINGS PORTFOLIO block above; do not attempt to call the sales read tools.
 
 When the user asks you to draft, write, send, follow up with, chase, or message a tenant — ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent — nothing leaves the system until the agent explicitly approves.
+
+CREATE_VIEWING — RESOLVE THEN CONFIRM:
+For voice-first viewing capture ("schedule a viewing with Jack Murphy Tuesday 6pm"), call create_viewing. Pass applicant_name and scheduled_at_natural verbatim from what the agent said; add property_hint only when they named a development. The tool resolves the applicant against agent_applicants and the property against the applicant's active enquiries — NEVER invent either.
+
+The result is one of two shapes:
+  status: "draft" — fully resolved. The chat surface renders a viewing card from the draft. Reply with one short sentence (<= 12 words) confirming you've prepared it. DO NOT echo applicant, property, or time in your reply — the card already shows them.
+  status: "needs_clarification" — the resolver could not finish. The result carries a \`reason\` and a user-friendly \`message\`. Ask the SINGLE targeted question the reason implies (e.g. "Which Jack — the one on Rathárd Park or the one on Longview Park?"). One question, max. When the agent answers, call create_viewing again with the clarification rolled in.
 
 DRAFT_LEASE_RENEWAL — IMPORTANT:
 When the user says "renewal", "renew the lease", "draft renewal offer", "reminder about [tenant]'s renewal", "remind [tenant] about their renewal", "lease end reminder", "draft a reminder about the upcoming renewal", or taps a renewal suggestion chip, call draft_lease_renewal. ANY phrasing that combines a tenant with the words "renewal", "renew", or "lease end" routes here — including "reminder" framings. Do NOT call draft_message for these requests; the resulting draft would be tagged buyer_followup instead of lease_renewal and land in the wrong inbox bucket.

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -16,6 +16,7 @@ import {
   logCommunication,
   generateDeveloperReport,
 } from './write-tools';
+import { createViewing } from './viewing-tools';
 // schedule_viewing is intentionally NOT imported here: its immediate-write
 // behaviour has been replaced by schedule_viewing_draft. The underlying
 // scheduleViewing function remains exported from './write-tools' for any
@@ -460,6 +461,30 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
     },
     execute: ((supabase, _tenantId, agentContext, params) =>
       runAgenticSkill(naturalQuery, supabase, agentContext, params as any)) as ToolFunction,
+  },
+  {
+    name: 'create_viewing',
+    description: [
+      'Schedule a new property viewing for a known applicant. Voice-first entry point — the agent says "schedule a viewing with Jack Murphy Tuesday 6pm" and this resolves the applicant, the property and the time, then returns a draft for the agent to confirm.',
+      'NEVER writes on its own — always returns either a draft for confirmation or a needs_clarification with one targeted question.',
+      'Resolution rules:',
+      '- Applicant: ilike match on agent_applicants.full_name within the agent\'s tenant. Zero matches → needs_clarification (applicant_not_found). Multiple matches → needs_clarification (applicant_ambiguous) with the candidate list.',
+      '- Property: pulled from the applicant\'s active enquiries. Single match → use it. Multiple → use property_hint (ilike on development name) when supplied; otherwise needs_clarification (property_ambiguous).',
+      '- Date / time: parsed against Europe/Dublin. Bare weekday means the next occurrence; if today is that weekday, defaults to next week unless the time is still ahead today.',
+      'When fully resolved, returns { status: "draft", draft, message: "Confirm to create this viewing" }. The chat surface renders a viewing card from the draft — DO NOT echo the draft fields in your reply, the card is the canonical surface.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        applicant_name: { type: 'string', description: 'Full or partial applicant name as the agent said it. Resolved server-side via ilike on agent_applicants.full_name.' },
+        property_hint: { type: 'string', description: 'Optional development-name hint when the applicant has enquiries on more than one scheme.' },
+        scheduled_at_natural: { type: 'string', description: 'Natural-language date and time, e.g. "Tuesday 6pm", "tomorrow at 11", "next Monday 3pm". Parsed against Europe/Dublin.' },
+        duration_minutes: { type: 'number', description: 'Viewing length in minutes. Defaults to 30. Clamped to 5-240.' },
+        notes: { type: 'string', description: 'Optional notes captured from the agent\'s instruction (parking, joint viewing, anything specific).' },
+      },
+      required: ['applicant_name', 'scheduled_at_natural'],
+    },
+    execute: createViewing as ToolFunction,
   },
   {
     name: 'schedule_viewing_draft',

--- a/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
@@ -1,0 +1,183 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { ToolResult, AgentContext } from '../types';
+import {
+  parseScheduledAtNatural,
+  resolveApplicantByName,
+  resolvePropertyForApplicant,
+  formatViewingTime,
+  DEFAULT_TZ,
+} from '../viewing-resolver';
+
+export interface ViewingDraft {
+  applicant_id: string;
+  applicant_name: string;
+  development_id: string;
+  development_name: string;
+  scheduled_at: string;
+  duration_minutes: number;
+  location: string | null;
+  notes: string | null;
+}
+
+export type CreateViewingResult =
+  | {
+      status: 'draft';
+      draft: ViewingDraft;
+      message: string;
+    }
+  | {
+      status: 'needs_clarification';
+      reason:
+        | 'applicant_not_found'
+        | 'applicant_ambiguous'
+        | 'property_not_found'
+        | 'property_ambiguous'
+        | 'date_unparseable'
+        | 'missing_time';
+      message: string;
+      candidates?: Array<Record<string, unknown>>;
+    };
+
+export async function createViewing(
+  supabase: SupabaseClient,
+  _tenantId: string,
+  agentContext: AgentContext,
+  params: {
+    applicant_name: string;
+    property_hint?: string;
+    scheduled_at_natural: string;
+    duration_minutes?: number;
+    notes?: string;
+  },
+): Promise<ToolResult> {
+  const tz = DEFAULT_TZ;
+
+  const parsedDate = parseScheduledAtNatural(params.scheduled_at_natural ?? '', { tz });
+  if (!parsedDate.ok) {
+    const reason = parsedDate.reason === 'missing_time' ? 'missing_time' : 'date_unparseable';
+    const message =
+      reason === 'missing_time'
+        ? `What time on ${params.scheduled_at_natural || 'that day'}? I need a time to schedule the viewing.`
+        : `I couldn't read "${params.scheduled_at_natural}" as a date. Try something like "Tuesday 6pm" or "tomorrow at 11".`;
+    const result: CreateViewingResult = { status: 'needs_clarification', reason, message };
+    return { data: result, summary: message };
+  }
+
+  const applicantRes = await resolveApplicantByName(supabase, agentContext.agentProfileId, params.applicant_name);
+  if (applicantRes.status === 'none') {
+    const message = `I don't have an applicant matching "${params.applicant_name}". Add them in Applicants first, or check the spelling.`;
+    const result: CreateViewingResult = {
+      status: 'needs_clarification',
+      reason: 'applicant_not_found',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+  if (applicantRes.status === 'ambiguous') {
+    const candidates = applicantRes.candidates ?? [];
+    const summaryLine = candidates
+      .map((c) => `${c.name}${c.latest_enquiry_property ? ` — ${c.latest_enquiry_property}` : ''}`)
+      .join('; ');
+    const message = `A few applicants match "${params.applicant_name}": ${summaryLine}. Which one?`;
+    const result: CreateViewingResult = {
+      status: 'needs_clarification',
+      reason: 'applicant_ambiguous',
+      message,
+      candidates,
+    };
+    return { data: result, summary: message };
+  }
+
+  const applicant = applicantRes.applicant!;
+
+  const propertyRes = await resolvePropertyForApplicant(supabase, {
+    agentProfileId: agentContext.agentProfileId,
+    applicantId: applicant.id,
+    applicantEmail: applicant.email,
+    applicantName: applicant.name,
+    propertyHint: params.property_hint,
+  });
+
+  if (propertyRes.status === 'none') {
+    const message = `${applicant.name} has no active enquiry I can pin a property to. Which development is this viewing for?`;
+    const result: CreateViewingResult = {
+      status: 'needs_clarification',
+      reason: 'property_not_found',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+
+  if (propertyRes.status === 'ambiguous') {
+    const candidates = propertyRes.candidates ?? [];
+    const summaryLine = candidates.map((c) => c.name).join(', ');
+    const message = `${applicant.name} has enquiries on more than one scheme: ${summaryLine}. Which one is this viewing for?`;
+    const result: CreateViewingResult = {
+      status: 'needs_clarification',
+      reason: 'property_ambiguous',
+      message,
+      candidates,
+    };
+    return { data: result, summary: message };
+  }
+
+  const property = propertyRes.property!;
+  const duration = Number.isFinite(params.duration_minutes) && params.duration_minutes! > 0
+    ? Math.min(Math.max(Math.round(params.duration_minutes!), 5), 240)
+    : 30;
+
+  const draft: ViewingDraft = {
+    applicant_id: applicant.id,
+    applicant_name: applicant.name,
+    development_id: property.development_id,
+    development_name: property.name,
+    scheduled_at: parsedDate.iso,
+    duration_minutes: duration,
+    location: property.name,
+    notes: params.notes?.trim() || null,
+  };
+
+  const message = `Viewing draft ready: ${applicant.name}, ${property.name}, ${formatViewingTime(parsedDate.iso, tz)}. Confirm to create.`;
+  const result: CreateViewingResult = {
+    status: 'draft',
+    draft,
+    message: 'Confirm to create this viewing',
+  };
+  return { data: result, summary: message };
+}
+
+export interface ConfirmViewingArgs {
+  draft: ViewingDraft;
+}
+
+export async function confirmViewing(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  args: ConfirmViewingArgs,
+): Promise<{ id: string; scheduled_at: string; status: string }> {
+  const { draft } = args;
+  const insert = {
+    tenant_id: agentContext.tenantId,
+    agent_id: agentContext.authUserId,
+    applicant_id: draft.applicant_id,
+    development_id: draft.development_id,
+    unit_id: null as string | null,
+    scheduled_at: draft.scheduled_at,
+    duration_minutes: draft.duration_minutes,
+    location: draft.location,
+    notes: draft.notes,
+    status: 'scheduled' as const,
+  };
+
+  const { data, error } = await supabase
+    .from('viewings')
+    .insert(insert)
+    .select('id, scheduled_at, status')
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Failed to create viewing');
+  }
+
+  return { id: data.id, scheduled_at: data.scheduled_at, status: data.status };
+}

--- a/apps/unified-portal/lib/agent-intelligence/viewing-resolver.ts
+++ b/apps/unified-portal/lib/agent-intelligence/viewing-resolver.ts
@@ -1,0 +1,358 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Natural-language scheduling helpers for the create_viewing tool.
+ *
+ * The voice transcript says things like "Tuesday 6pm", "tomorrow at 11",
+ * "next Monday", or "the 17th at 3". The resolver accepts a free-form string,
+ * the agent's IANA tz (defaults to Europe/Dublin since this is an Irish
+ * product), and the current Date, and returns either a concrete Date in UTC
+ * or an error reason.
+ *
+ * Rule per the spec: bare weekday means the NEXT occurrence of that weekday
+ * from today — if today is that weekday, default to next week unless the
+ * time is still in the future today, in which case use today.
+ */
+
+export const DEFAULT_TZ = 'Europe/Dublin';
+
+type ParsedDate =
+  | { ok: true; iso: string; date: Date }
+  | { ok: false; reason: string };
+
+const WEEKDAYS = [
+  ['sunday', 'sun'],
+  ['monday', 'mon'],
+  ['tuesday', 'tue', 'tues'],
+  ['wednesday', 'wed', 'weds'],
+  ['thursday', 'thu', 'thur', 'thurs'],
+  ['friday', 'fri'],
+  ['saturday', 'sat'],
+];
+
+function dayIndexFromToken(token: string): number | null {
+  const lower = token.toLowerCase();
+  for (let i = 0; i < WEEKDAYS.length; i++) {
+    if (WEEKDAYS[i].includes(lower)) return i;
+  }
+  return null;
+}
+
+function parseTimeToken(token: string): { hours: number; minutes: number } | null {
+  const t = token.trim().toLowerCase().replace(/\s+/g, '');
+  const match = t.match(/^(\d{1,2})(?::(\d{2}))?(am|pm)?$/);
+  if (!match) return null;
+  let hours = parseInt(match[1], 10);
+  const minutes = match[2] ? parseInt(match[2], 10) : 0;
+  const meridian = match[3];
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  if (meridian === 'pm' && hours < 12) hours += 12;
+  if (meridian === 'am' && hours === 12) hours = 0;
+  if (!meridian && hours >= 1 && hours <= 7) {
+    // bare "6", "7" without am/pm in a viewing context is almost always pm
+    hours += 12;
+  }
+  return { hours, minutes };
+}
+
+function getZonedParts(date: Date, tz: string): { year: number; month: number; day: number; hour: number; minute: number; weekday: number } {
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    weekday: 'short',
+  });
+  const parts: Record<string, string> = {};
+  for (const part of fmt.formatToParts(date)) {
+    if (part.type !== 'literal') parts[part.type] = part.value;
+  }
+  const wkMap: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  return {
+    year: parseInt(parts.year, 10),
+    month: parseInt(parts.month, 10),
+    day: parseInt(parts.day, 10),
+    hour: parseInt(parts.hour, 10),
+    minute: parseInt(parts.minute, 10),
+    weekday: wkMap[parts.weekday] ?? 0,
+  };
+}
+
+function buildZonedDate(year: number, month: number, day: number, hour: number, minute: number, tz: string): Date {
+  const utcGuess = Date.UTC(year, month - 1, day, hour, minute);
+  const probe = new Date(utcGuess);
+  const parts = getZonedParts(probe, tz);
+  const targetUtc = Date.UTC(year, month - 1, day, hour, minute);
+  const projectedUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute);
+  const offset = targetUtc - projectedUtc;
+  return new Date(utcGuess + offset);
+}
+
+export function parseScheduledAtNatural(input: string, opts: { tz?: string; now?: Date } = {}): ParsedDate {
+  const tz = opts.tz || DEFAULT_TZ;
+  const now = opts.now ?? new Date();
+  const text = input.trim().toLowerCase();
+  if (!text) return { ok: false, reason: 'empty_input' };
+
+  const todayParts = getZonedParts(now, tz);
+
+  let targetYear = todayParts.year;
+  let targetMonth = todayParts.month;
+  let targetDay = todayParts.day;
+  let targetHour: number | null = null;
+  let targetMinute = 0;
+
+  const timeRegex = /(\b\d{1,2}(?::\d{2})?\s*(?:am|pm)?\b)/i;
+  const timeMatch = text.match(timeRegex);
+  let bodyForDate = text;
+  if (timeMatch) {
+    const parsed = parseTimeToken(timeMatch[0]);
+    if (parsed) {
+      targetHour = parsed.hours;
+      targetMinute = parsed.minutes;
+      bodyForDate = (text.slice(0, timeMatch.index!) + ' ' + text.slice(timeMatch.index! + timeMatch[0].length))
+        .replace(/\bat\b/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+  }
+
+  const todayWord = /\btoday\b/.test(bodyForDate);
+  const tomorrowWord = /\btomorrow\b/.test(bodyForDate);
+  const nextWord = /\bnext\b/.test(bodyForDate);
+  const weekdayMatch = bodyForDate.match(/\b(sun|mon|tue|tues|wed|weds|thu|thur|thurs|fri|sat|sunday|monday|tuesday|wednesday|thursday|friday|saturday)\b/);
+
+  if (todayWord) {
+    // keep targetDate as today's date; require time
+  } else if (tomorrowWord) {
+    const t = buildZonedDate(targetYear, targetMonth, targetDay, 12, 0, tz);
+    const next = new Date(t.getTime() + 24 * 60 * 60 * 1000);
+    const np = getZonedParts(next, tz);
+    targetYear = np.year;
+    targetMonth = np.month;
+    targetDay = np.day;
+  } else if (weekdayMatch) {
+    const wantedIdx = dayIndexFromToken(weekdayMatch[0]);
+    if (wantedIdx === null) return { ok: false, reason: 'unparseable_date' };
+    let delta = (wantedIdx - todayParts.weekday + 7) % 7;
+    if (delta === 0) {
+      // Today IS that weekday. Use today only if the time is still in the future.
+      if (targetHour !== null) {
+        const candidate = buildZonedDate(targetYear, targetMonth, targetDay, targetHour, targetMinute, tz);
+        if (candidate.getTime() > now.getTime()) {
+          // use today, no shift
+        } else {
+          delta = 7;
+        }
+      } else {
+        delta = 7;
+      }
+    }
+    if (nextWord && delta < 7) delta += 7;
+    if (delta > 0) {
+      const noon = buildZonedDate(targetYear, targetMonth, targetDay, 12, 0, tz);
+      const shifted = new Date(noon.getTime() + delta * 24 * 60 * 60 * 1000);
+      const sp = getZonedParts(shifted, tz);
+      targetYear = sp.year;
+      targetMonth = sp.month;
+      targetDay = sp.day;
+    }
+  } else {
+    const dmy = bodyForDate.match(/(\d{1,2})[\/\-](\d{1,2})(?:[\/\-](\d{2,4}))?/);
+    if (dmy) {
+      targetDay = parseInt(dmy[1], 10);
+      targetMonth = parseInt(dmy[2], 10);
+      if (dmy[3]) {
+        const y = parseInt(dmy[3], 10);
+        targetYear = y < 100 ? 2000 + y : y;
+      }
+    } else {
+      const monthName = bodyForDate.match(/\b(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+(\d{1,2})\b/);
+      if (monthName) {
+        const months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+        const idx = months.indexOf(monthName[1].slice(0, 3));
+        if (idx >= 0) {
+          targetMonth = idx + 1;
+          targetDay = parseInt(monthName[2], 10);
+          const candidate = buildZonedDate(targetYear, targetMonth, targetDay, 12, 0, tz);
+          if (candidate.getTime() < now.getTime() - 24 * 60 * 60 * 1000) {
+            targetYear += 1;
+          }
+        } else {
+          return { ok: false, reason: 'unparseable_date' };
+        }
+      } else if (targetHour !== null) {
+        // bare time only: treat as today if future, else tomorrow
+        const todayCandidate = buildZonedDate(targetYear, targetMonth, targetDay, targetHour, targetMinute, tz);
+        if (todayCandidate.getTime() <= now.getTime()) {
+          const t = new Date(todayCandidate.getTime() + 24 * 60 * 60 * 1000);
+          const tp = getZonedParts(t, tz);
+          targetYear = tp.year;
+          targetMonth = tp.month;
+          targetDay = tp.day;
+        }
+      } else {
+        return { ok: false, reason: 'unparseable_date' };
+      }
+    }
+  }
+
+  if (targetHour === null) {
+    return { ok: false, reason: 'missing_time' };
+  }
+
+  const final = buildZonedDate(targetYear, targetMonth, targetDay, targetHour, targetMinute, tz);
+  if (Number.isNaN(final.getTime())) return { ok: false, reason: 'unparseable_date' };
+
+  return { ok: true, iso: final.toISOString(), date: final };
+}
+
+export interface ApplicantCandidate {
+  id: string;
+  name: string;
+  latest_enquiry_property: string | null;
+}
+
+export interface ApplicantResolution {
+  status: 'one' | 'none' | 'ambiguous';
+  applicant?: { id: string; name: string; email: string | null };
+  candidates?: ApplicantCandidate[];
+}
+
+export async function resolveApplicantByName(
+  supabase: SupabaseClient,
+  agentProfileId: string,
+  name: string,
+): Promise<ApplicantResolution> {
+  const trimmed = name.trim();
+  if (!trimmed) return { status: 'none' };
+
+  const { data: applicants } = await supabase
+    .from('agent_applicants')
+    .select('id, full_name, email')
+    .eq('agent_id', agentProfileId)
+    .ilike('full_name', `%${trimmed}%`)
+    .limit(20);
+
+  if (!applicants || applicants.length === 0) return { status: 'none' };
+  if (applicants.length === 1) {
+    const a = applicants[0];
+    return {
+      status: 'one',
+      applicant: { id: a.id, name: a.full_name, email: a.email ?? null },
+    };
+  }
+
+  const ids = applicants.map((a: any) => a.id);
+  const emails = applicants.map((a: any) => a.email).filter(Boolean);
+  let enqRows: Array<{ enquirer_email: string | null; enquirer_name: string | null; development_id: string | null; received_at: string | null }> = [];
+  if (emails.length || trimmed) {
+    const { data: enqs } = await supabase
+      .from('enquiries')
+      .select('enquirer_email, enquirer_name, development_id, received_at')
+      .eq('agent_id', agentProfileId)
+      .or([
+        emails.length ? `enquirer_email.in.(${emails.map((e: string) => `"${e}"`).join(',')})` : '',
+        `enquirer_name.ilike.%${trimmed}%`,
+      ].filter(Boolean).join(','))
+      .order('received_at', { ascending: false })
+      .limit(50);
+    enqRows = enqs ?? [];
+  }
+  const devIds = Array.from(new Set(enqRows.map((e) => e.development_id).filter(Boolean))) as string[];
+  const { data: devs } = devIds.length
+    ? await supabase.from('developments').select('id, name').in('id', devIds)
+    : { data: [] as Array<{ id: string; name: string }> };
+  const devName = (id: string | null): string | null => {
+    if (!id) return null;
+    const d = (devs as Array<{ id: string; name: string }> | null)?.find((x) => x.id === id);
+    return d?.name ?? null;
+  };
+
+  const candidates: ApplicantCandidate[] = applicants.map((a: any) => {
+    const matchEnq = enqRows.find((e) => (e.enquirer_email && e.enquirer_email === a.email) || (e.enquirer_name && a.full_name && e.enquirer_name.toLowerCase() === a.full_name.toLowerCase()));
+    return {
+      id: a.id,
+      name: a.full_name,
+      latest_enquiry_property: matchEnq ? devName(matchEnq.development_id) : null,
+    };
+  });
+
+  return { status: 'ambiguous', candidates };
+}
+
+export interface PropertyCandidate {
+  development_id: string;
+  name: string;
+}
+
+export interface PropertyResolution {
+  status: 'one' | 'none' | 'ambiguous';
+  property?: PropertyCandidate;
+  candidates?: PropertyCandidate[];
+}
+
+export async function resolvePropertyForApplicant(
+  supabase: SupabaseClient,
+  args: {
+    agentProfileId: string;
+    applicantId: string;
+    applicantEmail: string | null;
+    applicantName: string;
+    propertyHint?: string;
+  },
+): Promise<PropertyResolution> {
+  const orParts: string[] = [];
+  if (args.applicantEmail) orParts.push(`enquirer_email.eq.${args.applicantEmail}`);
+  if (args.applicantName) orParts.push(`enquirer_name.ilike.%${args.applicantName}%`);
+
+  let enquiries: Array<{ development_id: string | null; status: string }> = [];
+  if (orParts.length) {
+    const { data } = await supabase
+      .from('enquiries')
+      .select('development_id, status')
+      .eq('agent_id', args.agentProfileId)
+      .or(orParts.join(','))
+      .not('development_id', 'is', null)
+      .not('status', 'in', '("closed","archived","completed","won","lost")')
+      .order('received_at', { ascending: false });
+    enquiries = data ?? [];
+  }
+
+  const devIds = Array.from(new Set(enquiries.map((e) => e.development_id).filter(Boolean))) as string[];
+  if (devIds.length === 0) return { status: 'none' };
+
+  const { data: devs } = await supabase
+    .from('developments')
+    .select('id, name')
+    .in('id', devIds);
+  const candidates: PropertyCandidate[] = (devs ?? []).map((d: any) => ({ development_id: d.id, name: d.name }));
+
+  if (candidates.length === 1) return { status: 'one', property: candidates[0] };
+
+  if (args.propertyHint) {
+    const hint = args.propertyHint.trim().toLowerCase();
+    const matches = candidates.filter((c) => c.name.toLowerCase().includes(hint));
+    if (matches.length === 1) return { status: 'one', property: matches[0] };
+  }
+
+  return { status: 'ambiguous', candidates };
+}
+
+export function formatViewingTime(iso: string, tz: string = DEFAULT_TZ): string {
+  const date = new Date(iso);
+  const fmt = new Intl.DateTimeFormat('en-IE', {
+    timeZone: tz,
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return fmt.format(date);
+}

--- a/apps/unified-portal/lib/capacitor-calendar.ts
+++ b/apps/unified-portal/lib/capacitor-calendar.ts
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * Capacitor calendar bridge.
+ *
+ * Wraps `@ebarooni/capacitor-calendar`, the plugin Sam installs in the
+ * native wrapper repo (NOT in the unified-portal package.json — same
+ * convention as `capacitor-native.ts` and `usePushNotifications.ts`).
+ *
+ * Web fallback is a no-op: callers receive `{ status: 'unavailable' }`
+ * so the chat receipt card can render the "Not added to calendar" hint
+ * without breaking the booking flow.
+ */
+
+import { isCapacitorNative } from './capacitor-native';
+
+export interface CalendarEventInput {
+  title: string;
+  startMs: number;
+  endMs: number;
+  location?: string;
+  notes?: string;
+}
+
+export type CalendarWriteResult =
+  | { status: 'created'; eventId: string }
+  | { status: 'denied' }
+  | { status: 'unavailable' }
+  | { status: 'error'; message: string };
+
+let pluginCache: any | undefined;
+
+async function loadCalendarPlugin(): Promise<any | null> {
+  if (pluginCache !== undefined) return pluginCache;
+  try {
+    const specifier = '@ebarooni/capacitor-calendar';
+    // @ts-ignore — optional native dep, dynamic to avoid webpack static resolution
+    const mod = await import(/* webpackIgnore: true */ specifier);
+    pluginCache = mod?.CapacitorCalendar ?? null;
+    return pluginCache;
+  } catch {
+    pluginCache = null;
+    return null;
+  }
+}
+
+export async function ensureCalendarPermission(): Promise<'granted' | 'denied' | 'unavailable'> {
+  const native = await isCapacitorNative();
+  if (!native) return 'unavailable';
+
+  const plugin = await loadCalendarPlugin();
+  if (!plugin) return 'unavailable';
+
+  try {
+    if (typeof plugin.checkPermission === 'function') {
+      const check = await plugin.checkPermission({ alias: 'writeCalendar' }).catch(() => null);
+      if (check?.result === 'granted') return 'granted';
+    }
+    if (typeof plugin.requestWriteOnlyCalendarAccess === 'function') {
+      const res = await plugin.requestWriteOnlyCalendarAccess();
+      if (res?.result === 'granted') return 'granted';
+      return 'denied';
+    }
+    if (typeof plugin.requestPermission === 'function') {
+      const res = await plugin.requestPermission({ alias: 'writeCalendar' });
+      if (res?.result === 'granted') return 'granted';
+    }
+    return 'denied';
+  } catch {
+    return 'denied';
+  }
+}
+
+export async function addEventToDeviceCalendar(input: CalendarEventInput): Promise<CalendarWriteResult> {
+  const permission = await ensureCalendarPermission();
+  if (permission === 'unavailable') return { status: 'unavailable' };
+  if (permission === 'denied') return { status: 'denied' };
+
+  const plugin = await loadCalendarPlugin();
+  if (!plugin) return { status: 'unavailable' };
+
+  try {
+    const res = await plugin.createEventWithPrompt({
+      title: input.title,
+      startDate: input.startMs,
+      endDate: input.endMs,
+      location: input.location,
+      description: input.notes,
+    });
+    const eventId =
+      (typeof res?.result === 'string' && res.result) ||
+      (typeof res?.eventId === 'string' && res.eventId) ||
+      '';
+    if (!eventId) return { status: 'error', message: 'Calendar plugin returned no event id' };
+    return { status: 'created', eventId };
+  } catch (err) {
+    return {
+      status: 'error',
+      message: err instanceof Error ? err.message : 'Calendar write failed',
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Voice-first viewing capture for letting and estate agents. The agent says "schedule a viewing with Jack Murphy Tuesday 6pm" in the Intelligence chat; `create_viewing` resolves the applicant against `agent_applicants` and the property against the applicant's active enquiries, then surfaces a `ViewingCard` the agent confirms in one tap. Confirm writes to a new `viewings` table and the client calls the Capacitor calendar plugin to add the event to the device calendar, PATCHing `device_calendar_event_id` back when the write succeeds.

## What's in the change

**Database (Supabase: mddxbilpjukwskeefakz)**
- `viewings_create_table` — DDL with all columns and indexes per spec.
- `viewings_rls_policies` — RLS enabled with separate select / insert / update policies (agent owns row OR tenant admin via `admins`) plus a service-role policy.
- No seed data.

**Server**
- `lib/agent-intelligence/viewing-resolver.ts` — natural-language date parser (Europe/Dublin, "bare weekday → next occurrence" rule) plus applicant + property resolvers using real columns (`agent_applicants.full_name`, applicant's active `enquiries.development_id`).
- `lib/agent-intelligence/tools/viewing-tools.ts` — `createViewing` returns `{status:'draft', draft, message}` or `{status:'needs_clarification', reason, message, candidates?}`. `confirmViewing` writes the row.
- Wired into `tools/registry.ts`. Chat route emits a new `viewing_draft` SSE frame.
- `viewings.agent_id` references `auth.users(id)`, populated from `agentContext.authUserId`.
- `POST /api/agent-intelligence/confirm-viewing` — auth + assigned-scheme check, writes the row.
- `PATCH /api/agent-intelligence/viewings/[id]/calendar` — stores `device_calendar_event_id`.
- `/viewings/[id]` redirects to `/agent/viewings?focus=:id`.

**Capacitor + UI**
- `lib/capacitor-calendar.ts` — dynamic-import bridge for `@ebarooni/capacitor-calendar` (matches existing native-plugin convention; not added to web `package.json`).
- `ios/App/App/Info.plist` and `android/app/src/main/AndroidManifest.xml` with required calendar permission entries.
- `components/agent/intelligence/ViewingCard.tsx` — persistent chat card with draft → editing → confirming → receipt phases, in-place mutation, "Open in Viewings" link, and yellow "Not added to calendar — tap to retry" inline action when device write fails.

**Prompt**
- Added `CREATE_VIEWING — RESOLVE THEN CONFIRM` block to both sales and lettings system prompts: never invent, single targeted question on `needs_clarification`, no multi-step wizards.

## Test plan

- [ ] Open Intelligence chat as an agent with at least one applicant and an active enquiry.
- [ ] Say "schedule a viewing with [applicant] [day] [time]" — confirm a `ViewingCard` renders inline with applicant, property, date/time formatted in `en-IE`.
- [ ] Tap **Edit** — change date/time/property/duration, **Done** — values persist on the card.
- [ ] Tap **Create viewing** — row lands in `viewings` with `status='scheduled'`; card mutates to receipt with the **Open in Viewings** link routing to `/viewings/[id]`.
- [ ] On native iOS / Android: confirm the system prompts for calendar access, the event lands in the device calendar, and `device_calendar_event_id` is set on the row.
- [ ] On web: receipt shows "Calendar sync only on the iOS / Android app" without breaking the flow.
- [ ] Two applicants matching the same name → assistant asks one targeted question (not a wizard).
- [ ] Applicant with enquiries on multiple developments and no `property_hint` → assistant asks which one.
- [ ] Sam runs `npx cap sync` + Pod install in the native wrapper repo before the next TestFlight build.

https://claude.ai/code/session_012Tf924w7PrARFg5KfWuPHm

---
_Generated by [Claude Code](https://claude.ai/code/session_012Tf924w7PrARFg5KfWuPHm)_