### PR TITLE
fix(agent): viewing persistence, no-scheme applicant lookup, receipt render dedupe

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -142,6 +142,22 @@ function parseEmails(response: string): { emails: DraftedEmail[]; cleanText: str
   return { emails, cleanText };
 }
 
+// Stable per-envelope signature used to dedupe composite_draft frames that
+// arrive more than once in a single chat turn (multi-round tool calling,
+// SSE retries). Includes the viewings shape and applicant set so two
+// genuinely-distinct composite drafts in one turn still render separately.
+function compositeEnvelopeSignature(env: CompositeScheduleEnvelope): string {
+  const applicants = env.applicants_to_create
+    .map(a => `${a.full_name.toLowerCase()}|${(a.email ?? '').toLowerCase()}|${(a.phone ?? '')}`)
+    .sort()
+    .join('||');
+  const viewings = env.viewings_to_create
+    .map(v => `${v.development_id}|${v.scheduled_at}|${v.applicant_name.toLowerCase()}`)
+    .sort()
+    .join('||');
+  return `${applicants}::${viewings}`;
+}
+
 export default function IntelligencePage() {
   return (
     <ApprovalDrawerProvider>
@@ -408,14 +424,20 @@ function IntelligencePageInner() {
               });
             } else if (data.type === 'composite_draft' && data.envelope) {
               const envelope = data.envelope as CompositeScheduleEnvelope;
+              // Dedupe by payload signature. The server can emit the same
+              // envelope more than once (multi-round tool calling, retries),
+              // and the card has its own internal phase state — duplicate
+              // mounts caused the "6-8 receipt cards stacked" render thrash.
+              const sig = compositeEnvelopeSignature(envelope);
               setMessages(prev => {
                 const existing = prev.find(m => m.id === streamingMsgId);
                 if (existing) {
-                  return prev.map(m =>
-                    m.id === streamingMsgId
-                      ? { ...m, compositeDrafts: [...(m.compositeDrafts ?? []), envelope] }
-                      : m,
-                  );
+                  return prev.map(m => {
+                    if (m.id !== streamingMsgId) return m;
+                    const current = m.compositeDrafts ?? [];
+                    if (current.some(e => compositeEnvelopeSignature(e) === sig)) return m;
+                    return { ...m, compositeDrafts: [...current, envelope] };
+                  });
                 }
                 return [...prev, {
                   id: streamingMsgId,

--- a/apps/unified-portal/app/api/agent-intelligence/confirm-composite-schedule/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/confirm-composite-schedule/route.ts
@@ -189,6 +189,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const expectedApplicants = applicantsKept.length;
+    const expectedViewings = viewingsKept.length;
+
     const result = await confirmCompositeSchedule(supabaseAdmin, agentContext, {
       applicants_to_create: applicantsKept.map(({ a }) => ({
         full_name: a.full_name.trim(),
@@ -203,6 +206,33 @@ export async function POST(request: NextRequest) {
         {
           status: 'error',
           error: result.error,
+          created_applicants: result.created_applicants,
+          created_viewings: result.created_viewings,
+        },
+        { status: 500 },
+      );
+    }
+
+    // Mutation-result-integrity guard. The RPC reports success, but we
+    // refuse to call it success unless every expected row appears in the
+    // returned arrays. Without this, a silently-shorter array could be
+    // dressed up as a green receipt while half the writes never landed.
+    const actualApplicants = result.created_applicants.length;
+    const actualViewings = result.created_viewings.length;
+    if (actualApplicants !== expectedApplicants || actualViewings !== expectedViewings) {
+      const integrityMessage =
+        `RPC reported success but only ${actualApplicants}/${expectedApplicants} applicants and ` +
+        `${actualViewings}/${expectedViewings} viewings landed.`;
+      console.error('[confirm-composite-schedule] integrity mismatch', {
+        expectedApplicants,
+        actualApplicants,
+        expectedViewings,
+        actualViewings,
+      });
+      return NextResponse.json(
+        {
+          status: 'error',
+          error: integrityMessage,
           created_applicants: result.created_applicants,
           created_viewings: result.created_viewings,
         },

--- a/apps/unified-portal/app/api/agent/viewings/route.ts
+++ b/apps/unified-portal/app/api/agent/viewings/route.ts
@@ -33,27 +33,85 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'No agent profile found' }, { status: 404 });
     }
 
-    let query = supabase
+    // Read from BOTH tables. The agent-intelligence write path inserts into
+    // `viewings` (canonical schema with applicant_id / development_id /
+    // scheduled_at). The legacy manual form inserts into `agent_viewings`
+    // (denormalised columns). Until the manual form is migrated we have to
+    // surface both so nothing scheduled by either path goes invisible.
+    let legacyQuery = supabase
       .from('agent_viewings')
       .select('*')
       .eq('agent_id', profile.id)
       .order('viewing_date', { ascending: true })
       .order('viewing_time', { ascending: true });
+    if (from) legacyQuery = legacyQuery.gte('viewing_date', from);
+    if (to) legacyQuery = legacyQuery.lte('viewing_date', to);
+    if (status) legacyQuery = legacyQuery.eq('status', status);
 
-    if (from) query = query.gte('viewing_date', from);
-    if (to) query = query.lte('viewing_date', to);
-    if (status) query = query.eq('status', status);
+    let canonicalQuery = supabase
+      .from('viewings')
+      .select('id, agent_id, applicant_id, development_id, unit_id, scheduled_at, duration_minutes, location, status, notes, created_at, updated_at')
+      .eq('tenant_id', profile.tenant_id)
+      .order('scheduled_at', { ascending: true });
+    if (from) canonicalQuery = canonicalQuery.gte('scheduled_at', `${from}T00:00:00Z`);
+    if (to) canonicalQuery = canonicalQuery.lte('scheduled_at', `${to}T23:59:59Z`);
 
-    const { data: viewings, error } = await query;
+    const [legacyRes, canonicalRes] = await Promise.all([legacyQuery, canonicalQuery]);
 
-    if (error) {
-      console.error('[agent/viewings GET] Error:', error.message);
-      return NextResponse.json({ error: 'Failed to fetch viewings' }, { status: 500 });
+    if (legacyRes.error) {
+      console.error('[agent/viewings GET] legacy error:', legacyRes.error.message);
+    }
+    if (canonicalRes.error) {
+      console.error('[agent/viewings GET] canonical error:', canonicalRes.error.message);
     }
 
-    return NextResponse.json({
-      viewings: (viewings || []).map(formatViewing),
+    const canonicalRows = canonicalRes.data || [];
+    const applicantIds = Array.from(new Set(canonicalRows.map((r: any) => r.applicant_id).filter(Boolean)));
+    const developmentIds = Array.from(new Set(canonicalRows.map((r: any) => r.development_id).filter(Boolean)));
+
+    const [applicantsRes, developmentsRes] = await Promise.all([
+      applicantIds.length
+        ? supabase.from('agent_applicants').select('id, full_name').in('id', applicantIds)
+        : Promise.resolve({ data: [] as Array<{ id: string; full_name: string }>, error: null }),
+      developmentIds.length
+        ? supabase.from('developments').select('id, name').in('id', developmentIds)
+        : Promise.resolve({ data: [] as Array<{ id: string; name: string }>, error: null }),
+    ]);
+
+    const applicantNameById = new Map<string, string>(
+      (applicantsRes.data || []).map((a: any) => [a.id, a.full_name]),
+    );
+    const developmentNameById = new Map<string, string>(
+      (developmentsRes.data || []).map((d: any) => [d.id, d.name]),
+    );
+
+    const canonicalFormatted = canonicalRows
+      .map((r: any) => formatCanonicalViewing(r, applicantNameById, developmentNameById))
+      .filter((v) => !status || v.status === status);
+
+    const legacyFormatted = (legacyRes.data || []).map(formatViewing);
+
+    // Merge and dedupe. Canonical wins on id collision (defensive — these
+    // tables share no FK so collisions are extremely unlikely, but a row
+    // could exist in both if a manual form write later seeded a real
+    // viewings row by another path).
+    const seen = new Set<string>();
+    const merged: Viewing[] = [];
+    for (const v of [...canonicalFormatted, ...legacyFormatted]) {
+      if (seen.has(v.id)) continue;
+      seen.add(v.id);
+      merged.push(v);
+    }
+
+    console.log('[agent/viewings GET]', {
+      agentProfileId: profile.id,
+      tenantId: profile.tenant_id,
+      canonicalCount: canonicalFormatted.length,
+      legacyCount: legacyFormatted.length,
+      mergedCount: merged.length,
     });
+
+    return NextResponse.json({ viewings: merged });
   } catch (error: any) {
     console.error('[agent/viewings GET] Error:', error.message);
     return NextResponse.json({ error: 'Failed to fetch viewings' }, { status: 500 });
@@ -199,6 +257,77 @@ export async function DELETE(request: NextRequest) {
 
 /* ─── Helpers ─── */
 
+interface Viewing {
+  id: string;
+  agentId: string | null;
+  developmentId: string | null;
+  unitId: string | null;
+  buyerName: string;
+  buyerPhone: string | null;
+  buyerEmail: string | null;
+  schemeName: string | null;
+  unitRef: string | null;
+  viewingDate: string;
+  viewingTime: string;
+  status: string;
+  notes: string | null;
+  source: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+// Map canonical `viewings` rows into the legacy Viewing shape the page
+// expects. The agent-intelligence path stores scheduled_at as a timestamptz,
+// applicant_id / development_id as FKs, and status='scheduled'. Convert that
+// into date/time strings, denormalised buyer/scheme names, and a status the
+// StatusBadge knows about ('scheduled' -> 'confirmed').
+function formatCanonicalViewing(
+  row: any,
+  applicantNames: Map<string, string>,
+  developmentNames: Map<string, string>,
+): Viewing {
+  const scheduled = row.scheduled_at ? new Date(row.scheduled_at) : null;
+  const isoParts = scheduled
+    ? (() => {
+        const fmt = new Intl.DateTimeFormat('en-CA', {
+          timeZone: 'Europe/Dublin',
+          year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit', hour12: false,
+        });
+        const parts: Record<string, string> = {};
+        for (const p of fmt.formatToParts(scheduled)) {
+          if (p.type !== 'literal') parts[p.type] = p.value;
+        }
+        return {
+          date: `${parts.year}-${parts.month}-${parts.day}`,
+          time: `${parts.hour}:${parts.minute}`,
+        };
+      })()
+    : { date: '', time: '' };
+
+  const rawStatus = (row.status as string) || 'scheduled';
+  const status = rawStatus === 'scheduled' ? 'confirmed' : rawStatus;
+
+  return {
+    id: row.id,
+    agentId: row.agent_id ?? null,
+    developmentId: row.development_id ?? null,
+    unitId: row.unit_id ?? null,
+    buyerName: applicantNames.get(row.applicant_id) || 'Applicant',
+    buyerPhone: null,
+    buyerEmail: null,
+    schemeName: developmentNames.get(row.development_id) || null,
+    unitRef: null,
+    viewingDate: isoParts.date,
+    viewingTime: isoParts.time,
+    status,
+    notes: row.notes ?? null,
+    source: 'intelligence',
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+  };
+}
+
 async function getAuthenticatedAgent() {
   const supabaseAuth = createServerComponentClient({ cookies });
   const { data: { user }, error } = await supabaseAuth.auth.getUser();
@@ -216,23 +345,23 @@ async function getAuthenticatedAgent() {
   return { user, supabase };
 }
 
-function formatViewing(v: any) {
+function formatViewing(v: any): Viewing {
   return {
     id: v.id,
-    agentId: v.agent_id,
-    developmentId: v.development_id,
-    unitId: v.unit_id,
-    buyerName: v.buyer_name,
-    buyerPhone: v.buyer_phone,
-    buyerEmail: v.buyer_email,
-    schemeName: v.scheme_name,
-    unitRef: v.unit_ref,
-    viewingDate: v.viewing_date,
-    viewingTime: v.viewing_time,
+    agentId: v.agent_id ?? null,
+    developmentId: v.development_id ?? null,
+    unitId: v.unit_id ?? null,
+    buyerName: v.buyer_name ?? 'Applicant',
+    buyerPhone: v.buyer_phone ?? null,
+    buyerEmail: v.buyer_email ?? null,
+    schemeName: v.scheme_name ?? null,
+    unitRef: v.unit_ref ?? null,
+    viewingDate: v.viewing_date ?? '',
+    viewingTime: v.viewing_time ?? '',
     status: v.status,
-    notes: v.notes,
-    source: v.source,
-    createdAt: v.created_at,
-    updatedAt: v.updated_at,
+    notes: v.notes ?? null,
+    source: v.source ?? null,
+    createdAt: v.created_at ?? null,
+    updatedAt: v.updated_at ?? null,
   };
 }

--- a/apps/unified-portal/lib/agent-intelligence/applicant-lookup.ts
+++ b/apps/unified-portal/lib/agent-intelligence/applicant-lookup.ts
@@ -1,0 +1,21 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { resolveApplicantByName, type ApplicantResolution } from './viewing-resolver';
+
+/**
+ * Shared applicant-by-name lookup used by every scheduling tool that needs
+ * to resolve a free-form name into an agent_applicants row. Both
+ * create_viewing (single) and schedule_viewings (composite) go through this
+ * so the two flows can never diverge again — see bug log for the
+ * "no scheme provided" regression that caused the single-viewing tool to
+ * dead-end on applicant_not_found while the composite tool correctly
+ * treated the same name as a new applicant.
+ */
+export async function findApplicantByName(
+  supabase: SupabaseClient,
+  agentProfileId: string,
+  name: string,
+): Promise<ApplicantResolution> {
+  return resolveApplicantByName(supabase, agentProfileId, name);
+}
+
+export type { ApplicantResolution } from './viewing-resolver';

--- a/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
@@ -2,11 +2,11 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { ToolResult, AgentContext } from '../types';
 import {
   parseScheduledAtNatural,
-  resolveApplicantByName,
   resolvePropertyForApplicant,
   formatViewingTime,
   DEFAULT_TZ,
 } from '../viewing-resolver';
+import { findApplicantByName } from '../applicant-lookup';
 import { matchDevelopment } from '../property-matcher';
 
 /**
@@ -177,7 +177,7 @@ export async function scheduleViewings(
       return { data: result, summary: message };
     }
 
-    const applicantRes = await resolveApplicantByName(
+    const applicantRes = await findApplicantByName(
       supabase,
       agentContext.agentProfileId,
       applicantName,

--- a/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/viewing-tools.ts
@@ -2,11 +2,11 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { ToolResult, AgentContext } from '../types';
 import {
   parseScheduledAtNatural,
-  resolveApplicantByName,
   resolvePropertyForApplicant,
   formatViewingTime,
   DEFAULT_TZ,
 } from '../viewing-resolver';
+import { findApplicantByName } from '../applicant-lookup';
 import { matchDevelopment } from '../property-matcher';
 
 export interface ViewingDraft {
@@ -66,13 +66,23 @@ export async function createViewing(
     return { data: result, summary: message };
   }
 
-  const applicantRes = await resolveApplicantByName(supabase, agentContext.agentProfileId, params.applicant_name);
+  const applicantRes = await findApplicantByName(supabase, agentContext.agentProfileId, params.applicant_name);
   if (applicantRes.status === 'none') {
-    const message = `I don't have an applicant matching "${params.applicant_name}". Add them in Applicants first, or check the spelling.`;
+    // Applicant isn't on the books. Don't dead-end — instead route the caller
+    // toward picking a scheme. Once the user names one, the model will re-call
+    // via schedule_viewings (composite), which has a working new-applicant
+    // creation path. Without this redirect, "schedule a viewing with Jack
+    // Murphy at 7pm Tuesday" (no scheme) wrongly returns "applicant not
+    // found" even though Jack could be created.
+    const assignedDevelopments = (agentContext.assignedDevelopmentIds || [])
+      .map((id, idx) => ({ id, name: agentContext.assignedDevelopmentNames?.[idx] ?? '' }))
+      .filter((d) => d.name.length > 0);
+    const message = `I don't have ${params.applicant_name} on your books yet. Which development is this viewing for? I'll add them as a new applicant.`;
     const result: CreateViewingResult = {
       status: 'needs_clarification',
-      reason: 'applicant_not_found',
+      reason: 'no_property_specified',
       message,
+      candidates: assignedDevelopments.map((d) => ({ development_id: d.id, name: d.name })),
     };
     return { data: result, summary: message };
   }


### PR DESCRIPTION
## Summary

Three production bugs reported by QA on 11 May around the composite schedule flow.

### Bug A — viewing persisted but invisible in the Viewings tab
The composite RPC `schedule_viewings_atomic` writes to the canonical `viewings` table (`applicant_id`, `development_id`, `scheduled_at` timestamptz, status `scheduled`). The Viewings tab API queried the legacy `agent_viewings` table (denormalised `buyer_name`, `scheme_name`, `viewing_date`, `viewing_time`). Confirmed via SQL that the QA's "Test User Two" row exists in `viewings`, so the RPC was fine — the read was looking at the wrong table.

Fix: `/api/agent/viewings` now reads from both tables in parallel, joins canonical rows to `agent_applicants` / `developments` for buyer + scheme names, maps `scheduled` → `confirmed` for the badge, and merges with dedupe by id.

### Bug B — "no scheme" prompt dead-ended on applicant not found
When the user said "Schedule a viewing with Jack Murphy at 7pm Tuesday" (no scheme), the LLM picked `create_viewing` (single). At QA time Jack wasn't on the books yet, so `resolveApplicantByName` returned `none` and `create_viewing` returned `applicant_not_found` ("Add them in Applicants first"). The composite `schedule_viewings` flow handles the same case correctly: it treats them as new and asks for a scheme. Both tools should behave the same way at the first decision point.

Fix: extracted `findApplicantByName` into `lib/agent-intelligence/applicant-lookup.ts`. Both tools now go through it. When `create_viewing` finds no match, it returns `no_property_specified` with the assigned-scheme candidate list instead of dead-ending — the user's reply then routes through `schedule_viewings` which can create the applicant.

### Bug C — 6-8 duplicate receipt cards stacking on confirm
Each `composite_draft` SSE frame was appended to the message's `compositeDrafts` array. If the model fired `schedule_viewings` more than once in a turn (multi-round tool calling) or the frame arrived more than once, N identical cards stacked.

Fix: dedupe `composite_draft` arrivals by stable envelope signature (applicants + viewings shape).

### Mutation-result-integrity
The confirm-composite-schedule route now compares the requested applicant/viewing counts against the RPC's returned arrays and returns an explicit `status: 'error'` if any expected row didn't land. The card already reads receipts from API response data, so a silent shortfall now lights the red error state rather than rendering a green receipt.

## Test plan
- [ ] "schedule a viewing for QA Test Three at 4pm Thursday in Lakeside Manor" → confirm → check `viewings` row by SQL → check Viewings tab shows the row
- [ ] "schedule a viewing with Jack Murphy at 5pm Wednesday" (no scheme, Jack not yet on books) → response prompts for a development, not "applicant not found"
- [ ] Click Confirm All on a composite card → exactly one receipt card, no stack
- [ ] Temporarily ALTER the `viewings_status_check` constraint to forbid `scheduled` → confirm a composite → card renders red error state, not green receipt. Revert constraint after.

https://claude.ai/code/session_01ArP1Uwt6rkkaH9U3WApi59

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArP1Uwt6rkkaH9U3WApi59)_