### PR TITLE
fix(agent): restore auto-create for unknown applicants in composite resolver

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/composite-tools.ts
@@ -171,10 +171,12 @@ export async function scheduleViewings(
     const hint = (v.property_hint || '').trim();
     const hintMatch = hint ? matchDevelopment(hint, assignedDevelopments) : null;
 
-    // ---- Phase 2: classify what's missing in priority order. Inputs the
-    // user did NOT give are softer failures than inputs the user gave
-    // wrongly. We bias the clarification toward whatever the user gave
-    // so we don't lose information they already typed.
+    // ---- Phase 2: clarification-only cases. We early-return here ONLY for
+    // inputs the user gave wrongly or did not give at all. The
+    // "applicant doesn't exist" case is deliberately NOT in this block:
+    // the whole point of schedule_viewings is to auto-create unknown
+    // applicants in the same atomic write as the viewing. A future
+    // restructure must never add `applicantRes.status === 'none'` here.
 
     if (!applicantName) {
       const message = `Viewing #${i + 1} has no applicant name. Tell me who the viewing is for.`;
@@ -187,6 +189,8 @@ export async function scheduleViewings(
     }
 
     if (applicantRes.status === 'ambiguous') {
+      // 2+ existing applicants match the name. This is the only genuine
+      // applicant ambiguity. A brand new name (0 matches) falls through.
       const candidates = applicantRes.candidates ?? [];
       const summaryLine = candidates
         .map((c) => `${c.name}${c.latest_enquiry_property ? ` (${c.latest_enquiry_property})` : ''}`)
@@ -217,7 +221,10 @@ export async function scheduleViewings(
 
     const parsed = parsedDate;
 
-    // ---- Phase 3: applicant slot.
+    // ---- Phase 3: applicant slot. After Phase 2, applicantRes.status is
+    // either 'one' (use existing id) or 'none' (auto-create). The 'none'
+    // path is the happy path for new applicants, it must never route to
+    // a clarification.
     let applicant_ref: ApplicantRef;
     let resolvedApplicantName = applicantName;
     if (applicantRes.status === 'one' && applicantRes.applicant) {
@@ -225,6 +232,9 @@ export async function scheduleViewings(
       applicant_ref = { existing_id: a.id };
       resolvedApplicantName = a.name;
     } else {
+      // applicantRes.status === 'none': unknown name, add to
+      // applicants_to_create. Dedup by lowercased name so multiple
+      // viewings for the same new person share one slot.
       const lowerKey = applicantName.toLowerCase();
       const existingIdx = applicantsByLowerName.get(lowerKey);
       if (existingIdx === undefined) {


### PR DESCRIPTION
## Summary
- Lock in the four applicant-resolution cases for `schedule_viewings` so a future restructure cannot regress the auto-create branch back into a clarification path.
- After PR #111's parse-all-inputs-first restructure, the resolver's intent for `applicantRes.status === 'none'` relied on falling through an unmarked else. Phase 2 and Phase 3 now make the spec explicit at both decision points.

## Spec (now visible in code)
- **0 matches** -> add to `applicants_to_create` (the composite tool's whole point, this is the happy path, never a clarification).
- **1 match** -> reuse the existing id.
- **2+ matches** -> `needs_clarification(applicant_ambiguous)`, the only genuine applicant ambiguity.

Property resolution is unchanged from session 3.1: explicit `property_hint` wins; otherwise fall back to the applicant's enquiries; new applicant with no hint asks which scheme.

## Test plan
- [ ] `"schedule a viewing for QA Lifecycle One at 4pm Thursday in Lakeside Manor"` - composite card with QA Lifecycle One in `applicants_to_create`, viewing at Lakeside Manor. No clarification.
- [ ] `"schedule a viewing for QA Lifecycle One at 4pm Thursday"` - `needs_clarification(no_property_specified)` listing the agent's developments.
- [ ] `"schedule a viewing for Sarah Mitchell at 4pm Thursday in Lakeside Manor"` (existing applicant) - composite card with Sarah's existing id, viewing at Lakeside Manor.
- [ ] `"schedule a viewing for Sarah at 4pm Thursday"` (ambiguous partial name) - `needs_clarification(applicant_ambiguous)` listing candidates.
- [ ] `"schedule a viewing for QA Lifecycle One and QA Lifecycle Two at 4pm and 5pm Thursday in Lakeside Manor"` - composite card with both in `applicants_to_create` and two viewings.
- [ ] `npm run build` passes.

Pre-existing TS errors on main (unrelated `Record<string, unknown>[]` cast warnings in `candidates`) are not touched by this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)