### PR TITLE
fix(agent): hard rule against LLM value invention + mic visibility status

### DIFF
--- a/apps/unified-portal/app/agent/viewings/page.tsx
+++ b/apps/unified-portal/app/agent/viewings/page.tsx
@@ -23,7 +23,7 @@ interface Viewing {
   viewingDate: string;
   viewingTime: string;
   durationMinutes?: number;
-  status: 'confirmed' | 'pending' | 'completed' | 'cancelled' | 'no_show';
+  status: 'scheduled' | 'confirmed' | 'pending' | 'completed' | 'cancelled' | 'no_show';
   notes?: string;
   source?: string;
   developmentId?: string | null;
@@ -47,9 +47,12 @@ interface ActiveAction {
 // no-shows, and cancellations are out of scope, the voice loop wouldn't
 // change the outcome.
 function isViewingCaptureable(v: Viewing, nowMs: number = Date.now()): boolean {
-  // The API formatter remaps canonical status='scheduled' to 'confirmed'
-  // before returning, so we only check the post-remap states here.
-  if (v.status !== 'confirmed' && v.status !== 'pending') return false;
+  // The API formatter usually remaps canonical status='scheduled' to
+  // 'confirmed' before returning, but the live DB rows we've seen come
+  // back with status='scheduled' (the remap path is bypassed for at
+  // least one code path). Accept all three values so the mic shows up
+  // either way.
+  if (v.status !== 'confirmed' && v.status !== 'scheduled' && v.status !== 'pending') return false;
   if (!v.viewingDate) return false;
   // Compare on YYYY-MM-DD in Dublin. viewingDate already arrives in
   // Dublin-local form from the API formatter; build "today" the same

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -644,6 +644,21 @@ For any "schedule a viewing" request, call schedule_viewings (see SCHEDULING A V
 ============================================================
 SCHEDULING A VIEWING - USE schedule_viewings:
 ============================================================
+
+FAITHFUL EXTRACTION - HARD RULE:
+When calling schedule_viewings, you MUST pass values exactly as the user stated them. Never substitute. Never paraphrase. Never lift example strings from this prompt or from the tool description.
+
+  - applicant_name: pass the FULL name the user gave, not a truncation. A two-word name stays two words. A name with a surname stays with the surname.
+  - scheduled_at_natural: pass the EXACT time string the user used. If they said "9am today", pass "9am today". Do not change "9am" to "5pm". Do not drop "today". Do not invent a different weekday.
+  - property_hint: pass exactly what the user typed for the scheme or address.
+
+If the user did not state a value clearly, return needs_clarification with the right reason instead of guessing:
+  - Missing time: return needs_clarification, reason no_time_specified. Do NOT default to any time.
+  - Missing name: return needs_clarification, reason no_applicant_specified. Do NOT invent.
+  - Missing property: return needs_clarification, reason no_property_specified. Do NOT invent.
+
+NEVER pull values from this prompt's examples or from the tool description examples. Those are illustrations of structure, not defaults. Bare numbers, bare weekdays, or generic placeholders are NEVER acceptable tool arguments. If you cannot find the user's literal value in the current message, ask.
+
 For ANY request to schedule one or more viewings, call schedule_viewings. This includes:
   - One viewing for one person.
   - Multiple viewings in one turn.
@@ -1361,6 +1376,18 @@ MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
 For "add Tom Burke 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing (for anyone, on or off the list), call schedule_viewings - see the SCHEDULING A VIEWING section below.
 
 SCHEDULING A VIEWING - USE schedule_viewings:
+
+FAITHFUL EXTRACTION - HARD RULE:
+When calling schedule_viewings, you MUST pass values exactly as the user stated them. Never substitute. Never paraphrase. Never lift example strings from this prompt or from the tool description.
+  - applicant_name: pass the FULL name the user gave, not a truncation. A two-word name stays two words. A name with a surname stays with the surname.
+  - scheduled_at_natural: pass the EXACT time string the user used. If they said "9am today", pass "9am today". Do not change "9am" to "5pm". Do not drop "today". Do not invent a different weekday.
+  - property_hint: pass exactly what the user typed for the scheme or address.
+If the user did not state a value clearly, return needs_clarification with the right reason instead of guessing:
+  - Missing time: return needs_clarification, reason no_time_specified. Do NOT default to any time.
+  - Missing name: return needs_clarification, reason no_applicant_specified. Do NOT invent.
+  - Missing property: return needs_clarification, reason no_property_specified. Do NOT invent.
+NEVER pull values from this prompt's examples or from the tool description examples. Those are illustrations of structure, not defaults. Bare numbers, bare weekdays, or generic placeholders are NEVER acceptable tool arguments. If you cannot find the user's literal value in the current message, ask.
+
 For ANY request to schedule one or more viewings, call schedule_viewings. This covers a single viewing, multiple viewings in one turn, viewings for people not yet on the applicants list (the tool auto-creates them), viewings where the user named a property, and viewings where they did not. Do not pick between this and any other tool. The composite tool handles applicant creation atomically through a Postgres RPC. The chat surface renders one CompositeScheduleCard with one Confirm. NEVER invent email or phone for new applicants - pass full_name only inside the viewings array. When property is missing AND the applicant has no enquiry on file, the tool returns a needs_clarification asking which development; pass that question through to the user. When the applicant is brand new, the tool includes them in the applicants_to_create array. If the user states a calendar preference ("iPhone calendar"), pass calendar_preference; otherwise omit. One clarification question maximum. Never refuse a scheduling request - the tool handles every case.
 
 MANAGING VIEWINGS - UPDATE, CANCEL, MARK STATUS:

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -439,12 +439,12 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: 'draft_lease_renewal',
-    description: 'Draft lease renewal offers for tenancies in the renewal window (recently expired through next 90 days). Calculates RPZ-compliant rent uplift where applicable. Returns drafts for tenant approval. Pass `tenant_name` to scope to a single tenant when the user names one ("Aoife O\'Brien\'s renewal", "remind Mark"); fuzzy-matches against agent_tenancies.tenant_name. Pass nothing to draft for every tenancy in the window.',
+    description: 'Draft lease renewal offers for tenancies in the renewal window (recently expired through next 90 days). Calculates RPZ-compliant rent uplift where applicable. Returns drafts for tenant approval. Pass `tenant_name` to scope to a single tenant when the user names one (e.g. "<tenant first name>\'s renewal", "remind <tenant first name>"); fuzzy-matches against agent_tenancies.tenant_name. Pass nothing to draft for every tenancy in the window.',
     parameters: {
       type: 'object',
       properties: {
         tenancy_id: { type: 'string', description: 'Optional tenancy id to draft for a single renewal. Only pass when a previous tool result surfaced a real tenancy id; never invent one.' },
-        tenant_name: { type: 'string', description: 'Optional tenant name (partial OK — "Aoife", "Mark Donnelly") to scope the renewal to one tenancy. Resolved server-side via fuzzy ILIKE match against agent_tenancies.tenant_name.' },
+        tenant_name: { type: 'string', description: 'Optional tenant name (partial OK, e.g. a first name or a full name) to scope the renewal to one tenancy. Resolved server-side via fuzzy ILIKE match against agent_tenancies.tenant_name.' },
       },
       required: [],
     },
@@ -467,7 +467,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'manage_applicants',
     description: [
-      'Add, update or remove applicants on the agent\'s books. Voice-first and paste-first — the agent says "add Jack Murphy 087 123 4567" or pastes a list of names from an email.',
+      'Add, update or remove applicants on the agent\'s books. Voice-first and paste-first. The agent says "add <full name as stated> <phone number as stated>" or pastes a list of names from an email.',
       'NEVER writes on its own. Always returns a draft envelope; the agent confirms in the chat card. The agent\'s applicant_write_mode setting decides whether the card auto-confirms with undo (propose_undoable) or waits for an explicit tap (always_confirm). The mode is included in the result so the model can phrase its reply accordingly.',
       'Inputs by action:',
       '  add — pass `applicants` (one or more {full_name, email?, phone?, notes?, source?}) AND/OR `bulk_text` for raw pasted lists. The bulk parser is deterministic (regex over Irish phone formats and the common "Name <email>" / "Name (phone)" / comma / pipe / table shapes). Never invent email or phone — leave them null when the user did not provide them.',
@@ -536,8 +536,8 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
           items: {
             type: 'object',
             properties: {
-              applicant_name: { type: 'string', description: 'Name of the person the viewing is for, exactly as the user said it.' },
-              scheduled_at_natural: { type: 'string', description: 'Natural-language time, e.g. "Thursday 6pm". Parsed against Europe/Dublin.' },
+              applicant_name: { type: 'string', description: 'The applicant\'s FULL name exactly as the user stated it. Never truncate (a full name stays a full name; do not drop the surname). Never substitute. Never lift any example name from this description or any other prompt: pass only the literal name the current user message contains.' },
+              scheduled_at_natural: { type: 'string', description: 'The time the user stated, verbatim. Examples of the shape (NOT defaults): "<weekday> <time as user said it>", "tomorrow at <time as user said it>", "today at <time as user said it>". Always include both day reference and time AND am/pm if the user said am/pm. NEVER substitute a different time. NEVER lift one of these example strings as a literal. If the user did not state a time, return needs_clarification rather than guessing. Parsed against Europe/Dublin.' },
               property_hint: { type: 'string', description: 'Development name. Required for new applicants since they have no enquiries yet.' },
               duration_minutes: { type: 'number', description: 'Defaults to 30. Clamped to 5-240.' },
               notes: { type: 'string', description: 'Optional note to record on the viewing.' },
@@ -558,7 +558,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'update_viewing',
     description: [
-      'Reschedule or edit an existing viewing. Use when the user wants to change the time, date, property, duration, or notes on a viewing already on the books ("reschedule Jack to 7pm Friday", "move that viewing to Lakeside Manor", "change the duration to 45 minutes").',
+      'Reschedule or edit an existing viewing. Use when the user wants to change the time, date, property, duration, or notes on a viewing already on the books (e.g. "reschedule <applicant> to <new time as user said it>", "move that viewing to <scheme as user said it>", "change the duration to 45 minutes").',
       'Resolves the viewing by applicant name (and optional date hint). If the applicant has multiple viewings, returns needs_clarification with the candidates so you can ask one targeted question.',
       'Returns either { status: "draft", type: "viewing_update", ... } for the chat card, or { status: "needs_clarification", reason, message }. The chat surface renders one ViewingMutationCard with a previous → next diff. NEVER claim the change has been saved before the agent confirms the card.',
     ].join(' '),
@@ -570,7 +570,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
           description: 'How to identify the viewing.',
           properties: {
             applicant_name: { type: 'string', description: 'Applicant name as the user said it.' },
-            scheduled_at_natural: { type: 'string', description: 'Optional date/time hint to disambiguate when the applicant has multiple viewings ("Thursday viewing", "the 5pm one").' },
+            scheduled_at_natural: { type: 'string', description: 'Optional date/time hint, verbatim from the user, to disambiguate when the applicant has multiple viewings (e.g. "<weekday> viewing", "the <time the user said> one"). NEVER substitute a different time.' },
             viewing_id: { type: 'string', description: 'Optional explicit viewing UUID, only when surfaced by a previous tool result.' },
           },
         },
@@ -578,7 +578,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
           type: 'object',
           description: 'Fields to change. Pass only what the user asked to change.',
           properties: {
-            scheduled_at_natural: { type: 'string', description: 'New date/time, natural language ("Friday 7pm").' },
+            scheduled_at_natural: { type: 'string', description: 'New date/time, verbatim from the user (e.g. "<weekday> <new time as user said it>"). NEVER substitute. Always include both day reference and time the user actually stated.' },
             duration_minutes: { type: 'number', description: 'New length in minutes. Clamped 5-240.' },
             property_hint: { type: 'string', description: 'New development name. Resolved against the agent\'s assigned schemes.' },
             notes: { type: 'string', description: 'New notes. Pass empty string to clear.' },
@@ -592,7 +592,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'cancel_viewing',
     description: [
-      'Cancel a viewing that is on the books. Use when the user says "cancel Jack\'s viewing", "X cancelled", "scrap that viewing", or any clear cancellation phrasing.',
+      'Cancel a viewing that is on the books. Use when the user says "cancel <applicant>\'s viewing", "X cancelled", "scrap that viewing", or any clear cancellation phrasing.',
       'Resolves the viewing by applicant name (and optional date hint). Returns a draft envelope; the agent confirms via a red Confirm button on the ViewingMutationCard. Status moves to cancelled and any device calendar event is removed.',
       'NEVER call cancel_viewing for a request to remove or delete the applicant themselves, that is manage_applicants action="remove".',
     ].join(' '),
@@ -617,7 +617,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'mark_viewing_status',
     description: [
-      'Mark a viewing as no_show or completed after the fact. Use when the user reports outcome ("Jack didn\'t show", "viewing with X went well", "Sarah turned up", "X was a no-show").',
+      'Mark a viewing as no_show or completed after the fact. Use when the user reports outcome (e.g. "<applicant> didn\'t show", "viewing with <applicant> went well", "<applicant> turned up", "<applicant> was a no-show").',
       'Status no_show ONLY when the user clearly says someone did not attend. Status completed ONLY when the user clearly indicates the viewing happened. Do NOT infer either from a generic mention of the applicant.',
       'Returns a draft envelope for confirmation. The historical calendar event is preserved (no calendar action).',
     ].join(' '),


### PR DESCRIPTION
## Summary

Three surgical fixes against the PR #118 smoke-test residuals.

### FIX A (P0) — Anchor the LLM to user-stated values

**Evidence from PR #118 smoke test (live DB):**
- Test 2 produced two rows in `viewings`:
  - `Aoife O'Brien` at 17:00 UTC (LLM invented PM time)
  - `test` at 08:00 UTC (LLM truncated "Test Time" to "test")
- When the LLM gets times right, the DB stores them correctly.
- When wrong, it's lifting PM examples from registry tool descriptions and truncating names.

**Two layers of fix:**

`lib/agent-intelligence/system-prompt.ts` (sales + lettings prompts):
A new **FAITHFUL EXTRACTION — HARD RULE** subsection placed FIRST inside the SCHEDULING A VIEWING block (maximum prompt-position weight). It says: pass `applicant_name`, `scheduled_at_natural`, `property_hint` exactly as the user stated them. Never substitute. Never paraphrase. Never lift example strings from prompts or tool descriptions. If a value is missing, return `needs_clarification` with reason `no_time_specified` / `no_applicant_specified` / `no_property_specified` rather than guessing.

`lib/agent-intelligence/tools/registry.ts`:
Removed every concrete literal that could become a statistical default:
- `schedule_viewings.scheduled_at_natural`: dropped `"Thursday 6pm"`; new description uses shape placeholders (`"<weekday> <time as user said it>"`) and explicit NEVER-substitute language.
- `schedule_viewings.applicant_name`: FULL name only, no truncation, no example names.
- `update_viewing.scheduled_at_natural` (both fields): dropped `"Thursday viewing"`, `"the 5pm one"`, `"Friday 7pm"`. Shape placeholders only.
- `draft_lease_renewal`: dropped `"Aoife O'Brien's renewal"`, `"Mark Donnelly"`. Now `"<tenant first name>"` / `"<full name>"`.
- `manage_applicants`: dropped `"Jack Murphy 087 123 4567"`.
- `cancel_viewing`: dropped `"Jack's viewing"`.
- `mark_viewing_status`: dropped `"Jack didn't show"`, `"Sarah turned up"`.

Post-edit grep for `6pm|5pm|7pm|8pm|Niamh|Sean|Aoife|Jack[^_]|Mark Donnelly|Sarah Collins` against `registry.ts` returns **zero hits**.

### FIX B (P0) — Mic visibility status

`apps/unified-portal/app/agent/viewings/page.tsx`, `isViewingCaptureable`:
Was checking `status === 'confirmed' || 'pending'`. The API formatter is supposed to remap canonical `status='scheduled'` to `'confirmed'`, but live SQL confirms at least one code path bypasses the remap (DB rows arrive at the page with `status='scheduled'`). Helper now also accepts `'scheduled'`, and the `Viewing.status` type union extended accordingly. Defence in depth — works whether the remap fires or not.

```sql
-- Live evidence:
SELECT id, scheduled_at, status FROM viewings
WHERE tenant_id = '4cee69c6-...' ORDER BY created_at DESC LIMIT 5;
-- => status: 'scheduled' (both rows)
```

PR #118's "today or earlier" widening is intact (verified via `git show 5100687 -- apps/unified-portal/app/agent/viewings/page.tsx` — the `return v.viewingDate <= todayStr` line is present).

### FIX C (P2) — Registry audit

Done as part of FIX A. No additional real-data leakage in tool descriptions remains.

## Build / em-dash audit

- `npm run build` → `✓ Compiled successfully`.
- `git diff` em-dash count: **0**.

## Verification (post-deploy)

- [ ] `"Schedule for Niamh O'Brien at 9am today"` → composite card with Niamh + Lakeside Manor + **9am**. Repeat 10x; all 9am.
- [ ] `"Schedule for Test Person at 3pm Friday"` → composite card with **Test Person** (full name preserved) + 3pm.
- [ ] `"Schedule for Sean Murphy"` (no time) → `needs_clarification` asking for the time. No PM default.
- [ ] Viewings tab shows a mic icon on rows with DB `status='scheduled'`.
- [ ] No PM-flavoured times appear in `registry.ts` or in either system prompt's examples.

## PR #118 deployment check

PR #118 (`5100687`) is merged into `main`. The widening change (`return v.viewingDate <= todayStr;`) is present in `main`. No merge conflict, no silent revert. The mic-still-not-showing bug was status-related, not window-related.

https://claude.ai/code/session_01PWu3MXC2NaxEhoCYhaStM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWu3MXC2NaxEhoCYhaStM7)_