### PR TITLE
chore: temporary chat route tracing for tool-call diagnosis

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -359,6 +359,12 @@ export async function POST(request: NextRequest) {
       "I hit an error while running that. Try again, or rephrase the request.";
 
     while (rounds <= MAX_TOOL_ROUNDS) {
+      // TEMP: remove after diagnosis
+      console.log('[CHAT_TRACE] pre-completion', {
+        round: rounds,
+        userMessage: (effectiveMessage || '').slice(0, 200),
+        toolsSent: tools.map((t) => t.function?.name).filter(Boolean),
+      });
       const completion = await openai.chat.completions.create({
         model: 'gpt-4o-mini',
         messages,
@@ -369,6 +375,24 @@ export async function POST(request: NextRequest) {
       });
 
       const responseMessage = completion.choices[0]?.message;
+      // TEMP: remove after diagnosis
+      console.log('[CHAT_TRACE] post-completion', {
+        round: rounds,
+        hasResponse: Boolean(responseMessage),
+        toolCalls: responseMessage?.tool_calls?.map((tc) => {
+          let args: unknown = tc.function?.arguments;
+          try {
+            args = JSON.parse(tc.function?.arguments ?? '{}');
+          } catch {
+            // keep raw string if not valid JSON
+          }
+          return { name: tc.function?.name, args };
+        }) ?? null,
+        textContent:
+          responseMessage && !responseMessage.tool_calls?.length
+            ? (responseMessage.content ?? '').slice(0, 300)
+            : null,
+      });
       if (!responseMessage) break;
 
       // If no tool calls, we have a final text response but it came non-streamed.
@@ -482,6 +506,14 @@ export async function POST(request: NextRequest) {
         } else {
           toolResult = JSON.stringify({ error: `Unknown tool: ${toolCall.function.name}` });
         }
+
+        // TEMP: remove after diagnosis
+        console.log('[CHAT_TRACE] tool-dispatch', {
+          round: rounds,
+          tool: toolCall.function.name,
+          hasToolDef: Boolean(toolDef),
+          resultPreview: (toolResult ?? '').slice(0, 300),
+        });
 
         messages.push({
           role: 'tool',


### PR DESCRIPTION
## Summary
Add three temporary \`[CHAT_TRACE]\` \`console.log\` lines inside the tool-call \`while\` loop in \`app/api/agent-intelligence/chat/route.ts\`. Logging only, no behaviour change.

Every new line is marked with \`// TEMP: remove after diagnosis\` so the revert is mechanical (3 log statements + their comment lines).

## Trace points
1. **pre-completion** (just before \`openai.chat.completions.create\`): round number, first 200 chars of the user message, the names of every tool sent to OpenAI on this turn.
2. **post-completion** (just after \`responseMessage\` is read): round number, the model's \`tool_calls\` array (name + parsed args) when present, otherwise the first 300 chars of text content.
3. **tool-dispatch** (just after the per-tool result is assembled, before pushing the tool message): round number, tool name, whether the registry resolved the tool, and the first 300 chars of the tool result string.

## Why
Diagnose the A1 failure on build \`f870b75\`. The model returned a text clarification instead of calling \`schedule_viewings\` on \`"schedule a viewing for QA Lifecycle One at 4pm Thursday in Lakeside Manor"\`. The trace will tell us whether \`schedule_viewings\` is being called at all, or the model is bailing out to a text-only refusal.

## Revert
\`\`\`bash
git grep -n "TEMP: remove after diagnosis" apps/unified-portal/app/api/agent-intelligence/chat/route.ts
\`\`\`
Each match identifies the comment immediately above a single \`console.log('[CHAT_TRACE]', ...)\` block. Delete the comment + log block per match.

## Test plan
- [ ] Vercel preview deploys
- [ ] Sending the same A1 prompt produces \`[CHAT_TRACE]\` lines in Vercel logs
- [ ] No behaviour change vs main: same UI response, same tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)