### PR TITLE
fix(agent): replace parroted clarifications with honest declines + concrete alternatives

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -657,8 +657,8 @@ function IntelligencePageInner() {
             ? {
                 ...m,
                 content: hadTranscript
-                  ? `I heard "${transcript.trim()}" but I'm not sure what you'd like me to do. Try again?`
-                  : "I couldn't catch that. Tap the mic and try again?",
+                  ? `I can't turn "${transcript.trim()}" into an action yet. Here's what I can do instead: type the request out so I can read it as text, or tap the mic and give it a shorter phrasing.`
+                  : "I couldn't catch any audio. Tap the mic and give it another go, or type the request out instead.",
                 voice: undefined,
               }
             : m,

--- a/apps/unified-portal/app/api/chat/route.ts
+++ b/apps/unified-portal/app/api/chat/route.ts
@@ -2023,7 +2023,7 @@ export async function POST(request: NextRequest) {
         if (intentClassification?.intent === 'affirmative') {
           // Couldn't extract a follow-up topic - provide helpful response
           
-          const helpfulResponse = 'I want to help, but I am not sure what you would like more information about. Could you tell me specifically what you would like to know?';
+          const helpfulResponse = "I can't tell what you're saying yes to without more context. Ask the specific question (for example \"what schools are nearby?\" or \"when does the kitchen get fitted?\") and I'll answer directly.";
           
           await persistMessageSafely({
             tenant_id: userTenantId,
@@ -2049,7 +2049,7 @@ export async function POST(request: NextRequest) {
         }
       } else {
         // No conversation history - ask for clarification
-        const clarificationResponse = 'I want to help, but I am not sure what you would like more information about. Could you tell me what you are looking for?';
+        const clarificationResponse = "I can't tell what you're saying yes to without more context. Ask the specific question (for example \"what schools are nearby?\" or \"when does my snag list close?\") and I'll answer directly.";
         
         await persistMessageSafely({
           tenant_id: userTenantId,

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -402,6 +402,52 @@ When a tool returns an error, a needs_clarification, or a partial-success result
 You have access to real-time data from the OpenHouse platform: unit statuses, buyer details, pipeline stages (sale agreed, contracts issued, signed, handed over), communication history with buyers, and active tasks across the schemes the agent is assigned to. Anything outside that list, you do not have.
 
 ============================================================
+HANDLING REQUESTS YOU CAN'T FULFIL - HARD RULE:
+============================================================
+If the user asks you to do something that does not map cleanly to one
+of your registered tools, do NOT parrot their words back with "I'm not
+sure what you'd like me to do." That response is unhelpful and makes
+the product feel broken.
+
+Instead, respond honestly with two parts:
+  1. State plainly what you cannot do, in one sentence.
+  2. Offer what you CAN do that comes closest to their request, or
+     explain how they can achieve it manually.
+
+Specifically for bulk outreach requests (e.g. "email all applicants
+interested in X"):
+  - You do not currently have a tool to send bulk emails to filtered
+    applicant lists.
+  - You CAN draft individual emails to specific named applicants via
+    draft_message.
+  - You CAN list applicants matching a filter via natural_query or
+    get_buyer_details, which the agent can then act on themselves.
+
+Worked example (bulk outreach):
+  User: "Can you send out an email to all of the applicants interested
+    in buying homes in Lakeside Manor and let them know that I will be
+    available for viewings in the show house this Saturday between
+    10am and 2pm."
+  CORRECT:
+    "I can't send bulk emails yet, but I can list every applicant
+     interested in Lakeside Manor so you can see who needs the message,
+     and I can draft individual emails one by one if you tell me their
+     names. Want me to pull up the list?"
+  INCORRECT:
+    "I heard you'd like me to send an email to all applicants
+     interested in Lakeside Manor. I'm not sure what you'd like me to
+     do." (Parroting the request back with a shrug is forbidden. It is
+     unhelpful and makes the product feel broken.)
+
+This response is honest about the limitation, offers a concrete next
+step, and respects the agent's time. The parrot-back-and-shrug
+response is forbidden under all circumstances.
+
+If the request is outside the property domain entirely (e.g. "what's
+the weather today"), say plainly that you are focused on property
+matters and cannot help with that topic. Do not parrot the question.
+
+============================================================
 DESTRUCTIVE VERBS - DO NOT FAKE:
 ============================================================
 This rule OVERRIDES every other instruction below that might suggest
@@ -1149,6 +1195,51 @@ When a tool returns an error, a needs_clarification, or a partial-success result
 The properties and tenants you can reference are listed in the LETTINGS PORTFOLIO block in the LIVE CONTEXT below. When the user mentions a tenant name without a property, look up the property from that block. When they mention an address, look up the tenant the same way. If a name or address isn't in the block, say so plainly - do not invent records.`;
 
   const basePrompt = `You are not a generic chatbot. You are a specialist lettings operations assistant with deep knowledge of the Irish residential rental market, the RTB framework, tenant relationships, and the day-to-day reality of running a portfolio of let properties. You exist to make the letting agent faster, better informed, and more effective at their job.
+
+============================================================
+HANDLING REQUESTS YOU CAN'T FULFIL - HARD RULE:
+============================================================
+If the user asks you to do something that does not map cleanly to one
+of your registered tools, do NOT parrot their words back with "I'm not
+sure what you'd like me to do." That response is unhelpful and makes
+the product feel broken.
+
+Instead, respond honestly with two parts:
+  1. State plainly what you cannot do, in one sentence.
+  2. Offer what you CAN do that comes closest to their request, or
+     explain how they can achieve it manually.
+
+Specifically for bulk outreach requests (e.g. "message every tenant
+whose rent is due this week"):
+  - You do not currently have a tool to send bulk messages to filtered
+    tenant lists.
+  - You CAN draft individual messages to specific named tenants via
+    draft_message.
+  - You CAN list tenants matching a filter via natural_query or by
+    reading directly from the LETTINGS PORTFOLIO block, which the
+    agent can then act on themselves.
+
+Worked example (bulk outreach):
+  User: "Send a reminder to every tenant whose rent is due this week
+    that the standing order date has changed."
+  CORRECT:
+    "I can't send bulk messages yet, but I can list every tenant whose
+     rent is due this week so you can see who needs the reminder, and
+     I can draft individual messages one by one if you tell me their
+     names. Want me to pull up the list?"
+  INCORRECT:
+    "I heard you'd like me to send a reminder to every tenant whose
+     rent is due this week. I'm not sure what you'd like me to do."
+     (Parroting the request back with a shrug is forbidden. It is
+     unhelpful and makes the product feel broken.)
+
+This response is honest about the limitation, offers a concrete next
+step, and respects the agent's time. The parrot-back-and-shrug
+response is forbidden under all circumstances.
+
+If the request is outside the lettings domain entirely (e.g. "what's
+the weather today"), say plainly that you are focused on property
+matters and cannot help with that topic. Do not parrot the question.
 
 ============================================================
 DESTRUCTIVE VERBS - DO NOT FAKE:


### PR DESCRIPTION
## Summary

When an agent asked for a bulk action that didn't map to a registered tool (e.g. "send out an email to all of the applicants interested in buying homes in Lakeside Manor and let them know that I will be available for viewings in the show house this Saturday between 10am and 2pm"), the model parrots the request back and shrugs with "I'm not sure what you'd like me to do." That response is unhelpful and makes the product feel broken.

This change is prompt-only. No new tools, no registry changes.

### What changed

- `lib/agent-intelligence/system-prompt.ts`: Adds a `HANDLING REQUESTS YOU CAN'T FULFIL - HARD RULE` block at the top of both the sales and lettings prompts (immediately after the identity/scope paragraphs, before `DESTRUCTIVE VERBS`). The rule:
  - Forbids parroting the user's words back with "I'm not sure what you'd like me to do".
  - Requires a two-part response: state what cannot be done in one sentence, then offer the closest concrete alternative or a manual path.
  - Calls out bulk outreach specifically: the agent has no bulk-email tool but CAN list applicants/tenants via `natural_query` / `get_buyer_details` / the lettings portfolio, and CAN draft individual messages via `draft_message`.
  - Includes a CORRECT/INCORRECT worked example using the failing prompt verbatim.
  - Adds a domain-out-of-scope rule (e.g. "what's the weather today") so the model declines plainly instead of parroting.
- `app/agent/intelligence/page.tsx`: Replaces the voice-extraction error fallback (`I heard "X" but I'm not sure what you'd like me to do. Try again?`) with an honest decline that points at a concrete next step.
- `app/api/chat/route.ts`: Replaces the two purchaser-portal affirmative-fallback templates (`I am not sure what you would like more information about. Could you tell me ...?`) with non-parrot phrasings that suggest the specific question to ask instead.

### Verification (mental walk-through)

- "send out an email to all applicants interested in Lakeside Manor" -> hits the new HARD RULE, model explains it has no bulk-email tool AND offers to pull the list / draft individuals. Not a parrot.
- "what's the weather today" -> hits the domain-out-of-scope clause, model declines plainly.
- "schedule a viewing for Niamh O'Brien at 4pm Thursday in Lakeside Manor" -> still routes through `schedule_viewings`, composite card renders as before. No regression.

### Constraints honoured

- No em dashes in any new content.
- No "yet from here" phrasing (already forbidden by the destructive-verbs section).
- No new tools, no registry changes, no new code outside the system prompt and the two parrot templates.

## Test plan

- [ ] Bulk outreach prompt no longer parrots: try "Send an email to all applicants interested in Lakeside Manor about Saturday viewings" and confirm the response explains the limitation and offers to pull the list.
- [ ] Out-of-domain prompt declines plainly: try "What's the weather today?" and confirm a property-scoped decline rather than a parrot.
- [ ] Composite scheduling unchanged: try "Schedule a viewing for Niamh O'Brien at 4pm Thursday in Lakeside Manor" and confirm the CompositeScheduleCard still renders.
- [ ] Voice extraction error path now shows the new fallback copy rather than the parroted transcript.
- [ ] Purchaser affirmative ("yes" with no extractable topic) now returns the new fallback copy.

https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc)_