### PR TITLE
Harden PWA Capacitor mobile confidence checks

### DIFF
--- a/.github/workflows/capacitor-wrapper-quality.yml
+++ b/.github/workflows/capacitor-wrapper-quality.yml
@@ -1,0 +1,67 @@
+name: Capacitor wrapper quality
+
+on:
+  pull_request:
+    paths:
+      - "apps/unified-portal/android/**"
+      - "apps/unified-portal/ios/**"
+      - "apps/unified-portal/public/manifest.json"
+      - "apps/unified-portal/public/sw.js"
+      - "apps/unified-portal/public/.well-known/**"
+      - "apps/unified-portal/app/layout.tsx"
+      - "apps/unified-portal/app/care/sw-register.tsx"
+      - "apps/unified-portal/hooks/usePushNotifications.ts"
+      - "apps/unified-portal/lib/capacitor-native.ts"
+      - "apps/unified-portal/scripts/pwa-capacitor-audit.mjs"
+      - "apps/unified-portal/package.json"
+      - ".github/workflows/capacitor-wrapper-quality.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/unified-portal/android/**"
+      - "apps/unified-portal/ios/**"
+      - "apps/unified-portal/public/manifest.json"
+      - "apps/unified-portal/public/sw.js"
+      - "apps/unified-portal/public/.well-known/**"
+      - "apps/unified-portal/app/layout.tsx"
+      - "apps/unified-portal/app/care/sw-register.tsx"
+      - "apps/unified-portal/hooks/usePushNotifications.ts"
+      - "apps/unified-portal/lib/capacitor-native.ts"
+      - "apps/unified-portal/scripts/pwa-capacitor-audit.mjs"
+      - "apps/unified-portal/package.json"
+      - ".github/workflows/capacitor-wrapper-quality.yml"
+
+jobs:
+  pwa-capacitor-audit:
+    name: PWA and Capacitor audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/unified-portal
+    steps:
+      - name: Checkout audited files
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            apps/unified-portal/android/app/src/main/AndroidManifest.xml
+            apps/unified-portal/ios/App/App/Info.plist
+            apps/unified-portal/public/manifest.json
+            apps/unified-portal/public/sw.js
+            apps/unified-portal/public/.well-known/assetlinks.json
+            apps/unified-portal/public/.well-known/apple-app-site-association
+            apps/unified-portal/app/layout.tsx
+            apps/unified-portal/app/care/sw-register.tsx
+            apps/unified-portal/hooks/usePushNotifications.ts
+            apps/unified-portal/lib/capacitor-native.ts
+            apps/unified-portal/scripts/pwa-capacitor-audit.mjs
+            apps/unified-portal/package.json
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run PWA/Capacitor audit
+        run: npm run audit:pwa-capacitor

--- a/.github/workflows/mobile-quality.yml
+++ b/.github/workflows/mobile-quality.yml
@@ -1,87 +1,12 @@
 name: Mobile quality
 
 on:
-  pull_request:
-    paths:
-      - "apps/openhouse-select/**"
-      - "apps/unified-portal/android/**"
-      - "apps/unified-portal/ios/**"
-      - ".github/workflows/mobile-quality.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "apps/openhouse-select/**"
-      - "apps/unified-portal/android/**"
-      - "apps/unified-portal/ios/**"
-      - ".github/workflows/mobile-quality.yml"
+  workflow_dispatch:
 
 jobs:
-  openhouse-select:
-    name: Expo app checks
+  retired:
+    name: Retired in favour of Capacitor wrapper quality
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout mobile app
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            apps/openhouse-select
-          sparse-checkout-cone-mode: true
-
-      - name: Isolate mobile app
-        shell: bash
-        run: |
-          set -euo pipefail
-          cp -R apps/openhouse-select "$RUNNER_TEMP/openhouse-select"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        working-directory: ${{ runner.temp }}/openhouse-select
-        run: npm install
-
-      - name: Typecheck
-        working-directory: ${{ runner.temp }}/openhouse-select
-        run: npm run typecheck
-
-      - name: Expo config validation
-        working-directory: ${{ runner.temp }}/openhouse-select
-        run: npx expo config --type public
-
-      - name: Expo dependency health
-        working-directory: ${{ runner.temp }}/openhouse-select
-        run: npm run doctor
-
-  wrapper-metadata:
-    name: Native wrapper metadata checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout wrapper metadata
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            apps/unified-portal/android/app/src/main/AndroidManifest.xml
-            apps/unified-portal/ios/App/App/Info.plist
-          sparse-checkout-cone-mode: false
-
-      - name: Verify Android release hardening
-        shell: bash
-        run: |
-          set -euo pipefail
-          manifest="apps/unified-portal/android/app/src/main/AndroidManifest.xml"
-          grep -q 'android:usesCleartextTraffic="false"' "$manifest"
-          grep -q 'android:allowBackup="false"' "$manifest"
-          grep -q 'android:screenOrientation="portrait"' "$manifest"
-
-      - name: Verify iOS portrait orientation
-        shell: bash
-        run: |
-          set -euo pipefail
-          plist="apps/unified-portal/ios/App/App/Info.plist"
-          grep -q 'UIInterfaceOrientationPortrait' "$plist"
-          ! grep -q 'UIInterfaceOrientationLandscapeLeft' "$plist"
-          ! grep -q 'UIInterfaceOrientationLandscapeRight' "$plist"
+      - name: Explain replacement
+        run: echo "The production mobile app is the apps/unified-portal PWA wrapped by Capacitor. Use the Capacitor wrapper quality workflow for PR checks."

--- a/apps/unified-portal/hooks/usePushNotifications.ts
+++ b/apps/unified-portal/hooks/usePushNotifications.ts
@@ -8,6 +8,22 @@ interface UsePushNotificationsParams {
   enabled?: boolean;
 }
 
+let capacitorCache: any | undefined;
+
+async function getCapacitor(): Promise<any | null> {
+  if (capacitorCache !== undefined) return capacitorCache;
+  try {
+    const capacitorCore = '@capacitor/core';
+    // @ts-ignore - optional native dependency, dynamically imported
+    const { Capacitor } = await import(/* webpackIgnore: true */ capacitorCore);
+    capacitorCache = Capacitor ?? null;
+    return capacitorCache;
+  } catch {
+    capacitorCache = null;
+    return null;
+  }
+}
+
 /**
  * Hook to initialize push notifications.
  *
@@ -45,19 +61,18 @@ export function usePushNotifications({ unitUid, token, enabled = true }: UsePush
 
 async function tryCapacitorPush(unitUid: string, token: string): Promise<boolean> {
   try {
-    // Dynamically import Capacitor to avoid build errors when not installed
-    // Use variables to prevent webpack from statically analyzing the imports
-    const capacitorCore = '@capacitor/core';
-    const capacitorPush = '@capacitor/push-notifications';
-    // @ts-ignore - @capacitor/core is an optional dependency, dynamically imported
-    const { Capacitor } = await import(/* webpackIgnore: true */ capacitorCore);
-
-    if (!Capacitor.isNativePlatform()) {
+    const Capacitor = await getCapacitor();
+    if (!Capacitor || !Capacitor.isNativePlatform()) {
       return false;
     }
 
-    // @ts-ignore - @capacitor/push-notifications is an optional dependency, dynamically imported
-    const { PushNotifications } = await import(/* webpackIgnore: true */ capacitorPush);
+    // The native shell may not include the push plugin in every build. Read it
+    // from Capacitor's registered plugins instead of importing a bare module at
+    // runtime, which can become an unresolved WebView fetch in PWA shells.
+    const PushNotifications = Capacitor.Plugins?.PushNotifications;
+    if (!PushNotifications) {
+      return true;
+    }
 
     // Request permission
     const permResult = await PushNotifications.requestPermissions();

--- a/apps/unified-portal/package.json
+++ b/apps/unified-portal/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "next lint || true",
     "smoke": "bash scripts/smoke-test.sh http://localhost:5000",
+    "audit:pwa-capacitor": "node scripts/pwa-capacitor-audit.mjs",
     "load-test": "node scripts/load-test.js http://localhost:5000 10 10",
     "test:stability": "npm run typecheck && npm run build && npm run smoke",
     "hardening:test": "npx tsx scripts/hardening/test-tenant-isolation.ts",

--- a/apps/unified-portal/scripts/pwa-capacitor-audit.mjs
+++ b/apps/unified-portal/scripts/pwa-capacitor-audit.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function parseJson(relativePath) {
+  try {
+    return JSON.parse(read(relativePath));
+  } catch (error) {
+    throw new Error(`${relativePath} is not valid JSON: ${error.message}`);
+  }
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function importsOptionalPlugin(source, packageName) {
+  const code = stripComments(source);
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const staticImport = new RegExp(`\\bimport\\s+(?:type\\s+)?[^;\\n]*['"]${escaped}['"]`);
+  const directDynamicImport = new RegExp(`\\bimport\\s*\\(\\s*['"]${escaped}['"]`);
+  const packageSpecifier = new RegExp(`\\b(?:const|let|var)\\s+\\w+\\s*=\\s*['"]${escaped}['"]`);
+  return staticImport.test(code) || directDynamicImport.test(code) || packageSpecifier.test(code);
+}
+
+const manifest = parseJson('public/manifest.json');
+assert(manifest.display === 'standalone', 'PWA manifest display must be standalone');
+assert(manifest.orientation === 'portrait-primary', 'PWA manifest must stay portrait-primary');
+assert(manifest.start_url === '/', 'PWA manifest start_url must remain /');
+assert(Array.isArray(manifest.icons), 'PWA manifest icons must be an array');
+assert(manifest.icons.some((icon) => icon.sizes === '192x192'), 'PWA manifest must include a 192x192 icon');
+assert(manifest.icons.some((icon) => icon.sizes === '512x512'), 'PWA manifest must include a 512x512 icon');
+
+parseJson('public/.well-known/assetlinks.json');
+parseJson('public/.well-known/apple-app-site-association');
+
+const sw = read('public/sw.js');
+assert(sw.includes("self.addEventListener('install'"), 'Service worker must handle install');
+assert(sw.includes("self.addEventListener('activate'"), 'Service worker must handle activate');
+assert(sw.includes("self.addEventListener('fetch'"), 'Service worker must handle fetch');
+assert(sw.includes("url.pathname.startsWith('/care')"), 'Service worker must keep care route handling explicit');
+assert(sw.includes("event.request.mode === 'navigate'"), 'Service worker must provide a navigation offline fallback');
+
+const swRegister = read('app/care/sw-register.tsx');
+assert(swRegister.includes("navigator.serviceWorker.register('/sw.js')"), 'Care app must register /sw.js');
+
+const layout = read('app/layout.tsx');
+assert(layout.includes("manifest: '/manifest.json'"), 'Root metadata must reference /manifest.json');
+assert(layout.includes('apple-mobile-web-app-capable'), 'Root layout must include iOS web-app capability meta');
+assert(layout.includes("viewportFit: 'cover'"), 'Viewport must use viewportFit cover for native/PWA safe areas');
+
+const androidManifest = read('android/app/src/main/AndroidManifest.xml');
+assert(androidManifest.includes('android:usesCleartextTraffic="false"'), 'Android wrapper must reject cleartext traffic');
+assert(androidManifest.includes('android:allowBackup="false"'), 'Android wrapper must disable backups');
+assert(androidManifest.includes('android:screenOrientation="portrait"'), 'Android wrapper must stay portrait');
+assert(androidManifest.includes('android.permission.INTERNET'), 'Android wrapper must keep internet permission');
+
+const iosPlist = read('ios/App/App/Info.plist');
+assert(iosPlist.includes('UIInterfaceOrientationPortrait'), 'iOS wrapper must support portrait');
+assert(!iosPlist.includes('UIInterfaceOrientationLandscapeLeft'), 'iOS wrapper must not support landscape left');
+assert(!iosPlist.includes('UIInterfaceOrientationLandscapeRight'), 'iOS wrapper must not support landscape right');
+assert(iosPlist.includes('NSMicrophoneUsageDescription'), 'iOS wrapper must describe microphone usage');
+assert(iosPlist.includes('NSCalendarsWriteOnlyAccessUsageDescription'), 'iOS wrapper must describe calendar write usage');
+
+const capacitorNative = read('lib/capacitor-native.ts');
+assert(capacitorNative.includes('Capacitor.Plugins?.Microphone') || capacitorNative.includes('cap?.Plugins?.Microphone'), 'Microphone bridge must use registered Capacitor plugins');
+assert(!importsOptionalPlugin(capacitorNative, '@capacitor/microphone'), 'Microphone bridge must not import a bare optional plugin module at runtime');
+
+const push = read('hooks/usePushNotifications.ts');
+assert(push.includes('Capacitor.Plugins?.PushNotifications'), 'Push bridge must use registered Capacitor plugins');
+assert(!importsOptionalPlugin(push, '@capacitor/push-notifications'), 'Push bridge must not import a bare optional plugin module at runtime');
+assert(push.includes('tryWebPush'), 'Push bridge must keep the web push fallback');
+
+console.log('PWA/Capacitor audit passed');


### PR DESCRIPTION
## Summary
- Retires the obsolete `Mobile quality` workflow that was validating `apps/openhouse-select` with Expo commands.
- Adds a production-focused `Capacitor wrapper quality` workflow for the actual app path: `apps/unified-portal` PWA wrapped by Capacitor.
- Adds `npm run audit:pwa-capacitor`, which validates PWA manifest shape, service-worker registration/offline handling, Android/iOS wrapper safety metadata, association JSON, and native bridge patterns.
- Hardens push notification initialization so native builds use registered Capacitor plugins instead of runtime-importing the optional push package, while keeping the web push fallback.

## Safety notes
- This does not use Expo and does not edit `apps/openhouse-select`.
- This does not change Android package names, Apple team/app IDs, signing fingerprints, or app association values because those must match store/signing configuration.
- This does not invent a missing Capacitor config; it audits and hardens the wrapper files currently present in `apps/unified-portal`.

## Validation
- GitHub Actions: `Capacitor wrapper quality` passed on the latest PR commit.