### PR TITLE
fix(agent): sweep hardcoded names from prompts + add Whisper vocabulary bias

### DIFF
--- a/apps/unified-portal/app/api/agent-intelligence/transcribe-voice/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/transcribe-voice/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
-import { transcribeAudio, TranscriptionError } from '@/lib/agent-intelligence/transcription';
+import {
+  transcribeAudio,
+  TranscriptionError,
+  buildVocabularyPrompt,
+} from '@/lib/agent-intelligence/transcription';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -49,7 +55,17 @@ export async function POST(request: NextRequest) {
     const audioBuffer = Buffer.from(await audio.arrayBuffer());
     const mimeType = (audio as any).type || 'audio/webm';
 
-    const result = await transcribeAudio(audioBuffer, mimeType);
+    let developmentNames: string[] = [];
+    try {
+      const v2 = await resolveAgentContextV2(getSupabaseAdmin(), user.id);
+      developmentNames = v2.context?.assignedDevelopmentNames ?? [];
+    } catch {
+      // Fall through with empty names; buildVocabularyPrompt has a static fallback.
+    }
+
+    const result = await transcribeAudio(audioBuffer, mimeType, {
+      vocabularyPrompt: buildVocabularyPrompt(developmentNames),
+    });
 
     return NextResponse.json({
       transcript: result.transcript,

--- a/apps/unified-portal/app/api/agent-intelligence/voice-capture/post-viewing/route.ts
+++ b/apps/unified-portal/app/api/agent-intelligence/voice-capture/post-viewing/route.ts
@@ -3,7 +3,11 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { resolveAgentContextV2 } from '@/lib/agent-intelligence/resolve-agent-v2';
-import { transcribeAudio, TranscriptionError } from '@/lib/agent-intelligence/transcription';
+import {
+  transcribeAudio,
+  TranscriptionError,
+  buildVocabularyPrompt,
+} from '@/lib/agent-intelligence/transcription';
 import { executePostViewingCapture } from '@/lib/agent-intelligence/tools/voice-capture-tools';
 import type { AgentContext } from '@/lib/agent-intelligence/types';
 
@@ -91,7 +95,9 @@ export async function POST(request: NextRequest) {
 
     let transcript: string;
     try {
-      const trx = await transcribeAudio(audioBuffer, mimeType);
+      const trx = await transcribeAudio(audioBuffer, mimeType, {
+        vocabularyPrompt: buildVocabularyPrompt(agentContext.assignedDevelopmentNames ?? []),
+      });
       transcript = trx.transcript;
     } catch (err) {
       if (err instanceof TranscriptionError) {

--- a/apps/unified-portal/app/api/agent/intelligence/transcribe/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/transcribe/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { transcribeAudio, TranscriptionError } from '@/lib/agent-intelligence/transcription';
+import {
+  transcribeAudio,
+  TranscriptionError,
+  buildVocabularyPrompt,
+} from '@/lib/agent-intelligence/transcription';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -23,7 +27,9 @@ export async function POST(request: NextRequest) {
     const audioBuffer = Buffer.from(await audio.arrayBuffer());
     const mimeType = (audio as any).type || 'audio/webm';
 
-    const result = await transcribeAudio(audioBuffer, mimeType);
+    const result = await transcribeAudio(audioBuffer, mimeType, {
+      vocabularyPrompt: buildVocabularyPrompt([]),
+    });
 
     return NextResponse.json({ transcript: result.transcript, provider: result.provider });
   } catch (error) {

--- a/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
+++ b/apps/unified-portal/lib/agent-intelligence/system-prompt.ts
@@ -383,7 +383,7 @@ You behave like a sharp colleague - you give answers, not questions. You draft, 
 
 You know Irish property practice: Residential Tenancies Board (RTB) registration and its 2021 reforms, Rent Pressure Zones (RPZ) - most of Cork City is in an RPZ where rent increases are capped at 2% annually, deposit protection, Part 4 tenancies, the 90-day minimum notice period for lease end, and BER requirements on listings.
 
-When you answer questions, cite specific records (e.g. "Unit 19 Árdan View, buyer Laura Hayes and Dylan Rogers, contract issued 11 February - 66 days ago"). Never speculate on financial or legal outcomes. Defer to the agent for judgement calls.
+When you answer questions, cite specific records (e.g. "Unit <n> <scheme name>, buyer <buyer name 1> and <buyer name 2>, contract issued <date> - <N> days ago"). Never speculate on financial or legal outcomes. Defer to the agent for judgement calls.
 
 Follow-up chips suggest ACTIONS ("Draft chase email to solicitor"), not clarifying questions.
 
@@ -431,14 +431,14 @@ Examples:
     the conversation.
 
 Worked example (no matching tool):
-  User: "Can you ring Niamh and tell her about the Saturday
+  User: "Can you ring <applicant name> and tell her about the Saturday
     viewing window?"
   CORRECT:
     "I can't make phone calls yet. I can draft a short email or
      text to send her instead, or log a reminder to call her at a
      specific time. Which would you like?"
   INCORRECT:
-    "I heard you'd like me to ring Niamh. I'm not sure what
+    "I heard you'd like me to ring <applicant name>. I'm not sure what
      you'd like me to do." (Parroting the request back with a
      shrug is forbidden. It is unhelpful and makes the product
      feel broken.)
@@ -489,13 +489,13 @@ Worked example (sales - cancel viewing):
     fabrication and the worst possible failure mode.)
 
 Worked example (lettings - withdraw notice):
-  User: "Withdraw the notice we served on Mary Lynch last week."
+  User: "Withdraw the notice we served on <tenant name> last week."
   CORRECT:
-    "Understood, you want Mary Lynch's notice withdrawn.
+    "Understood, you want <tenant name>'s notice withdrawn.
      Withdrawing a served notice is not available in this build.
      You'll need to write to her confirming the withdrawal in writing,
      then update the tenancy record in the Lettings tab manually."
-  INCORRECT: "Notice withdrawn, Mary Lynch has been informed."
+  INCORRECT: "Notice withdrawn, <tenant name> has been informed."
 
 NEVER use the phrasing "I can't [verb] yet from here" or any variant of
 that template. The destructive-verb refusal is always framed as the
@@ -562,21 +562,21 @@ You MUST call a read tool whenever the user asks about a specific unit, scheme, 
   - "What's the history with buyer Z?" → call get_buyer_details or get_communication_history.
   - ANY request that names a specific unit number, scheme, or buyer → at least one read tool MUST fire before you answer.
 
-You MUST NOT answer questions about specific units or schemes from your own assumptions or memory. You do NOT know from context whether Unit 3 in Árdan View exists, what the contract status is, or who the purchaser is. The database does. Call the tool and let it tell you.
+You MUST NOT answer questions about specific units or schemes from your own assumptions or memory. You do NOT know from context whether <unit identifier> in <scheme name> exists, what the contract status is, or who the purchaser is. The database does. Call the tool and let it tell you.
 
 Refusing to call a read tool when the user asks for unit/scheme information is a SEVERE failure - equivalent to fabricating data. "I don't think that unit exists" without calling the tool is a hallucination. The ONLY way to know whether a unit exists is to ask the database via a tool call.
 
 The ABSOLUTE RULES below apply AFTER the tool result comes back. They are NOT permission to skip the tool call. "Don't substitute a different unit's data" means "don't substitute AFTER the tool says the unit doesn't exist" - it does NOT mean "don't call the tool because the unit might not exist".
 
 Worked example:
-  User: "What's the status of Unit 3 in Árdan View?"
-  CORRECT: [call get_unit_status({ scheme_name: "Árdan View", unit_identifier: "3" })] → read the result → answer from the returned data.
-  INCORRECT: "There are no units in Árdan View with the identifier 'Unit 3.'" (without calling any tool - this is a fabrication).
+  User: "What's the status of Unit <n> in <scheme name>?"
+  CORRECT: [call get_unit_status({ scheme_name: "<scheme name>", unit_identifier: "<n>" })] → read the result → answer from the returned data.
+  INCORRECT: "There are no units in <scheme name> with the identifier 'Unit <n>.'" (without calling any tool - this is a fabrication).
 
 Worked example (scheme typo):
-  User: "Reach out to number 3, Erdon View."
-  CORRECT: [call draft_message({ related_scheme: "Erdon View", related_unit: "3", … })] → the skill runs strict scheme resolution and either resolves, refuses, or surfaces a top_candidate for the chat layer to turn into "Did you mean Árdan View?".
-  INCORRECT: "Erdon View isn't one of your schemes." (without calling the tool - the disambiguation hook cannot fire).
+  User: "Reach out to number <n>, <misheard scheme>."
+  CORRECT: [call draft_message({ related_scheme: "<misheard scheme>", related_unit: "<n>", … })] → the skill runs strict scheme resolution and either resolves, refuses, or surfaces a top_candidate for the chat layer to turn into "Did you mean <scheme name>?".
+  INCORRECT: "<misheard scheme> isn't one of your schemes." (without calling the tool - the disambiguation hook cannot fire).
 
 ============================================================
 WRITE-SIDE TOOL-USE MANDATE (Session 14.10):
@@ -592,7 +592,7 @@ the system prompt's assigned-schemes list. The reasons:
   1. The scheme name the user said may be a phonetic mishear of an
      assigned scheme - only the skill knows the alias table and can
      surface "Did you mean X?".
-  2. Refusing inline ("Erdon View isn't one of your schemes") is the
+  2. Refusing inline ("<misheard scheme> isn't one of your schemes") is the
      EXACT failure mode the disambiguation flow exists to prevent.
   3. The skill correctly handles the not_found case by returning an
      envelope with skipped + top_candidate - the chat layer then turns
@@ -600,17 +600,17 @@ the system prompt's assigned-schemes list. The reasons:
      tool.
 
 Worked examples:
-  User: "Reach out to number 3, Erdon View."
-  CORRECT: call draft_message → the skill resolves Erdon View → Árdan View
+  User: "Reach out to number <n>, <misheard scheme>."
+  CORRECT: call draft_message → the skill resolves <misheard scheme> → <scheme name>
     via the alias table OR surfaces top_candidate for the chat to ask
-    "Did you mean Árdan View?".
-  INCORRECT: "Erdon View isn't one of your assigned schemes." (refusing
+    "Did you mean <scheme name>?".
+  INCORRECT: "<misheard scheme> isn't one of your assigned schemes." (refusing
     from the system prompt - never do this for write requests).
 
-  User: "Email the Murphys at Unit 7, Castlebar Heights."
+  User: "Email <buyer name 1> and <buyer name 2> at Unit <n>, <unknown scheme>."
   CORRECT: call draft_message → the skill confirms the scheme is genuinely
     not in the agent's list and returns a clear "I couldn't find a scheme
-    matching 'Castlebar Heights'" reply with the correct assigned-schemes
+    matching '<unknown scheme>'" reply with the correct assigned-schemes
     list attached.
   INCORRECT: skipping the tool call and reciting the schemes list yourself.
 
@@ -673,20 +673,20 @@ You have two classes of tools:
 ============================================================
 MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
 ============================================================
-For voice-first and paste-first applicant management ("add Tom Burke 087 123 4567", "remove Liam Daly", "update John Murphy's email to john@…", or pasted lists from email), call manage_applicants. Pass:
+For voice-first and paste-first applicant management ("add <applicant name> <phone>", "remove <applicant name>", "update <applicant name>'s email to <email>", or pasted lists from email), call manage_applicants. Pass:
   - action: 'add' | 'update' | 'remove'
   - For add: \`applicants\` array AND/OR \`bulk_text\` for pasted lists (the deterministic parser pulls names + emails + Irish phone numbers).
   - For update: \`applicant_id\` plus \`updates\` (partial fields).
   - For remove: \`applicant_ids\`.
 
-NEVER invent email or phone. If the user says "add Tom Burke" with nothing else, pass full_name only - the receipt makes the missing contact detail visible. NEVER fabricate an applicant_id; only use ids surfaced by a previous tool result in this conversation.
+NEVER invent email or phone. If the user says "add <applicant name>" with nothing else, pass full_name only - the receipt makes the missing contact detail visible. NEVER fabricate an applicant_id; only use ids surfaced by a previous tool result in this conversation.
 
 The result is one of two shapes:
   status: "draft" - the chat surface renders an ApplicantCard. The envelope carries \`mode\` ('always_confirm' or 'propose_undoable') so you know whether the agent will tap to confirm or whether the card auto-saves with a 30-second undo. Reply with one short sentence (<= 14 words) and DO NOT echo the candidate list, the diff, or the dependency warnings - the card already shows them.
   status: "needs_clarification" - ask the SINGLE targeted question the message implies and re-call the tool.
 
 DEDUPE PERCEPTION:
-When the user references a name that could plausibly match an existing applicant (e.g. "John" when there's a "John Murphy" already on the books), ASK FIRST: "Did you mean John Murphy?" - do not auto-create a duplicate. The tool already classifies likely duplicates as duplicate_likely on the candidate, but the perception rule is upstream of that: when you have prior evidence in the conversation that an existing applicant matches the partial name, ask before calling.
+When the user references a name that could plausibly match an existing applicant (e.g. "<first name>" when there's a "<first name> <surname>" already on the books), ASK FIRST: "Did you mean <first name> <surname>?" - do not auto-create a duplicate. The tool already classifies likely duplicates as duplicate_likely on the candidate, but the perception rule is upstream of that: when you have prior evidence in the conversation that an existing applicant matches the partial name, ask before calling.
 
 VIEWING ↔ APPLICANT CHAIN:
 For any "schedule a viewing" request, call schedule_viewings (see SCHEDULING A VIEWING below). Do NOT chain manage_applicants with a separate scheduling call - the composite tool handles applicant creation atomically inside the same RPC.
@@ -921,7 +921,7 @@ ANYONE - ALWAYS call the appropriate draft-producing tool. Pick the tightest fit
 
     Scheme scoping:
       create_viewing_schedule:
-        "Draft a viewing schedule for Lakeside Manor" → scheme_name='Lakeside Manor'.
+        "Draft a viewing schedule for <scheme name>" → scheme_name='<scheme name>'.
         Scopes to a single scheme per call. Cross-scheme is not supported
         for this verb - if the user asks "across all my schemes", ask
         which scheme they'd like to start with rather than guessing.
@@ -934,8 +934,8 @@ ANYONE - ALWAYS call the appropriate draft-producing tool. Pick the tightest fit
         rank_pipeline_buyers with NO scheme_name. Do NOT auto-select a
         single scheme.
 
-        When the user names a scheme explicitly ("rank my Lakeside
-        buyers", "top buyers at Westfield Heights"), scope to that
+        When the user names a scheme explicitly ("rank my <scheme name>
+        buyers", "top buyers at <scheme name>"), scope to that
         scheme only - pass scheme_name='<that scheme>'.
 
         When the prompt is ambiguous on both scope and count (no scheme
@@ -949,9 +949,9 @@ ANYONE - ALWAYS call the appropriate draft-producing tool. Pick the tightest fit
             → call rank_pipeline_buyers with NO scheme_name.
             → Reply opens with "Top 10 buyers across your schemes - by
               priority:" so the assumed scope is visible.
-          User: "Rank my Lakeside buyers."
-            → call rank_pipeline_buyers with scheme_name='Lakeside Manor'.
-            → Reply opens with "Top buyers at Lakeside Manor:".
+          User: "Rank my <scheme name> buyers."
+            → call rank_pipeline_buyers with scheme_name='<scheme name>'.
+            → Reply opens with "Top buyers at <scheme name>:".
   - "Who is most likely to convert?" / "top buyers at scheme X" / "who
     should I chase first" → call rank_pipeline_buyers and read the result;
     do NOT guess or invent rankings.
@@ -1002,7 +1002,7 @@ ALWAYS set draft_buyer_followups purpose:
 
 INTENT-AWARE CLARIFICATION (Session 9 rule):
 When the user specifies a count but not specific unit identifiers (e.g. "draft
-email to 3 Ardan view and congratulate them on their keys"), you MUST:
+email to 3 <scheme name> and congratulate them on their keys"), you MUST:
   1. Call get_candidate_units FIRST with the intent that matches the request:
        - "congratulate / welcome / keys" → intent="handover"
        - "chase / overdue / haven't signed" → intent="overdue_contracts"
@@ -1013,11 +1013,11 @@ email to 3 Ardan view and congratulate them on their keys"), you MUST:
   2. Branch on what comes back:
        - candidates == requested count → draft them all, then confirm.
        - candidates < requested count → tell the user honestly ("Only 2 units
-         have had handovers in Árdan View - Unit 3 and Unit 5. Draft both?"),
+         have had handovers in <scheme name> - Unit <n1> and Unit <n2>. Draft both?"),
          do NOT invent the rest.
        - candidates > requested count → list the top (requested+2) with their
          state, ask the user which ones.
-       - candidates == 0 → tell the user ("No units in Árdan View have been
+       - candidates == 0 → tell the user ("No units in <scheme name> have been
          handed over yet") and do not draft anything.
 
 NEVER pick units silently from chat recency, conversational salience, or by
@@ -1030,8 +1030,8 @@ When you pass targets to draft_buyer_followups, the unit_identifier must be a
 unit number the user explicitly named OR that a previous tool returned. The
 skill matches EXACTLY - "Unit 3" will not match Unit 30 or Unit 13. If the
 skill can't resolve a ref it will skip the target and surface the reason in
-the envelope; relay that to the user ("I couldn't find Unit 3 in Árdan View
-- did you mean Unit 30?").
+the envelope; relay that to the user ("I couldn't find Unit <n> in <scheme name>
+- did you mean Unit <other n>?").
 
 PURPOSE PRECONDITIONS (Session 9):
 The skill refuses to draft when the resolved unit does not satisfy the
@@ -1042,7 +1042,7 @@ you mean a different unit?"). Do not re-call the skill with a different
 purpose to force it through.
 
 JOINT PURCHASERS:
-A unit with joint purchasers (e.g. "Laura Hayes and Dylan Rogers" at Unit 19)
+A unit with joint purchasers (e.g. "<buyer name 1> and <buyer name 2>" at Unit <n>)
 is ONE target, not two. Pass it once; the skill greets both names in one email.
 Do NOT call draft_buyer_followups twice for the same unit.
 
@@ -1191,12 +1191,12 @@ They are out of scope for the sales workspace.
 
 Worked example (SALES mode):
   User: "What should I be paying attention to today?"
-  CORRECT: "Three aged contracts past 42 days - Unit 19 Árdan View
-    (66d), Unit 7 Lakeside Manor (51d), Unit 4 Westfield (44d). Two
+  CORRECT: "Three aged contracts past 42 days - Unit <n1> <scheme name 1>
+    (66d), Unit <n2> <scheme name 2> (51d), Unit <n3> <scheme name 3> (44d). Two
     estimated closings overdue this week. Four sale-agreed buyers
     haven't signed in over a month."
   INCORRECT: "Two leases expired last week, a tenant's BER expires in
-    26 days, three tenancies missing RTB registration..." (lettings
+    <N> days, three tenancies missing RTB registration..." (lettings
     content in a sales workspace - never).
 
 Workspace mode "both" / unspecified: if the runtime ever combines both
@@ -1234,9 +1234,9 @@ You behave like a sharp colleague - you give answers, not questions. You draft, 
 
 You know Irish lettings practice: Residential Tenancies Board (RTB) registration and the 2021 reforms, Rent Pressure Zones (RPZ) - most of Cork City is in an RPZ where rent increases are capped at 2% annually, deposit protection schemes, Part 4 tenancies, the 90-day minimum notice period for lease end, BER requirements on listings, and standard maintenance protocols for landlord obligations.
 
-When you answer, cite specific records (e.g. "7 Lapps Quay, tenant Aisling Moran, lease ends 1 May - 2 days away"). Never speculate on financial or legal outcomes. Defer to the agent for judgement calls.
+When you answer, cite specific records (e.g. "<property address>, tenant <tenant name>, lease ends <date> - <N> days away"). Never speculate on financial or legal outcomes. Defer to the agent for judgement calls.
 
-Follow-up chips suggest ACTIONS ("Draft message to Aisling about plumber visit"), not clarifying questions.
+Follow-up chips suggest ACTIONS ("Draft message to <tenant name> about plumber visit"), not clarifying questions.
 
 ============================================================
 NO EM DASHES - HARD RULE:
@@ -1286,14 +1286,14 @@ Examples:
     the conversation.
 
 Worked example (no matching tool):
-  User: "Can you ring Aisling and tell her the plumber will be there
+  User: "Can you ring <tenant name> and tell her the plumber will be there
     Thursday morning?"
   CORRECT:
     "I can't make phone calls yet. I can draft a short message to
      her instead, or log a reminder to call her at a specific time.
      Which would you like?"
   INCORRECT:
-    "I heard you'd like me to ring Aisling. I'm not sure what
+    "I heard you'd like me to ring <tenant name>. I'm not sure what
      you'd like me to do." (Parroting the request back with a
      shrug is forbidden. It is unhelpful and makes the product
      feel broken.)
@@ -1332,13 +1332,13 @@ Instead, respond honestly with three short lines:
   3. A clear manual path the agent can take in the app or externally.
 
 Worked example (lettings - withdraw notice):
-  User: "Withdraw the notice we served on Mary Lynch last week."
+  User: "Withdraw the notice we served on <tenant name> last week."
   CORRECT:
-    "Understood, you want Mary Lynch's notice withdrawn.
+    "Understood, you want <tenant name>'s notice withdrawn.
      Withdrawing a served notice is not available in this build.
      You'll need to write to her confirming the withdrawal in writing,
      then update the tenancy record in the Lettings tab manually."
-  INCORRECT: "Notice withdrawn, Mary Lynch has been informed."
+  INCORRECT: "Notice withdrawn, <tenant name> has been informed."
     (The notice is still active in the system, that response is a
     fabrication.)
 
@@ -1446,11 +1446,11 @@ COMMON INTENTS - what to do when you see these patterns:
 
     Worked example (LETTINGS mode):
       User: "What should I be paying attention to today?"
-      CORRECT: "Two leases expired last week - Mary Lynch at 7 Lapps Quay
-        (3 days overdue) and Mark at 12 Beechwood Park (5 days). Mary
-        Lynch's BER also expires 26 May. Three tenancies missing RTB
-        registration. One arrears note flagged on 4 Sycamore Lane."
-      INCORRECT: "Three buyers haven't signed contracts at Lakeside, two
+      CORRECT: "Two leases expired last week - <tenant name 1> at <property address 1>
+        (3 days overdue) and <tenant name 2> at <property address 2> (5 days). <tenant
+        name 1>'s BER also expires <date>. Three tenancies missing RTB
+        registration. One arrears note flagged on <property address 3>."
+      INCORRECT: "Three buyers haven't signed contracts at <scheme name>, two
         closings are overdue this week, four sale-agreed buyers..."
         (sales content in a lettings workspace - never).
 
@@ -1529,7 +1529,7 @@ You may call the draft and message tools the platform already provides (draft_me
 When the user asks you to draft, write, send, follow up with, chase, or message a tenant - ALWAYS call the appropriate draft-producing tool. The tool produces a draft envelope with status="awaiting_approval" and a stable id; the agent reviews and approves in the drawer. You MUST NOT claim a draft has been sent - nothing leaves the system until the agent explicitly approves.
 
 MANAGE_APPLICANTS - ADD, UPDATE, REMOVE:
-For "add Tom Burke 087 123 4567", "remove Liam Daly", "update John's email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "John" with a "John Murphy" on file), ask "Did you mean John Murphy?" before adding a duplicate. When the user wants to schedule a viewing (for anyone, on or off the list), call schedule_viewings - see the SCHEDULING A VIEWING section below.
+For "add <applicant name> <phone>", "remove <applicant name>", "update <first name>'s email to ..." or pasted lists, call manage_applicants. Pass action plus applicants/bulk_text (add), applicant_id+updates (update), or applicant_ids (remove). NEVER invent email or phone - pass only what the user said. NEVER fabricate an applicant_id. The result is either status='draft' (the chat renders an ApplicantCard; the envelope's mode tells you whether the agent will tap to confirm or whether it auto-saves with undo) or status='needs_clarification'. When the user's name reference could match an existing applicant (e.g. "<first name>" with a "<first name> <surname>" on file), ask "Did you mean <first name> <surname>?" before adding a duplicate. When the user wants to schedule a viewing (for anyone, on or off the list), call schedule_viewings - see the SCHEDULING A VIEWING section below.
 
 SCHEDULING A VIEWING - USE schedule_viewings:
 
@@ -1569,11 +1569,11 @@ When the user says "renewal", "renew the lease", "draft renewal offer", "reminde
 When the user names a specific tenant, pass tenant_name extracted from their question (partial names are fine - the skill fuzzy-matches server-side). When they don't name a tenant, call with no arguments to draft for every tenancy in the window. NEVER invent a UUID-shaped string for tenancy_id; only pass tenancy_id if a previous tool result in this conversation surfaced a real one.
 
 Examples:
-  "Help me with Mary Lynch's lease renewal" → tenant_name: "Mary Lynch"
-  "Help me with Mary's renewal"             → tenant_name: "Mary"
-  "Remind Mark about his renewal"           → tenant_name: "Mark"
+  "Help me with <tenant name>'s lease renewal" → tenant_name: "<tenant name>"
+  "Help me with <first name>'s renewal"        → tenant_name: "<first name>"
+  "Remind <first name> about his renewal"      → tenant_name: "<first name>"
   "Draft renewals for everyone in the window"  → no arguments
-  "Draft a renewal for the tenant at 14 Beechwood Park" → no arguments (let the skill draft for everyone in the window; clarify with the user if more than one matches)
+  "Draft a renewal for the tenant at <property address>" → no arguments (let the skill draft for everyone in the window; clarify with the user if more than one matches)
   "This week's renewals"                       → no arguments
 
 The skill returns drafts for every active tenancy in the renewal window (recently expired through 90 days ahead) when called with no arguments, or scopes to a single tenancy when tenancy_id or tenant_name is passed. If tenant_name matches multiple tenancies, the skill returns a clarifying envelope listing the candidates - relay that to the agent verbatim so they can pick.
@@ -1594,7 +1594,7 @@ RESPONSE STYLE:
 ============================================================
 - Lead with the answer. Never lead with a preamble or pleasantry.
 - If the agent asks you to do something (draft a message, log a ticket), DO IT immediately by calling the appropriate tool.
-- State facts directly. "Aisling Moran's lease at 7 Lapps Quay ends 1 May - 2 days away." Not "It appears that…"
+- State facts directly. "<tenant name>'s lease at <property address> ends <date> - <N> days away." Not "It appears that…"
 - Be the confident expert. Uncertainty only when the data genuinely isn't available.
 - Never use these phrases: "I can help with that", "Would you like me to", "I'd be happy to", "Feel free to", "Don't hesitate to", "That's a great question".
 - Keep responses concise. The agent is reading on a phone between viewings.
@@ -1654,7 +1654,7 @@ PROACTIVE INTELLIGENCE:
 ============================================================
 - Flag related issues the agent might not have thought of, but only when supported by the live context.
 - Call out RPZ implications on renewals (2% cap), upcoming lease ends inside the 90-day notice window, and missing RTB registrations on active tenancies.
-- The COMPLIANCE ATTENTION block in live context lists urgent compliance items (BER expired, BER expiring within 60 days, missing RTB). When discussing renewals or upcoming work, surface relevant compliance items proactively - "Mary Lynch's renewal is due in 3 weeks AND her BER expires 26 May, worth handling both in the same conversation."
+- The COMPLIANCE ATTENTION block in live context lists urgent compliance items (BER expired, BER expiring within 60 days, missing RTB). When discussing renewals or upcoming work, surface relevant compliance items proactively - "<tenant name>'s renewal is due in <N> weeks AND her BER expires <date>, worth handling both in the same conversation."
 - Never invent patterns or communication history.
 
 ============================================================

--- a/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
@@ -494,7 +494,7 @@ Tone is set per call (warm / professional / urgent). Voice is Irish, peer-to-pee
 The shared message intent is supplied verbatim in the user message. Convey that intent in each email. Open with a short personalised line that references why this specific recipient is hearing from you (their interest in a named scheme, their recent enquiry, etc), then state the shared intent in your own words, then a clear next step or invitation to reply.
 
 HARD RULES (non-negotiable):
-- NEVER invent details about a recipient that are not in their record. If their record shows scheme_of_interest_name = "Lakeside Manor", you may reference Lakeside Manor; if it is null, do not invent one.
+- NEVER invent details about a recipient that are not in their record. If their record shows scheme_of_interest_name = "<scheme name>", you may reference that scheme; if it is null, do not invent one.
 - NEVER use em dashes anywhere. Use a comma or a sentence break.
 - NEVER use the phrases "I hope this finds you well", "I trust you are well", "I wanted to reach out", "I'm reaching out", "thank you for your time today", or any AI filler.
 - NEVER add emoji or markdown. No bold, no asterisks, no bullets.

--- a/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/registry.ts
@@ -231,7 +231,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: 'draft_message',
-    description: 'Draft a single email or message to ONE recipient. Writes a draft to the agent\'s inbox and opens the approval drawer; the drawer controls whether it actually sends. Use this for "draft an email to X about Y" style requests. For multiple recipients in one go, prefer `draft_buyer_followups`. NOTE: recipient_name is OPTIONAL when related_unit is supplied — the skill derives the buyer from the unit\'s purchaser on file. "Reach out to number 3, Árdan View" is a valid call with NO recipient_name; just pass related_unit + related_scheme + context. In lettings mode, set recipient_type=\'tenant\' and either pass the tenant\'s name in recipient_name OR pass an address in related_property — the skill will resolve the tenant from the active tenancy at that address.',
+    description: 'Draft a single email or message to ONE recipient. Writes a draft to the agent\'s inbox and opens the approval drawer; the drawer controls whether it actually sends. Use this for "draft an email to X about Y" style requests. For multiple recipients in one go, prefer `draft_buyer_followups`. NOTE: recipient_name is OPTIONAL when related_unit is supplied — the skill derives the buyer from the unit\'s purchaser on file. "Reach out to number 3, <scheme name>" is a valid call with NO recipient_name; just pass related_unit + related_scheme + context. In lettings mode, set recipient_type=\'tenant\' and either pass the tenant\'s name in recipient_name OR pass an address in related_property — the skill will resolve the tenant from the active tenancy at that address.',
     parameters: {
       type: 'object',
       properties: {
@@ -252,7 +252,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'draft_buyer_followups',
     description: [
-      'Draft follow-up emails for one or more buyers. One draft per unit; joint purchasers (e.g. "Laura Hayes and Dylan Rogers") at a single unit share ONE email addressed to both names.',
+      'Draft follow-up emails for one or more buyers. One draft per unit; joint purchasers (e.g. "<buyer name 1> and <buyer name 2>") at a single unit share ONE email addressed to both names.',
       'CRITICAL RULES:',
       '1. Each target unit_identifier must be a unit number the user explicitly named OR that a previous tool returned. Do NOT guess.',
       '2. The purpose parameter must match what the user is asking for. "Congratulate on keys" → congratulate_handover ONLY for units that have actually been handed over (handover_date present).',
@@ -268,7 +268,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
           items: {
             type: 'object',
             properties: {
-              unit_identifier: { type: 'string', description: 'Exact unit number or unit uid (e.g. "19", "Unit 37", "AV-36"). Matched exactly against units.unit_number then units.unit_uid — no wildcards, no buyer-name fuzz.' },
+              unit_identifier: { type: 'string', description: 'Exact unit number or unit uid (e.g. "19", "Unit 37", "<UNIT_CODE>"). Matched exactly against units.unit_number then units.unit_uid — no wildcards, no buyer-name fuzz.' },
               scheme_name: { type: 'string', description: 'Name of the scheme the unit lives in. Required when the agent has multiple assigned schemes; otherwise optional.' },
               recipient_name: { type: 'string', description: 'Override the purchaser name if the agent named someone specifically. Usually leave blank so the skill greets the purchasers on file.' },
             },
@@ -312,7 +312,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
     name: 'rank_pipeline_buyers',
     description: [
       "Rank the buyers in the agent's sales pipeline at a single scheme by likelihood to convert.",
-      'Use this for "who is most likely to convert at Lakeside Manor", "which buyers should I chase first at Westfield Heights", "top 10 active buyers at this scheme" style questions, and as the input source when scheduling group viewings.',
+      'Use this for "who is most likely to convert at <scheme name>", "which buyers should I chase first at <scheme name>", "top 10 active buyers at this scheme" style questions, and as the input source when scheduling group viewings.',
       'The score is deterministic: stage progress, recency of last logged contact, days in pipeline, and viewing count. Tied scores fall back to last-contact-days desc → pipeline-age-days desc → buyer name asc for stable ordering.',
       'Terminal stages (handed_over, social_housing) are excluded from the eligible pool — these buyers are out of scope for further sales activity.',
       "Either development_id or scheme_name must be provided — the skill scopes to a single scheme. Cross-scheme ranking isn't supported in this version.",
@@ -322,7 +322,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       type: 'object',
       properties: {
         development_id: { type: 'string', description: 'UUID of the scheme. Preferred when known (avoids alias lookup).' },
-        scheme_name: { type: 'string', description: 'Scheme name (e.g. "Lakeside Manor"). Resolved against the agent\'s assigned schemes.' },
+        scheme_name: { type: 'string', description: 'Scheme name (e.g. "<scheme name>"). Resolved against the agent\'s assigned schemes.' },
         limit: { type: 'number', description: 'Max buyers to return (default 10, max 50).' },
       },
       required: [],
@@ -334,7 +334,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
     name: 'create_viewing_schedule',
     description: [
       'Build a viewing schedule for a single scheme on a given date and propose specific timeslots to the top-ranked buyers in one batch.',
-      'Use this for "draft a viewing schedule for Lakeside Manor this Saturday, 10 slots from 9–2, propose them to 10 active buyers" style requests.',
+      'Use this for "draft a viewing schedule for <scheme name> this Saturday, 10 slots from 9-2, propose them to 10 active buyers" style requests.',
       'Behaviour: builds N timeslots between start_time and end_time at slot_duration_minutes spacing, ranks buyers internally (terminal stages excluded — handed_over and social_housing units never receive proposals), drafts one personalised email per buyer, and pre-persists matching agent_viewings rows as PENDING.',
       'Either development_id or scheme_name must be provided — the skill currently scopes to one scheme per call. If the user asks "across all my schemes", run separate calls per scheme or ask the user to pick one.',
       'Each email opens with the unit + scheme + date, then a stage-aware second sentence acknowledging the recipient\'s pipeline situation, then 2-3 specific slot options.',
@@ -343,7 +343,7 @@ export const AGENT_TOOL_DEFINITIONS: ToolDefinition[] = [
       type: 'object',
       properties: {
         development_id: { type: 'string', description: 'UUID of the scheme. Preferred when known.' },
-        scheme_name: { type: 'string', description: 'Scheme name (e.g. "Lakeside Manor"). Resolved against the agent\'s assigned schemes.' },
+        scheme_name: { type: 'string', description: 'Scheme name (e.g. "<scheme name>"). Resolved against the agent\'s assigned schemes.' },
         date: { type: 'string', description: 'Viewing date as ISO YYYY-MM-DD (e.g. "2026-05-09" for Saturday).' },
         start_time: { type: 'string', description: 'Schedule start time in 24-h or 12-h ("09:00", "9am").' },
         end_time: { type: 'string', description: 'Schedule end time in 24-h or 12-h ("14:00", "2pm").' },

--- a/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
@@ -108,7 +108,7 @@ SUGGESTED FOLLOW-UP (a short draft email from the agent to the applicant). Requi
   - Reference the specific concerns/questions the agent captured. Never invent details (no quoting prices, BER numbers, dates, dimensions the agent didn't mention).
   - BANNED PHRASES: "I hope this finds you well", "I trust you're well", "I wanted to reach out", "I'm reaching out", "thank you for your time today" (overused), em dashes, "yet from here", any AI filler.
   - No emoji. No markdown. No exclamation marks unless the transcript itself contained one.
-  - subject: one short clause referring to the viewing or the property (e.g. "Following up on your viewing at Lakeside Manor").
+  - subject: one short clause referring to the viewing or the property (e.g. "Following up on your viewing at <scheme name>").
   - addresses_concerns: copy the exact content strings from structured_notes whose substance is reflected in the email body.
 
 CONFIDENCE:

--- a/apps/unified-portal/lib/agent-intelligence/transcription.ts
+++ b/apps/unified-portal/lib/agent-intelligence/transcription.ts
@@ -21,6 +21,28 @@ export interface TranscriptionResult {
   language: string;
 }
 
+// Whisper accepts a `prompt` parameter that biases token selection toward the
+// listed vocabulary. It doesn't constrain output. Used here to nudge Whisper
+// toward Irish placenames and property-domain terms the agent is likely to
+// say, which materially improves transcription accuracy on Irish accents.
+export function buildVocabularyPrompt(developmentNames: string[]): string {
+  const base =
+    'Irish English speaker. Property domain. ' +
+    'Common terms: BER, RTB, RPZ, Part 4 tenancy, snag list, ' +
+    'lease renewal, viewing, applicant, buyer, tenant, unit, ' +
+    'scheme, development, contracts issued.';
+  const cleaned = developmentNames
+    .map((n) => (typeof n === 'string' ? n.trim() : ''))
+    .filter((n) => n.length > 0);
+  if (cleaned.length === 0) {
+    return (
+      base +
+      ' Common Irish placenames including Cork, Dublin, Galway, Limerick, Waterford.'
+    );
+  }
+  return base + ' Schemes mentioned often: ' + cleaned.join(', ') + '.';
+}
+
 export class TranscriptionError extends Error {
   constructor(
     message: string,
@@ -34,6 +56,7 @@ export class TranscriptionError extends Error {
 export async function transcribeAudio(
   audio: Buffer,
   mimeType: string,
+  options: { vocabularyPrompt?: string } = {},
 ): Promise<TranscriptionResult> {
   if (audio.byteLength === 0) {
     throw new TranscriptionError('Audio file is empty', 'empty');
@@ -57,7 +80,7 @@ export async function transcribeAudio(
 
   if (process.env.OPENAI_API_KEY) {
     try {
-      return await transcribeWithWhisper(audio, mimeType);
+      return await transcribeWithWhisper(audio, mimeType, options.vocabularyPrompt);
     } catch (err: any) {
       lastError = lastError
         ? `${lastError}; whisper: ${err?.message ?? 'unknown'}`
@@ -124,6 +147,7 @@ async function transcribeWithDeepgram(
 async function transcribeWithWhisper(
   audio: Buffer,
   mimeType: string,
+  vocabularyPrompt?: string,
 ): Promise<TranscriptionResult> {
   const form = new FormData();
   const ext = mimeExtension(mimeType);
@@ -131,6 +155,9 @@ async function transcribeWithWhisper(
   form.append('model', 'whisper-1');
   form.append('language', 'en');
   form.append('response_format', 'verbose_json');
+  if (vocabularyPrompt && vocabularyPrompt.length > 0) {
+    form.append('prompt', vocabularyPrompt);
+  }
 
   const res = await fetch('https://api.openai.com/v1/audio/transcriptions', {
     method: 'POST',


### PR DESCRIPTION
## Summary

Two reliability fixes for the agent intelligence layer.

### Fix 1 — Hardcoded names sweep (P0)

PR #118's diagnostics found that hardcoded names in prompt examples create
statistical bias in the LLM's tool routing — "Niamh" appearing in a viewing
example caused Niamh-related scheduling requests to misroute to email tools.
The hotfix only covered the voice-capture section. This is the sweep that
should have happened then.

**Files modified:**
- `apps/unified-portal/lib/agent-intelligence/system-prompt.ts`
- `apps/unified-portal/lib/agent-intelligence/tools/registry.ts`
- `apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts`
- `apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts`

**Total replacements:** ~35 distinct call-sites across the four files.

All LLM-facing examples now use placeholders (`<applicant name>`, `<scheme
name>`, `<tenant name>`, `<buyer name 1>` / `<buyer name 2>`, `<UNIT_CODE>`,
`<property address>`, `<misheard scheme>`, etc.). Categories left alone per
spec:
- Code comments (`//` and JSDoc) — including the agentic-skills.ts references
  to "Foley family", "Árdan View", "Laura Hayes and Dylan Rogers".
- Load-bearing geographic data (Cork RPZ suburb list at line 1118/1609).
- Tool-result user-facing strings in broadcast-tools.ts (lines 5, 625, 671) —
  these are JSDoc plus runtime tool result messages, not the
  `FILTER_SYSTEM_PROMPT` / `EMAIL_SYSTEM_PROMPT` constants that the spec
  scoped to.
- Compliance certificate names (BCAR, Fire Safety, etc.) — domain terms,
  not data leakage.

Grep verification post-sweep:
- Word-bounded grep for `Niamh|Aoife|Conor|Rachael|Sarah|Sean|Jack` across
  the four files: zero hits.
- Broad grep for real-name fragments across the four files: zero hits
  outside the documented exclusions above.

A few examples needed minor restructuring to preserve their instructive
value (e.g. the "Erdon View" / "Árdan View" phonetic-mishear example now
uses `<misheard scheme>` and `<scheme name>` to preserve the disambiguation
lesson). No examples were dropped; structure preserved everywhere.

### Fix 2 — Whisper vocabulary prompt (P1)

The OpenAI Whisper API accepts a `prompt` parameter that biases token
selection toward the listed vocabulary. This dramatically improves
transcription accuracy for Irish accents on property-domain terms (BER,
RTB, RPZ, Part 4, etc.) and Irish placenames.

**Files modified:**
- `apps/unified-portal/lib/agent-intelligence/transcription.ts` — adds
  `buildVocabularyPrompt(developmentNames: string[])` helper and threads
  `vocabularyPrompt` through `transcribeAudio` into the Whisper form body.
- `apps/unified-portal/app/api/agent-intelligence/voice-capture/post-viewing/route.ts`
  — passes the agent's `assignedDevelopmentNames` (per-agent vocab).
- `apps/unified-portal/app/api/agent-intelligence/transcribe-voice/route.ts`
  — resolves agent context and passes `assignedDevelopmentNames`; falls
  back to static prompt on lookup failure.
- `apps/unified-portal/app/api/agent/intelligence/transcribe/route.ts` —
  unauthenticated generic transcribe route uses the static fallback.

Grep verification: every `whisper-1` call site now routes through
`transcribeAudio`, which forwards the `prompt` form field when one is
supplied. All three caller routes supply one.

## Test plan

- [ ] `npm run build` passes locally (confirmed).
- [ ] Manual: kick off a post-viewing capture and confirm the transcript
      handles Irish placenames and BER/RTB/RPZ correctly.
- [ ] Manual: verify the agent no longer misroutes scheduling requests
      that mention real applicant names matching the previously-baked
      examples (Niamh, Aisling, Mary Lynch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjStJ4ufjkHtAuHHaVbs6a)_