### PR TITLE
fix(agent): remove create_viewing from registry, consolidate scheduling to single tool

### DIFF
--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -16,7 +16,7 @@ import {
   logCommunication,
   generateDeveloperReport,
 } from './write-tools';
-import { createViewing, updateViewing, cancelViewing, markViewingStatus } from './viewing-tools';
+import { updateViewing, cancelViewing, markViewingStatus } from './viewing-tools';
 import { manageApplicants } from './applicant-tools';
 import { scheduleViewings } from './composite-tools';
 // schedule_viewing (immediate-write) is intentionally NOT imported here.
@@ -519,8 +519,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'schedule_viewings',
     description: [
-      'Composite scheduling tool. Use when the agent wants to schedule MORE THAN ONE viewing in one go, OR a single viewing for an applicant who is NOT yet on the books. The card surfaces one Confirm; the writes land atomically (applicants, audit log rows, and viewings together) so a property typo does not leave half the work done.',
-      'For a single viewing for an existing applicant, use create_viewing instead. This composite tool is overkill for that.',
+      'The single viewing-scheduling tool. Use for ANY request to schedule one or more viewings, whether the applicant is on the books or brand new, whether the user named a property or did not. The card surfaces one Confirm; the writes land atomically (applicants, audit log rows, and viewings together) so a property typo does not leave half the work done.',
       'Inputs:',
       '- viewings: array of { applicant_name, scheduled_at_natural, property_hint?, duration_minutes?, notes? }, one entry per viewing.',
       '- calendar_preference (optional): pass when the user explicitly asked ("add it to my iPhone calendar"). Otherwise omit.',
@@ -555,30 +554,6 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       required: ['viewings'],
     },
     execute: scheduleViewings as ToolFunction,
-  },
-  {
-    name: 'create_viewing',
-    description: [
-      'Schedule a new property viewing for a known applicant. Voice-first entry point — the agent says "schedule a viewing with Jack Murphy Tuesday 6pm" and this resolves the applicant, the property and the time, then returns a draft for the agent to confirm.',
-      'NEVER writes on its own — always returns either a draft for confirmation or a needs_clarification with one targeted question.',
-      'Resolution rules:',
-      '- Applicant: ilike match on agent_applicants.full_name within the agent\'s tenant. Zero matches → needs_clarification (applicant_not_found). Multiple matches → needs_clarification (applicant_ambiguous) with the candidate list.',
-      '- Property: pulled from the applicant\'s active enquiries. Single match → use it. Multiple → use property_hint (ilike on development name) when supplied; otherwise needs_clarification (property_ambiguous).',
-      '- Date / time: parsed against Europe/Dublin. Bare weekday means the next occurrence; if today is that weekday, defaults to next week unless the time is still ahead today.',
-      'When fully resolved, returns { status: "draft", draft, message: "Confirm to create this viewing" }. The chat surface renders a viewing card from the draft — DO NOT echo the draft fields in your reply, the card is the canonical surface.',
-    ].join(' '),
-    parameters: {
-      type: 'object',
-      properties: {
-        applicant_name: { type: 'string', description: 'Full or partial applicant name as the agent said it. Resolved server-side via ilike on agent_applicants.full_name.' },
-        property_hint: { type: 'string', description: 'Optional development-name hint when the applicant has enquiries on more than one scheme.' },
-        scheduled_at_natural: { type: 'string', description: 'Natural-language date and time, e.g. "Tuesday 6pm", "tomorrow at 11", "next Monday 3pm". Parsed against Europe/Dublin.' },
-        duration_minutes: { type: 'number', description: 'Viewing length in minutes. Defaults to 30. Clamped to 5-240.' },
-        notes: { type: 'string', description: 'Optional notes captured from the agent\'s instruction (parking, joint viewing, anything specific).' },
-      },
-      required: ['applicant_name', 'scheduled_at_natural'],
-    },
-    execute: createViewing as ToolFunction,
   },
   {
     name: 'update_viewing',


### PR DESCRIPTION
## Summary
- Delete the `create_viewing` registration from the LLM tool registry. The model now sees exactly one scheduling tool: `schedule_viewings`.
- Drop `createViewing` from the `./viewing-tools` import.
- Rewrite the `schedule_viewings` description to reflect that it is the only scheduling tool (the old copy pointed at `create_viewing` as the fallback for single-existing-applicant cases).

Same pattern as session 3.3's removal of `schedule_viewing_draft`. The underlying `createViewing` / `confirmCreateViewing` function bodies stay in `viewing-tools.ts`. Internal scaffolding in `chat/route.ts` still string-matches on `'create_viewing'` in a draft-frame emitter; that branch is now dead but harmless, exactly mirroring how `schedule_viewing_draft` scaffolding was left after 3.3.

## Why
Forensic diagnosis from session 3.3 already confirmed the failure mode is tool selection, not tool logic:
- `scheduleViewings` (composite) correctly auto-creates unknown applicants via Phase 3's else branch (audited in PR #113).
- `createViewing` (single) fires a clarification when the applicant isn't found, before checking `property_hint` (viewing-tools.ts lines 70-88). That is the path the LLM hit on `"schedule a viewing for QA Lifecycle One at 4pm Thursday in Lakeside Manor"`.
- SQL check ruled out `applicant_ambiguous`: zero stale rows for the test name.

Removing `create_viewing` from the registry leaves the model only one choice, which is the correct one.

## Verification
- [x] `registry.ts` no longer contains a `create_viewing` registration entry.
- [x] `createViewing` removed from the registry imports.
- [x] `system-prompt.ts` already clean (3.3 removed model-facing references). Confirmed by grep.
- [x] `npm run build` passes.
- [x] Remaining `create_viewing` matches in the repo are only comments, the function definition itself, and the one dead string-literal check in `chat/route.ts`. No registry entries.

## Test plan
- [ ] `"schedule a viewing for QA Lifecycle One at 4pm Thursday in Lakeside Manor"` produces a composite card with QA Lifecycle One in `applicants_to_create` and the viewing at Lakeside Manor. No text clarification.
- [ ] `"schedule a viewing for [existing applicant] Tuesday 6pm"` still routes through `schedule_viewings` and renders the composite card.
- [ ] Update / cancel / mark-status flows still work (those tools are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)