### PR TITLE
feat(agent): bulk personalised applicant broadcast (7a, backend)

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -657,8 +657,8 @@ function IntelligencePageInner() {
             ? {
                 ...m,
                 content: hadTranscript
-                  ? `I heard "${transcript.trim()}" but I'm not sure what you'd like me to do. Try again?`
-                  : "I couldn't catch that. Tap the mic and try again?",
+                  ? `I can't turn "${transcript.trim()}" into an action yet. Here's what I can do instead: type the request out so I can read it as text, or tap the mic and give it a shorter phrasing.`
+                  : "I couldn't catch any audio. Tap the mic and give it another go, or type the request out instead.",
                 voice: undefined,
               }
             : m,

--- a/apps/unified-portal/app/api/agent-intelligence/broadcast-history/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/broadcast-history/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+import { listBroadcastHistory } from '@/lib/agent-intelligence/tools/broadcast-tools';
+import type { AgentContext } from '@/lib/agent-intelligence/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabaseAdmin = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const v2 = await resolveAgentContextV2(supabaseAdmin, user.id);
+    const resolved = v2.context;
+    if (!resolved) return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
+
+    const agentContext: AgentContext = {
+      agentProfileId: resolved.agentProfileId,
+      authUserId: resolved.authUserId,
+      tenantId: resolved.tenantId ?? '',
+      displayName: resolved.displayName,
+      agencyName: resolved.agencyName,
+      agentType: resolved.agentType,
+      assignedSchemes: resolved.assignedSchemes,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      activeDevelopmentId: null,
+      isDemoMode: resolved.isDemoMode,
+    };
+
+    if (!agentContext.tenantId) {
+      return NextResponse.json({ error: 'Agent has no tenant assignment' }, { status: 403 });
+    }
+
+    const limitParam = request.nextUrl.searchParams.get('limit');
+    const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : DEFAULT_LIMIT;
+    const limit = Number.isFinite(parsedLimit) ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT) : DEFAULT_LIMIT;
+
+    const rows = await listBroadcastHistory(supabaseAdmin, agentContext, limit);
+    return NextResponse.json({ broadcasts: rows });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[broadcast-history] unhandled', { message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent-intelligence/cancel-broadcast/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/cancel-broadcast/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+import { cancelBroadcast } from '@/lib/agent-intelligence/tools/broadcast-tools';
+import type { AgentContext } from '@/lib/agent-intelligence/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const raw = await request.json();
+    const auditLogId = typeof raw?.audit_log_id === 'string' ? raw.audit_log_id.trim() : '';
+    if (!auditLogId) {
+      return NextResponse.json({ error: 'audit_log_id is required' }, { status: 400 });
+    }
+
+    const supabaseAdmin = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const v2 = await resolveAgentContextV2(supabaseAdmin, user.id);
+    const resolved = v2.context;
+    if (!resolved) return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
+
+    const agentContext: AgentContext = {
+      agentProfileId: resolved.agentProfileId,
+      authUserId: resolved.authUserId,
+      tenantId: resolved.tenantId ?? '',
+      displayName: resolved.displayName,
+      agencyName: resolved.agencyName,
+      agentType: resolved.agentType,
+      assignedSchemes: resolved.assignedSchemes,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      activeDevelopmentId: null,
+      isDemoMode: resolved.isDemoMode,
+    };
+
+    if (!agentContext.tenantId) {
+      return NextResponse.json({ error: 'Agent has no tenant assignment' }, { status: 403 });
+    }
+
+    const result = await cancelBroadcast(supabaseAdmin, agentContext, { audit_log_id: auditLogId });
+
+    if (result.status === 'not_found') {
+      return NextResponse.json({ status: 'not_found', error: result.error }, { status: 404 });
+    }
+    if (result.status === 'expired') {
+      return NextResponse.json({ status: 'expired', error: result.error }, { status: 410 });
+    }
+    if (result.status === 'error') {
+      return NextResponse.json({ status: 'error', error: result.error }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      status: result.status,
+      drafts_deleted: result.drafts_deleted,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[cancel-broadcast] unhandled', { message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/agent-intelligence/confirm-broadcast/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/confirm-broadcast/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
+import {
+  confirmBroadcast,
+  type BroadcastDraftEnvelope,
+  type BroadcastEmailDraft,
+} from '@/lib/agent-intelligence/tools/broadcast-tools';
+import type { AgentContext } from '@/lib/agent-intelligence/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface IncomingBody {
+  draft: BroadcastDraftEnvelope;
+  selected_applicant_ids?: string[];
+  selected_emails?: BroadcastEmailDraft[];
+}
+
+function isValidEmail(value: unknown): value is string {
+  return typeof value === 'string' && /.+@.+\..+/.test(value);
+}
+
+function validateBody(raw: any): { ok: true; data: IncomingBody } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'Invalid body' };
+  const draft = raw.draft;
+  if (!draft || typeof draft !== 'object') return { ok: false, error: 'draft is required' };
+  if (draft.status !== 'draft' || draft.type !== 'broadcast') {
+    return { ok: false, error: 'draft must be a broadcast envelope' };
+  }
+  if (!Array.isArray(draft.emails) || draft.emails.length === 0) {
+    return { ok: false, error: 'draft.emails must contain at least one entry' };
+  }
+  for (const e of draft.emails) {
+    if (!e || typeof e !== 'object') return { ok: false, error: 'Invalid email entry' };
+    if (!isValidEmail(e.recipient_email)) return { ok: false, error: 'Email recipient_email invalid' };
+    if (typeof e.subject !== 'string' || typeof e.body !== 'string') {
+      return { ok: false, error: 'Each email needs subject and body strings' };
+    }
+  }
+  return { ok: true, data: raw as IncomingBody };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const raw = await request.json();
+    const validated = validateBody(raw);
+    if (!validated.ok) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+    const body = validated.data;
+
+    const supabaseAdmin = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+
+    const v2 = await resolveAgentContextV2(supabaseAdmin, user.id);
+    const resolved = v2.context;
+    if (!resolved) return NextResponse.json({ error: 'No agent profile found' }, { status: 401 });
+
+    const agentContext: AgentContext = {
+      agentProfileId: resolved.agentProfileId,
+      authUserId: resolved.authUserId,
+      tenantId: resolved.tenantId ?? '',
+      displayName: resolved.displayName,
+      agencyName: resolved.agencyName,
+      agentType: resolved.agentType,
+      assignedSchemes: resolved.assignedSchemes,
+      assignedDevelopmentIds: resolved.assignedDevelopmentIds,
+      assignedDevelopmentNames: resolved.assignedDevelopmentNames,
+      activeDevelopmentId: null,
+      isDemoMode: resolved.isDemoMode,
+    };
+
+    if (!agentContext.tenantId) {
+      return NextResponse.json({ error: 'Agent has no tenant assignment' }, { status: 403 });
+    }
+
+    // selected_emails wins when supplied (the card sends edited subjects/bodies
+    // plus per-row selection). Otherwise selected_applicant_ids filters the
+    // envelope's emails by applicant_id, and a missing filter means "send all".
+    const candidateEmails = (body.selected_emails && body.selected_emails.length > 0)
+      ? body.selected_emails
+      : body.draft.emails;
+
+    const selectedIds = Array.isArray(body.selected_applicant_ids)
+      ? new Set(body.selected_applicant_ids)
+      : null;
+    const selectedEmailSet = Array.isArray(body.selected_emails)
+      ? new Set(body.selected_emails.map((e) => e.recipient_email.trim().toLowerCase()))
+      : null;
+
+    const emails = candidateEmails
+      .filter((e) => {
+        if (!e.subject?.trim() || !e.body?.trim()) return false;
+        if (selectedIds) {
+          if (e.applicant_id === null) return selectedEmailSet?.has(e.recipient_email.trim().toLowerCase()) ?? false;
+          return selectedIds.has(e.applicant_id);
+        }
+        if (selectedEmailSet) {
+          return selectedEmailSet.has(e.recipient_email.trim().toLowerCase());
+        }
+        return e.selected !== false;
+      })
+      .map((e) => ({
+        applicant_id: e.applicant_id ?? null,
+        recipient_email: e.recipient_email.trim(),
+        recipient_name: (e.recipient_name || '').trim() || e.recipient_email,
+        subject: e.subject.trim(),
+        body: e.body.trim(),
+      }));
+
+    if (emails.length === 0) {
+      return NextResponse.json({ error: 'Pick at least one recipient.' }, { status: 400 });
+    }
+
+    const result = await confirmBroadcast(supabaseAdmin, agentContext, {
+      intent: body.draft.intent,
+      filter_used: body.draft.filter_used,
+      filter_natural: body.draft.filter_natural,
+      tone: body.draft.tone,
+      emails,
+    });
+
+    if (result.status === 'error') {
+      return NextResponse.json(
+        { status: 'error', error: result.error, broadcast_id: result.broadcast_id, drafts_written: 0 },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      status: 'success',
+      broadcast_id: result.broadcast_id,
+      drafts_written: result.drafts_written,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[confirm-broadcast] unhandled', { message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/chat/route.ts
+++ b/apps/unified-portal/app/api/chat/route.ts
@@ -2023,7 +2023,7 @@ export async function POST(request: NextRequest) {
         if (intentClassification?.intent === 'affirmative') {
           // Couldn't extract a follow-up topic - provide helpful response
           
-          const helpfulResponse = 'I want to help, but I am not sure what you would like more information about. Could you tell me specifically what you would like to know?';
+          const helpfulResponse = "I can't tell what you're saying yes to without more context. Ask the specific question (for example \"what schools are nearby?\" or \"when does the kitchen get fitted?\") and I'll answer directly.";
           
           await persistMessageSafely({
             tenant_id: userTenantId,
@@ -2049,7 +2049,7 @@ export async function POST(request: NextRequest) {
         }
       } else {
         // No conversation history - ask for clarification
-        const clarificationResponse = 'I want to help, but I am not sure what you would like more information about. Could you tell me what you are looking for?';
+        const clarificationResponse = "I can't tell what you're saying yes to without more context. Ask the specific question (for example \"what schools are nearby?\" or \"when does my snag list close?\") and I'll answer directly.";
         
         await persistMessageSafely({
           tenant_id: userTenantId,

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -402,6 +402,52 @@ When a tool returns an error, a needs_clarification, or a partial-success result
 You have access to real-time data from the OpenHouse platform: unit statuses, buyer details, pipeline stages (sale agreed, contracts issued, signed, handed over), communication history with buyers, and active tasks across the schemes the agent is assigned to. Anything outside that list, you do not have.
 
 ============================================================
+HANDLING REQUESTS YOU CAN'T FULFIL - HARD RULE:
+============================================================
+If the user asks you to do something that does not map cleanly to one
+of your registered tools, do NOT parrot their words back with "I'm not
+sure what you'd like me to do." That response is unhelpful and makes
+the product feel broken.
+
+Instead, respond honestly with two parts:
+  1. State plainly what you cannot do, in one sentence.
+  2. Offer what you CAN do that comes closest to their request, or
+     explain how they can achieve it manually.
+
+Specifically for bulk outreach requests (e.g. "email all applicants
+interested in X"):
+  - You do not currently have a tool to send bulk emails to filtered
+    applicant lists.
+  - You CAN draft individual emails to specific named applicants via
+    draft_message.
+  - You CAN list applicants matching a filter via natural_query or
+    get_buyer_details, which the agent can then act on themselves.
+
+Worked example (bulk outreach):
+  User: "Can you send out an email to all of the applicants interested
+    in buying homes in Lakeside Manor and let them know that I will be
+    available for viewings in the show house this Saturday between
+    10am and 2pm."
+  CORRECT:
+    "I can't send bulk emails yet, but I can list every applicant
+     interested in Lakeside Manor so you can see who needs the message,
+     and I can draft individual emails one by one if you tell me their
+     names. Want me to pull up the list?"
+  INCORRECT:
+    "I heard you'd like me to send an email to all applicants
+     interested in Lakeside Manor. I'm not sure what you'd like me to
+     do." (Parroting the request back with a shrug is forbidden. It is
+     unhelpful and makes the product feel broken.)
+
+This response is honest about the limitation, offers a concrete next
+step, and respects the agent's time. The parrot-back-and-shrug
+response is forbidden under all circumstances.
+
+If the request is outside the property domain entirely (e.g. "what's
+the weather today"), say plainly that you are focused on property
+matters and cannot help with that topic. Do not parrot the question.
+
+============================================================
 DESTRUCTIVE VERBS - DO NOT FAKE:
 ============================================================
 This rule OVERRIDES every other instruction below that might suggest
@@ -1149,6 +1195,51 @@ When a tool returns an error, a needs_clarification, or a partial-success result
 The properties and tenants you can reference are listed in the LETTINGS PORTFOLIO block in the LIVE CONTEXT below. When the user mentions a tenant name without a property, look up the property from that block. When they mention an address, look up the tenant the same way. If a name or address isn't in the block, say so plainly - do not invent records.`;
 
   const basePrompt = `You are not a generic chatbot. You are a specialist lettings operations assistant with deep knowledge of the Irish residential rental market, the RTB framework, tenant relationships, and the day-to-day reality of running a portfolio of let properties. You exist to make the letting agent faster, better informed, and more effective at their job.
+
+============================================================
+HANDLING REQUESTS YOU CAN'T FULFIL - HARD RULE:
+============================================================
+If the user asks you to do something that does not map cleanly to one
+of your registered tools, do NOT parrot their words back with "I'm not
+sure what you'd like me to do." That response is unhelpful and makes
+the product feel broken.
+
+Instead, respond honestly with two parts:
+  1. State plainly what you cannot do, in one sentence.
+  2. Offer what you CAN do that comes closest to their request, or
+     explain how they can achieve it manually.
+
+Specifically for bulk outreach requests (e.g. "message every tenant
+whose rent is due this week"):
+  - You do not currently have a tool to send bulk messages to filtered
+    tenant lists.
+  - You CAN draft individual messages to specific named tenants via
+    draft_message.
+  - You CAN list tenants matching a filter via natural_query or by
+    reading directly from the LETTINGS PORTFOLIO block, which the
+    agent can then act on themselves.
+
+Worked example (bulk outreach):
+  User: "Send a reminder to every tenant whose rent is due this week
+    that the standing order date has changed."
+  CORRECT:
+    "I can't send bulk messages yet, but I can list every tenant whose
+     rent is due this week so you can see who needs the reminder, and
+     I can draft individual messages one by one if you tell me their
+     names. Want me to pull up the list?"
+  INCORRECT:
+    "I heard you'd like me to send a reminder to every tenant whose
+     rent is due this week. I'm not sure what you'd like me to do."
+     (Parroting the request back with a shrug is forbidden. It is
+     unhelpful and makes the product feel broken.)
+
+This response is honest about the limitation, offers a concrete next
+step, and respects the agent's time. The parrot-back-and-shrug
+response is forbidden under all circumstances.
+
+If the request is outside the lettings domain entirely (e.g. "what's
+the weather today"), say plainly that you are focused on property
+matters and cannot help with that topic. Do not parrot the question.
 
 ============================================================
 DESTRUCTIVE VERBS - DO NOT FAKE:

--- a/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
@@ -1,0 +1,937 @@
+/**
+ * Bulk personalised applicant broadcast.
+ *
+ * Real letting agents and sales agents do this several times a week:
+ * pick a filter ("everyone interested in Lakeside Manor"), state the
+ * thing to convey ("I'm in the show house Saturday 10-2"), and the
+ * platform produces N personalised drafts the agent can review.
+ *
+ * Pipeline is three phases inside planBroadcast:
+ *   Phase 1 - LLM parses the natural-language filter into a structured
+ *             filter object. Refuses to invent; returns clarification
+ *             when underspecified.
+ *   Phase 2 - SQL resolves the filter to a deduped list of recipients
+ *             from the enquiries table within the agent's tenant.
+ *   Phase 3 - LLM drafts one personalised email per recipient. Strict
+ *             never-invent contract: the recipient record + the
+ *             agent's stated intent are the only sources of truth.
+ *
+ * confirmBroadcast writes the audit row + N pending_drafts atomically
+ * (audit first to obtain the broadcast_id; drafts insert with that id;
+ * if drafts fail the audit is rolled back to cancelled to keep state
+ * honest).
+ *
+ * cancelBroadcast supports a 30-minute undo window. Pending drafts not
+ * yet sent are deleted; sent rows are left alone so the audit stays
+ * accurate as a partial_sent record.
+ */
+
+import OpenAI from 'openai';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { AgentContext, ToolResult } from '../types';
+import { matchDevelopment, type Development } from '../property-matcher';
+import { scrubFollowUpBody } from './voice-capture-tools';
+
+export type BroadcastTone = 'warm' | 'professional' | 'urgent';
+
+export interface BroadcastFilter {
+  interested_in_scheme_ids?: string[];
+  has_active_enquiry?: boolean;
+  viewed_property_ids?: string[];
+  last_contact_before_days?: number;
+  status?: string[];
+}
+
+export interface BroadcastRecipient {
+  applicant_id: string | null;
+  name: string;
+  email: string;
+  scheme_of_interest_id: string | null;
+  scheme_of_interest_name: string | null;
+  last_contact_date: string | null;
+}
+
+export interface BroadcastEmailDraft {
+  applicant_id: string | null;
+  recipient_email: string;
+  recipient_name: string;
+  subject: string;
+  body: string;
+  selected: boolean;
+}
+
+export interface BroadcastDraftEnvelope {
+  status: 'draft';
+  type: 'broadcast';
+  intent: string;
+  filter_used: BroadcastFilter;
+  filter_natural: string;
+  tone: BroadcastTone;
+  recipients: BroadcastRecipient[];
+  emails: BroadcastEmailDraft[];
+  shared_signoff: string;
+  message: string;
+}
+
+export type BroadcastClarificationReason =
+  | 'no_intent'
+  | 'no_filter'
+  | 'filter_unparseable'
+  | 'no_recipients_match'
+  | 'too_many_recipients'
+  | 'extraction_failed';
+
+export interface BroadcastClarification {
+  status: 'needs_clarification';
+  reason: BroadcastClarificationReason;
+  message: string;
+  sample_recipients?: BroadcastRecipient[];
+  recipient_count?: number;
+}
+
+export type BroadcastPlanResult = BroadcastDraftEnvelope | BroadcastClarification;
+
+interface PlanBroadcastParams {
+  intent?: string;
+  filter_natural?: string;
+  tone?: BroadcastTone;
+}
+
+interface PlanBroadcastOptions {
+  filterModel?: string;
+  emailModel?: string;
+  client?: OpenAI;
+  maxRecipients?: number;
+}
+
+const DEFAULT_FILTER_MODEL = 'gpt-4o-mini';
+const DEFAULT_EMAIL_MODEL = 'gpt-4o-mini';
+const DEFAULT_MAX_RECIPIENTS = 200;
+const VALID_TONES: BroadcastTone[] = ['warm', 'professional', 'urgent'];
+const UNDO_WINDOW_MS = 30 * 60 * 1000;
+
+function normaliseTone(raw: unknown): BroadcastTone {
+  if (typeof raw === 'string' && VALID_TONES.includes(raw as BroadcastTone)) {
+    return raw as BroadcastTone;
+  }
+  return 'warm';
+}
+
+function buildSchemeContext(agentContext: AgentContext): Development[] {
+  const ids = agentContext.assignedDevelopmentIds ?? [];
+  const names = agentContext.assignedDevelopmentNames ?? [];
+  const out: Development[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const name = names[i];
+    if (name) out.push({ id: ids[i], name });
+  }
+  return out;
+}
+
+// =====================================================================
+// Phase 1 - parse the natural-language filter
+// =====================================================================
+
+const FILTER_SYSTEM_PROMPT = `You convert a property agent's natural-language description of a recipient cohort into a structured filter object. The agent is Irish and may name schemes in casual English.
+
+Return JSON of exactly this shape:
+{
+  "interested_in_scheme_names": string[],
+  "has_active_enquiry": boolean | null,
+  "viewed_property_names": string[],
+  "last_contact_before_days": number | null,
+  "status": string[],
+  "confidence": "high" | "medium" | "low"
+}
+
+Rules:
+- Only populate a field when the agent's wording clearly implies it. Otherwise leave it null or empty.
+- interested_in_scheme_names: extract any scheme names the agent mentioned, exactly as they wrote them. Do not normalise. Do not invent.
+- has_active_enquiry: true when the agent's wording implies open or unresolved enquiries. null otherwise.
+- viewed_property_names: scheme or property names the agent said the recipients viewed.
+- last_contact_before_days: integer count of days, when the agent said something like "haven't heard from in 30 days". null otherwise.
+- status: enquiry status terms the agent used verbatim ("new", "warm", "cold"). Empty array otherwise.
+- confidence: "high" when the description is unambiguous, "low" when you had to guess.
+
+NEVER invent a scheme name the agent didn't say. NEVER infer days the agent didn't state. NEVER use em dashes anywhere in your output.`;
+
+interface FilterLLMOutput {
+  interested_in_scheme_names: string[];
+  has_active_enquiry: boolean | null;
+  viewed_property_names: string[];
+  last_contact_before_days: number | null;
+  status: string[];
+  confidence: 'high' | 'medium' | 'low';
+}
+
+function normaliseFilterLLMOutput(raw: any): FilterLLMOutput {
+  const schemes = Array.isArray(raw?.interested_in_scheme_names)
+    ? raw.interested_in_scheme_names.filter((s: any) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  const viewed = Array.isArray(raw?.viewed_property_names)
+    ? raw.viewed_property_names.filter((s: any) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  const statuses = Array.isArray(raw?.status)
+    ? raw.status.filter((s: any) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  const days =
+    typeof raw?.last_contact_before_days === 'number' && Number.isFinite(raw.last_contact_before_days)
+      ? Math.max(0, Math.floor(raw.last_contact_before_days))
+      : null;
+  const hasActive =
+    typeof raw?.has_active_enquiry === 'boolean' ? raw.has_active_enquiry : null;
+  const confidence =
+    raw?.confidence === 'high' || raw?.confidence === 'medium' || raw?.confidence === 'low'
+      ? raw.confidence
+      : 'medium';
+  return {
+    interested_in_scheme_names: schemes,
+    has_active_enquiry: hasActive,
+    viewed_property_names: viewed,
+    last_contact_before_days: days,
+    status: statuses,
+    confidence,
+  };
+}
+
+async function parseFilter(
+  filterNatural: string,
+  agentContext: AgentContext,
+  options: PlanBroadcastOptions,
+): Promise<FilterLLMOutput> {
+  const client = options.client ?? new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const model = options.filterModel ?? DEFAULT_FILTER_MODEL;
+  const assigned = buildSchemeContext(agentContext);
+  const userPrompt = `Agent's assigned schemes (context only, the agent may name any of them or none):
+${assigned.map((d) => `- ${d.name}`).join('\n') || '(none assigned)'}
+
+Filter description (verbatim from the agent):
+"""
+${filterNatural}
+"""
+
+Return the JSON object described in the system prompt.`;
+
+  const completion = await client.chat.completions.create({
+    model,
+    temperature: 0.1,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: FILTER_SYSTEM_PROMPT },
+      { role: 'user', content: userPrompt },
+    ],
+  });
+  const content = completion.choices[0]?.message?.content ?? '{}';
+  let raw: any;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    raw = {};
+  }
+  return normaliseFilterLLMOutput(raw);
+}
+
+function resolveSchemeIdsFromNames(
+  names: string[],
+  agentContext: AgentContext,
+): { ids: string[]; unresolved: string[] } {
+  const assigned = buildSchemeContext(agentContext);
+  const ids: string[] = [];
+  const unresolved: string[] = [];
+  for (const name of names) {
+    const match = matchDevelopment(name, assigned);
+    if (match.type === 'unique') {
+      ids.push(match.development.id);
+    } else {
+      unresolved.push(name);
+    }
+  }
+  return { ids: Array.from(new Set(ids)), unresolved };
+}
+
+function buildStructuredFilter(
+  parsed: FilterLLMOutput,
+  agentContext: AgentContext,
+): { filter: BroadcastFilter; unresolved_schemes: string[]; unresolved_viewed: string[] } {
+  const interested = resolveSchemeIdsFromNames(parsed.interested_in_scheme_names, agentContext);
+  const viewed = resolveSchemeIdsFromNames(parsed.viewed_property_names, agentContext);
+  const filter: BroadcastFilter = {};
+  if (interested.ids.length > 0) filter.interested_in_scheme_ids = interested.ids;
+  if (typeof parsed.has_active_enquiry === 'boolean') filter.has_active_enquiry = parsed.has_active_enquiry;
+  if (viewed.ids.length > 0) filter.viewed_property_ids = viewed.ids;
+  if (typeof parsed.last_contact_before_days === 'number')
+    filter.last_contact_before_days = parsed.last_contact_before_days;
+  if (parsed.status.length > 0) filter.status = parsed.status;
+  return {
+    filter,
+    unresolved_schemes: interested.unresolved,
+    unresolved_viewed: viewed.unresolved,
+  };
+}
+
+// =====================================================================
+// Phase 2 - resolve recipients from the database
+// =====================================================================
+
+interface EnquiryRow {
+  id: string;
+  enquirer_name: string | null;
+  enquirer_email: string | null;
+  development_id: string | null;
+  status: string | null;
+  last_contacted_at: string | null;
+  created_at: string;
+}
+
+const ACTIVE_ENQUIRY_STATUSES = new Set([
+  'new',
+  'open',
+  'active',
+  'warm',
+  'in_progress',
+  'pending',
+  'awaiting_response',
+]);
+
+function dedupeRecipients(
+  rows: EnquiryRow[],
+  schemeNameById: Map<string, string>,
+): BroadcastRecipient[] {
+  const byKey = new Map<string, BroadcastRecipient>();
+  for (const row of rows) {
+    const email = (row.enquirer_email || '').trim().toLowerCase();
+    const name = (row.enquirer_name || '').trim();
+    if (!email || !name) continue;
+    const key = email;
+    const schemeId = row.development_id || null;
+    const schemeName = schemeId ? schemeNameById.get(schemeId) || null : null;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, {
+        applicant_id: null,
+        name,
+        email,
+        scheme_of_interest_id: schemeId,
+        scheme_of_interest_name: schemeName,
+        last_contact_date: row.last_contacted_at,
+      });
+      continue;
+    }
+    // Prefer the most recently contacted record for the same email.
+    if (
+      row.last_contacted_at &&
+      (!existing.last_contact_date || row.last_contacted_at > existing.last_contact_date)
+    ) {
+      existing.last_contact_date = row.last_contacted_at;
+    }
+    if (!existing.scheme_of_interest_id && schemeId) {
+      existing.scheme_of_interest_id = schemeId;
+      existing.scheme_of_interest_name = schemeName;
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function attachApplicantIds(
+  supabase: SupabaseClient,
+  tenantId: string,
+  recipients: BroadcastRecipient[],
+): Promise<BroadcastRecipient[]> {
+  if (recipients.length === 0) return recipients;
+  const emails = recipients.map((r) => r.email);
+  const { data, error } = await supabase
+    .from('agent_applicants')
+    .select('id, email')
+    .eq('tenant_id', tenantId)
+    .in('email', emails);
+  if (error || !Array.isArray(data)) return recipients;
+  const byEmail = new Map<string, string>();
+  for (const row of data as Array<{ id: string; email: string | null }>) {
+    if (row.email) byEmail.set(row.email.trim().toLowerCase(), row.id);
+  }
+  return recipients.map((r) => ({ ...r, applicant_id: byEmail.get(r.email) ?? null }));
+}
+
+async function resolveRecipients(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  filter: BroadcastFilter,
+): Promise<BroadcastRecipient[]> {
+  const tenantId = agentContext.tenantId;
+  const assignedIds = new Set(agentContext.assignedDevelopmentIds ?? []);
+
+  let query = supabase
+    .from('enquiries')
+    .select('id, enquirer_name, enquirer_email, development_id, status, last_contacted_at, created_at')
+    .eq('tenant_id', tenantId)
+    .not('enquirer_email', 'is', null);
+
+  if (filter.interested_in_scheme_ids && filter.interested_in_scheme_ids.length > 0) {
+    query = query.in('development_id', filter.interested_in_scheme_ids);
+  } else if (assignedIds.size > 0) {
+    // No explicit scheme filter, but scope to the agent's assigned schemes so
+    // we never surface a recipient from outside the agent's own pipeline.
+    query = query.in('development_id', Array.from(assignedIds));
+  }
+
+  if (filter.status && filter.status.length > 0) {
+    query = query.in('status', filter.status);
+  }
+
+  if (filter.last_contact_before_days !== undefined) {
+    const cutoff = new Date(Date.now() - filter.last_contact_before_days * 24 * 60 * 60 * 1000);
+    query = query.or(`last_contacted_at.is.null,last_contacted_at.lt.${cutoff.toISOString()}`);
+  }
+
+  const { data, error } = await query.limit(1000);
+  if (error) {
+    console.error('[broadcast-tools] enquiry query failed', { message: error.message });
+    return [];
+  }
+  let rows = (data as EnquiryRow[]) ?? [];
+
+  if (filter.has_active_enquiry === true) {
+    rows = rows.filter((r) => r.status && ACTIVE_ENQUIRY_STATUSES.has(r.status.toLowerCase()));
+  } else if (filter.has_active_enquiry === false) {
+    rows = rows.filter((r) => !r.status || !ACTIVE_ENQUIRY_STATUSES.has(r.status.toLowerCase()));
+  }
+
+  // viewed_property_ids: cross-reference with agent_viewings on email match.
+  if (filter.viewed_property_ids && filter.viewed_property_ids.length > 0) {
+    const { data: viewings } = await supabase
+      .from('agent_viewings')
+      .select('buyer_email, development_id')
+      .eq('tenant_id', tenantId)
+      .in('development_id', filter.viewed_property_ids);
+    const viewedEmails = new Set<string>();
+    for (const v of (viewings as Array<{ buyer_email: string | null }> | null) ?? []) {
+      if (v.buyer_email) viewedEmails.add(v.buyer_email.trim().toLowerCase());
+    }
+    rows = rows.filter((r) => r.enquirer_email && viewedEmails.has(r.enquirer_email.trim().toLowerCase()));
+  }
+
+  const schemeNameById = new Map<string, string>();
+  const ids = agentContext.assignedDevelopmentIds ?? [];
+  const names = agentContext.assignedDevelopmentNames ?? [];
+  for (let i = 0; i < ids.length; i++) {
+    if (names[i]) schemeNameById.set(ids[i], names[i]);
+  }
+
+  const recipients = dedupeRecipients(rows, schemeNameById);
+  return attachApplicantIds(supabase, tenantId, recipients);
+}
+
+async function sampleTenantRecipients(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  limit = 5,
+): Promise<BroadcastRecipient[]> {
+  const { data } = await supabase
+    .from('enquiries')
+    .select('enquirer_name, enquirer_email, development_id, last_contacted_at, created_at')
+    .eq('tenant_id', agentContext.tenantId)
+    .not('enquirer_email', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  const rows = ((data as EnquiryRow[]) ?? []).map((r) => ({ ...r, id: '', status: null }));
+  const schemeNameById = new Map<string, string>();
+  const ids = agentContext.assignedDevelopmentIds ?? [];
+  const names = agentContext.assignedDevelopmentNames ?? [];
+  for (let i = 0; i < ids.length; i++) {
+    if (names[i]) schemeNameById.set(ids[i], names[i]);
+  }
+  return dedupeRecipients(rows, schemeNameById);
+}
+
+// =====================================================================
+// Phase 3 - draft personalised emails
+// =====================================================================
+
+const EMAIL_SYSTEM_PROMPT = `You are drafting bulk personalised emails on behalf of an Irish property agent. The agent will review each draft before anything is sent.
+
+Tone is set per call (warm / professional / urgent). Voice is Irish, peer-to-peer, one professional talking to another. Plain English.
+
+The shared message intent is supplied verbatim in the user message. Convey that intent in each email. Open with a short personalised line that references why this specific recipient is hearing from you (their interest in a named scheme, their recent enquiry, etc), then state the shared intent in your own words, then a clear next step or invitation to reply.
+
+HARD RULES (non-negotiable):
+- NEVER invent details about a recipient that are not in their record. If their record shows scheme_of_interest_name = "Lakeside Manor", you may reference Lakeside Manor; if it is null, do not invent one.
+- NEVER use em dashes anywhere. Use a comma or a sentence break.
+- NEVER use the phrases "I hope this finds you well", "I trust you are well", "I wanted to reach out", "I'm reaching out", "thank you for your time today", or any AI filler.
+- NEVER add emoji or markdown. No bold, no asterisks, no bullets.
+- Maximum six lines in the body. Short paragraphs. One blank line between paragraphs.
+- Open with "Hi <FirstName>," using only the recipient's actual first name (the part before the first space in their name).
+- End with the tone-appropriate sign-off on its own line, then the agent's name on the next line. For warm use "Cheers,". For professional use "Best,". For urgent use "Thanks,".
+- subject is one short clause referencing the property or the substance of the message. No clickbait, no exclamation marks.
+
+Output JSON of exactly this shape:
+{
+  "emails": [
+    { "recipient_index": number, "subject": string, "body": string }
+  ]
+}
+
+There must be exactly one entry per recipient in the input array, identified by recipient_index (0-based, in the order given). If you cannot draft for a recipient (e.g. their record has nothing personalisable AND the intent is too vague), still emit a clean generic-but-honest email - never skip.`;
+
+interface EmailLLMOutput {
+  emails: Array<{ recipient_index: number; subject: string; body: string }>;
+}
+
+interface DraftEmailsArgs {
+  intent: string;
+  tone: BroadcastTone;
+  recipients: BroadcastRecipient[];
+  agentDisplayName: string;
+}
+
+async function draftEmails(
+  args: DraftEmailsArgs,
+  options: PlanBroadcastOptions,
+): Promise<BroadcastEmailDraft[]> {
+  const client = options.client ?? new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const model = options.emailModel ?? DEFAULT_EMAIL_MODEL;
+  const agentFirstName = args.agentDisplayName.split(/\s+/)[0] || args.agentDisplayName;
+
+  const recipientPayload = args.recipients.map((r, idx) => ({
+    recipient_index: idx,
+    name: r.name,
+    first_name: r.name.split(/\s+/)[0] || r.name,
+    email: r.email,
+    scheme_of_interest_name: r.scheme_of_interest_name,
+    last_contact_date: r.last_contact_date,
+  }));
+
+  const userPrompt = `Tone: ${args.tone}
+Agent first name (for the sign-off): ${agentFirstName}
+
+Shared message intent (verbatim from the agent, convey this in each email without parroting word-for-word):
+"""
+${args.intent}
+"""
+
+Recipients (${recipientPayload.length}):
+${JSON.stringify(recipientPayload, null, 2)}
+
+Return the JSON object described in the system prompt.`;
+
+  const completion = await client.chat.completions.create({
+    model,
+    temperature: 0.4,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: EMAIL_SYSTEM_PROMPT },
+      { role: 'user', content: userPrompt },
+    ],
+  });
+  const content = completion.choices[0]?.message?.content ?? '{}';
+  let raw: any;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    raw = {};
+  }
+
+  const llmEmails: EmailLLMOutput['emails'] = Array.isArray(raw?.emails) ? raw.emails : [];
+  const byIndex = new Map<number, { subject: string; body: string }>();
+  for (const e of llmEmails) {
+    if (
+      typeof e?.recipient_index === 'number' &&
+      typeof e?.subject === 'string' &&
+      typeof e?.body === 'string'
+    ) {
+      byIndex.set(e.recipient_index, {
+        subject: e.subject.trim(),
+        body: scrubFollowUpBody(e.body),
+      });
+    }
+  }
+
+  const out: BroadcastEmailDraft[] = [];
+  for (let i = 0; i < args.recipients.length; i++) {
+    const r = args.recipients[i];
+    const draft = byIndex.get(i);
+    out.push({
+      applicant_id: r.applicant_id,
+      recipient_email: r.email,
+      recipient_name: r.name,
+      subject: draft?.subject ?? '',
+      body: draft?.body ?? '',
+      selected: true,
+    });
+  }
+  return out;
+}
+
+// =====================================================================
+// planBroadcast - the public entry point
+// =====================================================================
+
+export async function planBroadcast(
+  supabase: SupabaseClient,
+  _tenantId: string,
+  agentContext: AgentContext,
+  params: PlanBroadcastParams,
+  options: PlanBroadcastOptions = {},
+): Promise<ToolResult> {
+  const intent = (params.intent || '').trim();
+  const filterNatural = (params.filter_natural || '').trim();
+  const tone = normaliseTone(params.tone);
+
+  if (!intent) {
+    const message = 'Tell me what the email should say. Even a one-liner is enough.';
+    const result: BroadcastClarification = { status: 'needs_clarification', reason: 'no_intent', message };
+    return { data: result, summary: message };
+  }
+  if (!filterNatural) {
+    const message = 'Tell me who the email is for. For example, "everyone interested in Lakeside Manor".';
+    const result: BroadcastClarification = { status: 'needs_clarification', reason: 'no_filter', message };
+    return { data: result, summary: message };
+  }
+
+  let parsedFilter: FilterLLMOutput;
+  try {
+    parsedFilter = await parseFilter(filterNatural, agentContext, options);
+  } catch (err) {
+    const message = 'I could not parse that filter. Try naming the scheme or describing the cohort plainly.';
+    console.error('[broadcast-tools] filter parse failed', err);
+    const result: BroadcastClarification = {
+      status: 'needs_clarification',
+      reason: 'filter_unparseable',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+
+  const { filter, unresolved_schemes } = buildStructuredFilter(parsedFilter, agentContext);
+
+  // When the user named a scheme that didn't match any assigned development,
+  // surface that clearly. Avoid silently dropping the filter and broadcasting
+  // to a wider cohort than the user asked for.
+  if (
+    parsedFilter.interested_in_scheme_names.length > 0 &&
+    (!filter.interested_in_scheme_ids || filter.interested_in_scheme_ids.length === 0)
+  ) {
+    const assignedNames = (agentContext.assignedDevelopmentNames ?? []).join(', ') || '(none)';
+    const message = `I could not match "${unresolved_schemes.join(', ')}" to any of your assigned schemes. Your schemes are: ${assignedNames}. Which one did you mean?`;
+    const result: BroadcastClarification = {
+      status: 'needs_clarification',
+      reason: 'filter_unparseable',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+
+  const maxRecipients = options.maxRecipients ?? DEFAULT_MAX_RECIPIENTS;
+  const recipients = await resolveRecipients(supabase, agentContext, filter);
+
+  if (recipients.length === 0) {
+    const sample = await sampleTenantRecipients(supabase, agentContext, 5);
+    const message =
+      sample.length > 0
+        ? `No applicants match that filter. Recent applicants in your tenant include ${sample
+            .map((s) => s.name)
+            .join(', ')}. Want to narrow or rephrase the filter?`
+        : 'No applicants match that filter, and your tenant has no recent applicants on file.';
+    const result: BroadcastClarification = {
+      status: 'needs_clarification',
+      reason: 'no_recipients_match',
+      message,
+      sample_recipients: sample,
+      recipient_count: 0,
+    };
+    return { data: result, summary: message };
+  }
+
+  if (recipients.length > maxRecipients) {
+    const message = `${recipients.length} applicants match that filter, which is more than I send in one broadcast (cap is ${maxRecipients}). Narrow the filter further, for example by scheme, last contact, or enquiry status.`;
+    const result: BroadcastClarification = {
+      status: 'needs_clarification',
+      reason: 'too_many_recipients',
+      message,
+      recipient_count: recipients.length,
+    };
+    return { data: result, summary: message };
+  }
+
+  let emails: BroadcastEmailDraft[];
+  try {
+    emails = await draftEmails(
+      {
+        intent,
+        tone,
+        recipients,
+        agentDisplayName: agentContext.displayName,
+      },
+      options,
+    );
+  } catch (err) {
+    const message = 'I could not draft the emails. Try again, or rephrase the intent.';
+    console.error('[broadcast-tools] email drafting failed', err);
+    const result: BroadcastClarification = {
+      status: 'needs_clarification',
+      reason: 'extraction_failed',
+      message,
+    };
+    return { data: result, summary: message };
+  }
+
+  const signoff = buildSignoff(agentContext);
+  const envelope: BroadcastDraftEnvelope = {
+    status: 'draft',
+    type: 'broadcast',
+    intent,
+    filter_used: filter,
+    filter_natural: filterNatural,
+    tone,
+    recipients,
+    emails,
+    shared_signoff: signoff,
+    message: `Draft ${emails.length} email${emails.length === 1 ? '' : 's'} for review`,
+  };
+  return { data: envelope, summary: envelope.message };
+}
+
+function buildSignoff(agentContext: AgentContext): string {
+  const name = agentContext.displayName.trim();
+  const agency = (agentContext.agencyName ?? '').trim();
+  return agency ? `${name}, ${agency}` : name;
+}
+
+// =====================================================================
+// confirmBroadcast - persist audit + N drafts atomically
+// =====================================================================
+
+export interface ConfirmBroadcastInput {
+  intent: string;
+  filter_used: BroadcastFilter;
+  filter_natural: string;
+  tone: BroadcastTone;
+  emails: Array<{
+    applicant_id: string | null;
+    recipient_email: string;
+    recipient_name: string;
+    subject: string;
+    body: string;
+  }>;
+}
+
+export interface ConfirmBroadcastResult {
+  status: 'success' | 'error';
+  broadcast_id: string | null;
+  drafts_written: number;
+  error: string | null;
+}
+
+export async function confirmBroadcast(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  input: ConfirmBroadcastInput,
+): Promise<ConfirmBroadcastResult> {
+  if (input.emails.length === 0) {
+    return {
+      status: 'error',
+      broadcast_id: null,
+      drafts_written: 0,
+      error: 'No recipients selected for the broadcast.',
+    };
+  }
+
+  const { data: auditRow, error: auditError } = await supabase
+    .from('broadcast_audit_log')
+    .insert({
+      tenant_id: agentContext.tenantId,
+      agent_id: agentContext.authUserId,
+      intent: input.intent,
+      filter_used: input.filter_used,
+      recipient_count: input.emails.length,
+      status: 'drafted',
+    })
+    .select('id')
+    .single();
+
+  if (auditError || !auditRow) {
+    console.error('[broadcast-tools] audit insert failed', { message: auditError?.message });
+    return {
+      status: 'error',
+      broadcast_id: null,
+      drafts_written: 0,
+      error: auditError?.message ?? 'Could not record broadcast audit row.',
+    };
+  }
+
+  const broadcastId = auditRow.id as string;
+  const draftRows = input.emails.map((e) => ({
+    user_id: agentContext.authUserId,
+    tenant_id: agentContext.tenantId,
+    skin: 'agent',
+    draft_type: 'broadcast_email',
+    recipient_id: e.applicant_id ?? null,
+    content_json: {
+      subject: e.subject,
+      body: e.body,
+      to_email: e.recipient_email,
+      to_name: e.recipient_name,
+      tone: input.tone,
+      filter_natural: input.filter_natural,
+      skill: 'broadcast_to_applicants',
+      reasoning: 'Drafted from bulk applicant broadcast',
+      provenance: [
+        { id: 'broadcast', label: 'Broadcast', detail: `Cohort: ${input.filter_natural}` },
+      ],
+    },
+    send_method: 'email',
+    status: 'pending_review',
+    broadcast_id: broadcastId,
+  }));
+
+  const { error: draftError, data: draftData } = await supabase
+    .from('pending_drafts')
+    .insert(draftRows)
+    .select('id');
+
+  const written = Array.isArray(draftData) ? draftData.length : 0;
+
+  if (draftError || written !== input.emails.length) {
+    // Roll the audit row back to cancelled so the receipt cannot lie about
+    // partial writes. The pending_drafts rows that did land carry the same
+    // broadcast_id and will be cleaned up by the rollback delete below.
+    await supabase
+      .from('pending_drafts')
+      .delete()
+      .eq('broadcast_id', broadcastId)
+      .eq('status', 'pending_review');
+    await supabase
+      .from('broadcast_audit_log')
+      .update({ status: 'cancelled', cancelled_at: new Date().toISOString() })
+      .eq('id', broadcastId);
+
+    console.error('[broadcast-tools] draft insert failed', {
+      message: draftError?.message,
+      expected: input.emails.length,
+      written,
+    });
+    return {
+      status: 'error',
+      broadcast_id: broadcastId,
+      drafts_written: 0,
+      error:
+        draftError?.message ??
+        `Only ${written} of ${input.emails.length} drafts landed. Broadcast rolled back.`,
+    };
+  }
+
+  return {
+    status: 'success',
+    broadcast_id: broadcastId,
+    drafts_written: written,
+    error: null,
+  };
+}
+
+// =====================================================================
+// cancelBroadcast - 30-minute undo window
+// =====================================================================
+
+export interface CancelBroadcastInput {
+  audit_log_id: string;
+}
+
+export interface CancelBroadcastResult {
+  status: 'success' | 'error' | 'expired' | 'already_cancelled' | 'not_found';
+  drafts_deleted: number;
+  error: string | null;
+}
+
+export async function cancelBroadcast(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  input: CancelBroadcastInput,
+): Promise<CancelBroadcastResult> {
+  const { data: audit, error: readError } = await supabase
+    .from('broadcast_audit_log')
+    .select('id, tenant_id, agent_id, status, created_at')
+    .eq('id', input.audit_log_id)
+    .maybeSingle();
+
+  if (readError) {
+    return { status: 'error', drafts_deleted: 0, error: readError.message };
+  }
+  if (!audit) {
+    return { status: 'not_found', drafts_deleted: 0, error: 'Broadcast not found.' };
+  }
+  if (audit.tenant_id !== agentContext.tenantId || audit.agent_id !== agentContext.authUserId) {
+    return { status: 'not_found', drafts_deleted: 0, error: 'Broadcast not found.' };
+  }
+  if (audit.status === 'cancelled') {
+    return { status: 'already_cancelled', drafts_deleted: 0, error: null };
+  }
+
+  const createdAt = new Date(audit.created_at as string).getTime();
+  if (!Number.isFinite(createdAt) || Date.now() - createdAt > UNDO_WINDOW_MS) {
+    return {
+      status: 'expired',
+      drafts_deleted: 0,
+      error: 'The 30-minute undo window has passed. Cancel each remaining draft from the Drafts tab.',
+    };
+  }
+
+  const { data: deletedDrafts, error: deleteError } = await supabase
+    .from('pending_drafts')
+    .delete()
+    .eq('broadcast_id', audit.id)
+    .eq('status', 'pending_review')
+    .select('id');
+
+  if (deleteError) {
+    return { status: 'error', drafts_deleted: 0, error: deleteError.message };
+  }
+
+  const { error: updateError } = await supabase
+    .from('broadcast_audit_log')
+    .update({ status: 'cancelled', cancelled_at: new Date().toISOString() })
+    .eq('id', audit.id);
+
+  if (updateError) {
+    return {
+      status: 'error',
+      drafts_deleted: Array.isArray(deletedDrafts) ? deletedDrafts.length : 0,
+      error: updateError.message,
+    };
+  }
+
+  return {
+    status: 'success',
+    drafts_deleted: Array.isArray(deletedDrafts) ? deletedDrafts.length : 0,
+    error: null,
+  };
+}
+
+// =====================================================================
+// broadcastHistory - last N rows for the agent
+// =====================================================================
+
+export interface BroadcastHistoryRow {
+  id: string;
+  intent: string;
+  filter_used: BroadcastFilter;
+  recipient_count: number;
+  status: string;
+  sent_at: string | null;
+  cancelled_at: string | null;
+  created_at: string;
+}
+
+export async function listBroadcastHistory(
+  supabase: SupabaseClient,
+  agentContext: AgentContext,
+  limit = 20,
+): Promise<BroadcastHistoryRow[]> {
+  const { data, error } = await supabase
+    .from('broadcast_audit_log')
+    .select('id, intent, filter_used, recipient_count, status, sent_at, cancelled_at, created_at')
+    .eq('agent_id', agentContext.authUserId)
+    .eq('tenant_id', agentContext.tenantId)
+    .order('created_at', { ascending: false })
+    .limit(Math.max(1, Math.min(limit, 100)));
+  if (error || !Array.isArray(data)) return [];
+  return data as BroadcastHistoryRow[];
+}

--- a/apps/unified-portal/migrations/059_broadcast_audit_log.sql
+++ b/apps/unified-portal/migrations/059_broadcast_audit_log.sql
@@ -1,0 +1,60 @@
+-- Applicant broadcast audit table for the agent-intelligence bulk-email
+-- feature. One row per broadcast attempt, regardless of final delivery.
+-- Drafts created by a broadcast carry broadcast_id pointing back here so a
+-- single confirm gesture writes N rows in pending_drafts atomically.
+--
+-- Applied to project mddxbilpjukwskeefakz on 2026-05-12 via
+-- apply_migration (Supabase MCP). This file is kept in the repo as the
+-- source-of-truth replay for fresh environments.
+
+CREATE TABLE IF NOT EXISTS public.broadcast_audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL,
+  agent_id uuid NOT NULL REFERENCES auth.users(id),
+  intent text NOT NULL,
+  filter_used jsonb NOT NULL,
+  recipient_count integer NOT NULL CHECK (recipient_count >= 0),
+  status text NOT NULL CHECK (status IN ('drafted','sent','partial_sent','cancelled')),
+  sent_at timestamptz,
+  cancelled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_broadcast_audit_log_agent_created
+  ON public.broadcast_audit_log (agent_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_broadcast_audit_log_tenant_created
+  ON public.broadcast_audit_log (tenant_id, created_at DESC);
+
+ALTER TABLE public.broadcast_audit_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS broadcast_audit_log_owner_select ON public.broadcast_audit_log;
+CREATE POLICY broadcast_audit_log_owner_select
+  ON public.broadcast_audit_log
+  FOR SELECT
+  USING (agent_id = auth.uid());
+
+DROP POLICY IF EXISTS broadcast_audit_log_owner_modify ON public.broadcast_audit_log;
+CREATE POLICY broadcast_audit_log_owner_modify
+  ON public.broadcast_audit_log
+  FOR ALL
+  USING (agent_id = auth.uid())
+  WITH CHECK (agent_id = auth.uid());
+
+DROP POLICY IF EXISTS broadcast_audit_log_service_role ON public.broadcast_audit_log;
+CREATE POLICY broadcast_audit_log_service_role
+  ON public.broadcast_audit_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Group multiple pending_drafts rows under a single broadcast. Null is
+-- the historical case (single-recipient drafts created outside this
+-- feature) and stays valid.
+ALTER TABLE public.pending_drafts
+  ADD COLUMN IF NOT EXISTS broadcast_id uuid REFERENCES public.broadcast_audit_log(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_pending_drafts_broadcast_id
+  ON public.pending_drafts (broadcast_id)
+  WHERE broadcast_id IS NOT NULL;

--- a/apps/unified-portal/tests/agent-intelligence/broadcast-route.integration.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/broadcast-route.integration.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration guards for the broadcast routes.
+ *
+ * Hermetic. Stubs `@supabase/auth-helpers-nextjs`, `next/headers`,
+ * `@/lib/supabase-server`, and `@/lib/agent-intelligence/resolve-agent-v2`
+ * via jest.doMock. The broadcast-tools module is stubbed too so the route
+ * tests verify wire contract + selection logic only.
+ *
+ * Covered:
+ *   - 401 unauthenticated (confirm)
+ *   - 403 missing tenant (confirm)
+ *   - happy path: 3 recipients, all selected, 3 drafts written, audit id returned
+ *   - selective: 3 recipients, 2 selected by applicant_id, 2 drafts written
+ *   - cancel before send: drafts deleted, audit cancelled
+ */
+
+const DEFAULT_AGENT_CTX = {
+  agentProfileId: 'profile-1',
+  authUserId: 'auth-1',
+  tenantId: 'tenant-1',
+  displayName: 'Sarah Mitchell',
+  agencyName: 'Bridge Property Group',
+  agentType: 'sales',
+  assignedSchemes: [],
+  assignedDevelopmentIds: ['dev-lakeside'],
+  assignedDevelopmentNames: ['Lakeside Manor'],
+  isDemoMode: true,
+};
+
+interface ConfirmStub {
+  status: 'success' | 'error';
+  broadcast_id: string | null;
+  drafts_written: number;
+  error: string | null;
+}
+
+interface CancelStub {
+  status: 'success' | 'error' | 'expired' | 'already_cancelled' | 'not_found';
+  drafts_deleted: number;
+  error: string | null;
+}
+
+interface RouteStubState {
+  authUser: { id: string } | null;
+  agentContext: Record<string, any> | null;
+  confirmResult?: ConfirmStub;
+  cancelResult?: CancelStub;
+  recordedConfirm?: any;
+  recordedCancel?: any;
+}
+
+function fakeRequest(body: any, searchParams?: Record<string, string>): any {
+  return {
+    async json() {
+      return body;
+    },
+    nextUrl: {
+      searchParams: {
+        get(key: string) {
+          return searchParams?.[key] ?? null;
+        },
+      },
+    },
+  };
+}
+
+async function loadConfirmRoute(state: RouteStubState) {
+  jest.resetModules();
+  jest.doMock('@supabase/auth-helpers-nextjs', () => ({
+    createRouteHandlerClient: () => ({
+      auth: { getUser: async () => ({ data: { user: state.authUser } }) },
+    }),
+  }));
+  jest.doMock('next/headers', () => ({ cookies: () => ({}) }));
+  jest.doMock('@/lib/supabase-server', () => ({
+    getSupabaseAdmin: () => ({}),
+  }));
+  jest.doMock('@/lib/agent-intelligence/resolve-agent-v2', () => ({
+    resolveAgentContextV2: async () => ({ context: state.agentContext }),
+  }));
+  jest.doMock('@/lib/agent-intelligence/tools/broadcast-tools', () => ({
+    async confirmBroadcast(_supabase: any, _ctx: any, input: any) {
+      state.recordedConfirm = input;
+      return (
+        state.confirmResult ?? {
+          status: 'success',
+          broadcast_id: 'broadcast-1',
+          drafts_written: input.emails.length,
+          error: null,
+        }
+      );
+    },
+  }));
+  const mod = await import('../../app/api/agent-intelligence/confirm-broadcast/route');
+  return mod.POST;
+}
+
+async function loadCancelRoute(state: RouteStubState) {
+  jest.resetModules();
+  jest.doMock('@supabase/auth-helpers-nextjs', () => ({
+    createRouteHandlerClient: () => ({
+      auth: { getUser: async () => ({ data: { user: state.authUser } }) },
+    }),
+  }));
+  jest.doMock('next/headers', () => ({ cookies: () => ({}) }));
+  jest.doMock('@/lib/supabase-server', () => ({
+    getSupabaseAdmin: () => ({}),
+  }));
+  jest.doMock('@/lib/agent-intelligence/resolve-agent-v2', () => ({
+    resolveAgentContextV2: async () => ({ context: state.agentContext }),
+  }));
+  jest.doMock('@/lib/agent-intelligence/tools/broadcast-tools', () => ({
+    async cancelBroadcast(_supabase: any, _ctx: any, input: any) {
+      state.recordedCancel = input;
+      return (
+        state.cancelResult ?? {
+          status: 'success',
+          drafts_deleted: 3,
+          error: null,
+        }
+      );
+    },
+  }));
+  const mod = await import('../../app/api/agent-intelligence/cancel-broadcast/route');
+  return mod.POST;
+}
+
+function makeDraft(emailCount: number) {
+  const emails = Array.from({ length: emailCount }, (_, i) => ({
+    applicant_id: `appl-${i}`,
+    recipient_email: `person${i}@example.ie`,
+    recipient_name: `Person ${i}`,
+    subject: `Saturday viewings ${i}`,
+    body: `Hi Person ${i},\n\nSaturday 10-2.\n\nCheers,\nSarah`,
+    selected: true,
+  }));
+  return {
+    status: 'draft',
+    type: 'broadcast',
+    intent: 'Saturday viewings 10-2',
+    filter_used: { interested_in_scheme_ids: ['dev-lakeside'] },
+    filter_natural: 'everyone interested in Lakeside Manor',
+    tone: 'warm',
+    recipients: emails.map((e) => ({
+      applicant_id: e.applicant_id,
+      name: e.recipient_name,
+      email: e.recipient_email,
+      scheme_of_interest_id: 'dev-lakeside',
+      scheme_of_interest_name: 'Lakeside Manor',
+      last_contact_date: null,
+    })),
+    emails,
+    shared_signoff: 'Sarah Mitchell, Bridge Property Group',
+    message: `Draft ${emailCount} emails for review`,
+  };
+}
+
+describe('POST /api/agent-intelligence/confirm-broadcast', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const state: RouteStubState = { authUser: null, agentContext: DEFAULT_AGENT_CTX };
+    const POST = await loadConfirmRoute(state);
+    const res = await POST(fakeRequest({ draft: makeDraft(3) }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the agent has no tenant assignment', async () => {
+    const state: RouteStubState = {
+      authUser: { id: 'auth-1' },
+      agentContext: { ...DEFAULT_AGENT_CTX, tenantId: null },
+    };
+    const POST = await loadConfirmRoute(state);
+    const res = await POST(fakeRequest({ draft: makeDraft(3) }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when draft.emails is empty', async () => {
+    const state: RouteStubState = { authUser: { id: 'auth-1' }, agentContext: DEFAULT_AGENT_CTX };
+    const POST = await loadConfirmRoute(state);
+    const empty = { ...makeDraft(0), emails: [] };
+    const res = await POST(fakeRequest({ draft: empty }));
+    expect(res.status).toBe(400);
+  });
+
+  it('writes one draft per recipient when none are deselected (happy path)', async () => {
+    const state: RouteStubState = { authUser: { id: 'auth-1' }, agentContext: DEFAULT_AGENT_CTX };
+    const POST = await loadConfirmRoute(state);
+    const draft = makeDraft(3);
+    const res = await POST(fakeRequest({ draft }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('success');
+    expect(body.drafts_written).toBe(3);
+    expect(state.recordedConfirm?.emails.length).toBe(3);
+  });
+
+  it('honours selected_applicant_ids to write only the selected subset', async () => {
+    const state: RouteStubState = { authUser: { id: 'auth-1' }, agentContext: DEFAULT_AGENT_CTX };
+    const POST = await loadConfirmRoute(state);
+    const draft = makeDraft(3);
+    const res = await POST(
+      fakeRequest({ draft, selected_applicant_ids: ['appl-0', 'appl-2'] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.drafts_written).toBe(2);
+    expect(state.recordedConfirm?.emails.length).toBe(2);
+    expect(state.recordedConfirm?.emails.map((e: any) => e.applicant_id).sort()).toEqual([
+      'appl-0',
+      'appl-2',
+    ]);
+  });
+
+  it('surfaces a 500 when the broadcast helper reports an error', async () => {
+    const state: RouteStubState = {
+      authUser: { id: 'auth-1' },
+      agentContext: DEFAULT_AGENT_CTX,
+      confirmResult: {
+        status: 'error',
+        broadcast_id: 'broadcast-1',
+        drafts_written: 0,
+        error: 'audit insert failed',
+      },
+    };
+    const POST = await loadConfirmRoute(state);
+    const res = await POST(fakeRequest({ draft: makeDraft(2) }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe('error');
+    expect(body.error).toMatch(/audit/i);
+  });
+});
+
+describe('POST /api/agent-intelligence/cancel-broadcast', () => {
+  it('returns 401 when unauthenticated', async () => {
+    const state: RouteStubState = { authUser: null, agentContext: DEFAULT_AGENT_CTX };
+    const POST = await loadCancelRoute(state);
+    const res = await POST(fakeRequest({ audit_log_id: 'broadcast-1' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the broadcast was not found for this agent', async () => {
+    const state: RouteStubState = {
+      authUser: { id: 'auth-1' },
+      agentContext: DEFAULT_AGENT_CTX,
+      cancelResult: { status: 'not_found', drafts_deleted: 0, error: 'Broadcast not found.' },
+    };
+    const POST = await loadCancelRoute(state);
+    const res = await POST(fakeRequest({ audit_log_id: 'broadcast-1' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 410 when the 30-minute undo window has expired', async () => {
+    const state: RouteStubState = {
+      authUser: { id: 'auth-1' },
+      agentContext: DEFAULT_AGENT_CTX,
+      cancelResult: {
+        status: 'expired',
+        drafts_deleted: 0,
+        error: 'The 30-minute undo window has passed.',
+      },
+    };
+    const POST = await loadCancelRoute(state);
+    const res = await POST(fakeRequest({ audit_log_id: 'broadcast-1' }));
+    expect(res.status).toBe(410);
+  });
+
+  it('cancels and reports the number of drafts deleted on success', async () => {
+    const state: RouteStubState = {
+      authUser: { id: 'auth-1' },
+      agentContext: DEFAULT_AGENT_CTX,
+      cancelResult: { status: 'success', drafts_deleted: 2, error: null },
+    };
+    const POST = await loadCancelRoute(state);
+    const res = await POST(fakeRequest({ audit_log_id: 'broadcast-1' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('success');
+    expect(body.drafts_deleted).toBe(2);
+  });
+});

--- a/apps/unified-portal/tests/agent-intelligence/broadcast-tools.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/broadcast-tools.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Unit tests for planBroadcast.
+ *
+ * Hermetic. The OpenAI client is stubbed for both the filter-parse and
+ * the email-drafting steps. Supabase is stubbed with an in-memory store
+ * keyed by table name so the recipient resolver can be exercised against
+ * controlled enquiry rows.
+ *
+ * Test shapes:
+ *   - planBroadcast parses a simple filter (Lakeside Manor) and returns
+ *     the right cohort + emails.
+ *   - zero matches surface a needs_clarification with a sample.
+ *   - >200 matches surface a too_many_recipients clarification.
+ *   - the email drafter respects the never-invent rule (mock LLM returns
+ *     output, scrubber strips em dashes and AI filler).
+ */
+
+import {
+  planBroadcast,
+  type BroadcastDraftEnvelope,
+  type BroadcastClarification,
+} from '../../lib/agent-intelligence/tools/broadcast-tools';
+import type { AgentContext } from '../../lib/agent-intelligence/types';
+import type { AgentProfileId, AuthUserId } from '../../lib/agent-intelligence/ids';
+
+interface EnquiryRow {
+  id: string;
+  tenant_id: string;
+  enquirer_name: string | null;
+  enquirer_email: string | null;
+  development_id: string | null;
+  status: string | null;
+  last_contacted_at: string | null;
+  created_at: string;
+}
+
+interface FakeStore {
+  enquiries: EnquiryRow[];
+  agent_applicants: Array<{ id: string; tenant_id: string; email: string | null }>;
+}
+
+function makeFakeSupabase(store: FakeStore) {
+  return {
+    from(table: string) {
+      const filters: Record<string, any> = {};
+      const inFilters: Record<string, any[]> = {};
+      let orderField: string | null = null;
+      let orderAsc = true;
+      let limitN: number | null = null;
+      let notNullField: string | null = null;
+      let orClause: string | null = null;
+
+      const builder: any = {
+        select() {
+          return builder;
+        },
+        eq(col: string, val: any) {
+          filters[col] = val;
+          return builder;
+        },
+        in(col: string, vals: any[]) {
+          inFilters[col] = vals;
+          return builder;
+        },
+        not(col: string, _op: string, _val: any) {
+          notNullField = col;
+          return builder;
+        },
+        or(clause: string) {
+          orClause = clause;
+          return builder;
+        },
+        order(field: string, opts?: { ascending?: boolean }) {
+          orderField = field;
+          orderAsc = opts?.ascending ?? true;
+          return builder;
+        },
+        limit(n: number) {
+          limitN = n;
+          return builder;
+        },
+        async then(resolve: (v: any) => void) {
+          resolve(await this._exec());
+        },
+        async _exec() {
+          let rows: any[] = [];
+          if (table === 'enquiries') {
+            rows = store.enquiries.filter((r) => {
+              for (const [k, v] of Object.entries(filters)) {
+                if ((r as any)[k] !== v) return false;
+              }
+              for (const [k, vals] of Object.entries(inFilters)) {
+                if (!vals.includes((r as any)[k])) return false;
+              }
+              if (notNullField === 'enquirer_email' && r.enquirer_email == null) return false;
+              if (orClause && orClause.includes('last_contacted_at')) {
+                const m = orClause.match(/last_contacted_at\.lt\.([^,)]+)/);
+                if (m) {
+                  const cutoff = m[1];
+                  if (r.last_contacted_at !== null && r.last_contacted_at >= cutoff) return false;
+                }
+              }
+              return true;
+            });
+            if (orderField) {
+              rows.sort((a, b) => {
+                const av = (a as any)[orderField!] ?? '';
+                const bv = (b as any)[orderField!] ?? '';
+                if (av === bv) return 0;
+                return orderAsc ? (av < bv ? -1 : 1) : av < bv ? 1 : -1;
+              });
+            }
+            if (limitN != null) rows = rows.slice(0, limitN);
+            return { data: rows, error: null };
+          }
+          if (table === 'agent_applicants') {
+            rows = store.agent_applicants.filter((r) => {
+              for (const [k, v] of Object.entries(filters)) {
+                if ((r as any)[k] !== v) return false;
+              }
+              for (const [k, vals] of Object.entries(inFilters)) {
+                if (!vals.includes((r as any)[k])) return false;
+              }
+              return true;
+            });
+            return { data: rows, error: null };
+          }
+          if (table === 'agent_viewings') {
+            return { data: [], error: null };
+          }
+          return { data: [], error: null };
+        },
+      };
+      return builder;
+    },
+  } as any;
+}
+
+const AGENT_CTX: AgentContext = {
+  agentProfileId: 'profile-1' as AgentProfileId,
+  authUserId: 'auth-1' as AuthUserId,
+  tenantId: 'tenant-1',
+  displayName: 'Sarah Mitchell',
+  agencyName: 'Bridge Property Group',
+  agentType: 'sales',
+  assignedSchemes: [],
+  assignedDevelopmentIds: ['dev-lakeside'],
+  assignedDevelopmentNames: ['Lakeside Manor'],
+  activeDevelopmentId: null,
+  isDemoMode: true,
+};
+
+function stubFilterAndEmailClient(
+  filterPayload: any,
+  emailPayload: any,
+): any {
+  let call = 0;
+  return {
+    chat: {
+      completions: {
+        async create() {
+          call++;
+          const payload = call === 1 ? filterPayload : emailPayload;
+          return {
+            choices: [{ message: { content: JSON.stringify(payload) } }],
+          };
+        },
+      },
+    },
+  };
+}
+
+const LAKESIDE_ENQUIRIES: EnquiryRow[] = [
+  {
+    id: 'enq-1',
+    tenant_id: 'tenant-1',
+    enquirer_name: "Niamh O'Brien",
+    enquirer_email: 'niamh@example.ie',
+    development_id: 'dev-lakeside',
+    status: 'active',
+    last_contacted_at: '2026-05-01T10:00:00Z',
+    created_at: '2026-04-15T10:00:00Z',
+  },
+  {
+    id: 'enq-2',
+    tenant_id: 'tenant-1',
+    enquirer_name: 'Cian Murphy',
+    enquirer_email: 'cian@example.ie',
+    development_id: 'dev-lakeside',
+    status: 'new',
+    last_contacted_at: null,
+    created_at: '2026-04-20T11:00:00Z',
+  },
+  {
+    id: 'enq-3',
+    tenant_id: 'tenant-1',
+    enquirer_name: 'Aoife Walsh',
+    enquirer_email: 'aoife@example.ie',
+    development_id: 'dev-lakeside',
+    status: 'warm',
+    last_contacted_at: '2026-05-05T14:00:00Z',
+    created_at: '2026-04-25T09:00:00Z',
+  },
+];
+
+describe('planBroadcast', () => {
+  it('parses a simple scheme filter and drafts one email per recipient', async () => {
+    const store: FakeStore = { enquiries: LAKESIDE_ENQUIRIES, agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient(
+      {
+        interested_in_scheme_names: ['Lakeside Manor'],
+        has_active_enquiry: null,
+        viewed_property_names: [],
+        last_contact_before_days: null,
+        status: [],
+        confidence: 'high',
+      },
+      {
+        emails: [
+          {
+            recipient_index: 0,
+            subject: 'Saturday viewings at Lakeside Manor',
+            body: 'Hi Aoife,\n\nI will be in the show house this Saturday from 10 to 2.\n\nCheers,\nSarah',
+          },
+          {
+            recipient_index: 1,
+            subject: 'Saturday viewings at Lakeside Manor',
+            body: 'Hi Cian,\n\nI will be in the show house this Saturday from 10 to 2.\n\nCheers,\nSarah',
+          },
+          {
+            recipient_index: 2,
+            subject: 'Saturday viewings at Lakeside Manor',
+            body: 'Hi Niamh,\n\nI will be in the show house this Saturday from 10 to 2.\n\nCheers,\nSarah',
+          },
+        ],
+      },
+    );
+
+    const result = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      {
+        intent:
+          'I will be available for viewings in the show house this Saturday between 10am and 2pm.',
+        filter_natural: 'everyone interested in Lakeside Manor',
+        tone: 'warm',
+      },
+      { client },
+    );
+
+    expect(result.data.status).toBe('draft');
+    const draft = result.data as BroadcastDraftEnvelope;
+    expect(draft.type).toBe('broadcast');
+    expect(draft.tone).toBe('warm');
+    expect(draft.filter_used.interested_in_scheme_ids).toEqual(['dev-lakeside']);
+    expect(draft.recipients.length).toBe(3);
+    expect(draft.recipients.map((r) => r.email).sort()).toEqual([
+      'aoife@example.ie',
+      'cian@example.ie',
+      'niamh@example.ie',
+    ]);
+    expect(draft.emails.length).toBe(3);
+    for (const email of draft.emails) {
+      expect(email.subject.length).toBeGreaterThan(0);
+      expect(email.body.length).toBeGreaterThan(0);
+      expect(email.body).not.toMatch(/\u2014/);
+      expect(email.body.toLowerCase()).not.toContain('i hope this finds you well');
+    }
+  });
+
+  it('returns needs_clarification when no applicants match the filter', async () => {
+    const store: FakeStore = { enquiries: [], agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient(
+      {
+        interested_in_scheme_names: ['Lakeside Manor'],
+        has_active_enquiry: null,
+        viewed_property_names: [],
+        last_contact_before_days: null,
+        status: [],
+        confidence: 'high',
+      },
+      { emails: [] },
+    );
+
+    const result = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      {
+        intent: 'Saturday viewings 10-2',
+        filter_natural: 'everyone interested in Lakeside Manor',
+      },
+      { client },
+    );
+
+    expect(result.data.status).toBe('needs_clarification');
+    const clar = result.data as BroadcastClarification;
+    expect(clar.reason).toBe('no_recipients_match');
+    expect(clar.recipient_count).toBe(0);
+  });
+
+  it('returns needs_clarification when too many applicants match', async () => {
+    const many: EnquiryRow[] = Array.from({ length: 210 }, (_, i) => ({
+      id: `enq-${i}`,
+      tenant_id: 'tenant-1',
+      enquirer_name: `Person ${i}`,
+      enquirer_email: `person${i}@example.ie`,
+      development_id: 'dev-lakeside',
+      status: 'active',
+      last_contacted_at: null,
+      created_at: '2026-04-01T00:00:00Z',
+    }));
+    const store: FakeStore = { enquiries: many, agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient(
+      {
+        interested_in_scheme_names: ['Lakeside Manor'],
+        has_active_enquiry: null,
+        viewed_property_names: [],
+        last_contact_before_days: null,
+        status: [],
+        confidence: 'high',
+      },
+      { emails: [] },
+    );
+
+    const result = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      {
+        intent: 'Saturday viewings 10-2',
+        filter_natural: 'everyone interested in Lakeside Manor',
+      },
+      { client, maxRecipients: 200 },
+    );
+
+    expect(result.data.status).toBe('needs_clarification');
+    const clar = result.data as BroadcastClarification;
+    expect(clar.reason).toBe('too_many_recipients');
+    expect(clar.recipient_count).toBe(210);
+  });
+
+  it('refuses unresolved scheme names rather than broadcasting to a wider cohort', async () => {
+    const store: FakeStore = { enquiries: LAKESIDE_ENQUIRIES, agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient(
+      {
+        interested_in_scheme_names: ['Sunnyvale Towers'],
+        has_active_enquiry: null,
+        viewed_property_names: [],
+        last_contact_before_days: null,
+        status: [],
+        confidence: 'medium',
+      },
+      { emails: [] },
+    );
+
+    const result = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      {
+        intent: 'Saturday viewings 10-2',
+        filter_natural: 'everyone interested in Sunnyvale Towers',
+      },
+      { client },
+    );
+
+    expect(result.data.status).toBe('needs_clarification');
+    const clar = result.data as BroadcastClarification;
+    expect(clar.reason).toBe('filter_unparseable');
+    expect(clar.message).toMatch(/Sunnyvale Towers/);
+  });
+
+  it('scrubs em dashes from the LLM-drafted body before returning', async () => {
+    const store: FakeStore = { enquiries: LAKESIDE_ENQUIRIES.slice(0, 1), agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient(
+      {
+        interested_in_scheme_names: ['Lakeside Manor'],
+        has_active_enquiry: null,
+        viewed_property_names: [],
+        last_contact_before_days: null,
+        status: [],
+        confidence: 'high',
+      },
+      {
+        emails: [
+          {
+            recipient_index: 0,
+            subject: 'Saturday viewings \u2014 Lakeside Manor',
+            body: 'Hi Niamh \u2014 quick note about Saturday. Cheers, Sarah',
+          },
+        ],
+      },
+    );
+
+    const result = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      {
+        intent: 'Saturday viewings 10-2',
+        filter_natural: 'everyone interested in Lakeside Manor',
+      },
+      { client },
+    );
+
+    const draft = result.data as BroadcastDraftEnvelope;
+    expect(draft.emails[0].body).not.toMatch(/\u2014/);
+  });
+
+  it('rejects empty intent and empty filter_natural with distinct reasons', async () => {
+    const store: FakeStore = { enquiries: LAKESIDE_ENQUIRIES, agent_applicants: [] };
+    const supabase = makeFakeSupabase(store);
+    const client = stubFilterAndEmailClient({}, {});
+
+    const noIntent = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      { filter_natural: 'everyone interested in Lakeside Manor' },
+      { client },
+    );
+    expect(noIntent.data.status).toBe('needs_clarification');
+    expect((noIntent.data as BroadcastClarification).reason).toBe('no_intent');
+
+    const noFilter = await planBroadcast(
+      supabase,
+      'tenant-1',
+      AGENT_CTX,
+      { intent: 'Saturday viewings 10-2' },
+      { client },
+    );
+    expect(noFilter.data.status).toBe('needs_clarification');
+    expect((noFilter.data as BroadcastClarification).reason).toBe('no_filter');
+  });
+});


### PR DESCRIPTION
## Summary

Backend half of the bulk-personalised-applicant-broadcast feature (split deliberately into 7a backend + 7b UI per the original brief). This PR lands the database table, the broadcast tool, the API routes, and tests. The chat experience is **not yet wired up** - the LLM tool registration, system prompt update, and BroadcastCard UI all land in 7b.

The failing QA prompt this feature targets:
> "Can you send out an email to all of the applicants interested in buying homes in Lakeside Manor and let them know that I will be available for viewings in the show house this Saturday between 10am and 2pm."

After 7b, that prompt will produce N personalised drafts in a single review card. After 7a (this PR), the same workflow is exercisable via API calls.

## What's in

### DB
- `migrations/059_broadcast_audit_log.sql` and a matching `apply_migration` against `mddxbilpjukwskeefakz`:
  - New `broadcast_audit_log` table: tenant-scoped, agent-owned, RLS on (agent reads/writes own rows, service role bypass). Tracks intent, structured filter, recipient_count, status (`drafted` / `sent` / `partial_sent` / `cancelled`), sent_at, cancelled_at, created_at.
  - New `broadcast_id` column on `pending_drafts` (nullable, FK to `broadcast_audit_log.id`, ON DELETE SET NULL) so the N drafts of a broadcast are grouped, cancellable, and auditable as one batch.
  - Indexes for the two read paths and a partial index on `pending_drafts.broadcast_id`.

### Tool
- `lib/agent-intelligence/tools/broadcast-tools.ts` implements:
  - `planBroadcast` - three-phase pipeline: filter LLM parse, SQL recipient resolve (against `enquiries` within the agent's tenant), email LLM draft per recipient. Strict never-invent contract; reuses `scrubFollowUpBody` from `voice-capture-tools` for the em-dash / AI-filler defence layer.
  - `confirmBroadcast` - audit row + N `pending_drafts` rows atomic. Rollback to `cancelled` plus partial-draft cleanup if the inserts don't match the expected count.
  - `cancelBroadcast` - 30-minute undo window. Deletes only `pending_review` drafts so already-sent rows stay intact, marks the audit row `cancelled`.
  - `listBroadcastHistory` - last N rows for the agent, used by 7b's history view.

### Routes (under `/api/agent-intelligence/`)
- `POST confirm-broadcast` - auth + tenant required, validates the draft envelope, honours `selected_applicant_ids` so the card can deselect recipients before send, returns `{ broadcast_id, drafts_written }`.
- `POST cancel-broadcast` - auth + tenant required, returns `200` / `404` / `410` / `500` based on the helper outcome.
- `GET broadcast-history` - auth + tenant required, paginated by `limit` query param (default 20, max 100).

### Tests
- `tests/agent-intelligence/broadcast-tools.test.ts` - hermetic, stubbed OpenAI and an in-memory Supabase. Covers:
  - happy path (3 Lakeside Manor recipients, drafts produced, em-dash scrub asserted)
  - zero matches surfaces `no_recipients_match` with a sample
  - 200+ matches surfaces `too_many_recipients`
  - unresolved scheme name (e.g. "Sunnyvale Towers" not in assigned schemes) surfaces `filter_unparseable` rather than silently widening the cohort
  - scrubber strips em dashes from LLM output
  - empty intent / empty filter return distinct clarification reasons
- `tests/agent-intelligence/broadcast-route.integration.test.ts` - `jest.doMock`-based, mirrors the shape of the existing `voice-capture-route.integration.test.ts`. Covers the 401 / 403 / 400 / happy / selective / 500 paths on confirm and the 401 / 404 / 410 / 200 paths on cancel.

## Out of scope this PR (lands in 7b)

- Registering `broadcast_to_applicants` in `tools/registry.ts`.
- System prompt updates teaching sales + lettings prompts when to call it.
- BroadcastCard component, new `broadcast_draft` SSE frame, chat route dedup wiring.
- Updating PR #131's bulk-email worked example (currently still tells the user it can't do this; that becomes false in 7b).

## Constraints honoured

- No em dashes anywhere in new code. The two test strings that exercise the em-dash scrubber use `—` escapes so the source file is literally em-dash-free.
- No "yet from here" phrasing.
- Lucide icons only (none introduced; UI is in 7b).
- Mutation result integrity: `confirmBroadcast` refuses to claim success unless every expected `pending_drafts` row landed.
- No invented recipient details: the email LLM is constrained to scheme_of_interest_name + name and told to omit a field if it's null.

## Test plan

- [ ] Apply the migration to a non-prod project and confirm:
  - `broadcast_audit_log` exists with the indexes + RLS policies described.
  - `pending_drafts.broadcast_id` is present and nullable.
- [ ] Walk the unit tests manually (they are excluded from the Next build per `tsconfig.exclude`; this repo doesn't yet run jest in CI but the harness shape matches the existing voice-capture tests).
- [ ] `curl` `POST /api/agent-intelligence/confirm-broadcast` with a synthetic draft envelope and confirm one audit row + N pending_drafts rows land with matching `broadcast_id`.
- [ ] `curl` `POST /api/agent-intelligence/cancel-broadcast` within 30 minutes and confirm the drafts are deleted + audit row marked cancelled.
- [ ] `curl` `POST /api/agent-intelligence/cancel-broadcast` >30 minutes after creation and confirm the `410 expired` response.
- [ ] `curl` `GET /api/agent-intelligence/broadcast-history?limit=10` and confirm the recent rows return for the authenticated agent only.

https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc)_