### PR TITLE
fix(build): move tesseract.js to packages/api where it's actually used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "swr": "^2.3.6",
         "tailwind-merge": "^2.2.0",
         "tailwindcss": "^3.4.0",
-        "tesseract.js": "^6.0.1",
         "tiktoken": "^1.0.22",
         "tsx": "^4.20.6",
         "typescript": "^5.3.3",
@@ -5194,6 +5193,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5214,6 +5214,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5234,6 +5235,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5254,6 +5256,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5274,6 +5277,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5294,6 +5298,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5314,6 +5319,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5334,6 +5340,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5354,6 +5361,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5374,6 +5382,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5394,6 +5403,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -16955,6 +16965,7 @@
         "pdf-parse": "^2.4.5",
         "pg": "^8.13.1",
         "tailwind-merge": "^2.5.4",
+        "tesseract.js": "^6.0.1",
         "tiktoken": "^1.0.17",
         "unpdf": "^0.12.1",
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "swr": "^2.3.6",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "^3.4.0",
-    "tesseract.js": "^6.0.1",
     "tiktoken": "^1.0.22",
     "tsx": "^4.20.6",
     "typescript": "^5.3.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,6 +37,7 @@
     "pdf-parse": "^2.4.5",
     "pg": "^8.13.1",
     "tailwind-merge": "^2.5.4",
+    "tesseract.js": "^6.0.1",
     "tiktoken": "^1.0.17",
     "unpdf": "^0.12.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary

`tesseract.js` was declared at the root `package.json` but is only consumed inside the `@openhouse/api` workspace (`packages/api/src/train/ocr.ts`, `enhanced-ocr.ts`, `parse.ts`, which are transitively pulled in by `@api/document-processor`).

Vercel's install command in `vercel.json` runs `npm ci --workspace=... --include-workspace-root=false`, which means the root workspace's dependencies are skipped, so `tesseract.js` was never installed in production builds. The build broke with:

```
Error: Cannot find module 'tesseract.js'
Require stack:
  /vercel/path0/apps/unified-portal/.next/server/app/api/ingest/process-pending/route.js
```

The fix is surgical: move the `tesseract.js: "^6.0.1"` declaration from the root `package.json` into `packages/api/package.json`, where it belongs. `npm install` regenerates `package-lock.json` to record it under the correct workspace. No source code is touched and `vercel.json` is unchanged.

This is a pre-existing config issue exposed when PR #141 triggered a fresh deploy — PR #141 itself is clean, the failure is unrelated to the instrumentation work. **This is the SECOND failed deploy attempt's fix** — the first attempt was PR #141, which built locally but Vercel's install command exposed the missing dep.

## Test plan

- [x] `grep -rn "tesseract" packages/api/src/` confirms the dep is only used inside `@openhouse/api`
- [x] `npm install` succeeds and regenerates `package-lock.json` (13-line lockfile delta, no version change)
- [x] `npm --workspace=@openhouse/unified-portal run build` passes locally with `/api/ingest/process-pending` compiled cleanly
- [ ] Vercel deploy succeeds with the workspace-scoped install command unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_015C9vJxTFoZkE4ctVXix5k2)_