### PR TITLE
diagnose(agent): instrument cancel-freeze with FREEZE_DIAG markers

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -225,17 +225,35 @@ function IntelligencePageInner() {
   const inputElRef = useRef<HTMLInputElement | null>(null);
   const voiceIntentRef = useRef<string | undefined>(undefined);
 
+  // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+  // Runs on every render of IntelligencePageInner so we can see how
+  // many renders the parent does in the cancel re-render cycle.
+  if (typeof window !== 'undefined') {
+    console.log('[FREEZE_DIAG] IntelligencePage render', {
+      messageCount: messages.length,
+      isTyping,
+      hasUndoBatch: !!undoBatch,
+      timestamp: Date.now(),
+    });
+  }
+
   useEffect(() => {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] effect:scrollToBottom');
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
+    console.timeEnd('[FREEZE_DIAG] effect:scrollToBottom');
   }, [messages]);
 
   useEffect(() => {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] effect:matchMedia');
     const mq = window.matchMedia('(min-width: 900px)');
     const update = () => setIsDesktop(mq.matches);
     update();
     mq.addEventListener('change', update);
+    console.timeEnd('[FREEZE_DIAG] effect:matchMedia');
     return () => mq.removeEventListener('change', update);
   }, []);
 
@@ -243,11 +261,18 @@ function IntelligencePageInner() {
   // flight the carousel uses its fallback set, so first paint is never
   // blank.
   useEffect(() => {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] effect:fetchCapabilityChips');
     let cancelled = false;
     (async () => {
       const chips = await fetchCapabilityChips(activeWorkspace?.mode);
       if (!cancelled) setLiveChips(chips);
+      console.log('[FREEZE_DIAG] fetchCapabilityChips resolved', {
+        mode: activeWorkspace?.mode,
+        timestamp: Date.now(),
+      });
     })();
+    console.timeEnd('[FREEZE_DIAG] effect:fetchCapabilityChips');
     return () => { cancelled = true; };
   }, [activeWorkspace?.mode]);
 
@@ -256,6 +281,8 @@ function IntelligencePageInner() {
   // successful approve fires once per draftId; approve-all fires once
   // per draft in the batch.
   useEffect(() => {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] effect:onDraftSentListener');
     function onDraftSent(e: Event) {
       const detail = (e as CustomEvent).detail || {};
       const recipientName = typeof detail.recipientName === 'string' && detail.recipientName.length > 0
@@ -274,15 +301,19 @@ function IntelligencePageInner() {
       }]);
     }
     window.addEventListener('oh-draft-sent', onDraftSent);
+    console.timeEnd('[FREEZE_DIAG] effect:onDraftSentListener');
     return () => window.removeEventListener('oh-draft-sent', onDraftSent);
   }, []);
 
   // Handle prefilled prompt from URL
   useEffect(() => {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] effect:prefillPrompt');
     if (prefillPrompt && !prefillHandled.current) {
       prefillHandled.current = true;
       handleSend(prefillPrompt);
     }
+    console.timeEnd('[FREEZE_DIAG] effect:prefillPrompt');
   }, [prefillPrompt]);
 
   const handleSend = useCallback(async (text: string) => {

--- a/apps/unified-portal/components/agent/intelligence/ApplicantCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/ApplicantCard.tsx
@@ -344,7 +344,18 @@ export default function ApplicantCard({ envelope, onConfirmFailed }: ApplicantCa
   }
 
   function cancel() {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] ApplicantCard.cancel');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'ApplicantCard',
+      action: envelope.action,
+      phase,
+      timestamp: Date.now(),
+    });
     setPhase('cancelled');
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] ApplicantCard.cancel');
+    });
   }
 
   const Icon = actionIcon(envelope.action);

--- a/apps/unified-portal/components/agent/intelligence/BroadcastCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/BroadcastCard.tsx
@@ -328,7 +328,19 @@ export default function BroadcastCard({ envelope, onConfirmFailed }: BroadcastCa
   }
 
   function cancelDraft() {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] BroadcastCard.cancelDraft');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'BroadcastCard',
+      phase,
+      recipientCount: envelope.recipients.length,
+      emailCount: emails.length,
+      timestamp: Date.now(),
+    });
     setPhase('cancelled');
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] BroadcastCard.cancelDraft');
+    });
   }
 
   if (phase === 'cancelled') {

--- a/apps/unified-portal/components/agent/intelligence/CompositeScheduleCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/CompositeScheduleCard.tsx
@@ -439,7 +439,19 @@ export default function CompositeScheduleCard({ envelope, developments, onConfir
   }
 
   function cancel() {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] CompositeScheduleCard.cancel');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'CompositeScheduleCard',
+      phase,
+      envelopeViewingCount: envelope.viewings_to_create.length,
+      envelopeApplicantCount: envelope.applicants_to_create.length,
+      timestamp: Date.now(),
+    });
     setPhase('cancelled');
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] CompositeScheduleCard.cancel');
+    });
   }
 
   if (phase === 'cancelled') {

--- a/apps/unified-portal/components/agent/intelligence/ViewingCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/ViewingCard.tsx
@@ -269,8 +269,18 @@ export default function ViewingCard({
   }
 
   function handleCancel() {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] ViewingCard.handleCancel');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'ViewingCard',
+      phase,
+      timestamp: Date.now(),
+    });
     setPhase('cancelled');
     onCancelled?.();
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] ViewingCard.handleCancel');
+    });
   }
 
   if (phase === 'cancelled') {

--- a/apps/unified-portal/components/agent/intelligence/ViewingMutationCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/ViewingMutationCard.tsx
@@ -404,7 +404,18 @@ export default function ViewingMutationCard({ envelope, onConfirmFailed }: Viewi
     // Pure setState. No async, no event listeners to detach. The expensive
     // unmount path in the chat surface (re-rendering every other card) is
     // avoided by keeping the cancelled-state node in place.
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] ViewingMutationCard.cancel');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'ViewingMutationCard',
+      envelopeType: envelope.type,
+      phase,
+      timestamp: Date.now(),
+    });
     setPhase('cancelled');
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] ViewingMutationCard.cancel');
+    });
   }
 
   // ---------- Render branches ----------

--- a/apps/unified-portal/components/agent/intelligence/VoiceCaptureCard.tsx
+++ b/apps/unified-portal/components/agent/intelligence/VoiceCaptureCard.tsx
@@ -383,11 +383,23 @@ export default function VoiceCaptureCard({ viewing, onClose, onConfirmed }: Voic
   }
 
   function cancelRecording() {
+    // TODO: remove after freeze diagnosis (cancel-freeze diagnostic PR).
+    console.time('[FREEZE_DIAG] VoiceCaptureCard.cancelRecording');
+    console.log('[FREEZE_DIAG] cancel start', {
+      card: 'VoiceCaptureCard',
+      phase,
+      elapsed,
+      hasBlob: !!lastBlobRef.current,
+      timestamp: Date.now(),
+    });
     cleanupRecording();
     chunksRef.current = [];
     lastBlobRef.current = null;
     setPhase('idle');
     setElapsed(0);
+    queueMicrotask(() => {
+      console.timeEnd('[FREEZE_DIAG] VoiceCaptureCard.cancelRecording');
+    });
   }
 
   async function postCapture(blob: Blob | null) {


### PR DESCRIPTION
## Summary

Diagnose-only PR. QA has reported a 30 to 40 second freeze on the agent intelligence page after tapping Cancel on a draft card, intermittent at roughly an 80% rate across 5-attempt tests yesterday. Prior fix attempts failed because without instrumentation we cannot tell whether the freeze is React reconciliation, an async side effect, a re-fetch loop, or something else. This PR adds temporary `console.time` / `console.timeEnd` / `console.log` markers at every site that could plausibly be involved so the next QA capture surfaces the real cause.

No logic changes. No new dependencies. Every change is tagged with `TODO: remove after freeze diagnosis` so the cleanup pass after the follow-up fix is grep-able.

## Files instrumented

### Card cancel handlers (one `[FREEZE_DIAG]` start log + `console.time` / `queueMicrotask` end-time on each)

- `components/agent/intelligence/CompositeScheduleCard.tsx` -> `cancel()`
- `components/agent/intelligence/ViewingCard.tsx` -> `handleCancel()`
- `components/agent/intelligence/ApplicantCard.tsx` -> `cancel()`
- `components/agent/intelligence/ViewingMutationCard.tsx` -> `cancel()`
- `components/agent/intelligence/BroadcastCard.tsx` -> `cancelDraft()`
- `components/agent/intelligence/VoiceCaptureCard.tsx` -> `cancelRecording()`

### Intelligence page

- `app/agent/intelligence/page.tsx`: a render log at the top of `IntelligencePageInner` so we see how many times the parent re-renders during the cancel cycle, plus `console.time` / `console.timeEnd` around every `useEffect` body (5 in total: `scrollToBottom`, `matchMedia`, `fetchCapabilityChips`, `onDraftSentListener`, `prefillPrompt`). The `fetchCapabilityChips` effect also logs when its async resolves, so we can spot any in-flight network round-trip that completes during the freeze.

## How to capture the freeze

1. Open the deployed app on the device that reproduces (phone or laptop) with DevTools console open. On mobile, attach via remote debugging (Safari Web Inspector or `chrome://inspect`).
2. Filter the console by `[FREEZE_DIAG]` so the noise of normal app logs drops out.
3. Send a viewing prompt that produces a `CompositeScheduleCard`. The bullet from the brief works: "schedule a viewing for Test One at 3pm Friday in Lakeside Manor". Any composite card is fine; tap Cancel on whichever card surfaces.
4. As soon as the card renders, tap Cancel.
5. Wait for the page to become responsive again (or the typical 30 to 40 seconds).
6. Copy the full filtered console output and attach it here. The expected shape:
   - One `cancel start` log with the timestamp.
   - A long timing measurement on the `console.timeEnd` line for that handler.
   - Some number of `IntelligencePage render` logs after the cancel, each with `messageCount` so we can see whether the parent is being re-rendered repeatedly.
   - Any `effect:*` entries that fire during the freeze window.
7. If the page genuinely locks (not just slow), also capture a Performance tab recording: start recording, tap Cancel, stop after the freeze resolves. Attach the `.json` profile.

## What we expect to learn

- If the `cancel` `console.timeEnd` lands within a millisecond but the page takes 30 seconds to respond, the freeze is downstream of the setState in something React schedules.
- If `IntelligencePage render` fires many times after the cancel, the parent is re-rendering on every tick of something (an effect, a setState loop, a window event).
- If any `effect:*` entry lands during the freeze window with an unexpectedly long timing, that effect is the cause.
- If a network call resolves during the freeze (`fetchCapabilityChips resolved` log), the freeze is waiting on a fetch.

## Cleanup

Once the follow-up fix lands, run:

```
git grep -n FREEZE_DIAG apps/unified-portal/
```

Remove every match and the `TODO: remove after freeze diagnosis` comments above them.

## Constraints honoured

- No em dashes in new code (verified with `git diff | grep -- 'u2014' / em-dash literal`).
- Only `console.time`, `console.timeEnd`, and `console.log` calls added. No logic changes. No new dependencies.
- Build passes locally.

## Test plan

- [ ] After deploy, QA reproduces the freeze and captures the `[FREEZE_DIAG]` console output.
- [ ] Capture a Performance tab profile during the freeze if the page actually locks (no UI updates).
- [ ] Attach both to this PR (or to the follow-up fix PR) before opening the fix.
- [ ] After the fix lands, the FREEZE_DIAG calls are removed in a cleanup commit.

https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJtnwfWFtwBJs4v6rW4UTc)_