### PR TITLE
feat(agent): broadcast UI + prompt integration (7b)

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -23,6 +23,7 @@ import ViewingCard, { type ViewingDraftPayload } from '@/components/agent/intell
 import ApplicantCard, { type ApplicantDraftEnvelope } from '@/components/agent/intelligence/ApplicantCard';
 import CompositeScheduleCard, { type CompositeScheduleEnvelope } from '@/components/agent/intelligence/CompositeScheduleCard';
 import ViewingMutationCard, { type ViewingMutationEnvelope } from '@/components/agent/intelligence/ViewingMutationCard';
+import BroadcastCard, { type BroadcastEnvelope } from '@/components/agent/intelligence/BroadcastCard';
 import PostViewingPrompt from '@/components/agent/intelligence/PostViewingPrompt';
 
 // Session 7 — the landing-screen action-button grid and the SCHEME_PILLS /
@@ -105,6 +106,11 @@ interface Message {
   // update_viewing / cancel_viewing / mark_viewing_status envelopes. One
   // card per turn; suppresses the four other draft surfaces when present.
   viewingMutationDrafts?: ViewingMutationEnvelope[];
+  // broadcast_to_applicants envelopes. One card per turn at most; when
+  // present, the chat route suppresses every other card surface and the
+  // follow-up chips (the BroadcastCard already carries its own
+  // approve / cancel / undo affordances).
+  broadcastDrafts?: BroadcastEnvelope[];
 }
 
 interface UndoBatch {
@@ -161,6 +167,18 @@ function compositeEnvelopeSignature(env: CompositeScheduleEnvelope): string {
     .sort()
     .join('||');
   return `${applicants}::${viewings}`;
+}
+
+// Stable signature for broadcast drafts. Same dedupe pattern as composite
+// and mutation cards; an identical envelope arriving twice in one turn
+// collapses to a single rendered BroadcastCard.
+function broadcastEnvelopeSignature(env: BroadcastEnvelope): string {
+  const emails = env.recipients
+    .map((r) => r.email.toLowerCase())
+    .filter((s) => s.length > 0)
+    .sort()
+    .join(',');
+  return `${env.intent}::${env.filter_natural}::${emails}`;
 }
 
 // Matches the chat route's mutation signature so the same envelope landing
@@ -481,6 +499,26 @@ function IntelligencePageInner() {
                   role: 'assistant',
                   content: '',
                   viewingMutationDrafts: [envelope],
+                }];
+              });
+            } else if (data.type === 'broadcast_draft' && data.envelope) {
+              const envelope = data.envelope as BroadcastEnvelope;
+              const sig = broadcastEnvelopeSignature(envelope);
+              setMessages(prev => {
+                const existing = prev.find(m => m.id === streamingMsgId);
+                if (existing) {
+                  return prev.map(m => {
+                    if (m.id !== streamingMsgId) return m;
+                    const current = m.broadcastDrafts ?? [];
+                    if (current.some(e => broadcastEnvelopeSignature(e) === sig)) return m;
+                    return { ...m, broadcastDrafts: [...current, envelope] };
+                  });
+                }
+                return [...prev, {
+                  id: streamingMsgId,
+                  role: 'assistant',
+                  content: '',
+                  broadcastDrafts: [envelope],
                 }];
               });
             } else if (data.type === 'override') {
@@ -1244,6 +1282,21 @@ function IntelligencePageInner() {
                   {msg.viewingMutationDrafts && msg.viewingMutationDrafts.map((envelope, idx) => (
                     <ViewingMutationCard
                       key={`${msg.id}-mutation-${idx}`}
+                      envelope={envelope}
+                      onConfirmFailed={(note) => {
+                        setMessages(prev => prev.map(m => {
+                          if (m.id !== msg.id) return m;
+                          const existing = m.content || '';
+                          if (existing.includes(note)) return m;
+                          const next = existing.length > 0 ? `${existing}\n\n${note}` : note;
+                          return { ...m, content: next };
+                        }));
+                      }}
+                    />
+                  ))}
+                  {msg.broadcastDrafts && msg.broadcastDrafts.map((envelope, idx) => (
+                    <BroadcastCard
+                      key={`${msg.id}-broadcast-${idx}`}
                       envelope={envelope}
                       onConfirmFailed={(note) => {
                         setMessages(prev => prev.map(m => {

--- a/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/chat/route.ts
@@ -49,6 +49,21 @@ function mutationEnvelopeSignature(env: Record<string, unknown>): string {
   return `${type}|${id}`;
 }
 
+// Stable signature for broadcast drafts. Same pattern as the mutation
+// helper: collapses identical envelopes produced by multi-round tool
+// calling so we never render the same BroadcastCard twice.
+function broadcastEnvelopeSignature(env: Record<string, unknown>): string {
+  const intent = (env.intent as string) || '';
+  const filterNatural = (env.filter_natural as string) || '';
+  const recipientsRaw = Array.isArray(env.recipients) ? (env.recipients as Array<Record<string, unknown>>) : [];
+  const emails = recipientsRaw
+    .map((r) => String(r.email ?? '').toLowerCase())
+    .filter((s) => s.length > 0)
+    .sort()
+    .join(',');
+  return `${intent}::${filterNatural}::${emails}`;
+}
+
 function labelForTool(toolName: string): string {
   switch (toolName) {
     case 'draft_message': return 'Drafting message';
@@ -340,6 +355,10 @@ export async function POST(request: NextRequest) {
     // ViewingMutationCard. Mutually exclusive with the four other card
     // types per turn (composite, applicant, viewing, mutation).
     const viewingMutationDrafts: Array<Record<string, unknown>> = [];
+    // broadcast_to_applicants returns one envelope per call. The chat
+    // surface renders one BroadcastCard with N personalised emails. Same
+    // mutual-exclusion contract as the other card surfaces.
+    const broadcastDrafts: Array<Record<string, unknown>> = [];
 
     // Task 2 — track whether any skill threw inside the tool loop. The
     // legacy catch path JSON-stringified the raw exception into the
@@ -466,6 +485,15 @@ export async function POST(request: NextRequest) {
               ((result.data as any).type as string).startsWith('viewing_')
             ) {
               viewingMutationDrafts.push(result.data as Record<string, unknown>);
+            }
+            if (
+              toolCall.function.name === 'broadcast_to_applicants' &&
+              result?.data &&
+              typeof result.data === 'object' &&
+              (result.data as any).status === 'draft' &&
+              (result.data as any).type === 'broadcast'
+            ) {
+              broadcastDrafts.push(result.data as Record<string, unknown>);
             }
           } catch (err: unknown) {
             // Task 2 — sanitised tool-failure path.
@@ -793,11 +821,26 @@ export async function POST(request: NextRequest) {
             );
           }
 
-          // The five draft surfaces are mutually exclusive per turn. Order
-          // of precedence: viewing_mutation_draft > composite_draft >
-          // (viewing_draft | applicant_draft). The mutation card is the
-          // most specific (a single existing viewing being changed); when
-          // it fires, no other card surfaces this turn.
+          // The card surfaces are mutually exclusive per turn. Order of
+          // precedence: broadcast_draft > viewing_mutation_draft >
+          // composite_draft > (viewing_draft | applicant_draft). A
+          // broadcast is the broadest action the agent can take in one
+          // turn, so when it fires nothing else surfaces; below that the
+          // most specific single-record card wins.
+          const seenBroadcastSigs = new Set<string>();
+          const dedupedBroadcasts = broadcastDrafts.filter((env) => {
+            const sig = broadcastEnvelopeSignature(env);
+            if (seenBroadcastSigs.has(sig)) return false;
+            seenBroadcastSigs.add(sig);
+            return true;
+          });
+          const hasBroadcast = dedupedBroadcasts.length > 0;
+          for (const envelope of dedupedBroadcasts) {
+            controller.enqueue(
+              encoder.encode(JSON.stringify({ type: 'broadcast_draft', envelope }) + '\n'),
+            );
+          }
+
           const seenMutationSigs = new Set<string>();
           const dedupedMutations = viewingMutationDrafts.filter((env) => {
             const sig = mutationEnvelopeSignature(env);
@@ -805,22 +848,24 @@ export async function POST(request: NextRequest) {
             seenMutationSigs.add(sig);
             return true;
           });
-          const hasMutation = dedupedMutations.length > 0;
-          for (const envelope of dedupedMutations) {
-            controller.enqueue(
-              encoder.encode(JSON.stringify({ type: 'viewing_mutation_draft', envelope }) + '\n'),
-            );
+          const hasMutation = !hasBroadcast && dedupedMutations.length > 0;
+          if (!hasBroadcast) {
+            for (const envelope of dedupedMutations) {
+              controller.enqueue(
+                encoder.encode(JSON.stringify({ type: 'viewing_mutation_draft', envelope }) + '\n'),
+              );
+            }
           }
 
           const hasComposite = compositeDrafts.length > 0;
-          if (!hasMutation) {
+          if (!hasBroadcast && !hasMutation) {
             for (const envelope of compositeDrafts) {
               controller.enqueue(
                 encoder.encode(JSON.stringify({ type: 'composite_draft', envelope }) + '\n'),
               );
             }
           }
-          if (!hasMutation && !hasComposite) {
+          if (!hasBroadcast && !hasMutation && !hasComposite) {
             // Emit one viewing_draft frame per draft the create_viewing tool
             // returned this turn. The IntelligencePage stashes them on the
             // assistant message and renders a persistent ViewingCard the
@@ -1145,7 +1190,8 @@ export async function POST(request: NextRequest) {
             viewingDrafts.length > 0 ||
             applicantDrafts.length > 0 ||
             compositeDrafts.length > 0 ||
-            viewingMutationDrafts.length > 0
+            viewingMutationDrafts.length > 0 ||
+            broadcastDrafts.length > 0
           ) {
             controller.enqueue(
               encoder.encode(JSON.stringify({ type: 'done', sessionId: currentSessionId }) + '\n')

--- a/apps/unified-portal/components/agent/intelligence/BroadcastCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/BroadcastCard.tsx
@@ -1,0 +1,655 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  Mail,
+  Send,
+  Check,
+  CheckCircle,
+  XCircle,
+  X,
+  Loader2,
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+  Undo2,
+  Users,
+} from 'lucide-react';
+
+export type BroadcastTone = 'warm' | 'professional' | 'urgent';
+
+export interface BroadcastFilter {
+  interested_in_scheme_ids?: string[];
+  has_active_enquiry?: boolean;
+  viewed_property_ids?: string[];
+  last_contact_before_days?: number;
+  status?: string[];
+}
+
+export interface BroadcastRecipient {
+  applicant_id: string | null;
+  name: string;
+  email: string;
+  scheme_of_interest_id: string | null;
+  scheme_of_interest_name: string | null;
+  last_contact_date: string | null;
+}
+
+export interface BroadcastEmail {
+  applicant_id: string | null;
+  recipient_email: string;
+  recipient_name: string;
+  subject: string;
+  body: string;
+  selected: boolean;
+}
+
+export interface BroadcastEnvelope {
+  status: 'draft';
+  type: 'broadcast';
+  intent: string;
+  filter_used: BroadcastFilter;
+  filter_natural: string;
+  tone: BroadcastTone;
+  recipients: BroadcastRecipient[];
+  emails: BroadcastEmail[];
+  shared_signoff: string;
+  message: string;
+}
+
+type Phase = 'draft' | 'reviewing' | 'confirming' | 'receipt' | 'reverted' | 'cancelled' | 'error';
+
+interface ReceiptPayload {
+  broadcast_id: string;
+  drafts_written: number;
+  sent_at: number;
+}
+
+interface BroadcastCardProps {
+  envelope: BroadcastEnvelope;
+  onConfirmFailed?: (note: string) => void;
+}
+
+const UNDO_PROMINENT_MS = 30 * 1000;
+const UNDO_WINDOW_MS = 30 * 60 * 1000;
+
+const cardSurface: React.CSSProperties = {
+  background: '#FFFFFF',
+  borderRadius: 18,
+  padding: 16,
+  width: '100%',
+  maxWidth: '90%',
+  boxShadow:
+    '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.05), 0 0 0 0.5px rgba(0,0,0,0.04)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const sectionLabelText: React.CSSProperties = {
+  fontSize: 10.5,
+  fontWeight: 700,
+  color: '#9CA3AF',
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase',
+};
+
+const valueText: React.CSSProperties = {
+  fontSize: 13.5,
+  color: '#0D0D12',
+  letterSpacing: '-0.005em',
+  fontWeight: 500,
+};
+
+const subduedText: React.CSSProperties = {
+  fontSize: 12,
+  color: '#6B7280',
+};
+
+const primaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)',
+  border: 'none',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#FFFFFF',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const secondaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: '#F4F4F5',
+  border: '0.5px solid rgba(0,0,0,0.08)',
+  borderRadius: 999,
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#374151',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const tertiaryButton: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 6,
+  padding: '10px 14px',
+  background: 'transparent',
+  border: 'none',
+  fontSize: 13,
+  fontWeight: 500,
+  color: '#6B7280',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const inlineInputStyle: React.CSSProperties = {
+  padding: '8px 10px',
+  fontSize: 13,
+  border: '0.5px solid rgba(0,0,0,0.16)',
+  borderRadius: 8,
+  background: '#FFFFFF',
+  color: '#0D0D12',
+  fontFamily: 'inherit',
+  width: '100%',
+};
+
+const textAreaStyle: React.CSSProperties = {
+  ...inlineInputStyle,
+  resize: 'vertical',
+  minHeight: 160,
+  lineHeight: 1.5,
+  fontFamily: 'inherit',
+};
+
+function previewLine(body: string): string {
+  const collapsed = body.replace(/\s+/g, ' ').trim();
+  return collapsed.length > 60 ? `${collapsed.slice(0, 60)}...` : collapsed;
+}
+
+function Checkbox({ checked, disabled, onClick }: { checked: boolean; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={checked}
+      className="agent-tappable"
+      style={{
+        width: 20,
+        height: 20,
+        borderRadius: 6,
+        border: `1.5px solid ${checked ? '#C49B2A' : 'rgba(0,0,0,0.20)'}`,
+        background: checked ? 'linear-gradient(180deg, #D4AF37 0%, #C49B2A 100%)' : '#FFFFFF',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        flexShrink: 0,
+        marginTop: 2,
+        padding: 0,
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {checked && <Check size={14} strokeWidth={2.5} style={{ color: '#FFFFFF' }} />}
+    </button>
+  );
+}
+
+export default function BroadcastCard({ envelope, onConfirmFailed }: BroadcastCardProps) {
+  const [emails, setEmails] = useState<BroadcastEmail[]>(envelope.emails);
+  const initialSelectionKeys = useMemo(
+    () => new Set(envelope.emails.filter((e) => e.selected !== false).map(emailKey)),
+    [envelope.emails],
+  );
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(initialSelectionKeys);
+  const [recipientsExpanded, setRecipientsExpanded] = useState<boolean>(false);
+  const [expandedKey, setExpandedKey] = useState<string | null>(
+    envelope.emails.length > 0 ? emailKey(envelope.emails[0]) : null,
+  );
+  const [phase, setPhase] = useState<Phase>('draft');
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<ReceiptPayload | null>(null);
+  const [undoElapsed, setUndoElapsed] = useState<number>(0);
+
+  // Tick a second-resolution counter while a receipt is visible so the undo
+  // button transitions from prominent to subtle after 30 seconds and
+  // disappears entirely after 30 minutes. Cheap render churn (one re-render
+  // per second) confined to a single card.
+  useEffect(() => {
+    if (phase !== 'receipt' || !receipt) return;
+    const tick = () => setUndoElapsed(Date.now() - receipt.sent_at);
+    tick();
+    const handle = window.setInterval(tick, 1000);
+    return () => window.clearInterval(handle);
+  }, [phase, receipt]);
+
+  const selectedEmails = useMemo(
+    () => emails.filter((e) => selectedKeys.has(emailKey(e))),
+    [emails, selectedKeys],
+  );
+
+  function toggleRecipient(key: string) {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function updateEmail(key: string, patch: Partial<BroadcastEmail>) {
+    setEmails((prev) => prev.map((e) => (emailKey(e) === key ? { ...e, ...patch } : e)));
+  }
+
+  function expandEmail(key: string) {
+    setExpandedKey((prev) => (prev === key ? null : key));
+  }
+
+  function startReview() {
+    if (selectedEmails.length === 0) {
+      setErrorText('Pick at least one recipient.');
+      return;
+    }
+    setErrorText(null);
+    setPhase('reviewing');
+  }
+
+  const runConfirm = useCallback(async () => {
+    setPhase('confirming');
+    setErrorText(null);
+    try {
+      const body = {
+        draft: { ...envelope, emails },
+        selected_emails: selectedEmails.map((e) => ({
+          applicant_id: e.applicant_id,
+          recipient_email: e.recipient_email,
+          recipient_name: e.recipient_name,
+          subject: e.subject,
+          body: e.body,
+          selected: true,
+        })),
+      };
+      const res = await fetch('/api/agent-intelligence/confirm-broadcast', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "Couldn't queue the broadcast");
+      }
+      const data = await res.json();
+      if (!data?.broadcast_id) throw new Error('Broadcast returned no audit id.');
+      setReceipt({
+        broadcast_id: data.broadcast_id,
+        drafts_written: typeof data.drafts_written === 'number' ? data.drafts_written : selectedEmails.length,
+        sent_at: Date.now(),
+      });
+      setPhase('receipt');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Couldn't queue the broadcast";
+      setErrorText(message);
+      setPhase('error');
+      onConfirmFailed?.(
+        `Broadcast failed, no emails were queued. Reason: ${message}`,
+      );
+    }
+  }, [envelope, emails, selectedEmails, onConfirmFailed]);
+
+  async function runUndo() {
+    if (!receipt) return;
+    try {
+      const res = await fetch('/api/agent-intelligence/cancel-broadcast', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ audit_log_id: receipt.broadcast_id }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error || "Couldn't undo the broadcast");
+      }
+      setPhase('reverted');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Couldn't undo the broadcast";
+      setErrorText(message);
+    }
+  }
+
+  function cancelDraft() {
+    setPhase('cancelled');
+  }
+
+  if (phase === 'cancelled') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={{ ...cardSurface, gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <X size={16} strokeWidth={2} style={{ color: '#9CA3AF' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#6B7280' }}>Nothing sent</span>
+          </div>
+          <span style={{ fontSize: 12.5, color: '#6B7280' }}>Cancelled before queueing.</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'reverted') {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={{ ...cardSurface, gap: 6 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Undo2 size={16} strokeWidth={2} style={{ color: '#6B7280' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#374151' }}>Reverted</span>
+          </div>
+          <span style={{ fontSize: 12.5, color: '#6B7280' }}>
+            Pending drafts deleted. Nothing went out.
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === 'receipt' && receipt) {
+    const undoVisible = undoElapsed < UNDO_WINDOW_MS;
+    const undoProminent = undoElapsed < UNDO_PROMINENT_MS;
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+        <div style={cardSurface}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <CheckCircle size={16} strokeWidth={2.25} style={{ color: '#C49B2A' }} />
+            <span style={{ fontSize: 13, fontWeight: 600, color: '#0D0D12' }}>
+              {receipt.drafts_written} email{receipt.drafts_written === 1 ? '' : 's'} queued for sending
+            </span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <Link href="/agent/drafts" style={{ ...subduedText, fontWeight: 600, color: '#0D0D12', textDecoration: 'underline' }}>
+              Open in Drafts
+            </Link>
+            {undoVisible && (
+              undoProminent ? (
+                <button type="button" onClick={runUndo} style={secondaryButton} className="agent-tappable">
+                  <Undo2 size={13} strokeWidth={2.25} />
+                  Undo
+                </button>
+              ) : (
+                <button type="button" onClick={runUndo} style={tertiaryButton} className="agent-tappable">
+                  Undo
+                </button>
+              )
+            )}
+          </div>
+          {errorText && (
+            <span style={{ ...subduedText, color: '#B91C1C' }}>{errorText}</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const isError = phase === 'error';
+  const isConfirming = phase === 'confirming';
+  const isReviewing = phase === 'reviewing';
+  const cardSurfaceForPhase: React.CSSProperties = isError
+    ? {
+        ...cardSurface,
+        border: '1px solid rgba(220,38,38,0.45)',
+        boxShadow:
+          '0 1px 2px rgba(0,0,0,0.04), 0 4px 12px rgba(220,38,38,0.10), 0 0 0 0.5px rgba(220,38,38,0.20)',
+      }
+    : cardSurface;
+
+  const headerLabel = isError
+    ? "Couldn't queue"
+    : selectedEmails.length === 1
+      ? 'Draft 1 email for review'
+      : `Draft ${selectedEmails.length} emails for review`;
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <div style={cardSurfaceForPhase}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {isError ? (
+            <AlertTriangle size={16} strokeWidth={2.25} style={{ color: '#B91C1C' }} />
+          ) : (
+            <Mail size={16} strokeWidth={2} style={{ color: '#0D0D12' }} />
+          )}
+          <span style={{ fontSize: 13, fontWeight: 600, color: isError ? '#B91C1C' : '#0D0D12' }}>
+            {headerLabel}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <span style={{ ...subduedText }}>To: {envelope.filter_natural}</span>
+          <span style={{ ...subduedText, color: '#9CA3AF', fontStyle: 'italic' }}>
+            {envelope.intent.length > 140 ? `${envelope.intent.slice(0, 140)}...` : envelope.intent}
+          </span>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <button
+            type="button"
+            onClick={() => setRecipientsExpanded((v) => !v)}
+            className="agent-tappable"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 10px',
+              background: '#FAFAFA',
+              border: '0.5px solid rgba(0,0,0,0.06)',
+              borderRadius: 10,
+              fontSize: 12.5,
+              fontWeight: 600,
+              color: '#374151',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            <Users size={13} strokeWidth={2} style={{ color: '#6B7280' }} />
+            <span style={{ flex: 1, textAlign: 'left' }}>
+              Recipients ({selectedEmails.length}/{emails.length})
+            </span>
+            {recipientsExpanded ? <ChevronUp size={14} strokeWidth={2} /> : <ChevronDown size={14} strokeWidth={2} />}
+          </button>
+
+          {recipientsExpanded && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              {emails.map((e) => {
+                const key = emailKey(e);
+                const checked = selectedKeys.has(key);
+                return (
+                  <div
+                    key={`r-${key}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '8px 10px',
+                      background: checked ? '#FFFFFF' : '#FAFAFA',
+                      border: `0.5px solid ${checked ? 'rgba(0,0,0,0.10)' : 'rgba(0,0,0,0.06)'}`,
+                      borderRadius: 10,
+                    }}
+                  >
+                    <Checkbox
+                      checked={checked}
+                      disabled={isConfirming || isReviewing}
+                      onClick={() => toggleRecipient(key)}
+                    />
+                    <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+                      <span style={{ ...valueText, fontSize: 13 }}>{e.recipient_name}</span>
+                      <span style={{ ...subduedText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {e.recipient_email}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <span style={sectionLabelText}>Emails</span>
+          {selectedEmails.length === 0 ? (
+            <span style={{ ...subduedText }}>No recipients selected.</span>
+          ) : (
+            selectedEmails.map((e, idx) => {
+              const key = emailKey(e);
+              const expanded = expandedKey === key;
+              if (!expanded) {
+                return (
+                  <button
+                    key={`e-${key}`}
+                    type="button"
+                    onClick={() => expandEmail(key)}
+                    className="agent-tappable"
+                    disabled={isConfirming || isReviewing}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      padding: '10px 12px',
+                      background: '#FFFFFF',
+                      border: '0.5px solid rgba(0,0,0,0.08)',
+                      borderRadius: 12,
+                      cursor: isConfirming || isReviewing ? 'default' : 'pointer',
+                      fontFamily: 'inherit',
+                      textAlign: 'left',
+                    }}
+                  >
+                    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+                      <span style={{ ...valueText, fontSize: 13 }}>{e.recipient_name}</span>
+                      <span style={{ ...subduedText, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {previewLine(e.body)}
+                      </span>
+                    </div>
+                    <ChevronDown size={14} strokeWidth={2} style={{ color: '#6B7280' }} />
+                  </button>
+                );
+              }
+              return (
+                <div
+                  key={`e-${key}`}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                    padding: '12px 12px',
+                    background: '#FFFFFF',
+                    border: '0.5px solid rgba(0,0,0,0.12)',
+                    borderRadius: 12,
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ ...subduedText, fontWeight: 600, color: '#374151' }}>
+                      To: {e.recipient_name}
+                    </span>
+                    <span style={{ ...subduedText }}>{e.recipient_email}</span>
+                    <span style={{ flex: 1 }} />
+                    {idx < selectedEmails.length - 1 && (
+                      <button
+                        type="button"
+                        onClick={() => expandEmail(key)}
+                        className="agent-tappable"
+                        style={{
+                          ...tertiaryButton,
+                          padding: '4px 8px',
+                          fontSize: 12,
+                        }}
+                        disabled={isConfirming || isReviewing}
+                      >
+                        Collapse
+                      </button>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <span style={sectionLabelText}>Subject</span>
+                    <input
+                      type="text"
+                      value={e.subject}
+                      onChange={(ev) => updateEmail(key, { subject: ev.target.value })}
+                      disabled={isConfirming || isReviewing}
+                      style={inlineInputStyle}
+                    />
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <span style={sectionLabelText}>Body</span>
+                    <textarea
+                      value={e.body}
+                      onChange={(ev) => updateEmail(key, { body: ev.target.value })}
+                      disabled={isConfirming || isReviewing}
+                      rows={10}
+                      style={textAreaStyle}
+                    />
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {errorText && (
+          <span style={{ ...subduedText, color: '#B91C1C' }}>{errorText}</span>
+        )}
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          {isReviewing ? (
+            <>
+              <span style={{ ...subduedText, marginRight: 4 }}>
+                Send {selectedEmails.length} email{selectedEmails.length === 1 ? '' : 's'} now?
+              </span>
+              <button type="button" style={primaryButton} onClick={runConfirm} className="agent-tappable">
+                <Send size={14} strokeWidth={2.25} />
+                Confirm
+              </button>
+              <button type="button" style={tertiaryButton} onClick={() => setPhase('draft')} className="agent-tappable">
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                style={primaryButton}
+                onClick={isError ? runConfirm : startReview}
+                disabled={isConfirming || selectedEmails.length === 0}
+                className="agent-tappable"
+              >
+                {isConfirming ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    Queueing emails
+                  </>
+                ) : (
+                  <>
+                    <Send size={14} strokeWidth={2.25} />
+                    {isError ? 'Try again' : `Approve and send all (${selectedEmails.length})`}
+                  </>
+                )}
+              </button>
+              <button type="button" style={tertiaryButton} onClick={cancelDraft} className="agent-tappable" disabled={isConfirming}>
+                Cancel
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function emailKey(e: BroadcastEmail): string {
+  return e.applicant_id ?? `email:${e.recipient_email.toLowerCase()}`;
+}

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -414,33 +414,37 @@ Instead, respond honestly with two parts:
   2. Offer what you CAN do that comes closest to their request, or
      explain how they can achieve it manually.
 
-Specifically for bulk outreach requests (e.g. "email all applicants
-interested in X"):
-  - You do not currently have a tool to send bulk emails to filtered
-    applicant lists.
-  - You CAN draft individual emails to specific named applicants via
-    draft_message.
-  - You CAN list applicants matching a filter via natural_query or
-    get_buyer_details, which the agent can then act on themselves.
+For bulk outreach to a filtered cohort of applicants ("email
+everyone interested in <scheme>", "notify all applicants about
+<thing>", "tell the waitlist <message>"), use the
+broadcast_to_applicants tool. See the BROADCAST EMAILS section
+below. That path is supported; do NOT respond with an honest
+decline in those cases.
 
-Worked example (bulk outreach):
-  User: "Can you send out an email to all of the applicants interested
-    in buying homes in Lakeside Manor and let them know that I will be
-    available for viewings in the show house this Saturday between
-    10am and 2pm."
+The decline path is for requests with no matching tool at all.
+Examples:
+  - Making a phone call on the agent's behalf. You have no tool
+    for outbound voice. You CAN draft an email or a chase note.
+  - External lookups (weather, planning permission status, public
+    records). You have no tool for those.
+  - Anything you genuinely don't have a tool for that comes up in
+    the conversation.
+
+Worked example (no matching tool):
+  User: "Can you ring Niamh and tell her about the Saturday
+    viewing window?"
   CORRECT:
-    "I can't send bulk emails yet, but I can list every applicant
-     interested in Lakeside Manor so you can see who needs the message,
-     and I can draft individual emails one by one if you tell me their
-     names. Want me to pull up the list?"
+    "I can't make phone calls yet. I can draft a short email or
+     text to send her instead, or log a reminder to call her at a
+     specific time. Which would you like?"
   INCORRECT:
-    "I heard you'd like me to send an email to all applicants
-     interested in Lakeside Manor. I'm not sure what you'd like me to
-     do." (Parroting the request back with a shrug is forbidden. It is
-     unhelpful and makes the product feel broken.)
+    "I heard you'd like me to ring Niamh. I'm not sure what
+     you'd like me to do." (Parroting the request back with a
+     shrug is forbidden. It is unhelpful and makes the product
+     feel broken.)
 
-This response is honest about the limitation, offers a concrete next
-step, and respects the agent's time. The parrot-back-and-shrug
+This response is honest about the limitation, offers a concrete
+next step, and respects the agent's time. The parrot-back-and-shrug
 response is forbidden under all circumstances.
 
 If the request is outside the property domain entirely (e.g. "what's
@@ -728,6 +732,62 @@ Inputs shape: viewings: [{ applicant_name, scheduled_at_natural, property_hint?,
 When the result returns status='draft' with type='composite_schedule', reply with one short sentence (<= 14 words) confirming you've prepared it. DO NOT echo the per-row details; the card is the canonical surface.
 
 Never refuse a scheduling request. The tool handles every case.
+
+============================================================
+BROADCAST EMAILS - USE broadcast_to_applicants:
+============================================================
+When the user asks to email a group of applicants based on a filter
+rather than naming individuals, call broadcast_to_applicants.
+Triggering phrases include:
+  - "email everyone interested in <scheme>"
+  - "notify all applicants about <thing>"
+  - "tell the waitlist <message>"
+  - "send out an update to <group>"
+  - "let all the people who enquired about <X> know that <Y>"
+
+The tool drafts one personalised email per recipient. The chat
+renders a single BroadcastCard; the user reviews each draft,
+deselects any recipient, edits any individual email, then approves
+the whole batch with one tap. Drafts land in pending_drafts grouped
+under a broadcast_audit_log row so they can be cancelled together
+within a 30-minute window.
+
+When calling broadcast_to_applicants:
+  - intent: pass the user's full message about what to send
+    VERBATIM. Do not paraphrase, do not summarise. FAITHFUL
+    EXTRACTION applies here exactly as it does for schedule_viewings.
+  - filter_natural: pass the user's filter language VERBATIM. The
+    tool runs its own scheme resolution against the agent's
+    assigned developments. Do not normalise scheme names.
+  - tone: default "warm". Use "professional" for formal updates
+    (price changes, policy notices). Use "urgent" for time-sensitive
+    things (last chance, available now).
+
+When the tool returns status='draft' with type='broadcast', reply
+with one short sentence (<= 14 words) confirming the card is ready
+for review. DO NOT enumerate recipient names or email bodies; the
+card is the canonical surface.
+
+Clarification handling:
+  - status='needs_clarification', reason='no_recipients_match': the
+    filter matched zero applicants. The tool returns a sample of
+    recent applicants in the tenant. Relay the message verbatim so
+    the user can refine.
+  - status='needs_clarification', reason='too_many_recipients': the
+    filter matched more than 200 applicants. Relay the count and
+    ask the user to narrow.
+  - status='needs_clarification', reason='filter_unparseable': the
+    scheme name didn't resolve to one of the agent's assigned
+    schemes. Relay the message verbatim including the assigned
+    scheme list.
+
+NEVER invent message content beyond what the user said. NEVER
+invent applicant details that are not in their record. NEVER claim
+the broadcast was sent before the agent approves the card.
+
+This is the bulk-send path. It REPLACES the previous honest-decline
+behaviour for bulk-email requests; the HANDLING REQUESTS YOU CAN'T
+FULFIL section above now points to this tool for those cases.
 
 ============================================================
 MANAGING VIEWINGS - UPDATE, CANCEL, MARK STATUS:
@@ -1209,32 +1269,37 @@ Instead, respond honestly with two parts:
   2. Offer what you CAN do that comes closest to their request, or
      explain how they can achieve it manually.
 
-Specifically for bulk outreach requests (e.g. "message every tenant
-whose rent is due this week"):
-  - You do not currently have a tool to send bulk messages to filtered
-    tenant lists.
-  - You CAN draft individual messages to specific named tenants via
-    draft_message.
-  - You CAN list tenants matching a filter via natural_query or by
-    reading directly from the LETTINGS PORTFOLIO block, which the
-    agent can then act on themselves.
+For bulk outreach to a filtered cohort of tenants or applicants
+("message every tenant whose rent is due this week", "email all
+applicants about the new listing"), use the broadcast_to_applicants
+tool. See the BROADCAST EMAILS section below. That path is
+supported; do NOT respond with an honest decline in those cases.
 
-Worked example (bulk outreach):
-  User: "Send a reminder to every tenant whose rent is due this week
-    that the standing order date has changed."
+The decline path is for requests with no matching tool at all.
+Examples:
+  - Making a phone call on the agent's behalf. You have no tool
+    for outbound voice. You CAN draft a message or log a callback
+    reminder.
+  - External lookups (weather, planning permission status, public
+    records). You have no tool for those.
+  - Anything you genuinely don't have a tool for that comes up in
+    the conversation.
+
+Worked example (no matching tool):
+  User: "Can you ring Aisling and tell her the plumber will be there
+    Thursday morning?"
   CORRECT:
-    "I can't send bulk messages yet, but I can list every tenant whose
-     rent is due this week so you can see who needs the reminder, and
-     I can draft individual messages one by one if you tell me their
-     names. Want me to pull up the list?"
+    "I can't make phone calls yet. I can draft a short message to
+     her instead, or log a reminder to call her at a specific time.
+     Which would you like?"
   INCORRECT:
-    "I heard you'd like me to send a reminder to every tenant whose
-     rent is due this week. I'm not sure what you'd like me to do."
-     (Parroting the request back with a shrug is forbidden. It is
-     unhelpful and makes the product feel broken.)
+    "I heard you'd like me to ring Aisling. I'm not sure what
+     you'd like me to do." (Parroting the request back with a
+     shrug is forbidden. It is unhelpful and makes the product
+     feel broken.)
 
-This response is honest about the limitation, offers a concrete next
-step, and respects the agent's time. The parrot-back-and-shrug
+This response is honest about the limitation, offers a concrete
+next step, and respects the agent's time. The parrot-back-and-shrug
 response is forbidden under all circumstances.
 
 If the request is outside the lettings domain entirely (e.g. "what's
@@ -1480,6 +1545,17 @@ If the user did not state a value clearly, return needs_clarification with the r
 NEVER pull values from this prompt's examples or from the tool description examples. Those are illustrations of structure, not defaults. Bare numbers, bare weekdays, or generic placeholders are NEVER acceptable tool arguments. If you cannot find the user's literal value in the current message, ask.
 
 For ANY request to schedule one or more viewings, call schedule_viewings. This covers a single viewing, multiple viewings in one turn, viewings for people not yet on the applicants list (the tool auto-creates them), viewings where the user named a property, and viewings where they did not. Do not pick between this and any other tool. The composite tool handles applicant creation atomically through a Postgres RPC. The chat surface renders one CompositeScheduleCard with one Confirm. NEVER invent email or phone for new applicants - pass full_name only inside the viewings array. When property is missing AND the applicant has no enquiry on file, the tool returns a needs_clarification asking which development; pass that question through to the user. When the applicant is brand new, the tool includes them in the applicants_to_create array. If the user states a calendar preference ("iPhone calendar"), pass calendar_preference; otherwise omit. One clarification question maximum. Never refuse a scheduling request - the tool handles every case.
+
+BROADCAST EMAILS - USE broadcast_to_applicants:
+When the user asks to message a group of tenants or applicants based on a filter rather than naming individuals, call broadcast_to_applicants. Triggering phrases include "email everyone interested in <scheme>", "notify all applicants about <thing>", "message every tenant whose <criterion>", "tell the waitlist <message>", "send out an update to <group>", "let all the people who enquired about <X> know that <Y>". The tool drafts one personalised email per recipient. The chat renders a single BroadcastCard; the user reviews each draft, deselects any recipient, edits any individual email, then approves the whole batch with one tap. Drafts land in pending_drafts grouped under a broadcast_audit_log row so they can be cancelled together within a 30-minute window.
+When calling broadcast_to_applicants:
+  - intent: pass the user's full message about what to send VERBATIM. FAITHFUL EXTRACTION applies.
+  - filter_natural: pass the user's filter language VERBATIM. The tool resolves scheme names against the agent's assigned developments.
+  - tone: default "warm". Use "professional" for formal updates, "urgent" for time-sensitive things.
+When the tool returns status='draft' with type='broadcast', reply with one short sentence (<= 14 words) confirming the card is ready for review. DO NOT enumerate recipient names or email bodies; the card is the canonical surface.
+Clarification handling: relay the needs_clarification message verbatim. The reasons are no_recipients_match (filter matched zero, sample returned), too_many_recipients (more than 200, narrow further), and filter_unparseable (scheme didn't resolve to the agent's assigned list).
+NEVER invent message content beyond what the user said. NEVER invent applicant or tenant details that are not in their record. NEVER claim the broadcast was sent before the agent approves the card.
+This is the bulk-send path. It REPLACES the previous honest-decline behaviour for bulk-email requests; the HANDLING REQUESTS YOU CAN'T FULFIL section above now points to this tool for those cases.
 
 MANAGING VIEWINGS - UPDATE, CANCEL, MARK STATUS:
 For changes to existing viewings: "reschedule X" or "move X to" → update_viewing. "Cancel X" → cancel_viewing (red confirmation button). "X didn't show" → mark_viewing_status with no_show. "Viewing with X went well" → mark_viewing_status with completed. Resolve the viewing by applicant name (and optional date hint). If the applicant has more than one viewing, ask one targeted question ("Which one, Thursday or Friday?") and re-call with the answer. Default to the next upcoming viewing if there is exactly one in the future. Calendar updates and deletions happen automatically; do not ask about calendar unless the user explicitly wants to skip it. NEVER invent a status change the user did not request - "mark as completed" must come from the user, not from inference.

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -19,6 +19,7 @@ import {
 import { updateViewing, cancelViewing, markViewingStatus } from './viewing-tools';
 import { manageApplicants } from './applicant-tools';
 import { scheduleViewings } from './composite-tools';
+import { planBroadcast } from './broadcast-tools';
 // schedule_viewing (immediate-write) is intentionally NOT imported here.
 // All viewing scheduling goes through schedule_viewings (composite tool).
 // The underlying scheduleViewing function remains exported from
@@ -554,6 +555,44 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       required: ['viewings'],
     },
     execute: scheduleViewings as ToolFunction,
+  },
+  {
+    name: 'broadcast_to_applicants',
+    description: [
+      'Bulk personalised applicant broadcast. Use when the user wants to email a group of applicants based on a filter rather than naming each recipient.',
+      'Examples that should trigger this tool:',
+      '- "email everyone interested in <the scheme as user said it> about <the user\'s intent verbatim>"',
+      '- "notify all applicants who enquired about <the scheme as user said it> that <the user\'s intent verbatim>"',
+      '- "tell my waitlist <the user\'s intent verbatim>"',
+      '- "send out an update to anyone who viewed <the scheme as user said it>"',
+      'The tool runs three phases: it parses the natural-language filter, resolves recipients from the enquiries table within the agent\'s tenant, and drafts one personalised email per recipient. The chat surface renders one BroadcastCard with a single Approve gesture; the agent can deselect any recipient or edit any individual email before approving.',
+      'Inputs:',
+      '- intent: the user\'s message about what to send, VERBATIM. Never paraphrase. This is what each personalised email conveys. FAITHFUL EXTRACTION applies.',
+      '- filter_natural: the user\'s recipient filter, VERBATIM. Never paraphrase or normalise scheme names; the tool does its own resolution against the agent\'s assigned schemes.',
+      '- tone: optional. Defaults to "warm". Pass "professional" for formal updates (price changes, policy notices). Pass "urgent" for time-sensitive things (last chance, available now).',
+      'Returns either { status: "draft", type: "broadcast", recipients, emails, ... } for the chat card to render, or { status: "needs_clarification", reason, message }. Clarification reasons cover empty intent, empty filter, unresolved scheme, zero recipients (with a sample), and too many recipients (>200). Surface the clarification message verbatim and let the user narrow.',
+      'NEVER invent applicant details that are not in their record. NEVER claim the broadcast was sent before the agent approves the card.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        intent: {
+          type: 'string',
+          description: 'The user\'s message to convey to each recipient. Pass VERBATIM, never paraphrase or summarise. The same wording the user said.',
+        },
+        filter_natural: {
+          type: 'string',
+          description: 'The user\'s natural-language filter for who to email. Pass VERBATIM. Examples of structure (NOT defaults): "everyone interested in <scheme>", "anyone who enquired about <scheme> in the last <N> days", "applicants who viewed <scheme>". Never invent a scheme name the user did not say.',
+        },
+        tone: {
+          type: 'string',
+          enum: ['warm', 'professional', 'urgent'],
+          description: 'Tone for the drafted emails. Defaults to "warm". Use "professional" for formal updates, "urgent" for time-sensitive things.',
+        },
+      },
+      required: ['intent', 'filter_natural'],
+    },
+    execute: planBroadcast as ToolFunction,
   },
   {
     name: 'update_viewing',


### PR DESCRIPTION
## Summary

The UI half of the bulk-personalised-applicant-broadcast feature. PR #132 landed the migration, the tool, the API routes, and the tests. This PR registers the tool with the LLM, builds the card, wires the chat surface, and updates both system prompts.

After this lands, the QA failing prompt:

> "Can you send out an email to all of the applicants interested in buying homes in Lakeside Manor and let them know that I will be available for viewings in the show house this Saturday between 10am and 2pm."

now routes through `broadcast_to_applicants`, renders a BroadcastCard with N personalised drafts, and the agent approves the whole batch with one tap.

## What's in

### LLM tool registration
- `lib/agent-intelligence/tools/registry.ts`: `broadcast_to_applicants` registered with a description that uses abstract placeholders (`<the scheme as user said it>`, `<the user's intent verbatim>`) so the model doesn't copy example names or times into tool args (the PR #119 lesson). Schema accepts `intent`, `filter_natural`, optional `tone`.

### Card
- `components/agent/intelligence/BroadcastCard.tsx`: a sibling of `CompositeScheduleCard`. Six-phase state machine (`draft` -> `reviewing` -> `confirming` -> `receipt`, plus `reverted` / `cancelled` / `error`).
  - Header: Mail icon, "Draft N emails for review".
  - Sub-header: the user's filter verbatim ("To: everyone interested in Lakeside Manor") and a truncated intent summary.
  - Recipients section: collapsed by default with a chevron and a `(selected/total)` count. Each row has a checkbox + name + email. Deselecting filters the Emails section live.
  - Emails section: first selected email rendered fully expanded with editable subject input and a tall textarea body. Other selected emails render collapsed with name + 60-char preview, tap to swap which one is expanded (one expanded at a time).
  - Buttons: "Approve and send all (N)" primary, "Cancel" tertiary. Approve flips to a "Send N emails now? / Confirm / Cancel" review row before firing the API call.
  - Receipt: CheckCircle in gold, "N emails queued for sending", "Open in Drafts" link, and an Undo button that is prominent (secondary) for 30 seconds, subtle (tertiary) for the next 29 minutes, and gone at 30 minutes (matches the backend's `UNDO_WINDOW_MS`).
  - Cancelled / reverted / error phases each render a small, honest state card.

### Chat route SSE
- `app/api/agent-intelligence/chat/route.ts`: detects `broadcast_to_applicants` draft envelopes, emits a `broadcast_draft` SSE frame with stable-signature dedupe (intent + filter_natural + sorted recipient emails). Broadcast is now at the top of the mutual-exclusion gate (broadcast > viewing_mutation > composite > viewing/applicant); when a broadcast frame fires, no other card surfaces and the follow-up chips are suppressed.

### Intelligence page
- `app/agent/intelligence/page.tsx`: new `broadcast_draft` SSE handler with a matching client-side dedupe helper, `broadcastDrafts` slot on the `Message` shape, BroadcastCard render in the message stream with `onConfirmFailed` plumbing.

### System prompts (sales + lettings)
- New "BROADCAST EMAILS - USE broadcast_to_applicants" section after `SCHEDULING A VIEWING` and before `MANAGING VIEWINGS`. Teaches:
  - the trigger phrases (email everyone, notify all, tell the waitlist, send out an update, let all the people who enquired...)
  - the FAITHFUL EXTRACTION rule for `intent` and `filter_natural`
  - the tone heuristic
  - the three clarification reasons (no_recipients_match, too_many_recipients, filter_unparseable) and "relay verbatim"
  - never-invent / never-claim-sent rules
  - explicit pointer that this REPLACES the previous honest-decline behaviour for bulk email
- The `HANDLING REQUESTS YOU CAN'T FULFIL` section from PR #131 no longer uses bulk email as its worked example. Replaced with "Can you ring <name>?" since outbound voice genuinely isn't a capability. The rule structure (state plainly, offer the closest concrete alternative, never parrot) is otherwise unchanged.

## Constraints honoured

- No em dashes in any new content.
- No "yet from here" phrasing.
- Lucide icons only (Mail, Send, Check, CheckCircle, XCircle, X, Loader2, AlertTriangle, ChevronDown, ChevronUp, Undo2, Users).
- Surgical: card matches `CompositeScheduleCard` visual language (same `cardSurface`, button styles, label typography, checkbox treatment).
- Never invent applicant details: the recipient surface only renders what the envelope returned.
- Mutation result integrity: the receipt phase reads `drafts_written` and `broadcast_id` from the API response, never from optimistic state.
- Edits to subject/body and recipient deselection are passed through to the confirm API as `selected_emails`; the backend's selection logic accepts the edited list and writes only those drafts.

## Test plan (QA walkthrough)

- [ ] Sign in as `Agent-test@test.ie` (Sarah Mitchell at Bridge Property Group).
- [ ] Ensure at least 3 applicants have active enquiries on Lakeside Manor. If not, seed via voice or chat.
- [ ] In Intelligence chat, paste the failing prompt:
  > "Can you send out an email to all of the applicants interested in buying homes in Lakeside Manor and let them know that I will be available for viewings in the show house this Saturday between 10am and 2pm."
- [ ] BroadcastCard renders. Header reads "Draft N emails for review". Filter shown verbatim.
- [ ] Each email body:
  - Opens with the recipient's first name
  - References Lakeside Manor
  - Conveys the Saturday 10-2 window in natural Irish prose
  - Signs off as Sarah Mitchell
  - Has zero em dashes (the backend scrubber catches any that slip)
  - Does not contain "I hope this finds you well" or similar AI filler
- [ ] Expand the Recipients section, deselect one recipient, confirm the approve count and Emails section update live.
- [ ] Edit the subject of the expanded email; verify the local state updates.
- [ ] Tap "Approve and send all (N-1)". Confirm modal renders, tap "Confirm".
- [ ] Receipt card appears. "Open in Drafts" link present. Undo button prominent for 30 seconds.
- [ ] Tap Undo within 30 minutes. Card mutates to "Reverted". Pending drafts deleted, audit row marked cancelled (verify via SQL).
- [ ] Re-run the prompt with an unresolved scheme name. Confirm the chat surfaces the clarification message verbatim with the assigned scheme list.

https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc)_