### PR TITLE
Care Batch 1.5: RSC stream stability (P0)

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/layout.tsx
+++ b/apps/unified-portal/app/care/[installationId]/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata, Viewport } from 'next';
-import { createClient } from '@supabase/supabase-js';
 import { CareAppProvider } from './care-app-provider';
 import { SWRegister } from '../sw-register';
 import { notFound } from 'next/navigation';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +13,70 @@ export const viewport: Viewport = {
   userScalable: false,
   viewportFit: 'cover',
 };
+
+// Columns the homeowner Care app actually surfaces to the client. Listing them
+// explicitly does two things at once:
+//
+//   1. Performance. The previous `select('*')` pulled every column on
+//      `installations`, including large JSONB blobs the layout does not need.
+//      That made every RSC navigation slower than it had to be, and is the
+//      most plausible root cause of the gateway-level 503 the audit caught
+//      on `/care/[id]?_rsc=...` requests under cold-start conditions.
+//
+//   2. Security. `telemetry_api_key` is intentionally NOT in this list. It
+//      is plaintext on the row today (tracked separately in the security
+//      audit) and has no business being serialised into a client provider.
+//      Dropping `*` makes it impossible to leak by accident.
+//
+// Keep this list in sync with InstallationData in care-app-provider.tsx.
+const INSTALLATION_COLUMNS = [
+  'id',
+  'tenant_id',
+  'job_reference',
+  'customer_name',
+  'customer_email',
+  'customer_phone',
+  'address_line_1',
+  'city',
+  'county',
+  'system_type',
+  'system_category',
+  'system_size_kwp',
+  'inverter_model',
+  'panel_model',
+  'panel_count',
+  'install_date',
+  'warranty_expiry',
+  'health_status',
+  'portal_status',
+  'system_specs',
+  'heat_pump_model',
+  'heat_pump_serial',
+  'heat_pump_cop',
+  'flow_temp_current',
+  'zones_total',
+  'zones_active',
+  'hot_water_cylinder_model',
+  'hot_water_temp_current',
+  'controls_model',
+  'controls_issue',
+  'last_service_date',
+  'next_service_due',
+  'warranty_years',
+  'annual_service_required',
+  'seai_grant_amount',
+  'seai_grant_status',
+  'seai_grant_ref',
+  'seai_application_date',
+  'ber_rating',
+  'active_safety_alerts',
+  'indoor_temp_current',
+  'indoor_temp_target',
+  'daily_running_cost_cents',
+  'co2_saved_today_grams',
+  'monthly_running_cost_cents',
+  'monthly_budget_cents',
+].join(', ') + ', tenants(name, contact, logo_url)';
 
 export async function generateMetadata({
   params,
@@ -30,10 +94,16 @@ export async function generateMetadata({
       .from('installations')
       .select('tenants(logo_url)')
       .eq('id', installationId)
-      .single();
+      .maybeSingle();
     tenantLogo = (data as any)?.tenants?.logo_url ?? null;
-  } catch {
-    // Fall through to default icon.
+  } catch (err) {
+    // Non-fatal. The page renders fine with the default icon. Log so we can
+    // grep for a regression without needing another full audit.
+    console.warn(
+      '[care.layout.metadata_fetch_error] installation_id=%s error=%s',
+      installationId,
+      err instanceof Error ? err.message : String(err),
+    );
   }
 
   return {
@@ -51,14 +121,6 @@ export async function generateMetadata({
   };
 }
 
-function getSupabaseAdmin() {
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  );
-}
-
 export default async function CareAppLayout({
   children,
   params,
@@ -67,28 +129,58 @@ export default async function CareAppLayout({
   params: Promise<{ installationId: string }>;
 }) {
   const { installationId } = await params;
-  const supabase = getSupabaseAdmin();
 
-  const { data: installation, error } = await supabase
-    .from('installations')
-    .select('*, tenants(name, contact, logo_url)')
-    .eq('id', installationId)
-    .single();
+  let installation: Record<string, unknown> | null = null;
 
-  if (error || !installation) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from('installations')
+      .select(INSTALLATION_COLUMNS)
+      .eq('id', installationId)
+      .maybeSingle();
+
+    if (error) {
+      // Surface the database error path with a grep-able tag. Without this
+      // log, an upstream Supabase issue is invisible: the layout either
+      // 503s at the gateway (cold start + slow query) or silently 404s
+      // (notFound below) and we cannot tell the two apart.
+      console.error(
+        '[care.layout.installation_fetch_error] installation_id=%s code=%s message=%s',
+        installationId,
+        error.code,
+        error.message,
+      );
+    }
+
+    installation = data as Record<string, unknown> | null;
+  } catch (err) {
+    // createClient itself can throw if SUPABASE_SERVICE_ROLE_KEY is missing
+    // or malformed. The centralised getSupabaseAdmin in lib/supabase-server
+    // throws a descriptive error in that case; without this catch, the
+    // throw becomes an opaque 5xx from the function gateway.
+    console.error(
+      '[care.layout.supabase_client_error] installation_id=%s error=%s',
+      installationId,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  if (!installation) {
     notFound();
   }
 
-  const installerName = installation.tenants?.name || 'Your Installer';
+  const tenants = (installation as any).tenants ?? null;
+  const installerName = tenants?.name || 'Your Installer';
 
   const installationData = {
     ...installation,
     installer_name: installerName,
-    installer_contact: installation.tenants?.contact || {},
+    installer_contact: tenants?.contact || {},
   };
 
   return (
-    <CareAppProvider installationId={installationId} installation={installationData}>
+    <CareAppProvider installationId={installationId} installation={installationData as any}>
       <SWRegister />
       {children}
     </CareAppProvider>

--- a/apps/unified-portal/app/care/error.tsx
+++ b/apps/unified-portal/app/care/error.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+// Error boundary for the homeowner Care segment. Catches throws from
+// /care/[installationId]/layout.tsx and below.
+//
+// Without this boundary, an exception during RSC streaming from the layout's
+// Supabase call would surface as a gateway-level 503 with no UI fallback and
+// no useful client-side error. The audit (Care Batch 1.5) caught exactly
+// that pattern: `/care/[id]?_rsc=...` returning 503 with the renderer
+// frozen waiting for the stream.
+//
+// Copy is Irish service-person voice: direct, no filler, no apology.
+
+import { useEffect } from 'react';
+
+export default function CareError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Best-effort browser-side log so a regression is visible in the
+    // browser console even if the server log was lost.
+    console.error('[care.segment.error]', {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <div
+      style={{
+        minHeight: '100dvh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#FAFAFA',
+        padding: '32px 20px',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 360,
+          width: '100%',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 14,
+            background: '#FFF',
+            border: '1px solid #E5E7EB',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            margin: '0 auto 20px',
+          }}
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#9CA3AF"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+        </div>
+        <h1
+          style={{
+            fontSize: 17,
+            fontWeight: 600,
+            color: '#111827',
+            margin: '0 0 8px',
+          }}
+        >
+          Your portal didn't load.
+        </h1>
+        <p
+          style={{
+            fontSize: 14,
+            color: '#6B7280',
+            margin: '0 0 24px',
+            lineHeight: 1.5,
+          }}
+        >
+          The connection to your installer's records dropped. Try again. If it
+          keeps failing, your installer will know about it from their side.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            width: '100%',
+            padding: '12px 16px',
+            background: '#D4AF37',
+            color: '#FFF',
+            border: 'none',
+            borderRadius: 12,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Audit finding

Every Care portal page load was returning **503 on the RSC stream request** (`GET /care/[installationId]?_rsc=...`). This correlated with renderer freezes of 10-15 seconds on roughly 30% of interactions in the Chrome stress test. Every user session was being silently degraded.

## Diagnosis

Confidence: **medium**. The Vercel runtime logs show zero 503s over the last 7 days in production OR preview, which is consistent with the failure being gateway-level (a function that cold-starts past timeout, or throws before any console output is captured) rather than an application-level error that would surface in runtime logs.

The Care layout was the only server-side work on these routes (the page itself is `'use client'`), and it had three patterns that together explain the symptom under cold-start conditions:

1. **`select('*')` on `installations`.** Pulled every column including the `system_specs`, `active_safety_alerts`, and `performance_baseline` JSONB blobs that the layout never needed. On installations with large blobs, this is the slowest possible query.

2. **Local `getSupabaseAdmin()` with bare `process.env.X!`.** If `SUPABASE_SERVICE_ROLE_KEY` is missing or malformed in any environment, the layout throws an opaque error from inside `createClient`, surfacing as a gateway 5xx with no useful log line. The centralised helper in `lib/supabase-server.ts` has elaborate guards added in Session 14.4 for exactly this case; the Care layout was duplicating the function rather than using it.

3. **No error boundary at the Care segment.** A throw from `layout.tsx` blows up the whole RSC stream with no UI fallback.

## What changed

`apps/unified-portal/app/care/[installationId]/layout.tsx`:

- Switched to `getSupabaseAdmin` from `lib/supabase-server`. Env-var failures now throw a descriptive, fix-it error with the variable name and where to set it in Vercel.
- Replaced `select('*')` with an explicit column list in sync with the `InstallationData` interface in `care-app-provider.tsx`. The list intentionally omits `telemetry_api_key`, `qr_code`, `access_code`, `created_at`, `updated_at`. Small security improvement: plaintext `telemetry_api_key` (audit C008, tracked separately) can no longer be accidentally serialised into the client provider.
- Wrapped the data fetch in try/catch with grep-able structured logs:
  - `[care.layout.installation_fetch_error]` for Supabase-side errors
  - `[care.layout.supabase_client_error]` for `createClient` throws
  - `[care.layout.metadata_fetch_error]` for the parallel `generateMetadata` path
- Switched both `.single()` calls to `.maybeSingle()` so a missing row no longer surfaces as a Supabase error before reaching the `notFound()` path.

`apps/unified-portal/app/care/error.tsx` (new):

- Error boundary for the Care segment. Catches throws from `/care/[installationId]/layout.tsx` and below.
- Renders an Irish-voice fallback with a "Try again" button instead of letting the gateway 503 with a frozen renderer.
- Copy: "Your portal didn't load. The connection to your installer's records dropped. Try again. If it keeps failing, your installer will know about it from their side."

## Preview verification

Branch alias: `https://property-assistant-git-claude-care-799a32-openhouseais-projects.vercel.app`

- **Deployment state:** `READY` (`dpl_4mVwwZTkkU9yT9BpCgdofXfrzkdz`).
- **`/api/health`:** returns 200, `version: "c475967"`. Matches the commit SHA `c475967e0d50b86829f0089595b3db72bc15d865`. The preview alias serves new code.
- **`GET /care/00000000-0000-0000-0000-000000000000?_rsc=test1`:** returns **200** (not 503). Response carries `NEXT_NOT_FOUND` digest because the test UUID doesn't exist, but importantly the layout's data path executes cleanly, the error.tsx error boundary appears in the build manifest, and the route is reachable.
- **Runtime logs for the deployment:** `GET /care/...` logged at 200. No errors from the Care layout. (Only unrelated noise is a `git: command not found` from `/api/health` reading the git SHA at build time, which is pre-existing.)

I couldn't reproduce the original 503 against the preview to "before-and-after" the fix, because the failure was gateway-level on cold start. What I confirmed is that the layout's data path executes cleanly and the route returns 200 on the RSC prefetch shape. If the 503 returns after this lands, the structured logs will now tell us which path failed.

## Confidence and what's still in scope

Medium confidence that the fix addresses the root cause. The fix is **defence-in-depth**: every plausible failure path now either fails fast with a clear log, or is caught by the error boundary. The most likely root cause (heavy `select('*')` + cold start) is directly removed. The remaining cold-start exposure is bounded by the much tighter query.

If the 503 returns:
- The structured logs identify which path failed (`installation_fetch_error`, `supabase_client_error`, or something else).
- The error boundary surfaces a usable UI instead of a frozen renderer.
- We have a target for a dedicated batch instead of another full audit.

## Out of scope

- **No Next.js version bump.** Sticking with 14.2.18.
- **No architecture change.** Layout-level data fetch remains. A route-level loader pattern would remove cold-start exposure entirely but is a larger refactor.
- **No `unstable_cache` on the layout query.** `force-dynamic` is there for a reason; revisit when we understand the staleness requirements for tenant logo / branding changes.
- **Encrypting `telemetry_api_key`** (audit C008, separate batch).
- **The duplicate query between `generateMetadata` and the layout body** remains but both are now light. Consolidating into one query through Next's request memoisation is a follow-up.

## Test plan

- [x] Typecheck passes on every modified file.
- [x] No em-dashes in the diff.
- [x] Preview deployment is READY and serves the new commit SHA via `/api/health`.
- [x] `/care/[id]?_rsc=...` returns 200 on the preview.
- [x] Runtime logs for the preview deployment show no Care-related errors.
- [ ] Manual: hit a real installation on the preview alias and confirm the homeowner Care portal renders end to end.
- [ ] Production smoke test after merge: load a real installation page in Chrome and check the Network tab for the RSC request status.

Part of the Care reliability sprint. Sibling PR: PR #126 (warranty tab null-guard).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDhxcMr9DqukZBESKQTgnG)_