### PR TITLE
Care Batch 1.1: requireCareSession helper closes P0 cross-tenant route cluster

### DIFF
--- a/apps/unified-portal/app/api/care/activity-log/route.ts
+++ b/apps/unified-portal/app/api/care/activity-log/route.ts
@@ -1,28 +1,30 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export async function GET() {
-  const supabase = getSupabaseAdmin();
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  const { data, error } = await supabase
-    .from('activity_log')
-    .select('id, tenant_id, installation_id, activity_type, description, created_at')
-    .order('created_at', { ascending: false })
-    .limit(8);
+    const { data, error } = await supabase
+      .from('activity_log')
+      .select('id, tenant_id, installation_id, activity_type, description, created_at')
+      .eq('tenant_id', session.tenantId)
+      .order('created_at', { ascending: false })
+      .limit(8);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ activities: data || [] });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch activity log' }, { status: 500 });
   }
-
-  return NextResponse.json({ activities: data || [] });
 }

--- a/apps/unified-portal/app/api/care/dashboard-stats/route.ts
+++ b/apps/unified-portal/app/api/care/dashboard-stats/route.ts
@@ -1,27 +1,29 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export async function GET() {
-  const supabase = getSupabaseAdmin();
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  const { data, error } = await supabase
-    .from('installations')
-    .select('*')
-    .order('created_at', { ascending: false });
+    const { data, error } = await supabase
+      .from('installations')
+      .select('*')
+      .eq('tenant_id', session.tenantId)
+      .order('created_at', { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ installations: data || [] });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch dashboard stats' }, { status: 500 });
   }
-
-  return NextResponse.json({ installations: data || [] });
 }

--- a/apps/unified-portal/app/api/care/diagnostic-flows/route.ts
+++ b/apps/unified-portal/app/api/care/diagnostic-flows/route.ts
@@ -1,55 +1,57 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export async function GET() {
-  const supabase = getSupabaseAdmin();
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  const { data, error } = await supabase
-    .from('diagnostic_flows')
-    .select(`
-      id,
-      name,
-      description,
-      system_type,
-      status,
-      icon,
-      colour,
-      steps,
-      stats_started,
-      stats_resolved,
-      stats_escalated,
-      created_at,
-      updated_at
-    `)
-    .order('stats_started', { ascending: false });
+    const { data, error } = await supabase
+      .from('diagnostic_flows')
+      .select(`
+        id,
+        name,
+        description,
+        system_type,
+        status,
+        icon,
+        colour,
+        steps,
+        stats_started,
+        stats_resolved,
+        stats_escalated,
+        created_at,
+        updated_at,
+        tenant_id
+      `)
+      .eq('tenant_id', session.tenantId)
+      .order('stats_started', { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const flows = (data || []).map((f: Record<string, unknown>) => {
+      const steps = f.steps as unknown[] | null;
+      return {
+        id: f.id,
+        flow_name: f.name,
+        description: f.description,
+        system_type: f.system_type,
+        step_count: Array.isArray(steps) ? steps.length : 0,
+        times_triggered: (f.stats_started as number) || 0,
+        updated_at: f.updated_at,
+      };
+    });
+
+    return NextResponse.json({ flows });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch diagnostic flows' }, { status: 500 });
   }
-
-  // Map to friendlier shape
-  const flows = (data || []).map((f: Record<string, unknown>) => {
-    const steps = f.steps as unknown[] | null;
-    return {
-      id: f.id,
-      flow_name: f.name,
-      description: f.description,
-      system_type: f.system_type,
-      step_count: Array.isArray(steps) ? steps.length : 0,
-      times_triggered: (f.stats_started as number) || 0,
-      updated_at: f.updated_at,
-    };
-  });
-
-  return NextResponse.json({ flows });
 }

--- a/apps/unified-portal/app/api/care/dismiss-alert/route.ts
+++ b/apps/unified-portal/app/api/care/dismiss-alert/route.ts
@@ -1,6 +1,9 @@
 /**
  * POST /api/care/dismiss-alert
  * Removes a dismissed alert from the installation's active_safety_alerts JSONB array.
+ *
+ * Homeowner-side route (called from /care/[installationId]/HeatPumpHomeContent).
+ * Auth model deferred to Batch 2: homeowner session design.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -30,7 +33,6 @@ export async function POST(request: NextRequest) {
 
     const supabase = getSupabaseAdmin();
 
-    // Fetch current active_safety_alerts
     const { data: installation, error: fetchError } = await supabase
       .from('installations')
       .select('id, active_safety_alerts')
@@ -49,12 +51,10 @@ export async function POST(request: NextRequest) {
         ? installation.active_safety_alerts
         : [];
 
-    // Remove the dismissed alert by id
     const updatedAlerts = currentAlerts.filter(
       (alert) => alert.id !== alertId && alert.alert_id !== alertId
     );
 
-    // Update the installation
     const { error: updateError } = await supabase
       .from('installations')
       .update({ active_safety_alerts: updatedAlerts })

--- a/apps/unified-portal/app/api/care/installations-all/route.ts
+++ b/apps/unified-portal/app/api/care/installations-all/route.ts
@@ -1,15 +1,11 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
 
 // Mirrors migration 041: normalise legacy demo data at the API boundary so the
 // UI stays consistent even if the migration has not been run yet.
@@ -31,18 +27,24 @@ function normaliseInstallation(row: Record<string, unknown>) {
 }
 
 export async function GET() {
-  const supabase = getSupabaseAdmin();
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  const { data, error } = await supabase
-    .from('installations')
-    .select('*')
-    .order('install_date', { ascending: false, nullsFirst: false })
-    .order('created_at', { ascending: false });
+    const { data, error } = await supabase
+      .from('installations')
+      .select('*')
+      .eq('tenant_id', session.tenantId)
+      .order('install_date', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const installations = (data || []).map(normaliseInstallation);
+    return NextResponse.json({ installations });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch installations' }, { status: 500 });
   }
-
-  const installations = (data || []).map(normaliseInstallation);
-  return NextResponse.json({ installations });
 }

--- a/apps/unified-portal/app/api/care/installations/[id]/route.ts
+++ b/apps/unified-portal/app/api/care/installations/[id]/route.ts
@@ -1,20 +1,17 @@
 export const dynamic = 'force-dynamic'
 
 /**
- * GET /api/care/installations/[id] — Get installation details + telemetry
- * PUT /api/care/installations/[id] — Update installation
+ * GET /api/care/installations/[id]: Get installation details + telemetry
+ * PUT /api/care/installations/[id]: Update installation
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import { fetchSolarEdgeData } from '@/lib/care/solarEdgeApi';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
-}
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareSession,
+} from '@/lib/care/require-care-session';
 
 /**
  * GET: Installation details + current telemetry + performance summary
@@ -24,46 +21,29 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const installationId = params.id;
+    const { supabase, installation } = await requireCareSession({
+      installationId: params.id,
+    });
 
-    const supabase = getSupabaseAdmin();
-
-    // Get installation
-    const { data: installation, error: instError } = await supabase
-      .from('installations')
-      .select('*')
-      .eq('id', installationId)
-      .single();
-
-    if (instError || !installation) {
-      return NextResponse.json(
-        { error: 'Installation not found' },
-        { status: 404 }
-      );
-    }
-
-    // Get latest telemetry
-    const { data: telemetry, error: telError } = await supabase
+    // Get latest telemetry (24h)
+    const { data: telemetry } = await supabase
       .from('installation_telemetry')
       .select('*')
-      .eq('installation_id', installationId)
+      .eq('installation_id', installation.id)
       .order('recorded_at', { ascending: false })
-      .limit(24); // Last 24 hours
-
-    if (telError) {
-    }
+      .limit(24);
 
     // For solar systems, optionally fetch real SolarEdge data
     let solarData = null;
     if (installation.system_type === 'solar' && installation.telemetry_source === 'solarEdge') {
       try {
         solarData = await fetchSolarEdgeData(
-          installation.serial_number,
-          installation.telemetry_api_key // decrypted in production
+          installation.serial_number as string,
+          installation.telemetry_api_key as string, // decrypted in production
         );
       } catch (error) {
-        // Fall back to mock
         const { getMockDailyProfile } = await import('@/lib/care/solarEdgeApi');
+        void getMockDailyProfile;
         solarData = {
           generation: {
             today: 18.4 + Math.random() * 5,
@@ -82,7 +62,7 @@ export async function GET(
     const { data: alerts } = await supabase
       .from('installation_alerts')
       .select('*')
-      .eq('installation_id', installationId)
+      .eq('installation_id', installation.id)
       .order('created_at', { ascending: false })
       .limit(10);
 
@@ -92,21 +72,26 @@ export async function GET(
       solarData,
       alerts: alerts || [],
       summary: {
-        daysActive: Math.floor(
-          (new Date().getTime() - new Date(installation.installation_date).getTime()) / (1000 * 60 * 60 * 24)
-        ),
+        daysActive: installation.installation_date
+          ? Math.floor(
+              (new Date().getTime() - new Date(installation.installation_date as string).getTime()) /
+                (1000 * 60 * 60 * 24),
+            )
+          : null,
         warrantyRemaining: installation.warranty_expiry
           ? Math.ceil(
-              (new Date(installation.warranty_expiry).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
+              (new Date(installation.warranty_expiry as string).getTime() - new Date().getTime()) /
+                (1000 * 60 * 60 * 24),
             )
           : null,
         adoptionStatus: installation.adoption_status,
       },
     });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return NextResponse.json(
       { error: 'Failed to fetch installation' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -119,10 +104,10 @@ export async function PUT(
   { params }: { params: { id: string } }
 ) {
   try {
-    const installationId = params.id;
+    const { supabase, session, installation } = await requireCareSession({
+      installationId: params.id,
+    });
     const updates = await request.json();
-
-    const supabase = getSupabaseAdmin();
 
     // Only allow certain fields to be updated
     const allowedFields = ['adoption_status', 'adopted_at', 'notes', 'homeowner_email', 'component_specs'];
@@ -133,15 +118,17 @@ export async function PUT(
         return obj;
       }, {} as Record<string, any>);
 
-    // If adoption_status is changing to 'active', set adopted_at
     if (filteredUpdates.adoption_status === 'active' && !filteredUpdates.adopted_at) {
       filteredUpdates.adopted_at = new Date().toISOString();
     }
 
+    // Defence in depth: even though requireCareSession already verified
+    // tenant ownership, the update filter explicitly restates it.
     const { data, error } = await supabase
       .from('installations')
       .update(filteredUpdates)
-      .eq('id', installationId)
+      .eq('id', installation.id)
+      .eq('tenant_id', session.tenantId)
       .select()
       .single();
 
@@ -149,9 +136,10 @@ export async function PUT(
 
     return NextResponse.json({ installation: data });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return NextResponse.json(
       { error: 'Failed to update installation' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/apps/unified-portal/app/api/care/installations/onboard/route.ts
+++ b/apps/unified-portal/app/api/care/installations/onboard/route.ts
@@ -1,16 +1,12 @@
 export const dynamic = 'force-dynamic'
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 function generateAccessCode(): string {
   return crypto.randomBytes(3).toString('hex').toUpperCase();
@@ -18,6 +14,7 @@ function generateAccessCode(): string {
 
 export async function POST(request: NextRequest) {
   try {
+    const { supabase, session } = await requireCareTenantSession();
     const body = await request.json();
     const {
       customer_name,
@@ -41,16 +38,16 @@ export async function POST(request: NextRequest) {
     if (!customer_name || !address_line_1 || !city || !job_reference) {
       return NextResponse.json(
         { error: 'Missing required fields: customer_name, address_line_1, city, job_reference' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const supabase = getSupabaseAdmin();
     const access_code = generateAccessCode();
 
     const { data: installation, error } = await supabase
       .from('installations')
       .insert({
+        tenant_id: session.tenantId,
         customer_name,
         customer_email: customer_email || null,
         customer_phone: customer_phone || null,
@@ -80,7 +77,7 @@ export async function POST(request: NextRequest) {
       if (error.code === '23505') {
         return NextResponse.json(
           { error: 'A installation with this job reference already exists' },
-          { status: 409 }
+          { status: 409 },
         );
       }
       throw error;
@@ -88,9 +85,10 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ installation });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return NextResponse.json(
       { error: 'Failed to create installation' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/apps/unified-portal/app/api/care/installations/route.ts
+++ b/apps/unified-portal/app/api/care/installations/route.ts
@@ -1,41 +1,38 @@
 export const dynamic = 'force-dynamic'
 
 /**
- * GET /api/care/installations — List installations for tenant
- * POST /api/care/installations — Create new installation
+ * GET /api/care/installations: List installations for tenant
+ * POST /api/care/installations: Create new installation
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
-  );
-}
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 /**
- * GET: List installations for a development
+ * GET: List installations for a development (scoped to caller's tenant)
  */
 export async function GET(request: NextRequest) {
   try {
+    const { supabase, session } = await requireCareTenantSession();
     const { searchParams } = new URL(request.url);
     const developmentId = searchParams.get('developmentId');
 
     if (!developmentId) {
       return NextResponse.json(
         { error: 'developmentId required' },
-        { status: 400 }
+        { status: 400 },
       );
     }
-
-    const supabase = getSupabaseAdmin();
 
     const { data: installations, error } = await supabase
       .from('installations')
       .select('*')
       .eq('development_id', developmentId)
+      .eq('tenant_id', session.tenantId)
       .order('created_at', { ascending: false });
 
     if (error) throw error;
@@ -45,18 +42,20 @@ export async function GET(request: NextRequest) {
       count: installations?.length || 0,
     });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return NextResponse.json(
       { error: 'Failed to fetch installations' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 /**
- * POST: Create new installation
+ * POST: Create new installation under caller's tenant
  */
 export async function POST(request: NextRequest) {
   try {
+    const { supabase, session } = await requireCareTenantSession();
     const body = await request.json();
     const {
       developmentId,
@@ -72,38 +71,34 @@ export async function POST(request: NextRequest) {
       telemetrySource,
     } = body;
 
-    // Validation
     if (!developmentId || !systemType || !systemModel || !serialNumber) {
       return NextResponse.json(
         { error: 'Missing required fields' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const supabase = getSupabaseAdmin();
-
-    // Get tenant from development
+    // Verify the development belongs to the caller's tenant before inserting.
     const { data: dev, error: devError } = await supabase
       .from('developments')
       .select('tenant_id')
       .eq('id', developmentId)
-      .single();
+      .eq('tenant_id', session.tenantId)
+      .maybeSingle();
 
     if (devError || !dev) {
       return NextResponse.json(
         { error: 'Development not found' },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
-    // Generate QR code
     const qrCode = generateQRCode(developmentId, serialNumber);
 
-    // Insert installation
     const { data: installation, error: insertError } = await supabase
       .from('installations')
       .insert({
-        tenant_id: dev.tenant_id,
+        tenant_id: session.tenantId,
         development_id: developmentId,
         system_type: systemType,
         system_model: systemModel,
@@ -124,24 +119,24 @@ export async function POST(request: NextRequest) {
 
     if (insertError) throw insertError;
 
-    // Return with QR code
     return NextResponse.json({
       installation,
       qrCode,
       shareUrl: `${process.env.NEXT_PUBLIC_APP_URL}/care/${installation.id}?qr=${qrCode}`,
     });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return NextResponse.json(
       { error: 'Failed to create installation' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 function generateQRCode(developmentId: string, serialNumber: string): string {
-  // In production: generate actual QR code with encoded URL
-  // For demo: just a unique identifier
   const timestamp = Date.now();
-  const hash = Buffer.from(`${developmentId}:${serialNumber}:${timestamp}`).toString('base64').substring(0, 12);
+  const hash = Buffer.from(`${developmentId}:${serialNumber}:${timestamp}`)
+    .toString('base64')
+    .substring(0, 12);
   return `CARE_${hash.toUpperCase()}`;
 }

--- a/apps/unified-portal/app/api/care/installer-content/route.ts
+++ b/apps/unified-portal/app/api/care/installer-content/route.ts
@@ -1,54 +1,56 @@
 export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const tenantId = searchParams.get('tenantId');
+  try {
+    const { supabase, session } = await requireCareTenantSession();
+    const { searchParams } = new URL(req.url);
+    const requestedTenantId = searchParams.get('tenantId');
 
-  if (!tenantId) {
-    return NextResponse.json({ error: 'tenantId required' }, { status: 400 });
+    // The tenantId query param is preserved for backwards compatibility but
+    // we always scope to the caller's tenant; the param can no longer be
+    // used to cross tenants.
+    if (requestedTenantId && requestedTenantId !== session.tenantId) {
+      return NextResponse.json({ content: [], total: 0 });
+    }
+
+    const { data: content, error } = await supabase
+      .from('installer_content')
+      .select('id, title, content_type, system_type, description, file_url, status, created_at')
+      .eq('tenant_id', session.tenantId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    type ContentRow = {
+      id: string; title: string; content_type: string; system_type: string | null;
+      description: string | null; file_url: string | null; status: string | null; created_at: string;
+    };
+    const mapped = ((content || []) as ContentRow[]).map(item => ({
+      id: item.id,
+      title: item.title,
+      content_type: item.content_type,
+      system_type: item.system_type,
+      description: item.description,
+      url: item.file_url ?? null,
+      is_published: item.status === 'live',
+      created_at: item.created_at,
+    }));
+
+    return NextResponse.json({
+      content: mapped,
+      total: mapped.length,
+    });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch content' }, { status: 500 });
   }
-
-  const supabase = getSupabaseAdmin();
-
-  const { data: content, error } = await supabase
-    .from('installer_content')
-    .select('id, title, content_type, system_type, description, file_url, status, created_at')
-    .eq('tenant_id', tenantId)
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    console.error('installer_content fetch error:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  type ContentRow = {
-    id: string; title: string; content_type: string; system_type: string | null;
-    description: string | null; file_url: string | null; status: string | null; created_at: string;
-  };
-  const mapped = ((content || []) as ContentRow[]).map(item => ({
-    id: item.id,
-    title: item.title,
-    content_type: item.content_type,
-    system_type: item.system_type,
-    description: item.description,
-    url: item.file_url ?? null,
-    is_published: item.status === 'live',
-    created_at: item.created_at,
-  }));
-
-  return NextResponse.json({
-    content: mapped,
-    total: mapped.length,
-  });
 }

--- a/apps/unified-portal/app/api/care/intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/care/intelligence/chat/route.ts
@@ -1,9 +1,11 @@
 /**
  * POST /api/care/intelligence/chat
  *
- * Care Intelligence — the Care skin of the central OpenHouse Intelligence brain.
- * Installer-scoped: all queries filter by installer_name (e.g. "SE Systems")
- * regardless of which developer commissioned the installation.
+ * Care Intelligence: the Care skin of the central OpenHouse Intelligence brain.
+ * Scoped to the caller's tenant: every tool filters installations and related
+ * rows by session.tenantId, never by a hardcoded installer_name. This is the
+ * fix for audit finding C022 (hardcoded INSTALLER_NAME literal was the
+ * security boundary for the intelligence chat).
  *
  * Streams NDJSON to the client: each event is a single JSON object followed by
  * a newline. Matches the protocol used by scheme-intelligence/chat.
@@ -11,24 +13,16 @@
 
 import { NextRequest } from 'next/server';
 import OpenAI from 'openai';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
-
-// For the SE Systems demo, installer context is fixed at the route level.
-// When multi-installer is introduced, resolve from user_contexts instead.
-const INSTALLER_NAME = 'SE Systems';
-const INSTALLER_DISPLAY = 'SE Systems Cork';
-
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
 
 function getOpenAI() {
   return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -78,8 +72,7 @@ const TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
         properties: {
           window: {
             type: 'string',
-            enum: ['this_month', 'q2', 'next_90_days', 'expired'],
-            description: 'Warranty window to query',
+            description: "One of 'this_month', 'next_90_days', 'q2', 'expired'",
           },
         },
       },
@@ -90,7 +83,7 @@ const TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
     function: {
       name: 'get_support_queue',
       description:
-        'List open and in-progress support tickets / escalations, grouped by priority.',
+        'Return open escalations and support tickets that need attention. Use for "what needs my attention" questions.',
       parameters: { type: 'object', properties: {} },
     },
   },
@@ -99,7 +92,7 @@ const TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
     function: {
       name: 'get_customer_communications',
       description:
-        'Summarise recent customer queries grouped by theme (e.g. fault codes, portal access, performance). Use for "what are customers asking about most" questions.',
+        'Group recent support queries by theme to surface what homeowners are asking about.',
       parameters: {
         type: 'object',
         properties: {
@@ -113,13 +106,8 @@ const TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
     function: {
       name: 'get_performance_metrics',
       description:
-        'Return fleet yield metrics. Supports quarterly averages and flagging underperformers.',
-      parameters: {
-        type: 'object',
-        properties: {
-          quarter: { type: 'string', description: "Quarter label e.g. 'Q2' (default current quarter)" },
-        },
-      },
+        'Return solar generation performance for the installer fleet, including average annual yield per kWp and underperformers.',
+      parameters: { type: 'object', properties: {} },
     },
   },
   {
@@ -127,39 +115,28 @@ const TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = [
     function: {
       name: 'get_attention_required',
       description:
-        'Return a unified action list of items needing attention now: open high-priority tickets, faulted systems, warranties expiring soon.',
+        'High-level "what needs attention now" view: high-priority tickets, faulted installations, and warranties expiring within 60 days.',
       parameters: { type: 'object', properties: {} },
     },
   },
 ];
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
-function fmtAddress(inst: Record<string, unknown>): string {
-  const parts = [inst.address_line_1, inst.city, inst.county].filter(Boolean);
-  return parts.join(', ');
+// ── Formatters ──────────────────────────────────────────────────────────────
+function fmtAddress(r: Record<string, unknown>): string {
+  return [r.address_line_1, r.city, r.county].filter(Boolean).join(', ');
 }
 
-function fmtDate(d?: string | null): string {
-  if (!d) return 'unknown';
-  try {
-    return new Date(d).toLocaleDateString('en-IE', { day: 'numeric', month: 'short', year: 'numeric' });
-  } catch {
-    return d;
-  }
+function fmtDate(d: string | null | undefined): string | null {
+  if (!d) return null;
+  return new Date(d).toLocaleDateString('en-IE', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
-function firstDayOfQuarter(offset = 0): Date {
-  const now = new Date();
-  const q = Math.floor(now.getMonth() / 3) + offset;
-  const d = new Date(now.getFullYear(), q * 3, 1);
-  return d;
-}
-
-// ── Tool execution ─────────────────────────────────────────────────────────
+// ── Tool executor ───────────────────────────────────────────────────────────
 async function executeTool(
   name: string,
   args: Record<string, unknown>,
   supabase: SupabaseClient,
+  tenantId: string,
 ): Promise<Record<string, unknown>> {
   switch (name) {
     case 'search_installations': {
@@ -171,7 +148,7 @@ async function executeTool(
       let q = supabase
         .from('installations')
         .select('id, job_reference, customer_name, address_line_1, city, county, system_type, inverter_model, heat_pump_model, system_size_kwp, health_status, install_date, warranty_expiry')
-        .eq('installer_name', INSTALLER_NAME)
+        .eq('tenant_id', tenantId)
         .limit(limit);
 
       if (system_type) q = q.eq('system_type', system_type);
@@ -206,20 +183,19 @@ async function executeTool(
       const days = (args.days as number) || 30;
       const since = new Date(Date.now() - days * 86400000).toISOString();
 
-      // Join support_queries → installations to scope and group by product model
       const { data: queries } = await supabase
         .from('support_queries')
-        .select('query_text, query_category, escalated, resolved, created_at, installations!inner(installer_name, inverter_model, heat_pump_model, system_type)')
+        .select('query_text, query_category, escalated, resolved, created_at, installations!inner(tenant_id, inverter_model, heat_pump_model, system_type)')
+        .eq('installations.tenant_id', tenantId)
         .gte('created_at', since);
 
-      const scoped = (queries || []).filter((q: any) => q.installations?.installer_name === INSTALLER_NAME);
+      const scoped = (queries || []) as any[];
 
-      // Group by model + error code extracted from query_text
       const faultCounts = new Map<string, { model: string; fault: string; count: number; escalated: number }>();
-      for (const q of scoped as any[]) {
+      for (const q of scoped) {
         if (q.query_category !== 'fault_code' && q.query_category !== 'performance') continue;
         const text = (q.query_text as string) || '';
-        const model = q.installations.inverter_model || q.installations.heat_pump_model || 'Unknown';
+        const model = q.installations?.inverter_model || q.installations?.heat_pump_model || 'Unknown';
         const errMatch = text.match(/error\s+(\d{2,4})/i) || text.match(/\b([EFef]\d{1,3})\b/);
         const fault = errMatch ? `error ${errMatch[1]}` : 'unspecified fault';
         const key = `${model}||${fault}`;
@@ -255,7 +231,6 @@ async function executeTool(
         from = '2000-01-01';
         to = now.toISOString().slice(0, 10);
       } else {
-        // next_90_days
         from = now.toISOString().slice(0, 10);
         to = new Date(now.getTime() + 90 * 86400000).toISOString().slice(0, 10);
       }
@@ -263,7 +238,7 @@ async function executeTool(
       const { data } = await supabase
         .from('installations')
         .select('job_reference, customer_name, address_line_1, city, system_type, inverter_model, heat_pump_model, warranty_expiry')
-        .eq('installer_name', INSTALLER_NAME)
+        .eq('tenant_id', tenantId)
         .gte('warranty_expiry', from)
         .lte('warranty_expiry', to)
         .order('warranty_expiry', { ascending: true });
@@ -282,18 +257,18 @@ async function executeTool(
     case 'get_support_queue': {
       const { data } = await supabase
         .from('escalations')
-        .select('id, title, description, priority, status, created_at, installations!inner(installer_name, customer_name, address_line_1, city, job_reference)')
+        .select('id, title, description, priority, status, created_at, installations!inner(tenant_id, customer_name, address_line_1, city, job_reference)')
+        .eq('installations.tenant_id', tenantId)
         .in('status', ['open', 'in_progress'])
         .order('created_at', { ascending: false });
 
-      const scoped = (data || []).filter((e: any) => e.installations?.installer_name === INSTALLER_NAME);
-      const tickets = scoped.map((e: any) => ({
+      const tickets = ((data || []) as any[]).map((e) => ({
         title: e.title,
         priority: e.priority,
         status: e.status,
-        customer: e.installations.customer_name,
-        address: [e.installations.address_line_1, e.installations.city].filter(Boolean).join(', '),
-        job_reference: e.installations.job_reference,
+        customer: e.installations?.customer_name,
+        address: [e.installations?.address_line_1, e.installations?.city].filter(Boolean).join(', '),
+        job_reference: e.installations?.job_reference,
         opened: fmtDate(e.created_at),
       }));
 
@@ -309,14 +284,15 @@ async function executeTool(
 
       const { data } = await supabase
         .from('support_queries')
-        .select('query_text, query_category, created_at, installations!inner(installer_name, customer_name, city)')
+        .select('query_text, query_category, created_at, installations!inner(tenant_id, customer_name, city)')
+        .eq('installations.tenant_id', tenantId)
         .gte('created_at', since)
         .order('created_at', { ascending: false });
 
-      const scoped = (data || []).filter((q: any) => q.installations?.installer_name === INSTALLER_NAME);
+      const scoped = (data || []) as any[];
 
       const themes = new Map<string, { theme: string; count: number; examples: string[] }>();
-      for (const q of scoped as any[]) {
+      for (const q of scoped) {
         const theme = (q.query_category as string) || 'general';
         const existing = themes.get(theme) || { theme, count: 0, examples: [] };
         existing.count += 1;
@@ -338,19 +314,17 @@ async function executeTool(
       const { data } = await supabase
         .from('installations')
         .select('job_reference, customer_name, address_line_1, city, system_type, system_size_kwp, energy_generated_kwh, health_status, inverter_model')
-        .eq('installer_name', INSTALLER_NAME)
+        .eq('tenant_id', tenantId)
         .eq('system_type', 'solar_pv')
         .not('system_size_kwp', 'is', null);
 
       const rows = (data || []).filter((r) => r.energy_generated_kwh && r.system_size_kwp);
-      // Ireland baseline: 850 kWh/kWp/year → quarterly expected = 850/4 = 212.5 kWh/kWp
       const EXPECTED_Q = 212.5;
 
       const yields = rows.map((r) => {
         const size = Number(r.system_size_kwp) || 0;
         const generated = Number(r.energy_generated_kwh) || 0;
         const annual_yield = size > 0 ? generated / size : 0;
-        // Rough quarterly estimate: assume even spread
         const q_yield = annual_yield / 4;
         return {
           job_reference: r.job_reference,
@@ -383,38 +357,36 @@ async function executeTool(
     }
 
     case 'get_attention_required': {
-      // High-priority open tickets
       const ticketsRes = await supabase
         .from('escalations')
-        .select('title, priority, status, created_at, installations!inner(installer_name, customer_name, city, job_reference)')
+        .select('title, priority, status, created_at, installations!inner(tenant_id, customer_name, city, job_reference)')
+        .eq('installations.tenant_id', tenantId)
         .in('status', ['open', 'in_progress']);
 
-      const tickets = (ticketsRes.data || []).filter((e: any) => e.installations?.installer_name === INSTALLER_NAME);
-      const highPriority = tickets.filter((t: any) => t.priority === 'high' || t.priority === 'critical');
+      const tickets = (ticketsRes.data || []) as any[];
+      const highPriority = tickets.filter((t) => t.priority === 'high' || t.priority === 'critical');
 
-      // Installations with issue health status
       const faultedRes = await supabase
         .from('installations')
         .select('job_reference, customer_name, address_line_1, city, system_type, inverter_model, heat_pump_model, health_status')
-        .eq('installer_name', INSTALLER_NAME)
+        .eq('tenant_id', tenantId)
         .eq('health_status', 'issue');
 
-      // Warranties expiring within 60 days
       const soon = new Date(Date.now() + 60 * 86400000).toISOString().slice(0, 10);
       const today = new Date().toISOString().slice(0, 10);
       const warrantyRes = await supabase
         .from('installations')
         .select('job_reference, customer_name, address_line_1, city, warranty_expiry')
-        .eq('installer_name', INSTALLER_NAME)
+        .eq('tenant_id', tenantId)
         .gte('warranty_expiry', today)
         .lte('warranty_expiry', soon);
 
       return {
-        high_priority_tickets: highPriority.map((t: any) => ({
+        high_priority_tickets: highPriority.map((t) => ({
           title: t.title,
           priority: t.priority,
-          customer: t.installations.customer_name,
-          job_reference: t.installations.job_reference,
+          customer: t.installations?.customer_name,
+          job_reference: t.installations?.job_reference,
           opened: fmtDate(t.created_at),
         })),
         faulted_installations: (faultedRes.data || []).map((r) => ({
@@ -438,7 +410,7 @@ async function executeTool(
 }
 
 // ── System prompt ───────────────────────────────────────────────────────────
-function buildSystemPrompt(): string {
+async function buildSystemPrompt(supabase: SupabaseClient, tenantId: string): Promise<string> {
   const today = new Date().toLocaleDateString('en-IE', {
     weekday: 'long',
     year: 'numeric',
@@ -446,9 +418,23 @@ function buildSystemPrompt(): string {
     day: 'numeric',
   });
 
+  // Look up the tenant's display name for the prompt. Falls back to a
+  // generic label if the tenant row has no name set.
+  let installerDisplay = 'your installer team';
+  try {
+    const { data: tenant } = await supabase
+      .from('tenants')
+      .select('name')
+      .eq('id', tenantId)
+      .maybeSingle();
+    if (tenant?.name) installerDisplay = String(tenant.name);
+  } catch {
+    // Non-fatal; keep the fallback.
+  }
+
   return `You are OpenHouse Care Intelligence, a sharp, experienced colleague for renewable energy installers managing aftercare across multiple developments.
 
-You work for ${INSTALLER_DISPLAY}. You have full visibility across every installation ${INSTALLER_DISPLAY} has done, regardless of which developer commissioned it.
+You work for ${installerDisplay}. You have full visibility across every installation ${installerDisplay} has done, regardless of which developer commissioned it.
 
 Your job is to help installer teams (operations directors, technical directors, support staff) answer practical aftercare questions fast:
 - Which installations need attention right now
@@ -472,13 +458,16 @@ FORMAT:
 - Use Irish English (colour, realise) and Irish conventions (€, Cork, Eircode).
 
 CURRENT CONTEXT:
-Installer: ${INSTALLER_DISPLAY}
+Installer: ${installerDisplay}
 Today: ${today}`;
 }
 
 // ── Handler ─────────────────────────────────────────────────────────────────
 export async function POST(request: NextRequest) {
   try {
+    const { supabase, session } = await requireCareTenantSession();
+    const tenantId = session.tenantId;
+
     const body = await request.json();
     const { message, history } = body as {
       message?: string;
@@ -492,9 +481,8 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const supabase = getSupabaseAdmin();
     const openai = getOpenAI();
-    const systemPrompt = buildSystemPrompt();
+    const systemPrompt = await buildSystemPrompt(supabase, tenantId);
 
     const baseMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
       { role: 'system', content: systemPrompt },
@@ -505,7 +493,6 @@ export async function POST(request: NextRequest) {
       { role: 'user', content: message },
     ];
 
-    // First call — let the model pick tools
     const toolPick = await openai.chat.completions.create({
       model: 'gpt-4o-mini',
       messages: baseMessages,
@@ -535,7 +522,7 @@ export async function POST(request: NextRequest) {
         } catch {
           args = {};
         }
-        const result = await executeTool(call.function.name, args, supabase);
+        const result = await executeTool(call.function.name, args, supabase, tenantId);
         followUpMessages.push({
           role: 'tool',
           tool_call_id: call.id,
@@ -549,7 +536,6 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Stream the natural-language answer
     const encoder = new TextEncoder();
     const readable = new ReadableStream({
       async start(controller) {
@@ -574,7 +560,6 @@ export async function POST(request: NextRequest) {
               }
             }
           } else {
-            // No tools called — send the model's direct text (usually a clarification)
             const direct = choice?.content || 'No answer generated.';
             fullResponse = direct;
             controller.enqueue(
@@ -588,7 +573,6 @@ export async function POST(request: NextRequest) {
             );
           }
 
-          // Follow-up suggestions
           try {
             const followUpCompletion = await openai.chat.completions.create({
               model: 'gpt-4o-mini',
@@ -620,11 +604,11 @@ export async function POST(request: NextRequest) {
             // skip silently
           }
 
-          // Log the interaction (best-effort)
           try {
             await supabase.from('intelligence_interactions').insert({
               skin: 'care',
               user_role: 'admin',
+              tenant_id: tenantId,
               query_text: message,
               response_text: fullResponse,
               response_type: 'answer',
@@ -659,6 +643,7 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
     return new Response(
       JSON.stringify({
         error: error instanceof Error ? error.message : 'Internal server error',

--- a/apps/unified-portal/app/api/care/service-records/route.ts
+++ b/apps/unified-portal/app/api/care/service-records/route.ts
@@ -1,6 +1,12 @@
 /**
  * GET /api/care/service-records?installation_id=X
  * Returns service records for a given installation, ordered by date descending.
+ *
+ * Homeowner-side route (called from /care/[installationId]/ServiceScreen).
+ * Auth model deferred to Batch 2: homeowner session design. Until then this
+ * route trusts installationId from the query string. The structural cross-
+ * check applied to the chat route in Batch 1.3 will extend to this route in
+ * Batch 2.
  */
 
 import { NextRequest, NextResponse } from 'next/server';

--- a/apps/unified-portal/app/api/care/support-queries/route.ts
+++ b/apps/unified-portal/app/api/care/support-queries/route.ts
@@ -1,60 +1,61 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export async function GET() {
-  const supabase = getSupabaseAdmin();
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  // Fetch support queries joined with installation for address info
-  const { data, error } = await supabase
-    .from('support_queries')
-    .select(`
-      id,
-      installation_id,
-      query_text,
-      query_category,
-      resolved,
-      escalated,
-      resolved_without_callout,
-      response_source,
-      created_at,
-      installations ( job_reference, address_line_1, city, customer_name )
-    `)
-    .order('created_at', { ascending: false });
+    // Fetch support queries joined with installation for address info,
+    // scoped to caller's tenant via the installations relation.
+    const { data, error } = await supabase
+      .from('support_queries')
+      .select(`
+        id,
+        installation_id,
+        query_text,
+        query_category,
+        resolved,
+        escalated,
+        resolved_without_callout,
+        response_source,
+        created_at,
+        installations!inner ( job_reference, address_line_1, city, customer_name, tenant_id )
+      `)
+      .eq('installations.tenant_id', session.tenantId)
+      .order('created_at', { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const queries = (data || []).map((q: Record<string, unknown>) => {
+      const inst = q.installations as Record<string, string> | null;
+      let status = 'open';
+      if (q.resolved) status = 'resolved';
+      else if (q.response_source === 'in_progress') status = 'in_progress';
+
+      return {
+        id: q.id,
+        installation_id: q.installation_id,
+        customer_ref: inst?.customer_name || inst?.job_reference || 'Unknown',
+        address: inst ? `${inst.address_line_1}, ${inst.city}` : '',
+        query_type: q.query_category || 'General',
+        query_status: status,
+        description: q.query_text,
+        resolved_without_callout: q.resolved_without_callout,
+        created_at: q.created_at,
+      };
+    });
+
+    return NextResponse.json({ queries });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch support queries' }, { status: 500 });
   }
-
-  // Map to a friendlier shape for the frontend
-  const queries = (data || []).map((q: Record<string, unknown>) => {
-    const inst = q.installations as Record<string, string> | null;
-    // Derive status from resolved + response_source
-    let status = 'open';
-    if (q.resolved) status = 'resolved';
-    else if (q.response_source === 'in_progress') status = 'in_progress';
-
-    return {
-      id: q.id,
-      installation_id: q.installation_id,
-      customer_ref: inst?.customer_name || inst?.job_reference || 'Unknown',
-      address: inst ? `${inst.address_line_1}, ${inst.city}` : '',
-      query_type: q.query_category || 'General',
-      query_status: status,
-      description: q.query_text,
-      resolved_without_callout: q.resolved_without_callout,
-      created_at: q.created_at,
-    };
-  });
-
-  return NextResponse.json({ queries });
 }

--- a/apps/unified-portal/app/api/care/system-types/route.ts
+++ b/apps/unified-portal/app/api/care/system-types/route.ts
@@ -1,37 +1,39 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import {
+  CareAuthError,
+  careAuthErrorToResponse,
+  requireCareTenantSession,
+} from '@/lib/care/require-care-session';
 
 export const dynamic = 'force-dynamic';
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export async function GET() {
-  const supabase = getSupabaseAdmin();
-  const { data } = await supabase
-    .from('installations')
-    .select('system_type')
-    .eq('is_active', true);
+  try {
+    const { supabase, session } = await requireCareTenantSession();
 
-  const unique = [...new Set((data || []).map((r: any) => r.system_type).filter(Boolean))];
-  const systemTypes = unique.map((t: string) => ({
-    id: t,
-    name: t.replace('_', ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
-  }));
+    const { data } = await supabase
+      .from('installations')
+      .select('system_type')
+      .eq('tenant_id', session.tenantId)
+      .eq('is_active', true);
 
-  // Always include core types
-  const base = [
-    { id: 'solar_pv', name: 'Solar PV' },
-    { id: 'heat_pump', name: 'Heat Pump' },
-    { id: 'ev_charger', name: 'EV Charger' },
-    { id: 'battery_storage', name: 'Battery Storage' },
-  ];
-  const merged = [...base, ...systemTypes.filter(t => !base.find(b => b.id === t.id))];
+    const unique = [...new Set((data || []).map((r: any) => r.system_type).filter(Boolean))];
+    const systemTypes = unique.map((t: string) => ({
+      id: t,
+      name: t.replace('_', ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+    }));
 
-  return NextResponse.json({ systemTypes: merged });
+    const base = [
+      { id: 'solar_pv', name: 'Solar PV' },
+      { id: 'heat_pump', name: 'Heat Pump' },
+      { id: 'ev_charger', name: 'EV Charger' },
+      { id: 'battery_storage', name: 'Battery Storage' },
+    ];
+    const merged = [...base, ...systemTypes.filter(t => !base.find(b => b.id === t.id))];
+
+    return NextResponse.json({ systemTypes: merged });
+  } catch (error) {
+    if (error instanceof CareAuthError) return careAuthErrorToResponse(error);
+    return NextResponse.json({ error: 'Failed to fetch system types' }, { status: 500 });
+  }
 }

--- a/apps/unified-portal/lib/care/require-care-session.ts
+++ b/apps/unified-portal/lib/care/require-care-session.ts
@@ -1,0 +1,219 @@
+/**
+ * requireCareSession: single auth boundary for installer-side Care routes.
+ *
+ * Background. Pre-batch, every Care route under app/api/care/* spun up its own
+ * service-role Supabase client and queried `installations` by `id` with no
+ * tenant filter. A valid admin JWT for tenant A could pass installation_id
+ * for tenant B and the route served the data. This helper closes that gap
+ * by centralising session resolution and installation scoping in one
+ * auditable file.
+ *
+ * Scope. Installer-side routes only (admin session via cookies). Homeowner-
+ * side routes (chat, conversations, telemetry, third-party, content,
+ * manifest, access) have a fundamentally different auth model (QR-code
+ * entry, no admin login) and are out of scope for Batch 1. See the Batch 2
+ * follow-up issue.
+ *
+ * Trade-off documented for PR review. The session is resolved with a
+ * user-scoped Supabase client built from the request cookies. This is the
+ * primary auth boundary and uses the user's actual JWT. Subsequent queries
+ * (installation lookup, route business logic) use a service-role client
+ * scoped by mandatory tenant filters set inside this helper. The reason is
+ * that Care tables currently carry only service-role RLS policies (audit
+ * finding C015); migrating Care RLS to user-aware policies is a separate
+ * batch. The net effect: service-role usage drops from ~15 unauditable
+ * call sites to one file with a verified session always in hand.
+ */
+
+import { cookies } from 'next/headers';
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin, getServerSession } from '@/lib/supabase-server';
+import type { AdminSession } from '@/lib/supabase-server';
+
+type CareAuthErrorCode =
+  | 'unauthenticated'
+  | 'forbidden'
+  | 'not_found'
+  | 'cross_tenant_conversation';
+
+export class CareAuthError extends Error {
+  constructor(public code: CareAuthErrorCode) {
+    super(code);
+    this.name = 'CareAuthError';
+  }
+}
+
+export interface CareInstallation {
+  id: string;
+  tenant_id: string;
+  development_id: string | null;
+  system_type: string;
+  system_model: string | null;
+  serial_number: string | null;
+  installation_date: string | null;
+  warranty_expiry: string | null;
+  homeowner_email: string | null;
+  adoption_status: string | null;
+  adopted_at: string | null;
+  notes: string | null;
+  component_specs: Record<string, unknown> | null;
+  performance_baseline: Record<string, unknown> | null;
+  telemetry_source: string | null;
+  telemetry_api_key: string | null;
+  qr_code: string | null;
+  handover_date: string | null;
+  is_active: boolean | null;
+  access_code: string | null;
+  [key: string]: unknown;
+}
+
+export interface CareSessionContext {
+  supabase: SupabaseClient;
+  session: AdminSession;
+  installation: CareInstallation;
+}
+
+export interface CareTenantContext {
+  supabase: SupabaseClient;
+  session: AdminSession;
+}
+
+/**
+ * Resolve and verify an installer admin session. Used by routes that don't
+ * carry an installation id (lists, dashboard stats, intelligence chat). The
+ * returned supabase client is service-role scoped; the caller MUST filter
+ * by session.tenantId on every query.
+ */
+export async function requireCareTenantSession(): Promise<CareTenantContext> {
+  const session = await getServerSession();
+
+  if (!session) {
+    throw new CareAuthError('unauthenticated');
+  }
+
+  if (!session.tenantId) {
+    throw new CareAuthError('forbidden');
+  }
+
+  // Touch the user-scoped client to confirm the JWT in cookies is valid
+  // and not stale. If auth.getUser() rejects, this throws back as
+  // unauthenticated rather than serving data on a half-revoked session.
+  const userScoped = createServerComponentClient({ cookies });
+  const { data: { user }, error: userErr } = await userScoped.auth.getUser();
+  if (userErr || !user) {
+    throw new CareAuthError('unauthenticated');
+  }
+
+  return {
+    supabase: getSupabaseAdmin(),
+    session,
+  };
+}
+
+/**
+ * Resolve and verify an installer admin session, then load the requested
+ * installation under that session's tenant. If the installation does not
+ * exist or belongs to a different tenant, throw not_found (deliberately
+ * ambiguous; do not differentiate from absence in the response).
+ *
+ * If a conversationId is provided, verify it belongs to the same
+ * installation. This is the primary defence against the conversation
+ * context-bleed P0.
+ */
+export async function requireCareSession(opts: {
+  installationId: string;
+  conversationId?: string;
+}): Promise<CareSessionContext> {
+  const { installationId, conversationId } = opts;
+
+  if (!installationId) {
+    throw new CareAuthError('not_found');
+  }
+
+  const { supabase, session } = await requireCareTenantSession();
+
+  const { data: installation, error } = await supabase
+    .from('installations')
+    .select('*')
+    .eq('id', installationId)
+    .eq('tenant_id', session.tenantId)
+    .maybeSingle();
+
+  if (error || !installation) {
+    throw new CareAuthError('not_found');
+  }
+
+  if (conversationId) {
+    const { data: convo, error: convoErr } = await supabase
+      .from('care_conversations')
+      .select('id, installation_id')
+      .eq('id', conversationId)
+      .maybeSingle();
+
+    if (convoErr || !convo) {
+      throw new CareAuthError('not_found');
+    }
+
+    if (convo.installation_id !== installationId) {
+      throw new CareAuthError('cross_tenant_conversation');
+    }
+  }
+
+  return {
+    supabase,
+    session,
+    installation: installation as CareInstallation,
+  };
+}
+
+/**
+ * Map a CareAuthError to a NextResponse. Returns 401 for unauthenticated,
+ * 403 for forbidden (authenticated but no tenant claim), and 404 for both
+ * not_found and cross_tenant_conversation. The two 404 cases must look
+ * identical from outside; differentiating them would leak existence of
+ * other tenants' rows.
+ */
+export function careAuthErrorToResponse(err: CareAuthError): NextResponse {
+  if (err.code === 'unauthenticated') {
+    return NextResponse.json({ error: 'Unauthenticated' }, { status: 401 });
+  }
+  if (err.code === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  return NextResponse.json({ error: 'Not found' }, { status: 404 });
+}
+
+/**
+ * Convenience wrapper for the common try/catch pattern. Lets a route body
+ * stay focused on business logic.
+ */
+export async function withCareSession<T>(
+  opts: { installationId: string; conversationId?: string },
+  handler: (ctx: CareSessionContext) => Promise<NextResponse | T>,
+): Promise<NextResponse | T> {
+  try {
+    const ctx = await requireCareSession(opts);
+    return await handler(ctx);
+  } catch (err) {
+    if (err instanceof CareAuthError) {
+      return careAuthErrorToResponse(err);
+    }
+    throw err;
+  }
+}
+
+export async function withCareTenantSession<T>(
+  handler: (ctx: CareTenantContext) => Promise<NextResponse | T>,
+): Promise<NextResponse | T> {
+  try {
+    const ctx = await requireCareTenantSession();
+    return await handler(ctx);
+  } catch (err) {
+    if (err instanceof CareAuthError) {
+      return careAuthErrorToResponse(err);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Closing as redundant. PR #120 was merged (commit `03a8871`) with both Commits 1 and 2 squashed together, so the helper from this PR is now on main. No additional review action required here.

The work itself shipped: `requireCareSession` is in `apps/unified-portal/lib/care/require-care-session.ts` on main, and every installer-side Care route is gated behind it.