### PR TITLE
feat(agent): composite schedule_viewings with atomic RPC and unified card (session 3)

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -21,6 +21,7 @@ import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-i
 import ApprovalDrawer from '@/components/agent/intelligence/ApprovalDrawer';
 import ViewingCard, { type ViewingDraftPayload } from '@/components/agent/intelligence/ViewingCard';
 import ApplicantCard, { type ApplicantDraftEnvelope } from '@/components/agent/intelligence/ApplicantCard';
+import CompositeScheduleCard, { type CompositeScheduleEnvelope } from '@/components/agent/intelligence/CompositeScheduleCard';
 
 // Session 7 — the landing-screen action-button grid and the SCHEME_PILLS /
 // INDEPENDENT_PILLS 2×2 grid are gone. Capability surfacing is now the
@@ -95,6 +96,10 @@ interface Message {
   // as viewingDrafts; ApplicantCard handles add / update / remove
   // shapes plus the propose_undoable auto-confirm path.
   applicantDrafts?: ApplicantDraftEnvelope[];
+  // schedule_viewings (composite) envelopes. One card per turn at most;
+  // when present, the chat route suppresses the per-tool applicant_draft
+  // and viewing_draft frames so only the composite renders.
+  compositeDrafts?: CompositeScheduleEnvelope[];
 }
 
 interface UndoBatch {
@@ -399,6 +404,24 @@ function IntelligencePageInner() {
                   role: 'assistant',
                   content: '',
                   applicantDrafts: [envelope],
+                }];
+              });
+            } else if (data.type === 'composite_draft' && data.envelope) {
+              const envelope = data.envelope as CompositeScheduleEnvelope;
+              setMessages(prev => {
+                const existing = prev.find(m => m.id === streamingMsgId);
+                if (existing) {
+                  return prev.map(m =>
+                    m.id === streamingMsgId
+                      ? { ...m, compositeDrafts: [...(m.compositeDrafts ?? []), envelope] }
+                      : m,
+                  );
+                }
+                return [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: '',
+                  compositeDrafts: [envelope],
                 }];
               });
             } else if (data.type === 'override') {
@@ -1125,6 +1148,22 @@ function IntelligencePageInner() {
                     <ApplicantCard
                       key={`${msg.id}-applicant-${idx}`}
                       envelope={envelope}
+                      onConfirmFailed={(note) => {
+                        setMessages(prev => prev.map(m => {
+                          if (m.id !== msg.id) return m;
+                          const existing = m.content || '';
+                          if (existing.includes(note)) return m;
+                          const next = existing.length > 0 ? `${existing}\n\n${note}` : note;
+                          return { ...m, content: next };
+                        }));
+                      }}
+                    />
+                  ))}
+                  {msg.compositeDrafts && msg.compositeDrafts.map((envelope, idx) => (
+                    <CompositeScheduleCard
+                      key={`${msg.id}-composite-${idx}`}
+                      envelope={envelope}
+                      developments={developments?.map((d) => ({ id: d.id, name: d.name }))}
                       onConfirmFailed={(note) => {
                         setMessages(prev => prev.map(m => {
                           if (m.id !== msg.id) return m;

--- a/apps/unified-portal/app/agent/settings/autonomy/page.tsx
+++ b/apps/unified-portal/app/agent/settings/autonomy/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, PauseCircle, Sparkles } from 'lucide-react';
+import { ArrowLeft, PauseCircle, Sparkles, Calendar as CalendarIcon } from 'lucide-react';
 import AgentShell from '../../_components/AgentShell';
 import { useAgent } from '@/lib/agent/AgentContext';
 import { draftTypeLabel } from '@/lib/agent-intelligence/drafts';
@@ -55,6 +55,23 @@ export default function AutonomySettingsPage() {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ applicant_write_mode: next ? 'propose_undoable' : 'always_confirm' }),
+      });
+      if (res.ok) {
+        const body = await res.json();
+        if (body?.settings) setAgentSettings(body.settings as AgentSettings);
+      }
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const setPreferredCalendar = async (next: string | null) => {
+    setSaving('_preferred_calendar');
+    try {
+      const res = await fetch('/api/agent-intelligence/agent-settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ preferred_calendar_provider: next }),
       });
       if (res.ok) {
         const body = await res.json();
@@ -194,6 +211,11 @@ export default function AutonomySettingsPage() {
               enabled={agentSettings?.applicant_write_mode === 'propose_undoable'}
               saving={saving === '_applicant_write_mode'}
               onChange={toggleApplicantUndoMode}
+            />
+            <PreferredCalendarRow
+              value={agentSettings?.preferred_calendar_provider ?? null}
+              saving={saving === '_preferred_calendar'}
+              onChange={setPreferredCalendar}
             />
           </div>
 
@@ -461,6 +483,84 @@ function ApplicantUndoRow({
         onChange={onChange}
         testId="applicant-undo-toggle"
       />
+    </div>
+  );
+}
+
+function PreferredCalendarRow({
+  value,
+  saving,
+  onChange,
+}: {
+  value: string | null;
+  saving: boolean;
+  onChange: (next: string | null) => void;
+}) {
+  const options: Array<{ value: string; label: string; needsConnect?: boolean }> = [
+    { value: '__ask', label: 'Always ask' },
+    { value: 'device', label: 'iPhone' },
+    { value: 'google', label: 'Google Calendar', needsConnect: true },
+    { value: 'outlook', label: 'Outlook', needsConnect: true },
+    { value: 'apple', label: 'Apple Calendar' },
+  ];
+  const current = value ?? '__ask';
+  const selected = options.find((o) => o.value === current);
+  return (
+    <div
+      data-testid="preferred-calendar-row"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '14px 16px',
+        borderRadius: 14,
+        background: '#FFFFFF',
+        border: '0.5px solid rgba(0,0,0,0.06)',
+      }}
+    >
+      <div
+        style={{
+          width: 34,
+          height: 34,
+          borderRadius: 17,
+          background: 'rgba(212, 175, 55, 0.10)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#B8960C',
+          flexShrink: 0,
+        }}
+      >
+        <CalendarIcon size={18} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: '#0D0D12' }}>Preferred calendar</div>
+        <div style={{ fontSize: 12, color: '#6B7280', marginTop: 2 }}>
+          Where new viewings get added by default. {selected?.needsConnect ? 'Connect via OAuth before syncing actually starts.' : 'Change anytime.'}
+        </div>
+      </div>
+      <select
+        data-testid="preferred-calendar-select"
+        value={current}
+        disabled={saving}
+        onChange={(e) => onChange(e.target.value === '__ask' ? null : e.target.value)}
+        style={{
+          padding: '8px 12px',
+          fontSize: 13,
+          fontWeight: 500,
+          color: '#0D0D12',
+          border: '0.5px solid rgba(0,0,0,0.16)',
+          borderRadius: 999,
+          background: '#FFFFFF',
+          fontFamily: 'inherit',
+          cursor: saving ? 'progress' : 'pointer',
+          minWidth: 140,
+        }}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>{opt.label}{opt.needsConnect ? ' (Connect)' : ''}</option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -313,6 +313,11 @@ export async function POST(request: NextRequest) {
     // as an `applicant_draft` SSE frame; the assistant message renders an
     // ApplicantCard from it.
     const applicantDrafts: Array<Record<string, unknown>> = [];
+    // schedule_viewings (composite) returns a single envelope per call. The
+    // chat surface renders one CompositeScheduleCard. When composite drafts
+    // exist this turn, the per-tool applicant_draft / viewing_draft frames
+    // are suppressed so only the composite "one mental object" surfaces.
+    const compositeDrafts: Array<Record<string, unknown>> = [];
 
     // Task 2 — track whether any skill threw inside the tool loop. The
     // legacy catch path JSON-stringified the raw exception into the
@@ -394,6 +399,15 @@ export async function POST(request: NextRequest) {
               (result.data as any).status === 'draft'
             ) {
               applicantDrafts.push(result.data as Record<string, unknown>);
+            }
+            if (
+              toolCall.function.name === 'schedule_viewings' &&
+              result?.data &&
+              typeof result.data === 'object' &&
+              (result.data as any).status === 'draft' &&
+              (result.data as any).type === 'composite_schedule'
+            ) {
+              compositeDrafts.push(result.data as Record<string, unknown>);
             }
           } catch (err: unknown) {
             // Task 2 — sanitised tool-failure path.
@@ -713,23 +727,36 @@ export async function POST(request: NextRequest) {
             );
           }
 
-          // Emit one viewing_draft frame per draft the create_viewing tool
-          // returned this turn. The IntelligencePage stashes them on the
-          // assistant message and renders a persistent ViewingCard the
-          // agent confirms / edits / cancels.
-          for (const draft of viewingDrafts) {
+          // Composite schedule drafts win over the per-tool surfaces. When
+          // schedule_viewings ran this turn, its envelope already carries
+          // the applicants AND viewings AND calendar choice in one mental
+          // object; rendering separate ApplicantCard / ViewingCard cards
+          // alongside would duplicate the surface and confuse the agent.
+          const hasComposite = compositeDrafts.length > 0;
+          for (const envelope of compositeDrafts) {
             controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'viewing_draft', draft }) + '\n'),
+              encoder.encode(JSON.stringify({ type: 'composite_draft', envelope }) + '\n'),
             );
           }
-          // Emit one applicant_draft frame per envelope the manage_applicants
-          // tool returned. The chat surface renders an ApplicantCard from
-          // each. Multiple drafts in one turn happen when the agent issued
-          // distinct add/update/remove calls.
-          for (const envelope of applicantDrafts) {
-            controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'applicant_draft', envelope }) + '\n'),
-            );
+          if (!hasComposite) {
+            // Emit one viewing_draft frame per draft the create_viewing tool
+            // returned this turn. The IntelligencePage stashes them on the
+            // assistant message and renders a persistent ViewingCard the
+            // agent confirms / edits / cancels.
+            for (const draft of viewingDrafts) {
+              controller.enqueue(
+                encoder.encode(JSON.stringify({ type: 'viewing_draft', draft }) + '\n'),
+              );
+            }
+            // Emit one applicant_draft frame per envelope the manage_applicants
+            // tool returned. The chat surface renders an ApplicantCard from
+            // each. Multiple drafts in one turn happen when the agent issued
+            // distinct add/update/remove calls.
+            for (const envelope of applicantDrafts) {
+              controller.enqueue(
+                encoder.encode(JSON.stringify({ type: 'applicant_draft', envelope }) + '\n'),
+              );
+            }
           }
 
           // Session 14 — yes/no disambiguation short-circuit. When a skill
@@ -1032,7 +1059,7 @@ export async function POST(request: NextRequest) {
             controller.close();
             return;
           }
-          if (viewingDrafts.length > 0 || applicantDrafts.length > 0) {
+          if (viewingDrafts.length > 0 || applicantDrafts.length > 0 || compositeDrafts.length > 0) {
             controller.enqueue(
               encoder.encode(JSON.stringify({ type: 'done', sessionId: currentSessionId }) + '\n')
             );

--- a/apps/unified-portal/app/api/agent-intelligence/confirm-composite-schedule/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/confirm-composite-schedule/route.ts
@@ -1,0 +1,228 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+import {
+  confirmCompositeSchedule,
+  type ApplicantRef,
+  type CalendarPreference,
+} from '@/lib/agent-intelligence/tools/composite-tools';
+import type { AgentContext } from '@/lib/agent-intelligence/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const CALENDAR_CHOICES: CalendarPreference[] = ['device', 'google', 'outlook', 'apple', 'skip'];
+const STORABLE_PROVIDERS: CalendarPreference[] = ['device', 'google', 'outlook', 'apple'];
+
+interface IncomingApplicant {
+  full_name: string;
+  email?: string | null;
+  phone?: string | null;
+}
+
+interface IncomingViewing {
+  applicant_ref: ApplicantRef;
+  development_id: string;
+  scheduled_at: string;
+  duration_minutes: number;
+  location: string | null;
+  notes: string | null;
+  applicant_name?: string;
+  development_name?: string;
+}
+
+interface IncomingBody {
+  applicants_to_create: IncomingApplicant[];
+  viewings_to_create: IncomingViewing[];
+  selected_indices?: { applicants?: number[]; viewings?: number[] };
+  calendar_choice: CalendarPreference;
+}
+
+function isCalendarChoice(value: unknown): value is CalendarPreference {
+  return typeof value === 'string' && CALENDAR_CHOICES.includes(value as CalendarPreference);
+}
+
+function isApplicantRef(value: unknown): value is ApplicantRef {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.existing_id === 'string' && v.existing_id.length > 0) return true;
+  if (typeof v.new_index === 'number' && Number.isInteger(v.new_index) && v.new_index >= 0) return true;
+  return false;
+}
+
+function validateBody(body: any): { ok: true; data: IncomingBody } | { ok: false; error: string } {
+  if (!body || typeof body !== 'object') return { ok: false, error: 'Invalid body' };
+  if (!Array.isArray(body.applicants_to_create)) return { ok: false, error: 'applicants_to_create must be an array' };
+  if (!Array.isArray(body.viewings_to_create)) return { ok: false, error: 'viewings_to_create must be an array' };
+  if (!isCalendarChoice(body.calendar_choice)) return { ok: false, error: 'calendar_choice required' };
+
+  for (const a of body.applicants_to_create) {
+    if (!a || typeof a !== 'object') return { ok: false, error: 'Invalid applicant entry' };
+    if (typeof a.full_name !== 'string' || a.full_name.trim().length === 0) {
+      return { ok: false, error: 'Each applicant requires a full_name' };
+    }
+  }
+
+  for (const v of body.viewings_to_create) {
+    if (!v || typeof v !== 'object') return { ok: false, error: 'Invalid viewing entry' };
+    if (!isApplicantRef(v.applicant_ref)) return { ok: false, error: 'Viewing applicant_ref must contain existing_id or new_index' };
+    if (typeof v.development_id !== 'string' || v.development_id.length === 0) {
+      return { ok: false, error: 'Viewing development_id required' };
+    }
+    if (typeof v.scheduled_at !== 'string' || v.scheduled_at.length === 0) {
+      return { ok: false, error: 'Viewing scheduled_at required' };
+    }
+    if (typeof v.duration_minutes !== 'number' || !Number.isFinite(v.duration_minutes)) {
+      return { ok: false, error: 'Viewing duration_minutes must be a number' };
+    }
+  }
+
+  return { ok: true, data: body as IncomingBody };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const raw = await request.json();
+    const validated = validateBody(raw);
+    if (!validated.ok) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+    const body = validated.data;
+
+    const supabaseAdmin = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const v2 = await resolveAgentContextV2(supabaseAdmin, user.id);
+    const resolved = v2.context;
+    if (!resolved) return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
+
+    const agentContext: AgentContext = {
+      agentProfileId: resolved.agentProfileId,
+      authUserId: resolved.authUserId,
+      tenantId: resolved.tenantId ?? '',
+      displayName: resolved.displayName,
+      agencyName: resolved.agencyName,
+      agentType: resolved.agentType,
+      assignedSchemes: resolved.assignedSchemes,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      activeDevelopmentId: null,
+      isDemoMode: resolved.isDemoMode,
+    };
+
+    if (!agentContext.tenantId) {
+      return NextResponse.json({ error: 'Agent has no tenant assignment' }, { status: 403 });
+    }
+
+    // Apply selected_indices filtering. Defaults to "all selected" when the
+    // client omits the keys, which is what the card sends on initial confirm.
+    const selectedApplicants = Array.isArray(body.selected_indices?.applicants)
+      ? new Set(body.selected_indices!.applicants)
+      : new Set(body.applicants_to_create.map((_, i) => i));
+    const selectedViewings = Array.isArray(body.selected_indices?.viewings)
+      ? new Set(body.selected_indices!.viewings)
+      : new Set(body.viewings_to_create.map((_, i) => i));
+
+    // When the user deselects an applicant, drop any viewing that points to
+    // that applicant via new_index. The card already disables those checkboxes
+    // but we revalidate server-side because the client is untrusted.
+    const applicantsKept = body.applicants_to_create
+      .map((a, idx) => ({ a, idx }))
+      .filter(({ idx }) => selectedApplicants.has(idx));
+    const oldToNewIndex = new Map<number, number>();
+    applicantsKept.forEach(({ idx }, newIdx) => {
+      oldToNewIndex.set(idx, newIdx);
+    });
+
+    const viewingsKept = body.viewings_to_create
+      .map((v, idx) => ({ v, idx }))
+      .filter(({ v, idx }) => {
+        if (!selectedViewings.has(idx)) return false;
+        if ('new_index' in v.applicant_ref) {
+          return selectedApplicants.has(v.applicant_ref.new_index);
+        }
+        return true;
+      })
+      .map(({ v }) => {
+        let ref: ApplicantRef = v.applicant_ref;
+        if ('new_index' in ref) {
+          const remapped = oldToNewIndex.get(ref.new_index);
+          ref = remapped !== undefined ? { new_index: remapped } : ref;
+        }
+        return {
+          applicant_ref: ref,
+          development_id: v.development_id,
+          scheduled_at: v.scheduled_at,
+          duration_minutes: v.duration_minutes,
+          location: v.location,
+          notes: v.notes,
+        };
+      });
+
+    if (viewingsKept.length === 0) {
+      return NextResponse.json({ error: 'Pick at least one viewing to schedule' }, { status: 400 });
+    }
+
+    // Persist calendar preference when the choice differs from what's stored
+    // (and is something we can store, so 'skip' does not overwrite the
+    // saved value).
+    if (STORABLE_PROVIDERS.includes(body.calendar_choice)) {
+      try {
+        await supabaseAdmin
+          .from('agent_settings')
+          .upsert(
+            {
+              agent_id: agentContext.authUserId,
+              tenant_id: agentContext.tenantId,
+              preferred_calendar_provider: body.calendar_choice,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: 'agent_id' },
+          );
+      } catch (err) {
+        console.error('[confirm-composite-schedule] failed to upsert preferred calendar', err);
+      }
+    }
+
+    const result = await confirmCompositeSchedule(supabaseAdmin, agentContext, {
+      applicants_to_create: applicantsKept.map(({ a }) => ({
+        full_name: a.full_name.trim(),
+        email: a.email?.trim() || null,
+        phone: a.phone?.trim() || null,
+      })),
+      viewings_to_create: viewingsKept,
+    });
+
+    if (result.status === 'error') {
+      return NextResponse.json(
+        {
+          status: 'error',
+          error: result.error,
+          created_applicants: result.created_applicants,
+          created_viewings: result.created_viewings,
+        },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      status: 'success',
+      calendar_choice: body.calendar_choice,
+      created_applicants: result.created_applicants,
+      created_viewings: result.created_viewings,
+      // Echo the original payload so the receipt card can render names and
+      // dev info without a second round trip.
+      applicant_payload: body.applicants_to_create,
+      viewing_payload: body.viewings_to_create,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[confirm-composite-schedule] unhandled', { message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/components/agent/intelligence/CompositeScheduleCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/CompositeScheduleCard.tsx
@@ -1,0 +1,1066 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  Zap,
+  Check,
+  X,
+  ArrowRight,
+  AlertTriangle,
+  Loader2,
+  Pencil,
+  UserPlus,
+  Calendar,
+  Smartphone,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { addEventToDeviceCalendar } from '@/lib/capacitor-calendar';
+import { isCapacitorNative } from '@/lib/capacitor-native';
+
+export interface CompositeApplicantPayload {
+  temp_index: number;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  classification: 'new';
+}
+
+export type CompositeApplicantRef = { existing_id: string } | { new_index: number };
+
+export interface CompositeViewingPayload {
+  temp_index: number;
+  applicant_ref: CompositeApplicantRef;
+  applicant_name: string;
+  development_id: string;
+  development_name: string;
+  scheduled_at: string;
+  duration_minutes: number;
+  location: string | null;
+  notes: string | null;
+}
+
+export interface CompositeCalendarPayload {
+  preferred_provider: 'device' | 'google' | 'outlook' | 'apple' | 'skip' | null;
+  ask_user: boolean;
+}
+
+export interface CompositeScheduleEnvelope {
+  status: 'draft';
+  type: 'composite_schedule';
+  applicants_to_create: CompositeApplicantPayload[];
+  viewings_to_create: CompositeViewingPayload[];
+  calendar: CompositeCalendarPayload;
+  message: string;
+}
+
+export type CalendarChoice = 'device' | 'google' | 'outlook' | 'apple' | 'skip';
+
+interface DevelopmentOption {
+  id: string;
+  name: string;
+}
+
+interface CompositeScheduleCardProps {
+  envelope: CompositeScheduleEnvelope;
+  developments?: DevelopmentOption[];
+  /**
+   * Called when the confirm path fails irrecoverably so the chat surface
+   * can append a system note to the assistant message. Without this, the
+   * next-turn LLM history would still claim "Scheduled..." even though
+   * nothing was written. Same pattern as ApplicantCard's hook.
+   */
+  onConfirmFailed?: (note: string) => void;
+}
+
+type Phase = 'draft' | 'editing' | 'confirming' | 'receipt' | 'partial_error' | 'error' | 'cancelled';
+
+interface ReceiptPayload {
+  created_applicants: Array<{ temp_index: number; id: string; full_name: string; audit_log_id: string }>;
+  created_viewings: Array<{ temp_index: number; id: string; applicant_id: string; scheduled_at: string; duration_minutes: number }>;
+  calendar_choice: CalendarChoice;
+  calendar_outcomes: Array<{ viewing_temp_index: number; status: 'added' | 'unavailable' | 'denied' | 'error' | 'skipped'; message?: string }>;
+}
+
+const cardSurface: React.CSSProperties = {
+  background: '#FFFFFF',
+  borderRadius: 18,
+  padding: 16,
+  width: '100%',
+  maxWidth: '90%',
+  boxShadow:
+    '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const labelText: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#6B7280',
+  letterSpacing: 0,
+};
+
+const sectionLabelText: React.CSSProperties = {
+  fontSize: 10.5,
+  fontWeight: 700,
+  color: '#9CA3AF',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+};
+
+const valueText: React.CSSProperties = {
+  fontSize: 13.5,
+  color: '#0D0D12',
+  letterSpacing: '-0.005em',
+  fontWeight: 500,
+};
+
+const primaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)',
+  border: 'none',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#FFFFFF',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const secondaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: '#F4F4F5',
+  border: '0.5px solid rgba(0,0,0,0.08)',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#374151',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const tertiaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'transparent',
+  border: 'none',
+  fontSize: 13,
+  fontWeight: 500,
+  color: '#6B7280',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+function formatScheduled(iso: string): { date: string; time: string } {
+  const dt = new Date(iso);
+  const date = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  }).format(dt);
+  const time = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(dt);
+  return { date, time };
+}
+
+function isoToLocalInputValue(iso: string): string {
+  const dt = new Date(iso);
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(dt)) {
+    if (p.type !== 'literal') parts[p.type] = p.value;
+  }
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`;
+}
+
+function localInputValueToIso(value: string): string {
+  const [datePart, timePart] = value.split('T');
+  if (!datePart || !timePart) return new Date(value).toISOString();
+  const [y, m, d] = datePart.split('-').map((n) => parseInt(n, 10));
+  const [hh, mm] = timePart.split(':').map((n) => parseInt(n, 10));
+  const utcGuess = Date.UTC(y, m - 1, d, hh, mm);
+  const probe = new Date(utcGuess);
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(probe)) {
+    if (p.type !== 'literal') parts[p.type] = p.value;
+  }
+  const projected = Date.UTC(
+    parseInt(parts.year, 10),
+    parseInt(parts.month, 10) - 1,
+    parseInt(parts.day, 10),
+    parseInt(parts.hour, 10),
+    parseInt(parts.minute, 10),
+  );
+  const offset = utcGuess - projected;
+  return new Date(utcGuess + offset).toISOString();
+}
+
+function defaultCalendarChoice(envelope: CompositeScheduleEnvelope, isNative: boolean): CalendarChoice {
+  if (envelope.calendar.preferred_provider) {
+    return envelope.calendar.preferred_provider;
+  }
+  return isNative ? 'device' : 'skip';
+}
+
+export default function CompositeScheduleCard({ envelope, developments, onConfirmFailed }: CompositeScheduleCardProps) {
+  const initialApplicantSelection = useMemo<Set<number>>(() => {
+    return new Set(envelope.applicants_to_create.map((a) => a.temp_index));
+  }, [envelope]);
+  const initialViewingSelection = useMemo<Set<number>>(() => {
+    return new Set(envelope.viewings_to_create.map((v) => v.temp_index));
+  }, [envelope]);
+
+  const [applicants, setApplicants] = useState<CompositeApplicantPayload[]>(envelope.applicants_to_create);
+  const [viewings, setViewings] = useState<CompositeViewingPayload[]>(envelope.viewings_to_create);
+  const [selectedApplicants, setSelectedApplicants] = useState<Set<number>>(initialApplicantSelection);
+  const [selectedViewings, setSelectedViewings] = useState<Set<number>>(initialViewingSelection);
+  const [expandedApplicants, setExpandedApplicants] = useState<Set<number>>(new Set());
+  const [phase, setPhase] = useState<Phase>('draft');
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<ReceiptPayload | null>(null);
+  const [showCalendarSection, setShowCalendarSection] = useState<boolean>(envelope.calendar.ask_user);
+  const [isNative, setIsNative] = useState<boolean>(false);
+  const [calendarChoice, setCalendarChoice] = useState<CalendarChoice>(
+    defaultCalendarChoice(envelope, false),
+  );
+
+  // Detect Capacitor native context once so the iPhone / Apple options can
+  // surface only where they're useful.
+  useEffect(() => {
+    let cancelled = false;
+    isCapacitorNative()
+      .then((native) => {
+        if (cancelled) return;
+        setIsNative(native);
+        if (envelope.calendar.preferred_provider === null && native) {
+          setCalendarChoice('device');
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [envelope]);
+
+  // Whenever an applicant gets unchecked, force-disable any viewing that
+  // points to them via new_index.
+  useEffect(() => {
+    setSelectedViewings((prev) => {
+      const next = new Set(prev);
+      for (const v of viewings) {
+        if ('new_index' in v.applicant_ref && !selectedApplicants.has(v.applicant_ref.new_index)) {
+          next.delete(v.temp_index);
+        }
+      }
+      return next;
+    });
+  }, [selectedApplicants, viewings]);
+
+  function toggleApplicant(idx: number) {
+    setSelectedApplicants((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  function toggleApplicantExpand(idx: number) {
+    setExpandedApplicants((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  function toggleViewing(idx: number) {
+    setSelectedViewings((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  function updateApplicant(temp_index: number, patch: Partial<CompositeApplicantPayload>) {
+    setApplicants((prev) => prev.map((a) => (a.temp_index === temp_index ? { ...a, ...patch } : a)));
+  }
+
+  function updateViewing(temp_index: number, patch: Partial<CompositeViewingPayload>) {
+    setViewings((prev) => prev.map((v) => (v.temp_index === temp_index ? { ...v, ...patch } : v)));
+  }
+
+  function viewingDisabled(v: CompositeViewingPayload): boolean {
+    if ('new_index' in v.applicant_ref) {
+      return !selectedApplicants.has(v.applicant_ref.new_index);
+    }
+    return false;
+  }
+
+  async function writeDeviceCalendarEvents(payload: ReceiptPayload, sourceViewings: CompositeViewingPayload[]): Promise<ReceiptPayload> {
+    if (payload.calendar_choice !== 'device') return payload;
+    const outcomes: ReceiptPayload['calendar_outcomes'] = [];
+    for (const created of payload.created_viewings) {
+      const source = sourceViewings.find((v) => v.temp_index === created.temp_index);
+      if (!source) continue;
+      const start = new Date(created.scheduled_at).getTime();
+      const end = start + created.duration_minutes * 60 * 1000;
+      const result = await addEventToDeviceCalendar({
+        title: `Viewing: ${source.applicant_name} at ${source.development_name}`,
+        startMs: start,
+        endMs: end,
+        location: source.location ?? source.development_name,
+        notes: source.notes ?? undefined,
+      });
+      let status: 'added' | 'unavailable' | 'denied' | 'error' = 'added';
+      let message: string | undefined;
+      if (result.status === 'created') {
+        status = 'added';
+        try {
+          await fetch(`/api/agent-intelligence/viewings/${created.id}/calendar`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_calendar_event_id: result.eventId }),
+          });
+        } catch {
+          // Non-blocking. The DB row exists, the device event exists.
+        }
+      } else if (result.status === 'denied') {
+        status = 'denied';
+      } else if (result.status === 'unavailable') {
+        status = 'unavailable';
+      } else {
+        status = 'error';
+        message = result.message;
+      }
+      outcomes.push({ viewing_temp_index: created.temp_index, status, message });
+    }
+    return { ...payload, calendar_outcomes: outcomes };
+  }
+
+  async function runConfirm() {
+    setPhase('confirming');
+    setErrorText(null);
+    try {
+      const body = {
+        applicants_to_create: applicants.map((a) => ({
+          full_name: a.full_name,
+          email: a.email,
+          phone: a.phone,
+        })),
+        viewings_to_create: viewings.map((v) => ({
+          applicant_ref: v.applicant_ref,
+          development_id: v.development_id,
+          scheduled_at: v.scheduled_at,
+          duration_minutes: v.duration_minutes,
+          location: v.location,
+          notes: v.notes,
+        })),
+        selected_indices: {
+          applicants: Array.from(selectedApplicants.values()).sort((a, b) => a - b),
+          viewings: Array.from(selectedViewings.values()).sort((a, b) => a - b),
+        },
+        calendar_choice: calendarChoice,
+      };
+      const res = await fetch('/api/agent-intelligence/confirm-composite-schedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "Couldn't schedule");
+      }
+      const data = await res.json();
+
+      const calendarOutcomes: ReceiptPayload['calendar_outcomes'] =
+        calendarChoice === 'skip'
+          ? data.created_viewings.map((cv: any) => ({ viewing_temp_index: cv.temp_index, status: 'skipped' }))
+          : calendarChoice === 'google' || calendarChoice === 'outlook' || calendarChoice === 'apple'
+            ? data.created_viewings.map((cv: any) => ({
+                viewing_temp_index: cv.temp_index,
+                status: 'unavailable',
+                message: 'Connect your calendar in Settings to enable sync.',
+              }))
+            : [];
+
+      let receiptPayload: ReceiptPayload = {
+        created_applicants: data.created_applicants ?? [],
+        created_viewings: data.created_viewings ?? [],
+        calendar_choice: calendarChoice,
+        calendar_outcomes: calendarOutcomes,
+      };
+
+      if (calendarChoice === 'device') {
+        receiptPayload = await writeDeviceCalendarEvents(receiptPayload, viewings);
+      }
+
+      setReceipt(receiptPayload);
+      setPhase('receipt');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Couldn't schedule";
+      setErrorText(message);
+      setPhase('error');
+      onConfirmFailed?.(`Composite schedule failed, no applicants or viewings were created. Reason: ${message}`);
+    }
+  }
+
+  function cancel() {
+    setPhase('cancelled');
+  }
+
+  if (phase === 'cancelled') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={{ ...cardSurface, gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <X size={16} strokeWidth={2} style={{ color: '#9CA3AF' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#6B7280' }}>Nothing scheduled</span>
+          </div>
+          <span style={{ fontSize: 12.5, color: '#6B7280' }}>Cancelled before save.</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'receipt' && receipt) {
+    return <ReceiptView receipt={receipt} sourceApplicants={applicants} sourceViewings={viewings} />;
+  }
+
+  // Header content varies by phase
+  const isError = phase === 'error';
+  const headerLabel = isError
+    ? "Couldn't schedule"
+    : envelope.viewings_to_create.length === 1
+      ? 'Schedule viewing'
+      : `Schedule ${envelope.viewings_to_create.length} viewings`;
+  const newApplicantCount = envelope.applicants_to_create.length;
+
+  const cardSurfaceForPhase: React.CSSProperties = isError
+    ? {
+        ...cardSurface,
+        border: '1px solid rgba(220,38,38,0.45)',
+        boxShadow:
+          '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(220,38,38,0.10), 0 0 0 0.5px rgba(220,38,38,0.20)',
+      }
+    : cardSurface;
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div style={cardSurfaceForPhase}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {isError ? (
+            <AlertTriangle size={16} strokeWidth={2.25} style={{ color: '#B91C1C' }} />
+          ) : (
+            <Zap size={16} strokeWidth={2} style={{ color: '#0D0D12' }} />
+          )}
+          <span style={{ fontSize: 13, fontWeight: 600, color: isError ? '#B91C1C' : '#0D0D12' }}>{headerLabel}</span>
+          {!isError && newApplicantCount > 0 && (
+            <span style={{ fontSize: 11.5, color: '#9CA3AF', fontWeight: 500 }}>
+              {newApplicantCount} new applicant{newApplicantCount === 1 ? '' : 's'}
+            </span>
+          )}
+        </div>
+
+        {applicants.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={sectionLabelText}>New applicants</span>
+            {applicants.map((a) => {
+              const checked = selectedApplicants.has(a.temp_index);
+              const expanded = expandedApplicants.has(a.temp_index);
+              return (
+                <div
+                  key={`a-${a.temp_index}`}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 6,
+                    padding: '10px 12px',
+                    background: checked ? '#FFFFFF' : '#FAFAFA',
+                    border: `0.5px solid ${checked ? 'rgba(0,0,0,0.10)' : 'rgba(0,0,0,0.06)'}`,
+                    borderRadius: 12,
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <Checkbox checked={checked} onClick={() => toggleApplicant(a.temp_index)} disabled={phase === 'editing'} />
+                    <UserPlus size={13} strokeWidth={2} style={{ color: '#6B7280', flexShrink: 0 }} />
+                    {phase === 'editing' ? (
+                      <input
+                        type="text"
+                        value={a.full_name}
+                        onChange={(e) => updateApplicant(a.temp_index, { full_name: e.target.value })}
+                        style={inlineInputStyle}
+                      />
+                    ) : (
+                      <span style={{ ...valueText, flex: 1 }}>{a.full_name}</span>
+                    )}
+                    {phase !== 'editing' && (
+                      <button
+                        type="button"
+                        onClick={() => toggleApplicantExpand(a.temp_index)}
+                        aria-label={expanded ? 'Collapse details' : 'Add contact details'}
+                        className="agent-tappable"
+                        style={chevronButtonStyle}
+                      >
+                        {expanded ? <ChevronUp size={14} strokeWidth={2} /> : <ChevronDown size={14} strokeWidth={2} />}
+                      </button>
+                    )}
+                  </div>
+                  {(expanded || phase === 'editing') && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, paddingLeft: 30 }}>
+                      <ContactInputRow
+                        label="Email"
+                        value={a.email ?? ''}
+                        placeholder="optional"
+                        onChange={(v) => updateApplicant(a.temp_index, { email: v.trim() || null })}
+                      />
+                      <ContactInputRow
+                        label="Phone"
+                        value={a.phone ?? ''}
+                        placeholder="optional"
+                        onChange={(v) => updateApplicant(a.temp_index, { phone: v.trim() || null })}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <span style={sectionLabelText}>Viewings</span>
+          {viewings.map((v) => {
+            const checked = selectedViewings.has(v.temp_index);
+            const disabled = viewingDisabled(v);
+            const sched = formatScheduled(v.scheduled_at);
+            return (
+              <div
+                key={`v-${v.temp_index}`}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 6,
+                  padding: '10px 12px',
+                  background: checked && !disabled ? '#FFFFFF' : '#FAFAFA',
+                  border: `0.5px solid ${checked && !disabled ? 'rgba(0,0,0,0.10)' : 'rgba(0,0,0,0.06)'}`,
+                  borderRadius: 12,
+                  opacity: disabled ? 0.6 : 1,
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+                  <Checkbox
+                    checked={checked && !disabled}
+                    disabled={disabled || phase === 'editing'}
+                    onClick={() => toggleViewing(v.temp_index)}
+                  />
+                  <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <span style={valueText}>{v.applicant_name}</span>
+                    {phase === 'editing' ? (
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        <input
+                          type="datetime-local"
+                          value={isoToLocalInputValue(v.scheduled_at)}
+                          onChange={(e) => updateViewing(v.temp_index, { scheduled_at: localInputValueToIso(e.target.value) })}
+                          style={inlineInputStyle}
+                        />
+                        <select
+                          value={v.development_id}
+                          onChange={(e) => {
+                            const opt = (developments && developments.length > 0
+                              ? developments
+                              : [{ id: v.development_id, name: v.development_name }]).find((o) => o.id === e.target.value);
+                            updateViewing(v.temp_index, {
+                              development_id: e.target.value,
+                              development_name: opt?.name ?? v.development_name,
+                              location: opt?.name ?? v.location,
+                            });
+                          }}
+                          style={inlineInputStyle}
+                        >
+                          {(developments && developments.length > 0
+                            ? developments
+                            : [{ id: v.development_id, name: v.development_name }]).map((opt) => (
+                            <option key={opt.id} value={opt.id}>{opt.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    ) : (
+                      <>
+                        <span style={{ fontSize: 12, color: '#6B7280' }}>
+                          {sched.date} at {sched.time}
+                        </span>
+                        <span style={{ fontSize: 12, color: '#6B7280' }}>
+                          {v.development_name}
+                        </span>
+                      </>
+                    )}
+                    {disabled && (
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: '#8A6A00' }}>
+                        <AlertTriangle size={11} strokeWidth={2.25} />
+                        Needs the applicant above
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {(showCalendarSection || phase === 'editing') ? (
+          <CalendarSection
+            choice={calendarChoice}
+            onChange={setCalendarChoice}
+            isNative={isNative}
+          />
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <Calendar size={13} strokeWidth={2} style={{ color: '#6B7280' }} />
+            <span style={{ fontSize: 12, color: '#6B7280' }}>
+              {calendarChoice === 'skip' ? 'Skipping calendar' : `Calendar: ${calendarLabel(calendarChoice, isNative)}`}
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowCalendarSection(true)}
+              className="agent-tappable"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                fontSize: 12,
+                fontWeight: 600,
+                color: '#8A6E1F',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                padding: 0,
+              }}
+            >
+              Change
+            </button>
+          </div>
+        )}
+
+        {isError && errorText && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#B91C1C' }}>
+            <AlertTriangle size={14} strokeWidth={2.25} />
+            <span style={{ fontSize: 12.5, fontWeight: 500 }}>{errorText}</span>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 4 }}>
+          {phase === 'editing' ? (
+            <button type="button" style={primaryButton} onClick={() => setPhase('draft')} className="agent-tappable">
+              <Check size={14} strokeWidth={2.25} />
+              Done editing
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                style={primaryButton}
+                onClick={runConfirm}
+                disabled={phase === 'confirming' || selectedViewings.size === 0}
+                className="agent-tappable"
+              >
+                {phase === 'confirming' ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    Scheduling
+                  </>
+                ) : (
+                  <>
+                    <Check size={14} strokeWidth={2.25} />
+                    {phase === 'error' ? 'Try again' : 'Confirm all'}
+                  </>
+                )}
+              </button>
+              <button type="button" style={secondaryButton} onClick={() => setPhase('editing')} className="agent-tappable" disabled={phase === 'confirming'}>
+                <Pencil size={14} strokeWidth={2.25} />
+                Edit
+              </button>
+              <button type="button" style={tertiaryButton} onClick={cancel} className="agent-tappable" disabled={phase === 'confirming'}>
+                Cancel
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const inlineInputStyle: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: 13,
+  border: '0.5px solid rgba(0,0,0,0.16)',
+  borderRadius: 8,
+  background: '#FFFFFF',
+  color: '#0D0D12',
+  fontFamily: 'inherit',
+  width: '100%',
+};
+
+const chevronButtonStyle: React.CSSProperties = {
+  width: 24,
+  height: 24,
+  borderRadius: 12,
+  background: 'transparent',
+  border: 'none',
+  color: '#6B7280',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  flexShrink: 0,
+};
+
+function Checkbox({ checked, disabled, onClick }: { checked: boolean; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={checked}
+      className="agent-tappable"
+      style={{
+        width: 20,
+        height: 20,
+        borderRadius: 6,
+        border: `1.5px solid ${checked ? '#C49B2A' : 'rgba(0,0,0,0.20)'}`,
+        background: checked ? 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)' : '#FFFFFF',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        flexShrink: 0,
+        marginTop: 2,
+        padding: 0,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {checked && <Check size={14} strokeWidth={2.5} style={{ color: '#FFFFFF' }} />}
+    </button>
+  );
+}
+
+function ContactInputRow({ label, value, placeholder, onChange }: {
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span style={{ ...labelText, width: 50 }}>{label}</span>
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ ...inlineInputStyle, flex: 1 }}
+      />
+    </div>
+  );
+}
+
+function calendarLabel(choice: CalendarChoice, isNative: boolean): string {
+  switch (choice) {
+    case 'device':
+      return isNative ? 'iPhone calendar' : 'Device calendar';
+    case 'google':
+      return 'Google Calendar';
+    case 'outlook':
+      return 'Outlook';
+    case 'apple':
+      return 'Apple Calendar';
+    case 'skip':
+      return 'Skipped';
+  }
+}
+
+function CalendarSection({
+  choice,
+  onChange,
+  isNative,
+}: {
+  choice: CalendarChoice;
+  onChange: (next: CalendarChoice) => void;
+  isNative: boolean;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <span style={sectionLabelText}>Calendar</span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {isNative && (
+          <CalendarOption
+            selected={choice === 'device'}
+            onSelect={() => onChange('device')}
+            icon={<Smartphone size={13} strokeWidth={2} />}
+            label="Add to your iPhone calendar"
+          />
+        )}
+        <CalendarOption
+          selected={choice === 'google'}
+          onSelect={() => onChange('google')}
+          icon={<Calendar size={13} strokeWidth={2} />}
+          label="Add to Google Calendar"
+          rightSlot={<ConnectLink href="/agent/settings/autonomy" />}
+        />
+        <CalendarOption
+          selected={choice === 'outlook'}
+          onSelect={() => onChange('outlook')}
+          icon={<Calendar size={13} strokeWidth={2} />}
+          label="Add to Outlook"
+          rightSlot={<ConnectLink href="/agent/settings/autonomy" />}
+        />
+        {!isNative && (
+          <CalendarOption
+            selected={choice === 'apple'}
+            onSelect={() => onChange('apple')}
+            icon={<Calendar size={13} strokeWidth={2} />}
+            label="Add to Apple Calendar"
+            rightSlot={<ConnectLink href="/agent/settings/autonomy" />}
+          />
+        )}
+        <CalendarOption
+          selected={choice === 'skip'}
+          onSelect={() => onChange('skip')}
+          icon={<X size={13} strokeWidth={2} />}
+          label="Skip calendar"
+        />
+      </div>
+    </div>
+  );
+}
+
+function CalendarOption({
+  selected,
+  onSelect,
+  icon,
+  label,
+  rightSlot,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  icon: React.ReactNode;
+  label: string;
+  rightSlot?: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <button
+        type="button"
+        onClick={onSelect}
+        className="agent-tappable"
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 10px',
+          background: selected ? 'rgba(196,155,42,0.08)' : '#FFFFFF',
+          border: `0.5px solid ${selected ? 'rgba(196,155,42,0.45)' : 'rgba(0,0,0,0.08)'}`,
+          borderRadius: 10,
+          fontSize: 12.5,
+          fontWeight: selected ? 600 : 500,
+          color: '#0D0D12',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          textAlign: 'left',
+        }}
+      >
+        <span
+          style={{
+            width: 14,
+            height: 14,
+            borderRadius: 7,
+            border: `1.5px solid ${selected ? '#C49B2A' : 'rgba(0,0,0,0.25)'}`,
+            background: selected ? '#C49B2A' : '#FFFFFF',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
+        >
+          {selected && <span style={{ width: 5, height: 5, borderRadius: 3, background: '#FFFFFF' }} />}
+        </span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: '#374151' }}>
+          {icon}
+        </span>
+        <span style={{ flex: 1 }}>{label}</span>
+      </button>
+      {rightSlot}
+    </div>
+  );
+}
+
+function ConnectLink({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      className="agent-tappable"
+      style={{
+        fontSize: 11.5,
+        fontWeight: 600,
+        color: '#8A6E1F',
+        textDecoration: 'none',
+        background: 'rgba(196,155,42,0.10)',
+        padding: '4px 8px',
+        borderRadius: 999,
+        flexShrink: 0,
+      }}
+    >
+      Connect
+    </Link>
+  );
+}
+
+function ReceiptView({
+  receipt,
+  sourceApplicants,
+  sourceViewings,
+}: {
+  receipt: ReceiptPayload;
+  sourceApplicants: CompositeApplicantPayload[];
+  sourceViewings: CompositeViewingPayload[];
+}) {
+  const calendarLine = (() => {
+    if (receipt.calendar_choice === 'skip') {
+      return 'Skipped calendar.';
+    }
+    if (receipt.calendar_choice === 'device') {
+      const added = receipt.calendar_outcomes.filter((o) => o.status === 'added').length;
+      const total = receipt.calendar_outcomes.length;
+      if (added === total && total > 0) return 'Added to your iPhone calendar.';
+      if (added === 0) return "Couldn't add to your iPhone calendar. Tap a viewing to retry.";
+      return `Added ${added} of ${total} to your iPhone calendar.`;
+    }
+    if (receipt.calendar_choice === 'google') return 'Google Calendar will sync once connected.';
+    if (receipt.calendar_choice === 'outlook') return 'Outlook will sync once connected.';
+    return 'Apple Calendar will sync once connected.';
+  })();
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div style={cardSurface}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Check size={16} strokeWidth={2.25} style={{ color: '#10703C' }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>Done</span>
+        </div>
+
+        {receipt.created_applicants.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={sectionLabelText}>Applicants created</span>
+            {receipt.created_applicants.map((a) => (
+              <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <UserPlus size={13} strokeWidth={2} style={{ color: '#10703C' }} />
+                <span style={{ ...valueText, flex: 1 }}>Created {a.full_name}</span>
+                <Link
+                  href={`/agent/applicants/${a.id}`}
+                  className="agent-tappable"
+                  style={{
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    color: '#0D0D12',
+                    background: '#F4F4F5',
+                    border: '0.5px solid rgba(0,0,0,0.08)',
+                    padding: '4px 10px',
+                    borderRadius: 999,
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}
+                >
+                  View
+                  <ArrowRight size={11} strokeWidth={2.25} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={sectionLabelText}>Viewings scheduled</span>
+          {receipt.created_viewings.map((cv) => {
+            const source = sourceViewings.find((v) => v.temp_index === cv.temp_index);
+            const sched = formatScheduled(cv.scheduled_at);
+            const name = source?.applicant_name ?? '';
+            return (
+              <div key={cv.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <Calendar size={13} strokeWidth={2} style={{ color: '#10703C' }} />
+                <span style={{ ...valueText, flex: 1 }}>
+                  {name ? `Scheduled with ${name}, ` : 'Scheduled '}{sched.date} {sched.time}
+                </span>
+                <Link
+                  href={`/viewings/${cv.id}`}
+                  className="agent-tappable"
+                  style={{
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    color: '#0D0D12',
+                    background: '#F4F4F5',
+                    border: '0.5px solid rgba(0,0,0,0.08)',
+                    padding: '4px 10px',
+                    borderRadius: 999,
+                    textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                  }}
+                >
+                  Open
+                  <ArrowRight size={11} strokeWidth={2.25} />
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#10703C' }}>
+          <Calendar size={13} strokeWidth={2.25} />
+          <span style={{ fontSize: 12.5, fontWeight: 500 }}>{calendarLine}</span>
+        </div>
+        {/* sourceApplicants is intentionally accepted but not rendered in the
+            receipt; it's reserved for the partial_error branch which can
+            inspect what was attempted vs what landed. Keeping the parameter
+            stable lets future error UI reach for it without a breaking
+            signature change. */}
+        {sourceApplicants.length === 0 && null}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -390,7 +390,12 @@ Follow-up chips suggest ACTIONS ("Draft chase email to solicitor"), not clarifyi
 ============================================================
 NO EM DASHES - HARD RULE:
 ============================================================
-Never use em dashes (the long horizontal bar) in any output. Use a comma, a regular hyphen, or a sentence break instead. This applies to text replies, list formatting, structured output, list items in cards, and anything you put in a tool argument. If you find yourself reaching for an em dash, pick a comma. This rule is non-negotiable and overrides any stylistic preference.`;
+Never use em dashes (the long horizontal bar) in any output. Use a comma, a regular hyphen, or a sentence break instead. This applies to text replies, list formatting, structured output, list items in cards, and anything you put in a tool argument. If you find yourself reaching for an em dash, pick a comma. This rule is non-negotiable and overrides any stylistic preference.
+
+============================================================
+MUTATION RESULT INTEGRITY - HARD RULE:
+============================================================
+When a tool returns an error, a needs_clarification, or a partial-success result, your next reply MUST acknowledge that fact honestly. Do not claim a write succeeded when the tool returned an error. Do not say "added" or "scheduled" or "created" unless the tool result explicitly confirmed it. Do not infer prior success from conversation history alone, prior turns can be wrong, only the most recent tool result envelope is the source of truth. If the user asks "did that work?" after a failed tool call, the honest answer is no, and you say so plainly along with the failure reason if the envelope provided one. This rule overrides any prior phrasing or any tendency to be reassuring; reassurance about a failure is a lie.`;
 
   const basePrompt = `You are not a generic chatbot. You are a specialist sales operations assistant with deep knowledge of the Irish new homes market, the conveyancing process, buyer psychology, and the day-to-day reality of running property sales for developers. You exist to make the agent faster, better informed, and more effective at their job.
 
@@ -623,7 +628,27 @@ DEDUPE PERCEPTION:
 When the user references a name that could plausibly match an existing applicant (e.g. "John" when there's a "John Murphy" already on the books), ASK FIRST: "Did you mean John Murphy?" - do not auto-create a duplicate. The tool already classifies likely duplicates as duplicate_likely on the candidate, but the perception rule is upstream of that: when you have prior evidence in the conversation that an existing applicant matches the partial name, ask before calling.
 
 VIEWING ↔ APPLICANT CHAIN:
-When the user asks to schedule a viewing for a person who is not yet on the applicants list, call manage_applicants with action='add' for that person, then call create_viewing in the same turn. Two cards land in the chat. The agent confirms the applicant first, then the viewing.
+When the user asks to schedule a viewing for a person who is not yet on the applicants list, prefer the composite schedule_viewings tool (see COMPOSITE SCHEDULING below). Do NOT chain manage_applicants + create_viewing for that case any more, the composite tool handles applicant creation atomically.
+
+============================================================
+COMPOSITE SCHEDULING - schedule_viewings:
+============================================================
+Use schedule_viewings (the composite tool) instead of chaining manage_applicants and create_viewing whenever EITHER of these is true:
+  1. The user wants to schedule MORE THAN ONE viewing in one go ("schedule viewings for Jack at 6 and Rachael at 7 on Thursday").
+  2. The user wants ONE viewing for a person who is NOT yet on the applicants list ("schedule a viewing with Niamh Doyle for Tuesday 6pm").
+
+The composite tool handles applicant creation atomically through a Postgres RPC. Two applicants and two viewings either all land or none do, no half-finished state. The chat surface renders one CompositeScheduleCard with one Confirm.
+
+Rules:
+  - For a SINGLE viewing for an EXISTING applicant, keep using create_viewing. The composite tool is overkill for that.
+  - NEVER invent email or phone for new applicants. Pass full_name only inside the viewings array, the card lets the agent fill in details inline if they want.
+  - New applicants must have a property_hint that maps to one of the agent's assigned schemes; otherwise the tool returns needs_clarification.
+  - If the user states an explicit calendar preference in the message ("add it to my iPhone calendar"), pass calendar_preference. Otherwise omit, the card surfaces the choice.
+  - One question maximum if needs_clarification fires. Same rule as before.
+
+Inputs shape: viewings: [{ applicant_name, scheduled_at_natural, property_hint?, duration_minutes?, notes? }, ...]
+
+When the result returns status='draft' with type='composite_schedule', reply with one short sentence (<= 14 words) confirming you've prepared it. DO NOT echo the per-row details, the card is the canonical surface.
 
 ============================================================
 CREATE_VIEWING - RESOLVE THEN CONFIRM:
@@ -1047,7 +1072,12 @@ Follow-up chips suggest ACTIONS ("Draft message to Aisling about plumber visit")
 ============================================================
 NO EM DASHES - HARD RULE:
 ============================================================
-Never use em dashes (the long horizontal bar) in any output. Use a comma, a regular hyphen, or a sentence break instead. This applies to text replies, list formatting, structured output, card content, and anything you put in a tool argument. If you find yourself reaching for an em dash, pick a comma. This rule is non-negotiable and overrides any stylistic preference.`;
+Never use em dashes (the long horizontal bar) in any output. Use a comma, a regular hyphen, or a sentence break instead. This applies to text replies, list formatting, structured output, card content, and anything you put in a tool argument. If you find yourself reaching for an em dash, pick a comma. This rule is non-negotiable and overrides any stylistic preference.
+
+============================================================
+MUTATION RESULT INTEGRITY - HARD RULE:
+============================================================
+When a tool returns an error, a needs_clarification, or a partial-success result, your next reply MUST acknowledge that fact honestly. Do not claim a write succeeded when the tool returned an error. Do not say "added" or "scheduled" or "created" unless the tool result explicitly confirmed it. Do not infer prior success from conversation history alone, prior turns can be wrong, only the most recent tool result envelope is the source of truth. If the user asks "did that work?" after a failed tool call, the honest answer is no, and you say so plainly along with the failure reason if the envelope provided one. This rule overrides any prior phrasing or any tendency to be reassuring; reassurance about a failure is a lie.`;
 
   const scopeBlock = `Current agent context:
 - Name: ${agentContext.displayName}
@@ -1269,7 +1299,10 @@ You may call the draft and message tools the platform already provides (draft_me
 When the user asks you to draft, write, send, follow up with, chase, or message a tenant - ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent - nothing leaves the system until the agent explicitly approves.
 
 MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
-For "add Jack Murphy 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing for someone not yet on the list, call manage_applicants then create_viewing in the same turn.
+For "add Jack Murphy 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing for someone not yet on the list, prefer the composite schedule_viewings tool below.
+
+COMPOSITE SCHEDULING - schedule_viewings:
+Use schedule_viewings instead of chaining manage_applicants and create_viewing whenever the user wants MORE THAN ONE viewing in one go OR ONE viewing for a person not yet on the applicants list. The composite tool creates applicants and viewings atomically (Postgres RPC). One Confirm tap, all writes land together, no half-finished state. For a single viewing for an existing applicant, keep using create_viewing. NEVER invent email or phone for new applicants - pass full_name only inside the viewings array. New applicants need a property_hint that maps to one of the agent's assigned schemes. If the user states a calendar preference ("iPhone calendar"), pass calendar_preference; otherwise omit, the card surfaces the choice. One clarification question maximum if needs_clarification fires.
 
 CREATE_VIEWING - RESOLVE THEN CONFIRM:
 For voice-first viewing capture ("schedule a viewing with Jack Murphy Tuesday 6pm"), call create_viewing. Pass applicant_name and scheduled_at_natural verbatim from what the agent said; add property_hint only when they named a development. The tool resolves the applicant against agent_applicants and the property against the applicant's active enquiries - NEVER invent either.

--- a/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
@@ -1,0 +1,453 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { ToolResult, AgentContext } from '../types';
+import {
+  parseScheduledAtNatural,
+  resolveApplicantByName,
+  resolvePropertyForApplicant,
+  formatViewingTime,
+  DEFAULT_TZ,
+} from '../viewing-resolver';
+
+/**
+ * Composite scheduling tool, session 3.
+ *
+ * Whereas create_viewing handles a single existing applicant and
+ * manage_applicants handles a list of applicants in isolation, this
+ * composite handles "schedule N viewings, possibly creating M applicants"
+ * as one mental object. The card surfaces a single Confirm; the writes
+ * land atomically through schedule_viewings_atomic so a property typo
+ * does not leave half the applicants created.
+ */
+
+export type CalendarPreference = 'device' | 'google' | 'outlook' | 'apple' | 'skip';
+
+export interface CompositeApplicantToCreate {
+  temp_index: number;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  classification: 'new';
+}
+
+export type ApplicantRef = { existing_id: string } | { new_index: number };
+
+export interface CompositeViewingToCreate {
+  temp_index: number;
+  applicant_ref: ApplicantRef;
+  applicant_name: string;
+  development_id: string;
+  development_name: string;
+  scheduled_at: string;
+  duration_minutes: number;
+  location: string | null;
+  notes: string | null;
+}
+
+export interface CompositeCalendarBlock {
+  preferred_provider: CalendarPreference | null;
+  ask_user: boolean;
+}
+
+export interface CompositeScheduleDraft {
+  status: 'draft';
+  type: 'composite_schedule';
+  applicants_to_create: CompositeApplicantToCreate[];
+  viewings_to_create: CompositeViewingToCreate[];
+  calendar: CompositeCalendarBlock;
+  message: string;
+}
+
+export interface CompositeScheduleClarification {
+  status: 'needs_clarification';
+  reason:
+    | 'applicant_ambiguous'
+    | 'property_required_for_new_applicant'
+    | 'property_ambiguous'
+    | 'property_not_found'
+    | 'date_unparseable'
+    | 'missing_time'
+    | 'no_viewings';
+  message: string;
+  candidates?: Array<Record<string, unknown>>;
+}
+
+export type CompositeScheduleResult = CompositeScheduleDraft | CompositeScheduleClarification;
+
+interface ScheduleViewingsParams {
+  viewings?: Array<{
+    applicant_name: string;
+    scheduled_at_natural: string;
+    property_hint?: string;
+    duration_minutes?: number;
+    notes?: string;
+  }>;
+  calendar_preference?: CalendarPreference;
+}
+
+const VALID_CALENDAR_PREFERENCES: CalendarPreference[] = ['device', 'google', 'outlook', 'apple', 'skip'];
+
+function normalisePreference(raw: unknown): CalendarPreference | null {
+  if (typeof raw !== 'string') return null;
+  const lower = raw.trim().toLowerCase();
+  return VALID_CALENDAR_PREFERENCES.includes(lower as CalendarPreference)
+    ? (lower as CalendarPreference)
+    : null;
+}
+
+async function readPreferredCalendar(
+  supabase: SupabaseClient,
+  authUserId: string,
+): Promise<CalendarPreference | null> {
+  const { data } = await supabase
+    .from('agent_settings')
+    .select('preferred_calendar_provider')
+    .eq('agent_id', authUserId)
+    .maybeSingle();
+  return normalisePreference((data as any)?.preferred_calendar_provider);
+}
+
+interface AssignedDevelopment {
+  id: string;
+  name: string;
+}
+
+function pickDevelopmentByHint(
+  developments: AssignedDevelopment[],
+  hint: string | undefined | null,
+): { match?: AssignedDevelopment; ambiguous?: AssignedDevelopment[] } {
+  if (!hint) return {};
+  const lower = hint.trim().toLowerCase();
+  if (!lower) return {};
+  const matches = developments.filter((d) => d.name.toLowerCase().includes(lower));
+  if (matches.length === 1) return { match: matches[0] };
+  if (matches.length > 1) return { ambiguous: matches };
+  return {};
+}
+
+function clampDuration(raw: number | undefined): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return 30;
+  return Math.min(Math.max(Math.round(raw), 5), 240);
+}
+
+export async function scheduleViewings(
+  supabase: SupabaseClient,
+  _tenantId: string,
+  agentContext: AgentContext,
+  params: ScheduleViewingsParams,
+): Promise<ToolResult> {
+  const tz = DEFAULT_TZ;
+  const requested = Array.isArray(params.viewings) ? params.viewings : [];
+  if (requested.length === 0) {
+    const message = "Tell me which viewings you'd like scheduled. One name and time per slot.";
+    const result: CompositeScheduleResult = {
+      status: 'needs_clarification',
+      reason: 'no_viewings',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+
+  const assignedDevelopments: AssignedDevelopment[] = (agentContext.assignedDevelopmentIds || []).map((id, idx) => ({
+    id,
+    name: agentContext.assignedDevelopmentNames?.[idx] ?? '',
+  })).filter((d) => d.name.length > 0);
+
+  // Build new-applicant slots, deduped by lowercased full_name. Multiple
+  // viewings for the same new person share one applicants_to_create entry
+  // and reference it by the same new_index.
+  const applicantsByLowerName = new Map<string, number>();
+  const applicants_to_create: CompositeApplicantToCreate[] = [];
+  const viewings_to_create: CompositeViewingToCreate[] = [];
+
+  for (let i = 0; i < requested.length; i++) {
+    const v = requested[i];
+    const applicantName = (v.applicant_name || '').trim();
+    if (!applicantName) {
+      const message = `Viewing #${i + 1} has no applicant name. Tell me who the viewing is for.`;
+      const result: CompositeScheduleResult = {
+        status: 'needs_clarification',
+        reason: 'applicant_ambiguous',
+        message,
+      };
+      return { data: result, summary: message };
+    }
+
+    const parsed = parseScheduledAtNatural(v.scheduled_at_natural ?? '', { tz });
+    if (!parsed.ok) {
+      const reason = parsed.reason === 'missing_time' ? 'missing_time' : 'date_unparseable';
+      const message =
+        reason === 'missing_time'
+          ? `What time on ${v.scheduled_at_natural || 'that day'} for ${applicantName}?`
+          : `I couldn't read "${v.scheduled_at_natural}" as a date for ${applicantName}. Try "Thursday 6pm" or "tomorrow at 11".`;
+      const result: CompositeScheduleResult = {
+        status: 'needs_clarification',
+        reason,
+        message,
+      };
+      return { data: result, summary: message };
+    }
+
+    const applicantRes = await resolveApplicantByName(
+      supabase,
+      agentContext.agentProfileId,
+      applicantName,
+    );
+
+    if (applicantRes.status === 'ambiguous') {
+      const candidates = applicantRes.candidates ?? [];
+      const summaryLine = candidates
+        .map((c) => `${c.name}${c.latest_enquiry_property ? ` (${c.latest_enquiry_property})` : ''}`)
+        .join('; ');
+      const message = `A few applicants match "${applicantName}": ${summaryLine}. Which one?`;
+      const result: CompositeScheduleResult = {
+        status: 'needs_clarification',
+        reason: 'applicant_ambiguous',
+        message,
+        candidates,
+      };
+      return { data: result, summary: message };
+    }
+
+    let applicant_ref: ApplicantRef;
+    let resolvedApplicantName = applicantName;
+    let development_id: string | null = null;
+    let development_name: string | null = null;
+
+    if (applicantRes.status === 'one') {
+      const a = applicantRes.applicant!;
+      applicant_ref = { existing_id: a.id };
+      resolvedApplicantName = a.name;
+
+      const propertyRes = await resolvePropertyForApplicant(supabase, {
+        agentProfileId: agentContext.agentProfileId,
+        applicantId: a.id,
+        applicantEmail: a.email,
+        applicantName: a.name,
+        propertyHint: v.property_hint,
+      });
+
+      if (propertyRes.status === 'one') {
+        development_id = propertyRes.property!.development_id;
+        development_name = propertyRes.property!.name;
+      } else if (propertyRes.status === 'ambiguous') {
+        // Fall through to try property_hint against the agent's assigned schemes.
+        const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
+        if (hinted.match) {
+          development_id = hinted.match.id;
+          development_name = hinted.match.name;
+        } else {
+          const candidates = propertyRes.candidates ?? [];
+          const summaryLine = candidates.map((c) => c.name).join(', ');
+          const message = `${a.name} has enquiries on more than one scheme: ${summaryLine}. Which one for the ${formatViewingTime(parsed.iso, tz)} viewing?`;
+          const result: CompositeScheduleResult = {
+            status: 'needs_clarification',
+            reason: 'property_ambiguous',
+            message,
+            candidates,
+          };
+          return { data: result, summary: message };
+        }
+      } else {
+        // No active enquiry for this applicant. Fall back to property_hint.
+        const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
+        if (hinted.match) {
+          development_id = hinted.match.id;
+          development_name = hinted.match.name;
+        } else if (hinted.ambiguous && hinted.ambiguous.length > 0) {
+          const summaryLine = hinted.ambiguous.map((c) => c.name).join(', ');
+          const message = `"${v.property_hint}" matches more than one of your schemes: ${summaryLine}. Which one for ${a.name}?`;
+          const result: CompositeScheduleResult = {
+            status: 'needs_clarification',
+            reason: 'property_ambiguous',
+            message,
+            candidates: hinted.ambiguous.map((c) => ({ development_id: c.id, name: c.name })),
+          };
+          return { data: result, summary: message };
+        } else {
+          const message = `${a.name} has no active enquiry I can pin a property to. Which development for the ${formatViewingTime(parsed.iso, tz)} viewing?`;
+          const result: CompositeScheduleResult = {
+            status: 'needs_clarification',
+            reason: 'property_not_found',
+            message,
+          };
+          return { data: result, summary: message };
+        }
+      }
+    } else {
+      // New applicant. Property MUST come from property_hint.
+      const lowerKey = applicantName.toLowerCase();
+      const existingIdx = applicantsByLowerName.get(lowerKey);
+      if (existingIdx === undefined) {
+        const slotIdx = applicants_to_create.length;
+        applicants_to_create.push({
+          temp_index: slotIdx,
+          full_name: applicantName,
+          email: null,
+          phone: null,
+          classification: 'new',
+        });
+        applicantsByLowerName.set(lowerKey, slotIdx);
+        applicant_ref = { new_index: slotIdx };
+      } else {
+        applicant_ref = { new_index: existingIdx };
+      }
+
+      const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
+      if (hinted.match) {
+        development_id = hinted.match.id;
+        development_name = hinted.match.name;
+      } else if (hinted.ambiguous && hinted.ambiguous.length > 0) {
+        const summaryLine = hinted.ambiguous.map((c) => c.name).join(', ');
+        const message = `"${v.property_hint}" matches more than one of your schemes: ${summaryLine}. Which one for ${applicantName}?`;
+        const result: CompositeScheduleResult = {
+          status: 'needs_clarification',
+          reason: 'property_ambiguous',
+          message,
+          candidates: hinted.ambiguous.map((c) => ({ development_id: c.id, name: c.name })),
+        };
+        return { data: result, summary: message };
+      } else {
+        const message = `${applicantName} isn't on your applicants yet. Which development is the ${formatViewingTime(parsed.iso, tz)} viewing at?`;
+        const result: CompositeScheduleResult = {
+          status: 'needs_clarification',
+          reason: 'property_required_for_new_applicant',
+          message,
+        };
+        return { data: result, summary: message };
+      }
+    }
+
+    if (!development_id || !development_name) {
+      const message = `Couldn't pin a development for the ${formatViewingTime(parsed.iso, tz)} viewing. Tell me which scheme.`;
+      const result: CompositeScheduleResult = {
+        status: 'needs_clarification',
+        reason: 'property_not_found',
+        message,
+      };
+      return { data: result, summary: message };
+    }
+
+    viewings_to_create.push({
+      temp_index: viewings_to_create.length,
+      applicant_ref,
+      applicant_name: resolvedApplicantName,
+      development_id,
+      development_name,
+      scheduled_at: parsed.iso,
+      duration_minutes: clampDuration(v.duration_minutes),
+      location: development_name,
+      notes: (v.notes || '').trim() || null,
+    });
+  }
+
+  // Resolve calendar preference. If the message carried one explicitly,
+  // use it. Otherwise fall back to the stored agent_settings value.
+  const explicit = normalisePreference(params.calendar_preference);
+  const stored = await readPreferredCalendar(supabase, agentContext.authUserId);
+  const preferred = explicit ?? stored;
+
+  const summaryParts: string[] = [];
+  summaryParts.push(`Schedule ${viewings_to_create.length} viewing${viewings_to_create.length === 1 ? '' : 's'}`);
+  if (applicants_to_create.length > 0) {
+    summaryParts.push(`(${applicants_to_create.length} new applicant${applicants_to_create.length === 1 ? '' : 's'})`);
+  }
+  const message = summaryParts.join(' ');
+
+  const result: CompositeScheduleDraft = {
+    status: 'draft',
+    type: 'composite_schedule',
+    applicants_to_create,
+    viewings_to_create,
+    calendar: {
+      preferred_provider: preferred,
+      ask_user: preferred === null,
+    },
+    message,
+  };
+  return { data: result, summary: message };
+}
+
+// -------- Confirmation path, called from the API route ----------------
+
+export interface ConfirmCompositeScheduleArgs {
+  applicants_to_create: Array<Pick<CompositeApplicantToCreate, 'full_name' | 'email' | 'phone'>>;
+  viewings_to_create: Array<{
+    applicant_ref: ApplicantRef;
+    development_id: string;
+    scheduled_at: string;
+    duration_minutes: number;
+    location: string | null;
+    notes: string | null;
+  }>;
+}
+
+export interface ConfirmCompositeScheduleResult {
+  status: 'success' | 'error';
+  created_applicants: Array<{ temp_index: number; id: string; full_name: string; audit_log_id: string }>;
+  created_viewings: Array<{ temp_index: number; id: string; applicant_id: string; scheduled_at: string; duration_minutes: number }>;
+  error: string | null;
+}
+
+export async function confirmCompositeSchedule(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  args: ConfirmCompositeScheduleArgs,
+): Promise<ConfirmCompositeScheduleResult> {
+  console.log('[confirmCompositeSchedule] start', {
+    authUserId: agentContext.authUserId,
+    tenantId: agentContext.tenantId,
+    applicants: args.applicants_to_create.length,
+    viewings: args.viewings_to_create.length,
+  });
+
+  const { data, error } = await supabase.rpc('schedule_viewings_atomic', {
+    p_agent_id: agentContext.authUserId,
+    p_tenant_id: agentContext.tenantId,
+    p_applicants_to_create: args.applicants_to_create.map((a) => ({
+      full_name: a.full_name,
+      email: a.email,
+      phone: a.phone,
+    })),
+    p_viewings_to_create: args.viewings_to_create,
+  });
+
+  if (error) {
+    console.error('[confirmCompositeSchedule] rpc error', { message: error.message });
+    return {
+      status: 'error',
+      created_applicants: [],
+      created_viewings: [],
+      error: error.message,
+    };
+  }
+
+  const payload = (data ?? {}) as Record<string, unknown>;
+  if (typeof payload.error === 'string') {
+    console.error('[confirmCompositeSchedule] rpc returned error', { message: payload.error });
+    return {
+      status: 'error',
+      created_applicants: [],
+      created_viewings: [],
+      error: payload.error,
+    };
+  }
+
+  const created_applicants = Array.isArray(payload.created_applicants)
+    ? (payload.created_applicants as ConfirmCompositeScheduleResult['created_applicants'])
+    : [];
+  const created_viewings = Array.isArray(payload.created_viewings)
+    ? (payload.created_viewings as ConfirmCompositeScheduleResult['created_viewings'])
+    : [];
+
+  console.log('[confirmCompositeSchedule] done', {
+    applicants: created_applicants.length,
+    viewings: created_viewings.length,
+  });
+
+  return {
+    status: 'success',
+    created_applicants,
+    created_viewings,
+    error: null,
+  };
+}

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -18,6 +18,7 @@ import {
 } from './write-tools';
 import { createViewing } from './viewing-tools';
 import { manageApplicants } from './applicant-tools';
+import { scheduleViewings } from './composite-tools';
 // schedule_viewing is intentionally NOT imported here: its immediate-write
 // behaviour has been replaced by schedule_viewing_draft. The underlying
 // scheduleViewing function remains exported from './write-tools' for any
@@ -514,6 +515,46 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       required: ['action'],
     },
     execute: manageApplicants as ToolFunction,
+  },
+  {
+    name: 'schedule_viewings',
+    description: [
+      'Composite scheduling tool. Use when the agent wants to schedule MORE THAN ONE viewing in one go, OR a single viewing for an applicant who is NOT yet on the books. The card surfaces one Confirm; the writes land atomically (applicants, audit log rows, and viewings together) so a property typo does not leave half the work done.',
+      'For a single viewing for an existing applicant, use create_viewing instead. This composite tool is overkill for that.',
+      'Inputs:',
+      '- viewings: array of { applicant_name, scheduled_at_natural, property_hint?, duration_minutes?, notes? }, one entry per viewing.',
+      '- calendar_preference (optional): pass when the user explicitly asked ("add it to my iPhone calendar"). Otherwise omit.',
+      'NEVER invent email or phone for new applicants. Pass full_name only. The card lets the agent fill in details inline if they want.',
+      'New applicants need a property_hint that maps to one of the agent\'s assigned schemes; otherwise the tool returns needs_clarification. One question maximum.',
+      'Returns either { status: "draft", type: "composite_schedule", applicants_to_create, viewings_to_create, calendar, message } for the chat card to render, or { status: "needs_clarification", reason, message }. Do NOT echo the per-row details in your reply, the card is the canonical surface.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        viewings: {
+          type: 'array',
+          description: 'One entry per viewing. The same applicant_name appearing twice is fine, the tool dedupes for new-applicant creation.',
+          items: {
+            type: 'object',
+            properties: {
+              applicant_name: { type: 'string', description: 'Name of the person the viewing is for, exactly as the user said it.' },
+              scheduled_at_natural: { type: 'string', description: 'Natural-language time, e.g. "Thursday 6pm". Parsed against Europe/Dublin.' },
+              property_hint: { type: 'string', description: 'Development name. Required for new applicants since they have no enquiries yet.' },
+              duration_minutes: { type: 'number', description: 'Defaults to 30. Clamped to 5-240.' },
+              notes: { type: 'string', description: 'Optional note to record on the viewing.' },
+            },
+            required: ['applicant_name', 'scheduled_at_natural'],
+          },
+        },
+        calendar_preference: {
+          type: 'string',
+          enum: ['device', 'google', 'outlook', 'apple', 'skip'],
+          description: 'Pass when the user explicitly stated a calendar preference for these viewings.',
+        },
+      },
+      required: ['viewings'],
+    },
+    execute: scheduleViewings as ToolFunction,
   },
   {
     name: 'create_viewing',


### PR DESCRIPTION
## What this does

### composite `schedule_viewings` tool
Replaces the structurally-broken `manage_applicants → create_viewing` chain with a single tool that resolves every viewing in one shot. The tool:
- Accepts a list of viewings (each with applicant name/contact + unit + datetime)
- Looks up existing applicants or stages new ones
- Parses bare weekday names to the correct Europe/Dublin date
- Deduplicates new applicants by lowercased full name
- Reads `agent_settings.preferred_calendar_provider` to pre-select the calendar

Returns a `composite_draft` SSE frame; the chat route suppresses both per-tool frames and the followup-suggestion model call when a composite draft is present.

### `schedule_viewings_atomic` Postgres RPC
PL/pgSQL function (SECURITY INVOKER) that creates applicants + audit rows + viewings in a single transaction. Any FK violation or other error rolls the entire batch back — no partial state.

### `CompositeScheduleCard`
Unified confirm UI rendered from the `composite_draft` frame:
- New-applicant rows with checkbox + inline email/phone expand
- Viewing checkboxes auto-disable when their linked new-applicant is unchecked
- CalendarSection: iPhone (native Capacitor), Google, Outlook, Apple, Skip
- Receipt phase persists with applicant View links and Open-in-Viewings links
- `onConfirmFailed` appends a failure note to the assistant message so model history carries the truth

### MUTATION RESULT INTEGRITY system prompt rule
Hard rule added to both sales and lettings prompts: after any write tool confirms, the assistant must report exactly what the RPC returned — no fabricated counts, no assumed success.

## Why it was never testable before

The diagnostic session confirmed that `claude/composite-schedule-viewings` had no open PR and was never deployed — the Vercel preview (`property-assistant-6839t5qwo-...`) was tracking `main`. On `main`, the only path for "schedule a viewing for a new applicant" required `manage_applicants` to write to the DB and then `create_viewing` to find that row — but `manage_applicants` only returns a draft envelope, so `create_viewing` always 404'd on the applicant lookup. This PR is the fix.

## Testing
- "Schedule viewings for Jack Murphy and Sarah O'Brien at Unit 4A and Unit 2B next Tuesday at 10am and 11am" → should invoke `schedule_viewings`, show CompositeScheduleCard, confirm atomically
- Cancel mid-flow → no DB rows written
- Bad development → RPC rolls back, card shows error state


---
_Generated by [Claude Code](https://claude.ai/code/session_012Tf924w7PrARFg5KfWuPHm)_