### PR TITLE
fix(agent): property hint priority and action-message followup suppression

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -26,6 +26,7 @@ import type { AgentContext } from '@/lib/agent-intelligence/types';
 import { isAgenticSkillEnvelope, type AgenticSkillEnvelope } from '@/lib/agent-intelligence/envelope';
 import { captureInferredAlias, suggestClosestScheme, normaliseSchemeName } from '@/lib/agent-intelligence/scheme-resolver';
 import { redactEnvelopeForUser, redactSummaryForUser } from '@/lib/agent-intelligence/redact-scaffolding';
+import { isActionMessage } from '@/lib/agent-intelligence/action-classifier';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -1060,6 +1061,18 @@ export async function POST(request: NextRequest) {
             return;
           }
           if (viewingDrafts.length > 0 || applicantDrafts.length > 0 || compositeDrafts.length > 0) {
+            controller.enqueue(
+              encoder.encode(JSON.stringify({ type: 'done', sessionId: currentSessionId }) + '\n')
+            );
+            controller.close();
+            return;
+          }
+          // Action messages (schedule, add, cancel, log...) should never
+          // generate "draft an email" / "log inquiry details" chips, even
+          // when the tool returned needs_clarification (no draft frame).
+          // The model's job is to ask the clarifying question; the user
+          // answers it. Chips here are noise.
+          if (isActionMessage(message)) {
             controller.enqueue(
               encoder.encode(JSON.stringify({ type: 'done', sessionId: currentSessionId }) + '\n')
             );

--- a/apps/unified-portal/lib/agent-intelligence/action-classifier.ts
+++ b/apps/unified-portal/lib/agent-intelligence/action-classifier.ts
@@ -1,0 +1,47 @@
+/**
+ * Lightweight keyword classifier: does the user's message read as an
+ * action request (schedule a viewing, add an applicant, cancel X) or
+ * an info request (how many, what's the status)?
+ *
+ * Used by the chat route to suppress legacy followup chips on action
+ * messages. The previous gate only suppressed when a draft frame was
+ * emitted, but a tool returning needs_clarification doesn't emit a
+ * draft, so chips like "Draft a follow-up email" leaked back through.
+ *
+ * Irish-English aware: "pencil in" is a real phrase letting agents
+ * use, alongside the more universal verbs.
+ */
+
+const ACTION_KEYWORDS: string[] = [
+  'schedule',
+  'book',
+  'create',
+  'add',
+  'remove',
+  'delete',
+  'cancel',
+  'update',
+  'change',
+  'reschedule',
+  'move',
+  'mark',
+  'log',
+  'set up',
+  'sign up',
+  'put down',
+  'pencil in',
+];
+
+function escapeForRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function isActionMessage(message: string): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  for (const kw of ACTION_KEYWORDS) {
+    const regex = new RegExp(`\\b${escapeForRegex(kw)}\\b`);
+    if (regex.test(lower)) return true;
+  }
+  return false;
+}

--- a/apps/unified-portal/lib/agent-intelligence/property-matcher.ts
+++ b/apps/unified-portal/lib/agent-intelligence/property-matcher.ts
@@ -1,0 +1,64 @@
+/**
+ * Loose-match a free-text property hint against an agent's assigned
+ * developments. Used by create_viewing and schedule_viewings when the
+ * user names a scheme in plain English ("Lakeside", "Lakeside Manor
+ * Show House") rather than picking from a list.
+ *
+ * Strategy: lowercase both sides, strip common Irish-letting suffixes
+ * from the hint (show house / showhome / apartment / apt / house),
+ * then accept exact, hint-in-name, or name-in-hint matches.
+ */
+
+export interface Development {
+  id: string;
+  name: string;
+}
+
+export type MatchResult =
+  | { type: 'unique'; development: Development }
+  | { type: 'ambiguous'; candidates: Development[] }
+  | { type: 'no_match' };
+
+function normaliseHint(input: string): string {
+  let s = input.trim().toLowerCase();
+  s = s.replace(/\bshow\s*house\b/g, ' ');
+  s = s.replace(/\bshow\s*home\b/g, ' ');
+  s = s.replace(/\bapartments\b/g, ' ');
+  s = s.replace(/\bapartment\b/g, ' ');
+  s = s.replace(/\bapts\b/g, ' ');
+  s = s.replace(/\bapt\b/g, ' ');
+  s = s.replace(/\bhouse\b/g, ' ');
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+function normaliseName(input: string): string {
+  return input.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function matchDevelopment(
+  hint: string,
+  developments: Development[],
+): MatchResult {
+  const trimmed = (hint || '').trim();
+  if (!trimmed) return { type: 'no_match' };
+  const normHint = normaliseHint(trimmed);
+  if (!normHint) return { type: 'no_match' };
+
+  const matches: Development[] = [];
+  for (const dev of developments) {
+    if (!dev || !dev.name) continue;
+    const normDev = normaliseName(dev.name);
+    if (!normDev) continue;
+    if (
+      normHint === normDev ||
+      normDev.includes(normHint) ||
+      normHint.includes(normDev)
+    ) {
+      matches.push(dev);
+    }
+  }
+
+  if (matches.length === 1) return { type: 'unique', development: matches[0] };
+  if (matches.length > 1) return { type: 'ambiguous', candidates: matches };
+  return { type: 'no_match' };
+}

--- a/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
@@ -7,6 +7,7 @@ import {
   formatViewingTime,
   DEFAULT_TZ,
 } from '../viewing-resolver';
+import { matchDevelopment } from '../property-matcher';
 
 /**
  * Composite scheduling tool, session 3.
@@ -64,6 +65,8 @@ export interface CompositeScheduleClarification {
     | 'property_required_for_new_applicant'
     | 'property_ambiguous'
     | 'property_not_found'
+    | 'property_not_in_assigned_schemes'
+    | 'no_property_specified'
     | 'date_unparseable'
     | 'missing_time'
     | 'no_viewings';
@@ -109,19 +112,6 @@ async function readPreferredCalendar(
 interface AssignedDevelopment {
   id: string;
   name: string;
-}
-
-function pickDevelopmentByHint(
-  developments: AssignedDevelopment[],
-  hint: string | undefined | null,
-): { match?: AssignedDevelopment; ambiguous?: AssignedDevelopment[] } {
-  if (!hint) return {};
-  const lower = hint.trim().toLowerCase();
-  if (!lower) return {};
-  const matches = developments.filter((d) => d.name.toLowerCase().includes(lower));
-  if (matches.length === 1) return { match: matches[0] };
-  if (matches.length > 1) return { ambiguous: matches };
-  return {};
 }
 
 function clampDuration(raw: number | undefined): number {
@@ -217,64 +207,9 @@ export async function scheduleViewings(
       const a = applicantRes.applicant!;
       applicant_ref = { existing_id: a.id };
       resolvedApplicantName = a.name;
-
-      const propertyRes = await resolvePropertyForApplicant(supabase, {
-        agentProfileId: agentContext.agentProfileId,
-        applicantId: a.id,
-        applicantEmail: a.email,
-        applicantName: a.name,
-        propertyHint: v.property_hint,
-      });
-
-      if (propertyRes.status === 'one') {
-        development_id = propertyRes.property!.development_id;
-        development_name = propertyRes.property!.name;
-      } else if (propertyRes.status === 'ambiguous') {
-        // Fall through to try property_hint against the agent's assigned schemes.
-        const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
-        if (hinted.match) {
-          development_id = hinted.match.id;
-          development_name = hinted.match.name;
-        } else {
-          const candidates = propertyRes.candidates ?? [];
-          const summaryLine = candidates.map((c) => c.name).join(', ');
-          const message = `${a.name} has enquiries on more than one scheme: ${summaryLine}. Which one for the ${formatViewingTime(parsed.iso, tz)} viewing?`;
-          const result: CompositeScheduleResult = {
-            status: 'needs_clarification',
-            reason: 'property_ambiguous',
-            message,
-            candidates,
-          };
-          return { data: result, summary: message };
-        }
-      } else {
-        // No active enquiry for this applicant. Fall back to property_hint.
-        const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
-        if (hinted.match) {
-          development_id = hinted.match.id;
-          development_name = hinted.match.name;
-        } else if (hinted.ambiguous && hinted.ambiguous.length > 0) {
-          const summaryLine = hinted.ambiguous.map((c) => c.name).join(', ');
-          const message = `"${v.property_hint}" matches more than one of your schemes: ${summaryLine}. Which one for ${a.name}?`;
-          const result: CompositeScheduleResult = {
-            status: 'needs_clarification',
-            reason: 'property_ambiguous',
-            message,
-            candidates: hinted.ambiguous.map((c) => ({ development_id: c.id, name: c.name })),
-          };
-          return { data: result, summary: message };
-        } else {
-          const message = `${a.name} has no active enquiry I can pin a property to. Which development for the ${formatViewingTime(parsed.iso, tz)} viewing?`;
-          const result: CompositeScheduleResult = {
-            status: 'needs_clarification',
-            reason: 'property_not_found',
-            message,
-          };
-          return { data: result, summary: message };
-        }
-      }
     } else {
-      // New applicant. Property MUST come from property_hint.
+      // New applicant. Dedup by lowercased name so multiple viewings for
+      // the same new person share one applicants_to_create entry.
       const lowerKey = applicantName.toLowerCase();
       const existingIdx = applicantsByLowerName.get(lowerKey);
       if (existingIdx === undefined) {
@@ -291,30 +226,80 @@ export async function scheduleViewings(
       } else {
         applicant_ref = { new_index: existingIdx };
       }
+    }
 
-      const hinted = pickDevelopmentByHint(assignedDevelopments, v.property_hint);
-      if (hinted.match) {
-        development_id = hinted.match.id;
-        development_name = hinted.match.name;
-      } else if (hinted.ambiguous && hinted.ambiguous.length > 0) {
-        const summaryLine = hinted.ambiguous.map((c) => c.name).join(', ');
-        const message = `"${v.property_hint}" matches more than one of your schemes: ${summaryLine}. Which one for ${applicantName}?`;
+    // Property resolution. property_hint takes priority over enquiries:
+    // when the user named a development, trust them, even if the applicant
+    // also has enquiries on a different scheme.
+    const hint = (v.property_hint || '').trim();
+    if (hint) {
+      const hintMatch = matchDevelopment(hint, assignedDevelopments);
+      if (hintMatch.type === 'unique') {
+        development_id = hintMatch.development.id;
+        development_name = hintMatch.development.name;
+      } else if (hintMatch.type === 'ambiguous') {
+        const summaryLine = hintMatch.candidates.map((c) => c.name).join(', ');
+        const message = `"${hint}" matches more than one of your schemes: ${summaryLine}. Which one for ${resolvedApplicantName}?`;
         const result: CompositeScheduleResult = {
           status: 'needs_clarification',
           reason: 'property_ambiguous',
           message,
-          candidates: hinted.ambiguous.map((c) => ({ development_id: c.id, name: c.name })),
+          candidates: hintMatch.candidates.map((c) => ({ development_id: c.id, name: c.name })),
         };
         return { data: result, summary: message };
       } else {
-        const message = `${applicantName} isn't on your applicants yet. Which development is the ${formatViewingTime(parsed.iso, tz)} viewing at?`;
+        const message = `"${hint}" isn't in your assigned developments. Which one did you mean?`;
         const result: CompositeScheduleResult = {
           status: 'needs_clarification',
-          reason: 'property_required_for_new_applicant',
+          reason: 'property_not_in_assigned_schemes',
           message,
+          candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
         };
         return { data: result, summary: message };
       }
+    } else if (applicantRes.status === 'one') {
+      const a = applicantRes.applicant!;
+      const propertyRes = await resolvePropertyForApplicant(supabase, {
+        agentProfileId: agentContext.agentProfileId,
+        applicantId: a.id,
+        applicantEmail: a.email,
+        applicantName: a.name,
+      });
+
+      if (propertyRes.status === 'one') {
+        development_id = propertyRes.property!.development_id;
+        development_name = propertyRes.property!.name;
+      } else if (propertyRes.status === 'ambiguous') {
+        const candidates = propertyRes.candidates ?? [];
+        const summaryLine = candidates.map((c) => c.name).join(', ');
+        const message = `${a.name} has enquiries on more than one scheme: ${summaryLine}. Which one for the ${formatViewingTime(parsed.iso, tz)} viewing?`;
+        const result: CompositeScheduleResult = {
+          status: 'needs_clarification',
+          reason: 'property_ambiguous',
+          message,
+          candidates,
+        };
+        return { data: result, summary: message };
+      } else {
+        const message = 'Which development is this viewing for?';
+        const result: CompositeScheduleResult = {
+          status: 'needs_clarification',
+          reason: 'no_property_specified',
+          message,
+          candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
+        };
+        return { data: result, summary: message };
+      }
+    } else {
+      // New applicant + no hint: ask which scheme.
+      const message = 'Which development is this viewing for?';
+      const result: CompositeScheduleResult = {
+        status: 'needs_clarification',
+        reason: 'no_property_specified',
+        message,
+        candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
+      };
+      return { data: result, summary: message };
     }
 
     if (!development_id || !development_name) {

--- a/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
@@ -7,6 +7,7 @@ import {
   formatViewingTime,
   DEFAULT_TZ,
 } from '../viewing-resolver';
+import { matchDevelopment } from '../property-matcher';
 
 export interface ViewingDraft {
   applicant_id: string;
@@ -32,6 +33,8 @@ export type CreateViewingResult =
         | 'applicant_ambiguous'
         | 'property_not_found'
         | 'property_ambiguous'
+        | 'property_not_in_assigned_schemes'
+        | 'no_property_specified'
         | 'date_unparseable'
         | 'missing_time';
       message: string;
@@ -90,38 +93,74 @@ export async function createViewing(
 
   const applicant = applicantRes.applicant!;
 
-  const propertyRes = await resolvePropertyForApplicant(supabase, {
-    agentProfileId: agentContext.agentProfileId,
-    applicantId: applicant.id,
-    applicantEmail: applicant.email,
-    applicantName: applicant.name,
-    propertyHint: params.property_hint,
-  });
+  const assignedDevelopments = (agentContext.assignedDevelopmentIds || [])
+    .map((id, idx) => ({ id, name: agentContext.assignedDevelopmentNames?.[idx] ?? '' }))
+    .filter((d) => d.name.length > 0);
 
-  if (propertyRes.status === 'none') {
-    const message = `${applicant.name} has no active enquiry I can pin a property to. Which development is this viewing for?`;
-    const result: CreateViewingResult = {
-      status: 'needs_clarification',
-      reason: 'property_not_found',
-      message,
-    };
-    return { data: result, summary: message };
+  let property: { development_id: string; name: string } | null = null;
+
+  // property_hint takes priority over enquiries: when the user named a
+  // development, trust them, even if the applicant has enquiries on a
+  // different scheme.
+  const hint = (params.property_hint || '').trim();
+  if (hint) {
+    const hintMatch = matchDevelopment(hint, assignedDevelopments);
+    if (hintMatch.type === 'unique') {
+      property = { development_id: hintMatch.development.id, name: hintMatch.development.name };
+    } else if (hintMatch.type === 'ambiguous') {
+      const summaryLine = hintMatch.candidates.map((c) => c.name).join(', ');
+      const message = `"${hint}" matches more than one of your schemes: ${summaryLine}. Which one is this viewing for?`;
+      const result: CreateViewingResult = {
+        status: 'needs_clarification',
+        reason: 'property_ambiguous',
+        message,
+        candidates: hintMatch.candidates.map((c) => ({ development_id: c.id, name: c.name })),
+      };
+      return { data: result, summary: message };
+    } else {
+      const message = `"${hint}" isn't in your assigned developments. Which one did you mean?`;
+      const result: CreateViewingResult = {
+        status: 'needs_clarification',
+        reason: 'property_not_in_assigned_schemes',
+        message,
+        candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
+      };
+      return { data: result, summary: message };
+    }
+  } else {
+    const propertyRes = await resolvePropertyForApplicant(supabase, {
+      agentProfileId: agentContext.agentProfileId,
+      applicantId: applicant.id,
+      applicantEmail: applicant.email,
+      applicantName: applicant.name,
+    });
+
+    if (propertyRes.status === 'one') {
+      property = { development_id: propertyRes.property!.development_id, name: propertyRes.property!.name };
+    } else if (propertyRes.status === 'ambiguous') {
+      const candidates = propertyRes.candidates ?? [];
+      const summaryLine = candidates.map((c) => c.name).join(', ');
+      const message = `${applicant.name} has enquiries on more than one scheme: ${summaryLine}. Which one is this viewing for?`;
+      const result: CreateViewingResult = {
+        status: 'needs_clarification',
+        reason: 'property_ambiguous',
+        message,
+        candidates,
+      };
+      return { data: result, summary: message };
+    } else {
+      const message = 'Which development is this viewing for?';
+      const result: CreateViewingResult = {
+        status: 'needs_clarification',
+        reason: 'no_property_specified',
+        message,
+        candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
+      };
+      return { data: result, summary: message };
+    }
   }
 
-  if (propertyRes.status === 'ambiguous') {
-    const candidates = propertyRes.candidates ?? [];
-    const summaryLine = candidates.map((c) => c.name).join(', ');
-    const message = `${applicant.name} has enquiries on more than one scheme: ${summaryLine}. Which one is this viewing for?`;
-    const result: CreateViewingResult = {
-      status: 'needs_clarification',
-      reason: 'property_ambiguous',
-      message,
-      candidates,
-    };
-    return { data: result, summary: message };
-  }
-
-  const property = propertyRes.property!;
+  const resolvedProperty = property!;
   const duration = Number.isFinite(params.duration_minutes) && params.duration_minutes! > 0
     ? Math.min(Math.max(Math.round(params.duration_minutes!), 5), 240)
     : 30;
@@ -129,15 +168,15 @@ export async function createViewing(
   const draft: ViewingDraft = {
     applicant_id: applicant.id,
     applicant_name: applicant.name,
-    development_id: property.development_id,
-    development_name: property.name,
+    development_id: resolvedProperty.development_id,
+    development_name: resolvedProperty.name,
     scheduled_at: parsedDate.iso,
     duration_minutes: duration,
-    location: property.name,
+    location: resolvedProperty.name,
     notes: params.notes?.trim() || null,
   };
 
-  const message = `Viewing draft ready: ${applicant.name}, ${property.name}, ${formatViewingTime(parsedDate.iso, tz)}. Confirm to create.`;
+  const message = `Viewing draft ready: ${applicant.name}, ${resolvedProperty.name}, ${formatViewingTime(parsedDate.iso, tz)}. Confirm to create.`;
   const result: CreateViewingResult = {
     status: 'draft',
     draft,


### PR DESCRIPTION
## Reproducer

> "Schedule a viewing with Jack Murphy in Lakeside Manor Show house at 7pm on Tuesday"

(Lakeside Manor exists in agent-test@test.ie's tenant.) The assistant
returned "Jack Murphy has no active enquiry I can pin a property to.
Which development is this viewing for?" plus three legacy followup chips.
Both bugs need to go.

## BUG 1: property_hint should beat enquiries

The resolver checked an applicant's active enquiries first and only used
`property_hint` as a tiebreaker between multiple enquiries. For a
brand-new applicant (zero enquiries), the hint was effectively ignored,
so the model asked "which development?" even after the user had already
named one.

Fix: a shared helper in `lib/agent-intelligence/property-matcher.ts`
performs loose matching against the agent's assigned developments
(lowercase both sides, strip "show house" / "showhome" / "apartment" /
"apt" / "house" from the hint, accept exact / contains either way).
Both `schedule_viewings` and `create_viewing` now:

1. If `property_hint` is provided → loose-match against assigned
   developments. Unique → use; ambiguous → clarify with the matched
   set; no match → clarify with reason `property_not_in_assigned_schemes`
   and the agent's full development list as candidates.
2. Only if no hint → fall back to the applicant's enquiries (existing
   applicants only). Zero enquiries surfaces reason `no_property_specified`
   with the agent's full development list — never the misleading "no
   active enquiry" copy.

## BUG 2: action messages still got followup chips

The previous followup-suppression gate triggered only when a draft frame
was emitted. Tools returning `needs_clarification` emit no draft, so
legacy chips like "Draft a follow-up email" / "Log Jack Murphy's inquiry
details" leaked back through on action messages.

Fix: a keyword classifier in `lib/agent-intelligence/action-classifier.ts`
(schedule, book, create, add, remove, delete, cancel, update, change,
reschedule, move, mark, log, set up, sign up, put down, pencil in)
classifies the user message before the followup model runs. Action
messages skip followup generation entirely. Question-style messages
("how many applicants do I have?") still get chips.

## Files changed
- `lib/agent-intelligence/property-matcher.ts` (new, ~64 lines)
- `lib/agent-intelligence/action-classifier.ts` (new, ~47 lines)
- `lib/agent-intelligence/tools/composite-tools.ts` (rewrote property
  resolution branch; dropped local `pickDevelopmentByHint`)
- `lib/agent-intelligence/tools/viewing-tools.ts` (same priority fix
  for `create_viewing`)
- `app/api/agent-intelligence/chat/route.ts` (action-classifier gate
  before followup model)

## Manual test plan
- Schedule viewing with new applicant + named scheme → composite card
  with property correctly resolved (not asked again)
- Same with "Show House" suffix on the hint
- Partial match ("Lakeside") → unique if no other dev contains it
- Unknown scheme name → clarify with reason
  `property_not_in_assigned_schemes` and agent's full dev list
- No property mentioned, applicant has no enquiry → clarify
  ("Which development is this viewing for?") with full dev list, no
  mention of enquiries
- No property mentioned, applicant has one enquiry → uses it silently
- Any of the above → zero followup chips
- "How many applicants do I have?" → followup chips still render


---
_Generated by [Claude Code](https://claude.ai/code/session_012Tf924w7PrARFg5KfWuPHm)_