### PR TITLE
fix(agent): remove hardcoded names from prompts, tenant-scope capture query, widen mic visibility, em-dash cleanup

### DIFF
--- a/apps/unified-portal/app/agent/viewings/page.tsx
+++ b/apps/unified-portal/app/agent/viewings/page.tsx
@@ -40,19 +40,30 @@ interface ActiveAction {
 
 // "Captureable" = the viewing has happened in real life so a post-viewing
 // voice loop makes sense. We allow capture for any scheduled/confirmed
-// viewing whose start time is in the past OR within the next 2 hours
-// (an agent might tap straight after a viewing wraps but before the
-// official end time). Already-completed, no-shows, and cancellations
-// are out of scope, the voice loop wouldn't change the outcome.
+// viewing whose start time is today (in Europe/Dublin) or earlier. The
+// agent often only gets to their phone at the end of the day, so a
+// 9am-then-11am-then-2pm string of viewings all need to be captureable
+// from one Viewings tab visit later that evening. Already-completed,
+// no-shows, and cancellations are out of scope, the voice loop wouldn't
+// change the outcome.
 function isViewingCaptureable(v: Viewing, nowMs: number = Date.now()): boolean {
   // The API formatter remaps canonical status='scheduled' to 'confirmed'
   // before returning, so we only check the post-remap states here.
   if (v.status !== 'confirmed' && v.status !== 'pending') return false;
-  if (!v.viewingDate || !v.viewingTime) return false;
-  const iso = `${v.viewingDate}T${v.viewingTime.slice(0, 5)}:00`;
-  const scheduled = new Date(iso).getTime();
-  if (Number.isNaN(scheduled)) return false;
-  return scheduled - nowMs <= 2 * 60 * 60 * 1000;
+  if (!v.viewingDate) return false;
+  // Compare on YYYY-MM-DD in Dublin. viewingDate already arrives in
+  // Dublin-local form from the API formatter; build "today" the same
+  // way so a 4pm viewing on Tuesday stays captureable until midnight.
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  });
+  const parts: Record<string, string> = {};
+  for (const p of fmt.formatToParts(new Date(nowMs))) {
+    if (p.type !== 'literal') parts[p.type] = p.value;
+  }
+  const todayStr = `${parts.year}-${parts.month}-${parts.day}`;
+  return v.viewingDate <= todayStr;
 }
 
 export default function ViewingsPage() {

--- a/apps/unified-portal/app/api/agent-intelligence/transcribe-voice/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/transcribe-voice/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
     const message = error instanceof Error ? error.message : 'Transcription request failed';
     console.error('[agent-intelligence/transcribe-voice] Error:', message);
     return NextResponse.json(
-      { error: "Couldn't transcribe — try again.", details: message },
+      { error: "Couldn't transcribe. Try again.", details: message },
       { status: 500 },
     );
   }

--- a/apps/unified-portal/app/api/agent-intelligence/voice-capture/post-viewing/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/voice-capture/post-viewing/route.ts
@@ -108,7 +108,7 @@ export async function POST(request: NextRequest) {
       const message = err instanceof Error ? err.message : 'Transcription failed';
       console.error('[voice-capture/post-viewing] transcription error', { message });
       return NextResponse.json(
-        { error: "Couldn't transcribe — try again.", step: 'transcribe' },
+        { error: "Couldn't transcribe. Try again.", step: 'transcribe' },
         { status: 502 },
       );
     }

--- a/apps/unified-portal/app/api/agent/viewings/route.ts
+++ b/apps/unified-portal/app/api/agent/viewings/route.ts
@@ -109,7 +109,11 @@ export async function GET(request: NextRequest) {
     // button for a "Captured" badge; the Intelligence proactive prompt
     // uses it to suppress the "just finished?" card for already-captured
     // viewings.
-    const captureIds = await viewingIdsWithCapture(supabase, merged.map((v) => v.id));
+    const captureIds = await viewingIdsWithCapture(
+      supabase,
+      profile.tenant_id,
+      merged.map((v) => v.id),
+    );
     for (const v of merged) v.hasCapture = captureIds.has(v.id);
 
     console.log('[agent/viewings GET]', {

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -439,13 +439,13 @@ Worked example (sales - cancel viewing):
     fabrication and the worst possible failure mode.)
 
 Worked example (lettings - withdraw notice):
-  User: "Withdraw the notice we served on Aoife last week."
+  User: "Withdraw the notice we served on Mary Lynch last week."
   CORRECT:
-    "Understood, you want Aoife's notice withdrawn.
+    "Understood, you want Mary Lynch's notice withdrawn.
      Withdrawing a served notice is not available in this build.
-     You'll need to write to Aoife confirming the withdrawal in writing,
+     You'll need to write to her confirming the withdrawal in writing,
      then update the tenancy record in the Lettings tab manually."
-  INCORRECT: "Notice withdrawn, Aoife has been informed."
+  INCORRECT: "Notice withdrawn, Mary Lynch has been informed."
 
 NEVER use the phrasing "I can't [verb] yet from here" or any variant of
 that template. The destructive-verb refusal is always framed as the
@@ -623,13 +623,13 @@ You have two classes of tools:
 ============================================================
 MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
 ============================================================
-For voice-first and paste-first applicant management ("add Jack Murphy 087 123 4567", "remove Liam Daly", "update John Murphy's email to john@…", or pasted lists from email), call manage_applicants. Pass:
+For voice-first and paste-first applicant management ("add Tom Burke 087 123 4567", "remove Liam Daly", "update John Murphy's email to john@…", or pasted lists from email), call manage_applicants. Pass:
   - action: 'add' | 'update' | 'remove'
   - For add: \`applicants\` array AND/OR \`bulk_text\` for pasted lists (the deterministic parser pulls names + emails + Irish phone numbers).
   - For update: \`applicant_id\` plus \`updates\` (partial fields).
   - For remove: \`applicant_ids\`.
 
-NEVER invent email or phone. If the user says "add Jack Murphy" with nothing else, pass full_name only - the receipt makes the missing contact detail visible. NEVER fabricate an applicant_id; only use ids surfaced by a previous tool result in this conversation.
+NEVER invent email or phone. If the user says "add Tom Burke" with nothing else, pass full_name only - the receipt makes the missing contact detail visible. NEVER fabricate an applicant_id; only use ids surfaced by a previous tool result in this conversation.
 
 The result is one of two shapes:
   status: "draft" - the chat surface renders an ApplicantCard. The envelope carries \`mode\` ('always_confirm' or 'propose_undoable') so you know whether the agent will tap to confirm or whether the card auto-saves with a 30-second undo. Reply with one short sentence (<= 14 words) and DO NOT echo the candidate list, the diff, or the dependency warnings - the card already shows them.
@@ -715,9 +715,9 @@ You do NOT call transcription tools yourself. But:
 - Be aware that viewings with a "post-viewing voice capture" entry in
   their notes already had this loop run; the outcome, concerns, and
   next steps are recorded on the applicant.
-- When the agent asks follow-up questions like "what did Niamh say about
-  heating?" or "what did I commit to with Jack?", quote the relevant
-  captured notes from the applicant record.
+- When the agent asks follow-up questions like "what did the applicant
+  say about heating?" or "what did I commit to with them?", quote the
+  relevant captured notes from the applicant record.
 - When the agent in chat says "just had a viewing with X" or "finished
   viewing X", reply with one short sentence pointing them at the mic:
   "Tap the mic on that viewing's row to capture it, the voice loop is
@@ -1074,8 +1074,8 @@ Worked example (SALES mode):
     (66d), Unit 7 Lakeside Manor (51d), Unit 4 Westfield (44d). Two
     estimated closings overdue this week. Four sale-agreed buyers
     haven't signed in over a month."
-  INCORRECT: "Two leases expired last week, Aoife's BER expires in 26
-    days, three tenancies missing RTB registration..." (lettings
+  INCORRECT: "Two leases expired last week, a tenant's BER expires in
+    26 days, three tenancies missing RTB registration..." (lettings
     content in a sales workspace - never).
 
 Workspace mode "both" / unspecified: if the runtime ever combines both
@@ -1161,13 +1161,13 @@ Instead, respond honestly with three short lines:
   3. A clear manual path the agent can take in the app or externally.
 
 Worked example (lettings - withdraw notice):
-  User: "Withdraw the notice we served on Aoife last week."
+  User: "Withdraw the notice we served on Mary Lynch last week."
   CORRECT:
-    "Understood, you want Aoife's notice withdrawn.
+    "Understood, you want Mary Lynch's notice withdrawn.
      Withdrawing a served notice is not available in this build.
-     You'll need to write to Aoife confirming the withdrawal in writing,
+     You'll need to write to her confirming the withdrawal in writing,
      then update the tenancy record in the Lettings tab manually."
-  INCORRECT: "Notice withdrawn, Aoife has been informed."
+  INCORRECT: "Notice withdrawn, Mary Lynch has been informed."
     (The notice is still active in the system, that response is a
     fabrication.)
 
@@ -1275,9 +1275,9 @@ COMMON INTENTS - what to do when you see these patterns:
 
     Worked example (LETTINGS mode):
       User: "What should I be paying attention to today?"
-      CORRECT: "Two leases expired last week - Aoife at 7 Lapps Quay
-        (3 days overdue) and Mark at 12 Beechwood Park (5 days). Aoife's
-        BER also expires 26 May. Three tenancies missing RTB
+      CORRECT: "Two leases expired last week - Mary Lynch at 7 Lapps Quay
+        (3 days overdue) and Mark at 12 Beechwood Park (5 days). Mary
+        Lynch's BER also expires 26 May. Three tenancies missing RTB
         registration. One arrears note flagged on 4 Sycamore Lane."
       INCORRECT: "Three buyers haven't signed contracts at Lakeside, two
         closings are overdue this week, four sale-agreed buyers..."
@@ -1358,7 +1358,7 @@ You may call the draft and message tools the platform already provides (draft_me
 When the user asks you to draft, write, send, follow up with, chase, or message a tenant - ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent - nothing leaves the system until the agent explicitly approves.
 
 MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
-For "add Jack Murphy 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing (for anyone, on or off the list), call schedule_viewings - see the SCHEDULING A VIEWING section below.
+For "add Tom Burke 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing (for anyone, on or off the list), call schedule_viewings - see the SCHEDULING A VIEWING section below.
 
 SCHEDULING A VIEWING - USE schedule_viewings:
 For ANY request to schedule one or more viewings, call schedule_viewings. This covers a single viewing, multiple viewings in one turn, viewings for people not yet on the applicants list (the tool auto-creates them), viewings where the user named a property, and viewings where they did not. Do not pick between this and any other tool. The composite tool handles applicant creation atomically through a Postgres RPC. The chat surface renders one CompositeScheduleCard with one Confirm. NEVER invent email or phone for new applicants - pass full_name only inside the viewings array. When property is missing AND the applicant has no enquiry on file, the tool returns a needs_clarification asking which development; pass that question through to the user. When the applicant is brand new, the tool includes them in the applicants_to_create array. If the user states a calendar preference ("iPhone calendar"), pass calendar_preference; otherwise omit. One clarification question maximum. Never refuse a scheduling request - the tool handles every case.
@@ -1367,7 +1367,7 @@ MANAGING VIEWINGS - UPDATE, CANCEL, MARK STATUS:
 For changes to existing viewings: "reschedule X" or "move X to" → update_viewing. "Cancel X" → cancel_viewing (red confirmation button). "X didn't show" → mark_viewing_status with no_show. "Viewing with X went well" → mark_viewing_status with completed. Resolve the viewing by applicant name (and optional date hint). If the applicant has more than one viewing, ask one targeted question ("Which one, Thursday or Friday?") and re-call with the answer. Default to the next upcoming viewing if there is exactly one in the future. Calendar updates and deletions happen automatically; do not ask about calendar unless the user explicitly wants to skip it. NEVER invent a status change the user did not request - "mark as completed" must come from the user, not from inference.
 
 POST-VIEWING VOICE CAPTURE:
-Agents capture post-viewing context via a dedicated voice loop, not chat. A mic button on each viewing row records 15-90 seconds; the audio is transcribed, structured into outcome + notes + next actions + a follow-up draft, and the silent updates (status, applicant notes, reminders, audit log) land automatically. The follow-up email waits in the drafts queue for approval. You do NOT handle transcription. When the agent asks follow-up questions ("what did Niamh say about heating?"), quote the captured notes from the applicant record. When the agent says "just had a viewing with X" or "finished viewing X", reply with one short sentence: "Tap the mic on that viewing's row to capture it, the voice loop is faster than chat." Then stop. Do NOT call mark_viewing_status or draft a follow-up email here.
+Agents capture post-viewing context via a dedicated voice loop, not chat. A mic button on each viewing row records 15-90 seconds; the audio is transcribed, structured into outcome + notes + next actions + a follow-up draft, and the silent updates (status, applicant notes, reminders, audit log) land automatically. The follow-up email waits in the drafts queue for approval. You do NOT handle transcription. When the agent asks follow-up questions about a viewing ("what did the applicant say about heating?"), quote the captured notes from the applicant record. When the agent says "just had a viewing with X" or "finished viewing X", reply with one short sentence: "Tap the mic on that viewing's row to capture it, the voice loop is faster than chat." Then stop. Do NOT call mark_viewing_status or draft a follow-up email here.
 
 DRAFT_LEASE_RENEWAL - IMPORTANT:
 When the user says "renewal", "renew the lease", "draft renewal offer", "reminder about [tenant]'s renewal", "remind [tenant] about their renewal", "lease end reminder", "draft a reminder about the upcoming renewal", or taps a renewal suggestion chip, call draft_lease_renewal. ANY phrasing that combines a tenant with the words "renewal", "renew", or "lease end" routes here - including "reminder" framings. Do NOT call draft_message for these requests; the resulting draft would be tagged buyer_followup instead of lease_renewal and land in the wrong inbox bucket.
@@ -1375,9 +1375,9 @@ When the user says "renewal", "renew the lease", "draft renewal offer", "reminde
 When the user names a specific tenant, pass tenant_name extracted from their question (partial names are fine - the skill fuzzy-matches server-side). When they don't name a tenant, call with no arguments to draft for every tenancy in the window. NEVER invent a UUID-shaped string for tenancy_id; only pass tenancy_id if a previous tool result in this conversation surfaced a real one.
 
 Examples:
-  "Help me with Aoife O'Brien's lease renewal" → tenant_name: "Aoife O'Brien"
-  "Help me with Aoife's renewal"               → tenant_name: "Aoife"
-  "Remind Mark about his renewal"              → tenant_name: "Mark"
+  "Help me with Mary Lynch's lease renewal" → tenant_name: "Mary Lynch"
+  "Help me with Mary's renewal"             → tenant_name: "Mary"
+  "Remind Mark about his renewal"           → tenant_name: "Mark"
   "Draft renewals for everyone in the window"  → no arguments
   "Draft a renewal for the tenant at 14 Beechwood Park" → no arguments (let the skill draft for everyone in the window; clarify with the user if more than one matches)
   "This week's renewals"                       → no arguments
@@ -1460,7 +1460,7 @@ PROACTIVE INTELLIGENCE:
 ============================================================
 - Flag related issues the agent might not have thought of, but only when supported by the live context.
 - Call out RPZ implications on renewals (2% cap), upcoming lease ends inside the 90-day notice window, and missing RTB registrations on active tenancies.
-- The COMPLIANCE ATTENTION block in live context lists urgent compliance items (BER expired, BER expiring within 60 days, missing RTB). When discussing renewals or upcoming work, surface relevant compliance items proactively - "Aoife's renewal is due in 3 weeks AND her BER expires 26 May, worth handling both in the same conversation."
+- The COMPLIANCE ATTENTION block in live context lists urgent compliance items (BER expired, BER expiring within 60 days, missing RTB). When discussing renewals or upcoming work, surface relevant compliance items proactively - "Mary Lynch's renewal is due in 3 weeks AND her BER expires 26 May, worth handling both in the same conversation."
 - Never invent patterns or communication history.
 
 ============================================================

--- a/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
@@ -81,28 +81,28 @@ export interface PostViewingContext {
 
 const POST_VIEWING_SYSTEM_PROMPT = `You are the structured-extraction layer behind a post-viewing voice capture loop for an Irish property agent CRM.
 
-The agent has just finished a viewing. They speak for 15-90 seconds about how it went, what the applicant said, and what to do next. Your job is to convert that transcript into a structured action plan — and draft a short follow-up email in the agent's own voice.
+The agent has just finished a viewing. They speak for 15-90 seconds about how it went, what the applicant said, and what to do next. Your job is to convert that transcript into a structured action plan, and draft a short follow-up email in the agent's own voice.
 
 Return ONLY valid JSON matching the schema in the user message. Never invent details the agent did not say.
 
-OUTCOME — pick exactly one:
+OUTCOME (pick exactly one):
   - "high_interest": applicant strongly engaged, wants next step soon (second viewing, application, offer).
   - "mild_interest": polite but non-committal; reasonable to follow up.
   - "no_interest": applicant ruled the property out.
   - "callback_needed": applicant has a specific question or blocker that needs a follow-up before progressing.
   - "viewing_didnt_happen": agent reports the applicant didn't show or the viewing was cancelled in person.
 
-STRUCTURED NOTES — one entry per distinct thing the agent mentioned. Categories:
+STRUCTURED NOTES (one entry per distinct thing the agent mentioned). Categories:
   - "concern": something the applicant is worried about (heating bills, noise, commute).
   - "question": a question the applicant asked that the agent hasn't answered yet.
   - "next_step": something the AGENT explicitly committed to doing.
   - "general": colour the agent shared that doesn't fit the above.
 Keep each content to one short sentence in the agent's voice. Reuse the agent's own wording where possible.
 
-NEXT ACTIONS — explicit follow-ups the agent stated. ONLY emit when the agent stated it. If timing is vague ("later in the week") set timing to null and use details to capture the phrase. If timing is concrete ("Friday morning"), put a plain natural-language hint in timing — DO NOT invent a calendar date.
+NEXT ACTIONS (explicit follow-ups the agent stated). ONLY emit when the agent stated it. If timing is vague ("later in the week") set timing to null and use details to capture the phrase. If timing is concrete ("Friday morning"), put a plain natural-language hint in timing. DO NOT invent a calendar date.
 
-SUGGESTED FOLLOW-UP — a short draft email from the agent to the applicant. Required UNLESS outcome is "no_interest" or "viewing_didnt_happen" (then return null). Constraints:
-  - Open with "Hi <FirstName>," — use only the applicant's actual first name. No "Dear", no "Hello".
+SUGGESTED FOLLOW-UP (a short draft email from the agent to the applicant). Required UNLESS outcome is "no_interest" or "viewing_didnt_happen" (then return null). Constraints:
+  - Open with "Hi <FirstName>,". Use only the applicant's actual first name. No "Dear", no "Hello".
   - End with "Cheers," on its own line then the agent's first name on the next line.
   - Body: 2-4 short paragraphs, peer-to-peer Irish English. One professional talking to another.
   - Reference the specific concerns/questions the agent captured. Never invent details (no quoting prices, BER numbers, dates, dimensions the agent didn't mention).

--- a/apps/unified-portal/lib/agent-intelligence/transcription.ts
+++ b/apps/unified-portal/lib/agent-intelligence/transcription.ts
@@ -72,7 +72,7 @@ export async function transcribeAudio(
     );
   }
   throw new TranscriptionError(
-    "Couldn't transcribe — try again.",
+    "Couldn't transcribe. Try again.",
     'provider',
     lastError,
   );

--- a/apps/unified-portal/lib/agent-intelligence/voice-capture-status.ts
+++ b/apps/unified-portal/lib/agent-intelligence/voice-capture-status.ts
@@ -22,11 +22,14 @@ const VOICE_CAPTURE_SKILL = 'post_viewing_voice_capture';
 
 export async function hasCaptureForViewing(
   supabase: SupabaseClient,
+  tenantId: string,
   viewingId: string,
 ): Promise<boolean> {
+  if (!tenantId) return false;
   const { data, error } = await supabase
     .from('pending_drafts')
     .select('id')
+    .eq('tenant_id', tenantId)
     .eq('content_json->>skill', VOICE_CAPTURE_SKILL)
     .eq('content_json->affected_record->>id', viewingId)
     .limit(1);
@@ -37,16 +40,23 @@ export async function hasCaptureForViewing(
 /**
  * Batched variant for list views that need to annotate many viewings at once.
  * Returns a Set of viewing_ids that have at least one capture marker.
+ *
+ * Tenant-scoped: the route handler uses the service-role admin client which
+ * bypasses RLS, so this helper MUST filter by tenant_id explicitly to avoid
+ * a cross-tenant read.
  */
 export async function viewingIdsWithCapture(
   supabase: SupabaseClient,
+  tenantId: string,
   viewingIds: string[],
 ): Promise<Set<string>> {
   const out = new Set<string>();
+  if (!tenantId) return out;
   if (viewingIds.length === 0) return out;
   const { data, error } = await supabase
     .from('pending_drafts')
     .select('content_json')
+    .eq('tenant_id', tenantId)
     .eq('content_json->>skill', VOICE_CAPTURE_SKILL);
   if (error || !data) return out;
   const requested = new Set(viewingIds);


### PR DESCRIPTION
## Summary

Four hotfixes against PR #116 / #117 regressions surfaced in QA. Diagnoses from the prior forensic pass led to these specific patches.

### FIX 1 (P0) — Remove hardcoded names from system prompts

The POST-VIEWING VOICE CAPTURE section added in PR #116 named **"Niamh"** and **"Jack"** directly. Pre-existing worked examples used **"Aoife"** and **"Jack Murphy"**. Verified against the live demo Supabase:

```sql
SELECT full_name FROM agent_applicants WHERE full_name ILIKE ANY(ARRAY['%Niamh%','%Jack Murphy%']);
-- Jack Murphy
-- Niamh O'Brien
SELECT tenant_name FROM agent_tenancies WHERE tenant_name ILIKE '%Aoife%';
-- Aoife O'Brien
```

All three names match real seed-data records. That's a textbook statistical-pull pattern — the model encounters "Niamh" in its system prompt right before processing a user message containing "Niamh O'Brien", and biases away from the cleanly-named tool toward the prompt's mentioned context (drafts queue).

Replaced with generic conversational phrasing ("the applicant", "the tenant") for inline references, and synthetic names ("Mary Lynch", "Tom Burke") that don't exist in seed data for worked-example dialogue. Sales prompt + lettings prompt both updated.

### FIX 2 (P0) — Tenant-scope the capture-status query

`lib/agent-intelligence/voice-capture-status.ts` ran an unfiltered query against `pending_drafts` using the service-role admin client. Two functions now require `tenantId`:

```ts
export async function viewingIdsWithCapture(
  supabase: SupabaseClient,
  tenantId: string,
  viewingIds: string[],
): Promise<Set<string>> {
  ...
  .eq('tenant_id', tenantId)
  .eq('content_json->>skill', VOICE_CAPTURE_SKILL);
  ...
}
```

Caller in `GET /api/agent/viewings` threads `profile.tenant_id` through. Verified `pending_drafts.tenant_id` already exists (`uuid` column) so no migration needed. Closes a cross-tenant read and a performance time-bomb (359 drafts total in demo today, would scan all of them on every viewings fetch).

### FIX 4 (P1) — Widen mic visibility to "today or earlier"

Previous gate: "within next 2 hours OR in the past". Too tight — an agent finishing viewings at 9am / 11am / 2pm couldn't capture all three at end-of-day.

New gate: visible for any `confirmed`/`pending` viewing whose `viewingDate` is **today (in Europe/Dublin) or earlier**. Comparison is on the YYYY-MM-DD string the API already produces in Dublin-local form, so DST edges around midnight are correct.

The "Captured" badge suppression is preserved by the existing ternary (`hasCapture ? badge : isViewingCaptureable(v) ? mic : null`).

### FIX 5 (P2) — Em-dash cleanup in PR #116 files

Three user-facing error strings:
- `"Couldn't transcribe — try again."` → `"Couldn't transcribe. Try again."` in three routes (transcription.ts, transcribe-voice/route.ts, voice-capture/post-viewing/route.ts).

The `POST_VIEWING_SYSTEM_PROMPT` body itself in `voice-capture-tools.ts`: every em dash in section headers ("OUTCOME — pick exactly one") rewritten as colons or parentheses. The prompt's own BANNED PHRASES section explicitly forbids em dashes; the prompt now complies with its own rule. (Test files and JSDoc comments left as-is — no runtime impact.)

## What this does NOT fix

### FIX 3 (P0, deferred) — 17:00 misparse diagnosis

[CHAT_TRACE] logging is still active in `app/api/agent-intelligence/chat/route.ts` at lines 363/379/511 (added by PR #115). The `[CHAT_TRACE] post-completion` log captures `toolCalls[].name` + JSON-parsed `args`, so the `scheduled_at_natural` value the LLM passes to `schedule_viewings` will appear there.

This session has no Vercel-log access. Manual capture path:

```bash
vercel logs --since 5m --output=raw | grep CHAT_TRACE
# In the deployed UI: "schedule a viewing for Test Time at 9am today in Lakeside Manor"
# Read the post-completion line; check scheduled_at_natural value
```

Hypothesis: the LLM emits a bare `"5"` or literal `"5pm"`, lifted from the registry tool-description examples (`"Thursday 6pm"`, `"the 5pm one"`). Bare `"5"` then trips the 1-7 → +12 rule at `viewing-resolver.ts:52-55`, producing 17:00.

If confirmed: fix is in the system prompt — explicitly require `scheduled_at_natural` to include both the hour AND am/pm marker AND date reference, never bare numbers, never defaults.

### FIX 6 (P2, conditional) — Re-verify Niamh routing post-deploy

If FIX 1 resolves the email-action error: no further action. If not: capture CHAT_TRACE for the failing request to identify which tool the LLM is mis-routing to.

## Build / type-check

`npm run build` passes locally. `✓ Compiled successfully`. No new TypeScript errors introduced in modified files.

## Test plan

- [ ] Deploy to preview/prod. Send `"schedule a viewing for Niamh O'Brien at 9am today in Lakeside Manor"`. Verify it lands on `schedule_viewings` (not a draft skill).
- [ ] Same prompt with `Jack Murphy`. Should also work.
- [ ] Send `"what did Niamh say about heating?"` — model should quote captured notes (or say "no notes yet"), NOT loop.
- [ ] Sign in as one tenant, view `/agent/viewings`. Sign in as another tenant. Verify no cross-tenant "Captured" badges appear.
- [ ] Schedule a viewing for today at 9am. Confirm. Then at end of day (after 5pm) verify the mic icon is still visible on that row.
- [ ] CHAT_TRACE log capture for FIX 3 (manual). Report `scheduled_at_natural` value from `"schedule a viewing for X at 9am today"`.

https://claude.ai/code/session_01PWu3MXC2NaxEhoCYhaStM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWu3MXC2NaxEhoCYhaStM7)_