### PR TITLE
Add mobile release readiness gate

### DIFF
--- a/.github/workflows/mobile-release-readiness.yml
+++ b/.github/workflows/mobile-release-readiness.yml
@@ -1,0 +1,51 @@
+name: Mobile release readiness
+
+on:
+  pull_request:
+    paths:
+      - "apps/unified-portal/android/**"
+      - "apps/unified-portal/ios/**"
+      - "apps/unified-portal/public/**"
+      - "apps/unified-portal/app/layout.tsx"
+      - "apps/unified-portal/app/care/sw-register.tsx"
+      - "apps/unified-portal/hooks/usePushNotifications.ts"
+      - "apps/unified-portal/lib/capacitor-native.ts"
+      - "apps/unified-portal/scripts/pwa-capacitor-audit.mjs"
+      - "apps/unified-portal/scripts/mobile-release-readiness.mjs"
+      - "apps/unified-portal/docs/MOBILE_RELEASE_QA.md"
+      - "apps/unified-portal/package.json"
+      - ".github/workflows/mobile-release-readiness.yml"
+  workflow_dispatch:
+    inputs:
+      require_native_build_projects:
+        description: "Fail unless complete Android Gradle and iOS Xcode projects are checked in"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  release-readiness:
+    name: PWA, wrapper, and release-readiness audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/unified-portal
+    env:
+      STRICT_NATIVE_BUILDS: ${{ github.event_name == 'workflow_dispatch' && inputs.require_native_build_projects == 'true' && 'true' || 'false' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run PWA/Capacitor audit
+        run: npm run audit:pwa-capacitor
+
+      - name: Run mobile release readiness audit
+        run: npm run audit:mobile-release-readiness

--- a/apps/unified-portal/docs/MOBILE_RELEASE_QA.md
+++ b/apps/unified-portal/docs/MOBILE_RELEASE_QA.md
@@ -1,0 +1,49 @@
+# Mobile Release QA
+
+Use this checklist before showing the iOS or Android app to customers, investors, partners, or field teams. Cloud checks can prove the PWA and wrapper metadata are coherent; real confidence still needs device passes because permissions, push delivery, offline behaviour, and installed-app navigation depend on the OS.
+
+## Install and Launch
+
+- Install the latest Android build on a clean physical Android device.
+- Install the latest iOS build through TestFlight on a clean physical iPhone.
+- Launch from the home screen and confirm the app opens without a browser address bar.
+- Force quit and relaunch; the last valid app route should recover cleanly.
+- Rotate the device and confirm the app remains in the intended portrait experience.
+
+## Authentication
+
+- Sign in as a known valid test user.
+- Sign out, close the app, relaunch, and confirm the signed-out state is stable.
+- Try an expired or invalid session and confirm the user is returned to sign-in without a blank screen.
+- Confirm passwordless, magic-link, or redirect flows return to the installed app where supported.
+
+## Assistant and Property Workflows
+
+- Open the assistant and send a normal property question.
+- Confirm assistant responses render, scroll, and preserve context after backgrounding the app.
+- Open a property/viewing flow and complete the primary expected action.
+- Confirm loading, empty, and error states are understandable on mobile width.
+- Verify key screens with poor connectivity or server errors do not trap the user.
+
+## Native Capabilities
+
+- Grant microphone permission and confirm voice input either works or fails with a clear fallback.
+- Deny microphone permission and confirm the rest of the assistant remains usable.
+- Add a viewing to the calendar and confirm the OS permission prompt, event title, date, and time.
+- Enable notifications and confirm the device token is registered server-side.
+- Tap a delivered notification and confirm it opens the correct app route.
+
+## Offline and Recovery
+
+- Launch once online, then enable airplane mode and reopen the app.
+- Confirm the service worker fallback is shown for unavailable network routes.
+- Restore connectivity and confirm the app recovers without requiring reinstall.
+- Confirm stale cached content cannot expose the wrong user's data after sign-out/sign-in.
+
+## Release Sign-off
+
+- Android physical device pass recorded with OS version, device model, build number, tester, and date.
+- iOS physical device pass recorded with OS version, device model, TestFlight build number, tester, and date.
+- Push notification, microphone, and calendar permission results recorded for both allow and deny paths.
+- Any failed item has a linked issue or PR before wider sharing.
+- Store identifiers, signing certificates, asset links, and Apple app-site association values are checked against the intended production app IDs.

--- a/apps/unified-portal/package.json
+++ b/apps/unified-portal/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint || true",
     "smoke": "bash scripts/smoke-test.sh http://localhost:5000",
     "audit:pwa-capacitor": "node scripts/pwa-capacitor-audit.mjs",
+    "audit:mobile-release-readiness": "node scripts/mobile-release-readiness.mjs",
     "load-test": "node scripts/load-test.js http://localhost:5000 10 10",
     "test:stability": "npm run typecheck && npm run build && npm run smoke",
     "hardening:test": "npx tsx scripts/hardening/test-tenant-isolation.ts",

--- a/apps/unified-portal/scripts/mobile-release-readiness.mjs
+++ b/apps/unified-portal/scripts/mobile-release-readiness.mjs
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const strictNativeBuilds = process.env.STRICT_NATIVE_BUILDS === 'true';
+const githubActions = process.env.GITHUB_ACTIONS === 'true';
+
+const requiredMetadata = [
+  'public/manifest.json',
+  'public/sw.js',
+  'public/.well-known/assetlinks.json',
+  'public/.well-known/apple-app-site-association',
+  'android/app/src/main/AndroidManifest.xml',
+  'ios/App/App/Info.plist',
+  'hooks/usePushNotifications.ts',
+  'lib/capacitor-native.ts',
+  'docs/MOBILE_RELEASE_QA.md',
+];
+
+const nativeBuildProjects = {
+  android: [
+    'android/settings.gradle',
+    'android/build.gradle',
+    'android/gradlew',
+    'android/app/build.gradle',
+    'android/gradle/wrapper/gradle-wrapper.properties',
+  ],
+  ios: [
+    'ios/App/Podfile',
+    'ios/App/App.xcodeproj/project.pbxproj',
+  ],
+};
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(root, relativePath));
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function fail(message) {
+  if (githubActions) {
+    console.error(`::error::${message}`);
+  }
+  throw new Error(message);
+}
+
+function warn(message) {
+  if (githubActions) {
+    console.warn(`::warning::${message}`);
+  } else {
+    console.warn(`Warning: ${message}`);
+  }
+}
+
+const missingMetadata = requiredMetadata.filter((file) => !exists(file));
+if (missingMetadata.length > 0) {
+  fail(`Missing mobile release metadata: ${missingMetadata.join(', ')}`);
+}
+
+const qa = read('docs/MOBILE_RELEASE_QA.md');
+for (const heading of [
+  'Install and Launch',
+  'Authentication',
+  'Assistant and Property Workflows',
+  'Native Capabilities',
+  'Offline and Recovery',
+  'Release Sign-off',
+]) {
+  if (!qa.includes(heading)) {
+    fail(`Mobile QA checklist is missing the ${heading} section`);
+  }
+}
+
+const missingNative = Object.entries(nativeBuildProjects).flatMap(([platform, files]) =>
+  files.filter((file) => !exists(file)).map((file) => `${platform}: ${file}`)
+);
+
+if (missingNative.length > 0) {
+  const message = `Native build projects are incomplete, so CI cannot yet create real Android/iOS artifacts: ${missingNative.join(', ')}`;
+  if (strictNativeBuilds) {
+    fail(message);
+  }
+  warn(message);
+} else {
+  console.log('Native build project files are present. Add platform build jobs for ./gradlew assembleDebug and xcodebuild archive next.');
+}
+
+console.log('Mobile release readiness audit completed');


### PR DESCRIPTION
## Summary
- Adds a `Mobile release readiness` workflow for the production `apps/unified-portal` PWA/Capacitor app.
- Adds `npm run audit:mobile-release-readiness` to verify release-critical metadata, the mobile QA checklist, and whether complete Android/iOS native build projects are present.
- Adds a physical-device QA checklist covering install, auth, assistant/property flows, native permissions, push, offline recovery, and release sign-off.

## Important finding
- The repository currently has Android/iOS metadata folders, but it does not appear to have complete Gradle/Xcode project files checked in. The manual workflow can run in strict mode and fail until those files exist, so we do not accidentally claim cloud-native builds are proven when they are not.

## Validation
- GitHub Actions: `Capacitor wrapper quality` passed.
- GitHub Actions: `Mobile release readiness` passed in PR mode.

## Release gate
- Before external demos or store submission, run `Mobile release readiness` manually with `require_native_build_projects=true`. That is the stricter gate that should stay red until complete native build projects are committed or the app build pipeline is connected.