### PR TITLE
Care Batch 1.3: conversation context bleed fix (P0)

### DIFF
--- a/apps/unified-portal/app/api/care/chat/route.ts
+++ b/apps/unified-portal/app/api/care/chat/route.ts
@@ -20,6 +20,7 @@ import {
   getRelevantCareKnowledge,
   formatCareKnowledge,
 } from '@/lib/care/care-knowledge';
+import { verifyConversationBelongsToInstallation } from '@/lib/care/verify-conversation-ownership';
 import {
   getSeSystemsKnowledge,
   getSeSystemsInstallerContext,
@@ -374,6 +375,45 @@ export async function POST(request: NextRequest) {
 
     const supabase = getSupabaseAdmin();
 
+    // STOPGAP CROSS-CHECK (Batch 1.3, audit C002): if the request supplies
+    // a conversation_id, verify it belongs to the same installationId before
+    // we load any history into the model context. Without this check, a
+    // caller can pass another homeowner's conversation_id and have that
+    // conversation's history streamed into the prompt.
+    //
+    // This is a structural fix only. The homeowner side of the Care app has
+    // no admin session today (QR-code entry per middleware.ts:37), which
+    // means we cannot rely on RLS or session-tenant filtering here. Batch 2
+    // will replace this stopgap with the real homeowner session model. Until
+    // then, the verifier below is the security boundary.
+    if (conversation_id) {
+      const ownership = await verifyConversationBelongsToInstallation(
+        supabase,
+        conversation_id,
+        installationId,
+      );
+      if (ownership.status === 'cross_tenant') {
+        // Stable tag for log greps; do not include the actual other-tenant
+        // installation id in the response.
+        console.warn(
+          '[CARE_CROSS_TENANT_CONVERSATION] conversation_id=%s requested_installation_id=%s actual_installation_id=%s',
+          conversation_id,
+          installationId,
+          ownership.actualInstallationId,
+        );
+        return NextResponse.json(
+          { error: 'Conversation not found' },
+          { status: 404 },
+        );
+      }
+      if (ownership.status === 'not_found') {
+        return NextResponse.json(
+          { error: 'Conversation not found' },
+          { status: 404 },
+        );
+      }
+    }
+
     // Get installation — fall back to demo data if not in DB (e.g. demo portal URLs)
     const { data: dbInstallation } = await supabase
       .from('installations')
@@ -428,10 +468,16 @@ export async function POST(request: NextRequest) {
       })(),
       (async () => {
         if (!conversation_id) return [];
+        // Defence in depth on top of the explicit verifier above: join
+        // through care_conversations and filter by installation_id, so even
+        // if the verifier is ever bypassed or removed, the history query
+        // itself can never return messages from another installation's
+        // conversation.
         const { data: history } = await supabase
           .from('care_messages')
-          .select('role, content')
+          .select('role, content, care_conversations!inner(installation_id)')
           .eq('conversation_id', conversation_id)
+          .eq('care_conversations.installation_id', installationId)
           .order('created_at', { ascending: true })
           .limit(20);
         return (history || [])

--- a/apps/unified-portal/lib/care/verify-conversation-ownership.ts
+++ b/apps/unified-portal/lib/care/verify-conversation-ownership.ts
@@ -1,0 +1,75 @@
+/**
+ * verifyConversationBelongsToInstallation
+ *
+ * Stopgap structural cross-check for the homeowner Care chat route.
+ *
+ * Background. The chat route accepts `installationId` and `conversation_id`
+ * from the request body and loads history by `conversation_id` only. Without
+ * verifying the conversation actually belongs to the installation, a caller
+ * could pass any UUID as `conversation_id` and have another homeowner's
+ * history loaded into the model context.
+ *
+ * Strategy. Until Batch 2 lands a proper homeowner session model, every chat
+ * request that includes a `conversation_id` must pass that id through this
+ * verifier. The verifier returns a discriminated result so the caller can
+ * branch cleanly:
+ *
+ *   { status: 'ok', conversationId }
+ *   { status: 'not_found' }              the conversation does not exist
+ *   { status: 'cross_tenant' }           the conversation exists but is on
+ *                                        a different installation
+ *
+ * Callers must respond 404 for BOTH not_found and cross_tenant. The two
+ * cases are reported separately so the route can log the cross-tenant
+ * variant as a security event without leaking the distinction to the
+ * client.
+ *
+ * Logging contract: the caller should log every `cross_tenant` outcome with
+ * the stable tag `[CARE_CROSS_TENANT_CONVERSATION]` so the line can be
+ * grepped from production logs. The verifier itself does not log; that is
+ * the route's job because it has the request metadata.
+ *
+ * This helper deliberately accepts the Supabase client by parameter rather
+ * than constructing one. That lets the chat route keep its existing service-
+ * role client (the homeowner side has no admin session today) and lets the
+ * unit test pass a mocked client. When Batch 2 lands a homeowner session,
+ * this helper folds into `requireCareSession` and goes away.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type ConversationOwnershipResult =
+  | { status: 'ok'; conversationId: string }
+  | { status: 'not_found' }
+  | { status: 'cross_tenant'; actualInstallationId: string };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function verifyConversationBelongsToInstallation(
+  supabase: SupabaseClient,
+  conversationId: unknown,
+  installationId: unknown,
+): Promise<ConversationOwnershipResult> {
+  if (typeof conversationId !== 'string' || !UUID_RE.test(conversationId)) {
+    return { status: 'not_found' };
+  }
+  if (typeof installationId !== 'string' || !UUID_RE.test(installationId)) {
+    return { status: 'not_found' };
+  }
+
+  const { data, error } = await supabase
+    .from('care_conversations')
+    .select('id, installation_id')
+    .eq('id', conversationId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return { status: 'not_found' };
+  }
+
+  if (data.installation_id !== installationId) {
+    return { status: 'cross_tenant', actualInstallationId: data.installation_id };
+  }
+
+  return { status: 'ok', conversationId: data.id };
+}

--- a/apps/unified-portal/tests/care/verify-conversation-ownership.test.ts
+++ b/apps/unified-portal/tests/care/verify-conversation-ownership.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression test for the Care chat conversation cross-tenant bleed.
+ *
+ * Audit finding C002: the chat route loaded conversation history by
+ * conversation_id alone, with no link to the installationId in the request
+ * body. A caller could pass any conversation_id and have another homeowner's
+ * history injected into the model context. The verifier below is the
+ * structural cross-check that closes that path.
+ *
+ * The homeowner Care app has no admin session today (QR-code entry per
+ * middleware.ts:37), so a full end-to-end test with two authenticated
+ * tenants is not possible without first building the homeowner session
+ * model (Batch 2). Per the task spec, the minimum acceptable test is a
+ * unit test that exercises the helper with mismatched IDs and verifies the
+ * cross_tenant outcome.
+ *
+ * This test runs against a mocked Supabase client. It does NOT exercise the
+ * full route. The full-route end-to-end test will land alongside Batch 2.
+ */
+
+import { verifyConversationBelongsToInstallation } from '@/lib/care/verify-conversation-ownership';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type MockRow = { id: string; installation_id: string } | null;
+
+function makeSupabase(row: MockRow, error: { message: string } | null = null): SupabaseClient {
+  const builder = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: row, error }),
+  };
+  return {
+    from: jest.fn().mockReturnValue(builder),
+  } as unknown as SupabaseClient;
+}
+
+const installA = '11111111-1111-1111-1111-111111111111';
+const installB = '22222222-2222-2222-2222-222222222222';
+const convoOnA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+describe('verifyConversationBelongsToInstallation', () => {
+  it('returns ok when conversation belongs to the requested installation', async () => {
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installA });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      installA,
+    );
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.conversationId).toBe(convoOnA);
+    }
+  });
+
+  it('returns cross_tenant when conversation exists on a different installation (THE REGRESSION)', async () => {
+    // Conversation lives on installation A. Caller authenticates as
+    // installation B and passes installation A's conversation_id. The
+    // verifier must report cross_tenant so the route returns 404 and does
+    // not load installation A's history.
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installA });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      installB,
+    );
+    expect(result.status).toBe('cross_tenant');
+    if (result.status === 'cross_tenant') {
+      expect(result.actualInstallationId).toBe(installA);
+    }
+  });
+
+  it('returns cross_tenant in the reverse direction too', async () => {
+    // Symmetry check: conversation on B, request claims to be on A.
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installB });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      installA,
+    );
+    expect(result.status).toBe('cross_tenant');
+  });
+
+  it('returns not_found when the conversation does not exist', async () => {
+    const supabase = makeSupabase(null);
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      installA,
+    );
+    expect(result.status).toBe('not_found');
+  });
+
+  it('returns not_found when supabase reports an error', async () => {
+    const supabase = makeSupabase(null, { message: 'db down' });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      installA,
+    );
+    expect(result.status).toBe('not_found');
+  });
+
+  it('returns not_found for a malformed conversation_id', async () => {
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installA });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      'not-a-uuid',
+      installA,
+    );
+    expect(result.status).toBe('not_found');
+    // The DB should not be queried at all for a malformed input.
+    expect((supabase.from as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found for a malformed installationId', async () => {
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installA });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      convoOnA,
+      'not-a-uuid',
+    );
+    expect(result.status).toBe('not_found');
+    expect((supabase.from as jest.Mock)).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found when conversation_id is not a string', async () => {
+    const supabase = makeSupabase({ id: convoOnA, installation_id: installA });
+    const result = await verifyConversationBelongsToInstallation(
+      supabase,
+      123 as unknown as string,
+      installA,
+    );
+    expect(result.status).toBe('not_found');
+  });
+});


### PR DESCRIPTION
## The bug

Audit finding C002. The homeowner Care chat route at `app/api/care/chat/route.ts` accepted both `installationId` and `conversation_id` from the request body and loaded conversation history with `WHERE conversation_id = ?` alone, with no link back to `installationId`. A caller could pass any conversation_id and have another homeowner's chat history streamed into the model context.

Silent cross-tenant context bleed in an AI assistant is the worst category of bug we could ship. The model would reason over the foreign history as if it were the caller's own, and the homeowner would have no way to know it had happened.

## The fix

Two layers, both structural:

**Layer 1: Explicit cross-check before any history loads.** New helper `lib/care/verify-conversation-ownership.ts` performs the cross-check and returns a discriminated result:

- `ok` → the conversation belongs to the requested installation.
- `not_found` → the conversation does not exist (or input is malformed).
- `cross_tenant` → the conversation exists but is on a different installation.

The chat route responds **404 for both `not_found` and `cross_tenant`**. The two cases must look identical from outside; differentiating would leak existence of other tenants' rows. Cross-tenant attempts are logged with the stable tag `[CARE_CROSS_TENANT_CONVERSATION]` so the line can be grepped from production logs.

**Layer 2: Defence in depth on the history query itself.** The `care_messages` SELECT now joins through `care_conversations` and filters by `care_conversations.installation_id = installationId`. Even if layer 1 is ever bypassed or removed, the history query itself can never return another installation's messages.

## Regression test

`tests/care/verify-conversation-ownership.test.ts` covers the regression in both directions plus the not_found, malformed-input, and ok paths:

- Conversation belongs to requested installation → ok.
- **Conversation on A, requested as B → cross_tenant. (THE REGRESSION.)**
- Conversation on B, requested as A → cross_tenant. (Symmetry check.)
- Conversation does not exist → not_found.
- DB error → not_found.
- Malformed conversation_id → not_found (DB is not even queried).
- Malformed installationId → not_found (DB is not even queried).
- Non-string conversation_id → not_found.

A full end-to-end test against a live database with two authenticated tenants is not possible until Batch 2 lands the homeowner session model. Per the task spec, the minimum acceptable test is a unit test that exercises the verifier with mismatched IDs and verifies the `cross_tenant` outcome. This PR delivers that and more.

## Stopgap notice

**This PR uses service-role on the homeowner chat route.** That conflicts with the "no service-role in any Care route" rule from the batch brief. The conflict is unavoidable in Batch 1: the homeowner Care app has no admin session today (QR-code entry per `middleware.ts:37`), so a user-scoped client would run as anon and RLS would return empty arrays for every Care table.

The proper resolution lives in **Care Batch 2: homeowner session design (#123)**. Once that ships:
- `/api/care/access` mints a session token.
- Every homeowner route reads `installationId` from the session, not the body.
- This verifier folds into `requireCareSession` and goes away.
- Service-role usage on the homeowner side drops to zero.

This PR is the stopgap that prevents real-world context bleed while #123 is in design.

## Other call sites I checked

Searched the codebase for every place that loads conversation history by id:

- `app/api/care/chat/route.ts` — fixed in this PR.
- `app/api/care/conversations/route.ts` — lists conversations filtered by `installation_id`, no cross-tenant id flow. Not vulnerable; left alone.

No other call sites found.

## Test plan

- [x] Typecheck passes for the new helper, the new test, and the patched chat route (two pre-existing errors in `chat/route.ts` lines 539 and 594 are on the demo-fallback installation object and are unrelated to this PR).
- [ ] Manual: with installations A and B and conversations on both, POST `/api/care/chat` with `installationId = B` and `conversation_id = <conversation on A>` must return 404 with body `{"error":"Conversation not found"}`. No content from A's conversation must leak into the response.
- [ ] Manual: the same call with a missing `conversation_id` (new conversation flow) must continue to work.
- [ ] Manual: a malformed `conversation_id` (e.g. `"not-a-uuid"`) must return 404 without touching the database.

Part of Care Batch 1 (security foundations). Sibling work shipped in PR #120.
Follow-up issue: **#123 Care Batch 2: homeowner session design**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDhxcMr9DqukZBESKQTgnG)_