### PR TITLE
Fix cross-workspace draft leakage in agent intelligence

### DIFF
--- a/apps/unified-portal/app/agent/intelligence/page.tsx
+++ b/apps/unified-portal/app/agent/intelligence/page.tsx
@@ -776,7 +776,15 @@ function IntelligencePageInner() {
         const res = await fetch('/api/agent/intelligence/execute-actions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ actions, transcript: msg.voice.transcript }),
+          body: JSON.stringify({
+            actions,
+            transcript: msg.voice.transcript,
+            // Pass the active workspace mode so the server stamps the
+            // correct workspace_id on every draft it writes. Without
+            // this, voice-action drafts default to the sales workspace
+            // and surface in the wrong inbox.
+            mode: activeWorkspace?.mode ?? 'sales',
+          }),
         });
 
         if (!res.ok) throw new Error('execute failed');
@@ -876,6 +884,7 @@ function IntelligencePageInner() {
             actions: [action],
             batchId: msg.voice.batchId,
             sharedContext: msg.voice.sharedContext,
+            mode: activeWorkspace?.mode ?? 'sales',
           }),
         });
         if (!res.ok) throw new Error('retry failed');

--- a/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/capability-chips/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
 import { FALLBACK_CAPABILITY_CHIPS } from '@/lib/agent-intelligence/capability-chips';
+import { resolveSessionWorkspace } from '@/lib/agent-intelligence/workspace-resolution';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -41,9 +42,15 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     const mode = url.searchParams.get('mode') === 'lettings' ? 'lettings' : 'sales';
 
+    // Resolve the session's workspace_id so the drafts count below is
+    // scoped to the current workspace, not all of the agent's workspaces.
+    const session = user?.id
+      ? await resolveSessionWorkspace(supabase, user.id, mode)
+      : null;
+
     const chips = mode === 'lettings'
       ? await composeLettingsChips(supabase, profile.id)
-      : await composeChips(supabase, profile.id);
+      : await composeChips(supabase, profile.id, session?.workspaceId ?? null);
     return NextResponse.json<ChipResponse>({ chips });
   } catch {
     return NextResponse.json<ChipResponse>({ chips: [...FALLBACK_CAPABILITY_CHIPS] });
@@ -141,7 +148,21 @@ async function composeLettingsChips(
 async function composeChips(
   supabase: ReturnType<typeof getSupabaseAdmin>,
   agentId: string,
+  workspaceId: string | null,
 ): Promise<string[]> {
+  // The drafts count is workspace-scoped so a lettings session doesn't
+  // see "Review my drafts" surfaced because sales has pending items
+  // (and vice versa). When no workspace can be resolved, drafts count
+  // defaults to zero rather than leaking a count across workspaces.
+  const draftsCountQuery = workspaceId
+    ? supabase
+        .from('pending_drafts')
+        .select('id', { count: 'exact', head: true })
+        .eq('workspace_id', workspaceId)
+        .eq('skin', 'agent')
+        .eq('status', 'pending_review')
+    : Promise.resolve({ count: 0, error: null } as any);
+
   const [
     assignmentsRes,
     draftsCountRes,
@@ -151,12 +172,7 @@ async function composeChips(
       .select('development_id')
       .eq('agent_id', agentId)
       .eq('is_active', true),
-    supabase
-      .from('pending_drafts')
-      .select('id', { count: 'exact', head: true })
-      .eq('user_id', agentId)
-      .eq('skin', 'agent')
-      .eq('status', 'pending_review'),
+    draftsCountQuery,
   ]);
 
   const developmentIds = Array.from(

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/[id]/route.ts
@@ -7,17 +7,35 @@ import {
   toDraftRecord,
 } from '@/lib/agent-intelligence/drafts';
 import { authorizeDraftMutation } from '@/lib/agent-intelligence/draft-auth';
+import { resolveSessionWorkspace } from '@/lib/agent-intelligence/workspace-resolution';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/agent/intelligence/drafts/:id
- * Returns the full draft (subject, body, recipient, context chips).
+ *
+ * Returns the full draft. Workspace-scoped: a Sales draft is invisible to
+ * a Lettings session (and vice versa) — the route returns 404 rather than
+ * the draft so direct URL navigation can't reveal a draft from the other
+ * workspace.
  */
 export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const supabase = getSupabaseAdmin();
+    const cookieStore = cookies();
+    const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
+    const { data: { user } } = await supabaseAuth.auth.getUser();
+
+    if (!user?.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const session = await resolveSessionWorkspace(supabase, user.id, null);
+    if (!session) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
     const { data: row, error } = await supabase
       .from('pending_drafts')
       .select('*')
@@ -26,6 +44,13 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     if (!row) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    // Cross-workspace fetches return 404 — not 403, not the draft. The
+    // existence of a draft id is itself information a different workspace
+    // shouldn't be able to confirm.
+    if (row.workspace_id !== session.workspaceId) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
 
     const recipient = await resolveRecipient(supabase, row.draft_type, row.recipient_id);
     return NextResponse.json({ draft: toDraftRecord(row, recipient) });
@@ -37,9 +62,9 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
 /**
  * PATCH /api/agent/intelligence/drafts/:id
  * Body: { subject?, body?, sendMethod?, recipientId? }
- * Saves edits back into content_json. Any save implicitly means the user
- * touched the draft — the send route reads this flag off a later diff rather
- * than tracking it here, to keep this route dumb.
+ *
+ * Cross-workspace mutations return 404 by design — the route refuses to
+ * acknowledge a draft from a different workspace.
  */
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -58,11 +83,16 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     if (getErr) return NextResponse.json({ error: getErr.message }, { status: 500 });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    // Auth + tenant guard. See `lib/agent-intelligence/draft-auth.ts` —
-    // closes the falsy-bypass that let unauthenticated PATCH requests
-    // slip through to the service-role admin client.
     const authResult = await authorizeDraftMutation(supabase, user, existing);
     if (!authResult.ok) return authResult.response;
+
+    // Workspace scope check — defense beyond the user/tenant check.
+    if (user?.id) {
+      const session = await resolveSessionWorkspace(supabase, user.id, null);
+      if (!session || existing.workspace_id !== session.workspaceId) {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      }
+    }
 
     const nextContent = { ...(existing.content_json || {}) };
     if (typeof body.subject === 'string') nextContent.subject = body.subject;
@@ -93,16 +123,9 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
 
 /**
  * DELETE /api/agent/intelligence/drafts/:id
- * Hard-deletes — drafts are disposable by design. The recent_actions row from
- * Session 1 is removed too so the Session 1 undo pill can't resurrect a draft
- * the user explicitly discarded.
  *
- * TODO: when discarding a viewing_proposal draft, also delete the matching
- * pending agent_viewings row by (unit_id, viewing_date, viewing_time). The
- * viewing-scheduler audit accepted orphan PENDING viewings as agent-facing-
- * only for the promo recording; once the join key shape is decided, wire
- * this DELETE to clean up the matching slot so the agent's viewings list
- * doesn't accumulate stale "PENDING" entries from discarded proposals.
+ * Cross-workspace deletes return 404. Same reasoning as GET — confirming
+ * a draft id from another workspace is itself a leak.
  */
 export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -113,17 +136,21 @@ export async function DELETE(_request: NextRequest, { params }: { params: { id: 
 
     const { data: existing } = await supabase
       .from('pending_drafts')
-      .select('user_id, tenant_id')
+      .select('user_id, tenant_id, workspace_id')
       .eq('id', params.id)
       .maybeSingle();
 
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    // Auth + tenant guard. See `lib/agent-intelligence/draft-auth.ts` —
-    // closes the falsy-bypass that let unauthenticated DELETE requests
-    // slip through to the service-role admin client.
     const authResult = await authorizeDraftMutation(supabase, user, existing);
     if (!authResult.ok) return authResult.response;
+
+    if (user?.id) {
+      const session = await resolveSessionWorkspace(supabase, user.id, null);
+      if (!session || existing.workspace_id !== session.workspaceId) {
+        return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      }
+    }
 
     await supabase
       .from('recent_actions')

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/route.ts
@@ -5,18 +5,32 @@ import { getSupabaseAdmin } from '@/lib/supabase-server';
 import {
   resolveRecipient,
   toDraftRecord,
-  draftTypesForMode,
   type DraftRecord,
 } from '@/lib/agent-intelligence/drafts';
+import {
+  resolveSessionWorkspace,
+  assertDraftWorkspace,
+  type WorkspaceMode,
+} from '@/lib/agent-intelligence/workspace-resolution';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/agent/intelligence/drafts
- * Returns every pending_review draft for the authenticated user, newest first.
- * Also returns a `count` field so the bottom nav / sidebar badge can stay
- * live without a second round trip.
+ * Returns every pending_review draft for the authenticated user's active
+ * workspace, newest first. Also returns a `count` field so the bottom nav /
+ * sidebar badge can stay live without a second round trip.
+ *
+ * Workspace isolation:
+ *   - The query filters on workspace_id only. The historical filter by
+ *     draft_type is gone — it was the source of the Bridge Property
+ *     Group bleed (buyer_followup drafts surfaced in both sales and
+ *     lettings inboxes because the type appeared in both filters).
+ *   - A server-side tripwire asserts every returned row's workspace_id
+ *     matches the resolved session workspace. Any mismatch throws — this
+ *     is defence-in-depth against a regression in the SQL filter or RLS
+ *     policy, not a silent filter.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -25,35 +39,38 @@ export async function GET(request: NextRequest) {
     const supabaseAuth = createRouteHandlerClient({ cookies: () => cookieStore });
     const { data: { user } } = await supabaseAuth.auth.getUser();
 
-    const userId = user?.id || (await fallbackUserId(supabase));
-    if (!userId) {
+    if (!user?.id) {
+      // No auth → no drafts. The earlier `fallbackUserId` heuristic that
+      // dropped onto the first agent profile in dev mode is gone — it
+      // was a per-user data leak waiting to happen the moment the
+      // codepath landed in production.
       return NextResponse.json({ drafts: [], count: 0 }, { status: 200 });
     }
 
-    // Workspace partition. `?mode=sales|lettings` restricts the list to draft
-    // types belonging to that workspace plus the shared `buyer_followup`
-    // type (used by both sales and lettings flows). Without `mode`, return
-    // every draft so legacy / non-workspace consumers behave as before.
     const modeParam = request.nextUrl.searchParams.get('mode');
-    const mode: 'sales' | 'lettings' | null =
+    const modeHint: WorkspaceMode | null =
       modeParam === 'sales' || modeParam === 'lettings' ? modeParam : null;
 
-    let query = supabase
-      .from('pending_drafts')
-      .select('*')
-      .eq('user_id', userId)
-      .eq('status', 'pending_review')
-      .order('created_at', { ascending: false });
-
-    if (mode) {
-      query = query.in('draft_type', draftTypesForMode(mode));
+    const session = await resolveSessionWorkspace(supabase, user.id, modeHint);
+    if (!session) {
+      return NextResponse.json({ drafts: [], count: 0 }, { status: 200 });
     }
 
-    const { data: rows, error } = await query;
+    const { data: rows, error } = await supabase
+      .from('pending_drafts')
+      .select('*')
+      .eq('workspace_id', session.workspaceId)
+      .eq('status', 'pending_review')
+      .order('created_at', { ascending: false });
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    // Tripwire — every row MUST already match the session workspace. If
+    // the SQL filter regresses (or RLS leaks rows the application layer
+    // depended on it to hide), this throws instead of silently filtering.
+    assertDraftWorkspace(rows || [], session.workspaceId);
 
     const drafts: DraftRecord[] = [];
     for (const row of rows || []) {
@@ -69,16 +86,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
-
-async function fallbackUserId(supabase: ReturnType<typeof getSupabaseAdmin>): Promise<string | null> {
-  // Mirrors the voice capture routes — dev/preview mode drops onto the first
-  // agent profile so you can exercise the screen without a real session.
-  const { data } = await supabase
-    .from('agent_profiles')
-    .select('user_id')
-    .order('created_at', { ascending: true })
-    .limit(1)
-    .maybeSingle();
-  return data?.user_id || null;
 }

--- a/apps/unified-portal/app/api/agent/intelligence/drafts/tweak-all/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/drafts/tweak-all/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import OpenAI from 'openai';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { resolveSessionWorkspace } from '@/lib/agent-intelligence/workspace-resolution';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -57,11 +58,22 @@ export async function POST(request: NextRequest) {
     });
 
     const supabase = getSupabaseAdmin();
+
+    // Workspace scope — only drafts belonging to the caller's active
+    // workspace are rewritable. Drafts from the other workspace are
+    // simply not included in the result (rather than erroring per-id)
+    // so the batch UI can still rewrite the in-scope subset cleanly.
+    const session = await resolveSessionWorkspace(supabase, user.id, null);
+    if (!session) {
+      return NextResponse.json({ error: 'No active workspace' }, { status: 404 });
+    }
+
     const { data: rows, error: fetchErr } = await supabase
       .from('pending_drafts')
-      .select('id, content_json, user_id')
+      .select('id, content_json, user_id, workspace_id')
       .in('id', draftIds)
-      .eq('user_id', user.id);
+      .eq('user_id', user.id)
+      .eq('workspace_id', session.workspaceId);
 
     if (fetchErr) {
       return NextResponse.json({ error: fetchErr.message }, { status: 500 });
@@ -128,7 +140,8 @@ export async function POST(request: NextRequest) {
           updated_at: new Date().toISOString(),
         }, { count: 'exact' })
         .eq('id', draft.id)
-        .eq('user_id', user.id);
+        .eq('user_id', user.id)
+        .eq('workspace_id', session.workspaceId);
       if (updErr) {
         console.error('[tweak-all] update failed', { id: draft.id, message: updErr.message });
         failures.push({ id: draft.id, reason: updErr.message });

--- a/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/execute-actions/route.ts
@@ -11,6 +11,7 @@ import {
   type SendHistoryRow,
 } from '@/lib/agent-intelligence/autonomy';
 import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
+import { resolveWriteWorkspace, type WorkspaceMode } from '@/lib/agent-intelligence/workspace-resolution';
 import type {
   ExtractedAction,
   ExecutedAction,
@@ -88,6 +89,30 @@ export async function POST(request: NextRequest) {
     const userId = user?.id || agentProfile.user_id;
     const timezone = agentProfile.timezone || 'Europe/Dublin';
 
+    // Workspace resolution. The client passes `mode` so we can stamp
+    // workspace_id at write time from the active session, not infer it
+    // from the originating record after the fact. If the client didn't
+    // pass mode (legacy callers), fall back to sales — the historical
+    // default for the voice-action pipeline, which originated in the
+    // sales flow.
+    const modeFromBody: WorkspaceMode =
+      body?.mode === 'lettings' ? 'lettings' : 'sales';
+    let workspaceId: string | null = null;
+    try {
+      workspaceId = await resolveWriteWorkspace(supabase, userId, modeFromBody);
+    } catch (err: any) {
+      // Hard fail: drafts shouldn't be written without a workspace.
+      console.error('[execute-actions] workspace resolution failed', {
+        userId,
+        mode: modeFromBody,
+        message: err?.message,
+      });
+      return NextResponse.json(
+        { error: 'No active workspace for this user; cannot execute draft actions.' },
+        { status: 400 },
+      );
+    }
+
     // Sequential execution needs a shared context so each action can reference
     // ids produced by earlier actions in the same batch. Client can also pass
     // a prior shared context back when retrying a failed subset.
@@ -126,6 +151,7 @@ export async function POST(request: NextRequest) {
         userId,
         tenantId: agentProfile.tenant_id,
         agentId: agentProfile.id,
+        workspaceId,
         timezone,
         autonomy,
         recentByType,
@@ -192,6 +218,13 @@ interface ExecCtx {
   userId: string;
   tenantId: string;
   agentId: string;
+  /**
+   * The workspace_id the action's drafts must be written into. Resolved
+   * once per request from the client-supplied mode + the agent's
+   * workspaces. Every draft insertion in this file MUST pass this value
+   * through to the pending_drafts row.
+   */
+  workspaceId: string;
   timezone: string;
   autonomy: Awaited<ReturnType<typeof loadAutonomyPreferences>>;
   recentByType: Map<string, SendHistoryRow[]>;
@@ -365,6 +398,7 @@ async function execDraftVendorUpdate(
     .insert({
       user_id: userId,
       tenant_id: tenantId,
+      workspace_id: ctx.workspaceId,
       skin: 'agent',
       draft_type: draftType,
       recipient_id: f.vendor_id ? String(f.vendor_id) : null,
@@ -466,6 +500,7 @@ async function insertDraftAndMaybeAutoSend(
     .insert({
       user_id: userId,
       tenant_id: tenantId,
+      workspace_id: ctx.workspaceId,
       skin: 'agent',
       draft_type: opts.draftType,
       recipient_id: opts.recipientId,
@@ -689,6 +724,7 @@ async function execDraftPriceReductionNotice(
       .insert({
         user_id: userId,
         tenant_id: tenantId,
+        workspace_id: ctx.workspaceId,
         skin: 'agent',
         draft_type: 'price_reduction_notice',
         recipient_id: recipientId,

--- a/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
+++ b/apps/unified-portal/app/api/agent/intelligence/send-draft/route.ts
@@ -7,6 +7,7 @@ import { getResendClient } from '@/lib/resend';
 import { resolveRecipient } from '@/lib/agent-intelligence/drafts';
 import { isStatutoryDraftType } from '@/lib/agent-intelligence/autonomy';
 import { authorizeDraftMutation } from '@/lib/agent-intelligence/draft-auth';
+import { resolveSessionWorkspace } from '@/lib/agent-intelligence/workspace-resolution';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -62,6 +63,19 @@ export async function POST(request: NextRequest) {
     // draft id slip through to the service-role admin client.
     const authResult = await authorizeDraftMutation(supabase, user, draft);
     if (!authResult.ok) return authResult.response;
+
+    // Workspace scope. A Lettings session must not be able to send a
+    // Sales draft — even with a valid draftId and matching tenant. We
+    // resolve the caller's active workspace and compare against the
+    // draft's stamped workspace_id. Cross-workspace sends 404 by design
+    // (existence of the draft id is itself information the other
+    // workspace shouldn't be able to confirm).
+    if (user?.id) {
+      const session = await resolveSessionWorkspace(supabase, user.id, null);
+      if (!session || draft.workspace_id !== session.workspaceId) {
+        return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+      }
+    }
     console.log('[send-draft] entry', {
       draftId,
       userId: draft.user_id,

--- a/apps/unified-portal/lib/agent-intelligence/draft-store.ts
+++ b/apps/unified-portal/lib/agent-intelligence/draft-store.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { AgenticSkillDraft, AgenticSkillEnvelope } from './envelope';
 import type { AgentContext } from './types';
+import { resolveWriteWorkspace } from './workspace-resolution';
 
 /**
  * Session 5A — single path that writes agentic-skill drafts to `pending_drafts`.
@@ -78,6 +79,14 @@ export interface SkillPersistContext {
   userId: string;
   tenantId: string | null;
   skill: string;
+  /**
+   * The workspace the draft belongs to. Stamped at write time from the
+   * active session's workspace (resolved via resolveWriteWorkspace in the
+   * convenience wrapper below), never inferred later from the originating
+   * record. NULL is intentionally disallowed — every new draft has a
+   * workspace decision attached at creation.
+   */
+  workspaceId: string;
 }
 
 /**
@@ -218,6 +227,7 @@ export async function persistDraftsForEnvelope(
       .insert({
         user_id: ctx.userId,
         tenant_id: ctx.tenantId,
+        workspace_id: ctx.workspaceId,
         skin: 'agent',
         draft_type: draftType,
         recipient_id: recipientId,
@@ -268,15 +278,30 @@ export async function persistDraftsForEnvelope(
  * Convenience wrapper used by the tools/registry adapter. Takes a full
  * AgentContext (what the chat route already has) and resolves the skill name
  * automatically from the envelope.
+ *
+ * Resolves the workspace_id at write time from `agentContext.mode` (the
+ * mode the client sent with the request — the active workspace pill in
+ * the header). resolveWriteWorkspace throws when no matching workspace
+ * exists for the user; that's an upstream bug we'd rather see surfaced
+ * than write a NULL workspace_id and have the row flagged for manual
+ * review.
  */
 export async function persistSkillEnvelope(
   supabase: SupabaseClient,
   envelope: AgenticSkillEnvelope,
   agentContext: AgentContext,
 ): Promise<AgenticSkillEnvelope> {
+  if (!envelope.drafts.length) return envelope;
+  const mode = agentContext.mode ?? 'sales';
+  const workspaceId = await resolveWriteWorkspace(
+    supabase,
+    agentContext.authUserId,
+    mode,
+  );
   return persistDraftsForEnvelope(supabase, envelope, {
     userId: agentContext.authUserId,
     tenantId: agentContext.tenantId,
     skill: envelope.skill,
+    workspaceId,
   });
 }

--- a/apps/unified-portal/lib/agent-intelligence/drafts.ts
+++ b/apps/unified-portal/lib/agent-intelligence/drafts.ts
@@ -73,44 +73,15 @@ const BUYER_DRAFT_TYPES: readonly string[] = [
   'chain_update_to_buyer',
 ];
 
-// Workspace-mode partition for the drafts list filter. `buyer_followup` is
-// produced by both `draft_message` and `draft_buyer_followups`, both of
-// which are reachable from sales AND lettings flows (the lettings system
-// prompt at system-prompt.ts:645 and the registry's lettings recipient_type
-// branch). Keep it visible in BOTH modes — the alternative is hiding real
-// lettings drafts from the lettings inbox, which is worse than minor
-// cross-pollination.
-export const SALES_DRAFT_TYPES: readonly string[] = [
-  'solicitor_chase',
-  'viewing_followup',
-  'viewing_proposal',
-  'viewing_record',
-  'weekly_briefing',
-  'intelligence_report',
-  'intelligence_answer',
-  'intelligence_draft',
-  'schedule_viewing',
-  'vendor_update',
-  'offer_response',
-  'price_reduction_notice',
-  'chain_update_to_buyer',
-];
-
-export const LETTINGS_DRAFT_TYPES: readonly string[] = [
-  'lease_renewal',
-  'application_invitation',
-  'landlord_statement',
-];
-
-export const SHARED_DRAFT_TYPES: readonly string[] = [
-  'buyer_followup',
-];
-
-export function draftTypesForMode(mode: 'sales' | 'lettings'): string[] {
-  return mode === 'lettings'
-    ? [...LETTINGS_DRAFT_TYPES, ...SHARED_DRAFT_TYPES]
-    : [...SALES_DRAFT_TYPES, ...SHARED_DRAFT_TYPES];
-}
+// The SALES_DRAFT_TYPES / LETTINGS_DRAFT_TYPES / SHARED_DRAFT_TYPES
+// constants and the draftTypesForMode helper that lived here were the
+// previous workspace partition for the drafts inbox query — drafts were
+// filtered by `draft_type` and the SHARED bucket (buyer_followup)
+// surfaced in BOTH workspace inboxes. That's exactly the bleed that
+// migration 060 closes. The inbox query now filters on workspace_id
+// directly; the per-type lists are no longer needed at runtime. If a
+// future caller wants to know which draft types belong to which mode,
+// the backfill SQL in migrations/062 is the canonical reference.
 
 export async function resolveRecipient(
   supabase: SupabaseClient,

--- a/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/broadcast-tools.ts
@@ -31,6 +31,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { AgentContext, ToolResult } from '../types';
 import { matchDevelopment, type Development } from '../property-matcher';
 import { scrubFollowUpBody } from './voice-capture-tools';
+import { resolveWriteWorkspace } from '../workspace-resolution';
 
 export type BroadcastTone = 'warm' | 'professional' | 'urgent';
 
@@ -774,6 +775,24 @@ export async function confirmBroadcast(
     };
   }
 
+  // Resolve the workspace_id up-front so a broadcast can't be sent
+  // between workspaces. Broadcast is sales-or-lettings specific (an
+  // agent broadcasts to applicants in a single product context), so
+  // the active workspace is the correct scope.
+  const mode = agentContext.mode ?? 'sales';
+  let workspaceId: string;
+  try {
+    workspaceId = await resolveWriteWorkspace(supabase, agentContext.authUserId, mode);
+  } catch (err: any) {
+    console.error('[broadcast-tools] workspace resolution failed', { message: err?.message });
+    return {
+      status: 'error',
+      broadcast_id: null,
+      drafts_written: 0,
+      error: 'No active workspace for this user; cannot stage a broadcast.',
+    };
+  }
+
   const { data: auditRow, error: auditError } = await supabase
     .from('broadcast_audit_log')
     .insert({
@@ -801,6 +820,7 @@ export async function confirmBroadcast(
   const draftRows = input.emails.map((e) => ({
     user_id: agentContext.authUserId,
     tenant_id: agentContext.tenantId,
+    workspace_id: workspaceId,
     skin: 'agent',
     draft_type: 'broadcast_email',
     recipient_id: e.applicant_id ?? null,

--- a/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
+++ b/apps/unified-portal/lib/agent-intelligence/tools/voice-capture-tools.ts
@@ -24,6 +24,7 @@ import {
   type MarkStatus,
 } from './viewing-tools';
 import { formatViewingTime, DEFAULT_TZ } from '../viewing-resolver';
+import { resolveWriteWorkspace } from '../workspace-resolution';
 
 export type PostViewingOutcome =
   | 'high_interest'
@@ -705,11 +706,18 @@ export async function executePostViewingCapture(
     const cleanBody = scrubFollowUpBody(extraction.suggested_follow_up.body);
     const subject = extraction.suggested_follow_up.subject.trim();
     try {
+      // Stamp the workspace at write time from the active session's
+      // mode. Voice capture runs from inside the chat route or
+      // intelligence drawer, so agentContext.mode is set by the chat
+      // route's request body (active workspace pill).
+      const mode = agentContext.mode ?? 'sales';
+      const workspaceId = await resolveWriteWorkspace(supabase, agentContext.authUserId, mode);
       const { data, error } = await supabase
         .from('pending_drafts')
         .insert({
           user_id: agentContext.authUserId,
           tenant_id: agentContext.tenantId,
+          workspace_id: workspaceId,
           skin: 'agent',
           draft_type: 'viewing_followup',
           recipient_id: viewing.applicant_id ?? null,

--- a/apps/unified-portal/lib/agent-intelligence/workspace-resolution.ts
+++ b/apps/unified-portal/lib/agent-intelligence/workspace-resolution.ts
@@ -1,0 +1,146 @@
+/**
+ * Workspace resolution for the drafts pipeline.
+ *
+ * Every read path that hits pending_drafts goes through resolveSessionWorkspace,
+ * and every write path goes through resolveWriteWorkspace. Both return the
+ * concrete agent_workspaces.id the draft is being read from / written into.
+ *
+ * Why a dedicated helper instead of stuffing the lookup into each route:
+ *   1. The read path's "session workspace" depends on a `mode` query param
+ *      OR the agent's persisted last_active_workspace_id. One source of
+ *      truth keeps the drafts list, the count badge, and the deep-link
+ *      route in lockstep.
+ *   2. The write path needs the same lookup at the moment a draft is
+ *      persisted (chat route, execute-actions route, broadcast, voice
+ *      capture, drawer-store skill registry) so the workspace_id is
+ *      stamped at creation from the active session, never inferred later
+ *      from the originating record.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type WorkspaceMode = 'sales' | 'lettings';
+
+export interface ResolvedSessionWorkspace {
+  workspaceId: string;
+  mode: WorkspaceMode;
+  agentProfileId: string;
+  tenantId: string | null;
+}
+
+/**
+ * Resolve the workspace the current request should read drafts from.
+ *
+ * Order of resolution:
+ *   1. Explicit `mode` argument from the URL query — sales/lettings sub-
+ *      pages always pass this through deriveEffectiveMode.
+ *   2. agent_profiles.last_active_workspace_id — the persisted pick from
+ *      the header workspace switcher, used on mode-neutral pages
+ *      (/agent/drafts, /agent/home, /agent/intelligence).
+ *   3. The agent's default workspace as a final fallback so a
+ *      misconfigured client can't silently leak across workspaces.
+ *
+ * Returns null when no workspace can be resolved (no agent profile, no
+ * workspaces seeded yet). Callers MUST treat null as "no drafts to show",
+ * never as "show everything".
+ */
+export async function resolveSessionWorkspace(
+  supabase: SupabaseClient,
+  authUserId: string,
+  modeHint: WorkspaceMode | null,
+): Promise<ResolvedSessionWorkspace | null> {
+  const { data: profile, error: profileErr } = await supabase
+    .from('agent_profiles')
+    .select('id, tenant_id, last_active_workspace_id')
+    .eq('user_id', authUserId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (profileErr || !profile) return null;
+
+  const { data: workspaces, error: wsErr } = await supabase
+    .from('agent_workspaces')
+    .select('id, mode, is_default')
+    .eq('agent_id', profile.id);
+
+  if (wsErr || !workspaces || workspaces.length === 0) return null;
+
+  // If the URL says lettings/sales explicitly, that wins. The header
+  // pill's persisted pick is only the fallback for mode-neutral routes.
+  let chosen = modeHint
+    ? workspaces.find((w: any) => w.mode === modeHint)
+    : workspaces.find((w: any) => w.id === profile.last_active_workspace_id);
+
+  if (!chosen) {
+    chosen = workspaces.find((w: any) => w.is_default) ?? workspaces[0];
+  }
+
+  if (!chosen) return null;
+
+  return {
+    workspaceId: chosen.id,
+    mode: chosen.mode as WorkspaceMode,
+    agentProfileId: profile.id,
+    tenantId: profile.tenant_id ?? null,
+  };
+}
+
+/**
+ * Resolve the workspace a new draft should be written into.
+ *
+ * Called from every write path so workspace_id is stamped at creation
+ * from the active session, never inferred from the originating record.
+ *
+ * The `mode` argument comes from the chat route's body param (the client
+ * passes the active workspace's mode through), the execute-actions
+ * route's body, etc. Throws when no workspace matches — that's an upstream
+ * bug (e.g. seeding) and we'd rather fail loudly than write a NULL
+ * workspace_id and have it flagged for manual review.
+ */
+export async function resolveWriteWorkspace(
+  supabase: SupabaseClient,
+  authUserId: string,
+  mode: WorkspaceMode,
+): Promise<string> {
+  const resolved = await resolveSessionWorkspace(supabase, authUserId, mode);
+  if (!resolved) {
+    throw new Error(
+      `[workspace-resolution] No ${mode} workspace for user ${authUserId}. ` +
+      `Drafts cannot be written without a workspace.`,
+    );
+  }
+  if (resolved.mode !== mode) {
+    // resolveSessionWorkspace falls back to the default workspace when
+    // the requested mode isn't found. Write paths can't tolerate that
+    // fallback — a lettings draft written into the sales workspace is
+    // exactly the bleed we're fixing.
+    throw new Error(
+      `[workspace-resolution] User ${authUserId} has no workspace with mode=${mode}; ` +
+      `resolver returned ${resolved.mode} instead. Refusing to write.`,
+    );
+  }
+  return resolved.workspaceId;
+}
+
+/**
+ * Server-side tripwire used by the drafts list endpoint and the
+ * by-id endpoint. Every row returned from a workspace-scoped query
+ * MUST already have workspace_id === sessionWorkspaceId; if not, the
+ * SQL filter or RLS policy regressed and we throw rather than silently
+ * filter. Filtering hides the bug; throwing surfaces it the next time
+ * the request runs.
+ */
+export function assertDraftWorkspace<T extends { id: string; workspace_id: string | null }>(
+  rows: T[],
+  sessionWorkspaceId: string,
+): void {
+  for (const row of rows) {
+    if (row.workspace_id !== sessionWorkspaceId) {
+      throw new Error(
+        `[drafts] Tripwire: draft ${row.id} has workspace_id=${row.workspace_id ?? 'null'} ` +
+        `but session workspace is ${sessionWorkspaceId}. Cross-workspace leak detected.`,
+      );
+    }
+  }
+}

--- a/apps/unified-portal/migrations/060_pending_drafts_workspace_id_column.sql
+++ b/apps/unified-portal/migrations/060_pending_drafts_workspace_id_column.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- APPLIED TO PRODUCTION via Supabase MCP on 2026-05-19.
+-- DO NOT RE-RUN. Recorded here for audit / future env bootstrap only.
+-- ============================================================================
+--
+-- Migration: 060_pending_drafts_workspace_id_column.sql
+--
+-- Adds the workspace_id link to pending_drafts so the drafts inbox query
+-- can no longer return a Sales draft to a Lettings session (or vice
+-- versa). Bridge Property Group audit found two Sales offer drafts on
+-- Unit 51 Ardan View (€515k, recipient ailbhe.tierney+u45@example.com)
+-- in the Lettings drafts inbox — one tap from a sales offer reaching a
+-- buyer through the wrong workspace. The root cause: drafts were
+-- partitioned only by draft_type, and `buyer_followup` is a SHARED
+-- type that appears in both workspaces' filters.
+--
+-- This migration is DDL only — column + flag + indexes. No policy
+-- changes, no row updates. Three migrations chained per project
+-- convention so ordering failures don't lose work mid-way:
+--   060: DDL
+--   061: RLS
+--   062: DML backfill + CHECK constraint
+--
+-- workspace_id is nullable for the moment so the backfill in 062 can
+-- run without the column rejecting every existing row. After 062 every
+-- row either has workspace_id set or has needs_workspace_review = true,
+-- enforced by a CHECK constraint added at the end of 062.
+
+ALTER TABLE pending_drafts
+  ADD COLUMN IF NOT EXISTS workspace_id UUID
+    REFERENCES agent_workspaces(id) ON DELETE RESTRICT;
+
+-- Manual-review flag for drafts whose origin is too ambiguous to map to a
+-- workspace conservatively. Stays false on every new write; only the
+-- backfill in 062 sets it to true. Drafts with this flag are excluded
+-- from both workspace inboxes via the workspace_id JOIN in the read
+-- path, so they never bleed while a human triages them.
+ALTER TABLE pending_drafts
+  ADD COLUMN IF NOT EXISTS needs_workspace_review BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_pending_drafts_workspace
+  ON pending_drafts(workspace_id);
+
+-- Partial index supports the hot path: list pending_review drafts for a
+-- given workspace. The drafts inbox endpoint is the only consumer.
+CREATE INDEX IF NOT EXISTS idx_pending_drafts_workspace_status
+  ON pending_drafts(workspace_id, status)
+  WHERE status = 'pending_review';

--- a/apps/unified-portal/migrations/061_pending_drafts_workspace_rls.sql
+++ b/apps/unified-portal/migrations/061_pending_drafts_workspace_rls.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- APPLIED TO PRODUCTION via Supabase MCP on 2026-05-19.
+-- DO NOT RE-RUN. Recorded here for audit / future env bootstrap only.
+-- ============================================================================
+--
+-- Migration: 061_pending_drafts_workspace_rls.sql
+--
+-- Replaces the user-scoped RLS policy with a workspace-scoped one. The
+-- application layer (drafts route + send-draft route + draft-store
+-- writer) is the primary security boundary; this policy is belt-and-
+-- braces for the case where someone queries pending_drafts via
+-- PostgREST without going through the API.
+--
+-- The old policy (pending_drafts_self_access) said `user_id = auth.uid()`.
+-- That's safe for single-workspace users but every Bridge agent has ONE
+-- auth user owning TWO workspaces (sales + lettings). Under the old policy
+-- a user JWT could read every draft on every workspace they own. Under
+-- the new policy the workspace_id must also belong to the calling user's
+-- agent_profile.
+--
+-- Note: the existing pending_drafts_service_role policy (USING (true))
+-- is intentionally left untouched. API routes use the service-role
+-- client and bypass RLS — the application-layer assertion in the read
+-- paths is what enforces active-workspace scoping for those callers.
+
+DROP POLICY IF EXISTS pending_drafts_self_access ON pending_drafts;
+
+CREATE POLICY pending_drafts_self_workspace ON pending_drafts
+  FOR ALL
+  USING (
+    user_id = auth.uid()
+    AND (
+      workspace_id IS NOT NULL
+      AND workspace_id IN (
+        SELECT aw.id
+        FROM agent_workspaces aw
+        JOIN agent_profiles ap ON aw.agent_id = ap.id
+        WHERE ap.user_id = auth.uid()
+      )
+    )
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    AND (
+      workspace_id IS NOT NULL
+      AND workspace_id IN (
+        SELECT aw.id
+        FROM agent_workspaces aw
+        JOIN agent_profiles ap ON aw.agent_id = ap.id
+        WHERE ap.user_id = auth.uid()
+      )
+    )
+  );

--- a/apps/unified-portal/migrations/062_pending_drafts_workspace_backfill.sql
+++ b/apps/unified-portal/migrations/062_pending_drafts_workspace_backfill.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- APPLIED TO PRODUCTION via Supabase MCP on 2026-05-19.
+-- DO NOT RE-RUN. Recorded here for audit / future env bootstrap only.
+-- Backfill results on Bridge Property Group:
+--   total rows before: 4
+--   workspace_assigned after: 4
+--   flagged_for_review: 0
+--   sales / lettings split: 2 / 2
+-- ============================================================================
+--
+-- Migration: 062_pending_drafts_workspace_backfill.sql
+--
+-- Backfills workspace_id on every existing pending_drafts row. Conservative
+-- rules — never guess. Origin signals, in order of priority:
+--
+--   1. Definitive draft_type. lease_renewal, application_invitation,
+--      landlord_statement are lettings-only. The sales-only list mirrors
+--      SALES_DRAFT_TYPES in lib/agent-intelligence/drafts.ts.
+--   2. content_json.affected_record.kind. When draft_type is in the
+--      SHARED bucket (today: buyer_followup), the persisted
+--      affected_record.kind disambiguates: sales_unit/listing → sales,
+--      tenancy/letting_property → lettings.
+--   3. No match → needs_workspace_review = true, workspace_id stays
+--      NULL. These rows are dropped from both inboxes by the
+--      workspace_id JOIN in the new read path.
+--
+-- After the UPDATE, a CHECK constraint locks in the invariant: every row
+-- either has a workspace_id, or carries needs_workspace_review = true.
+-- New writes always set workspace_id (see lib/agent-intelligence/draft-
+-- store.ts and the API routes), so the flag column is only ever set by
+-- this backfill.
+
+WITH inferred AS (
+  SELECT
+    pd.id AS draft_id,
+    pd.tenant_id,
+    pd.user_id,
+    pd.draft_type,
+    pd.content_json,
+    CASE
+      WHEN pd.draft_type IN ('lease_renewal', 'application_invitation', 'landlord_statement')
+        THEN 'lettings'
+      WHEN pd.draft_type IN (
+        'solicitor_chase', 'viewing_followup', 'viewing_proposal',
+        'viewing_record', 'weekly_briefing', 'intelligence_report',
+        'intelligence_answer', 'intelligence_draft', 'schedule_viewing',
+        'vendor_update', 'offer_response', 'price_reduction_notice',
+        'chain_update_to_buyer'
+      )
+        THEN 'sales'
+      WHEN pd.content_json->'affected_record'->>'kind' IN ('sales_unit', 'listing', 'unit')
+        THEN 'sales'
+      WHEN pd.content_json->'affected_record'->>'kind' IN ('tenancy', 'letting_property', 'lettings_property')
+        THEN 'lettings'
+      ELSE NULL
+    END AS inferred_mode
+  FROM pending_drafts pd
+  WHERE pd.workspace_id IS NULL
+),
+resolved AS (
+  SELECT
+    i.draft_id,
+    i.inferred_mode,
+    aw.id AS workspace_id
+  FROM inferred i
+  LEFT JOIN agent_profiles ap ON ap.user_id = i.user_id
+  LEFT JOIN agent_workspaces aw
+    ON aw.agent_id = ap.id
+    AND aw.tenant_id = i.tenant_id
+    AND aw.mode = i.inferred_mode
+)
+UPDATE pending_drafts pd
+SET
+  workspace_id = r.workspace_id,
+  needs_workspace_review = (r.workspace_id IS NULL),
+  updated_at = now()
+FROM resolved r
+WHERE pd.id = r.draft_id;
+
+-- Invariant: every row has a clear workspace decision attached. New
+-- inserts MUST set workspace_id; the backfill is the only path that
+-- ever sets needs_workspace_review.
+ALTER TABLE pending_drafts
+  DROP CONSTRAINT IF EXISTS pending_drafts_workspace_decision_check;
+
+ALTER TABLE pending_drafts
+  ADD CONSTRAINT pending_drafts_workspace_decision_check
+  CHECK (workspace_id IS NOT NULL OR needs_workspace_review = true);

--- a/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-pipeline.test.ts
@@ -125,6 +125,7 @@ describe('draftMessageSkill (Session 6D)', () => {
       userId: SKILL_CTX.userId,
       tenantId: 'tenant-1',
       skill: envelope.skill,
+      workspaceId: 'workspace-test',
     });
     expect(persisted.drafts[0].id).not.toBe(envelope.drafts[0].id); // rewritten
   });

--- a/apps/unified-portal/tests/agent-intelligence/drafts-workspace-isolation.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/drafts-workspace-isolation.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Workspace isolation guard for pending_drafts.
+ *
+ * Regression: Bridge Property Group's Lettings inbox displayed Sales offer
+ * drafts (Unit 51 Ardan View, €515k, recipient ailbhe.tierney+u45@example.com)
+ * because the drafts query partitioned by draft_type and SHARED draft types
+ * (buyer_followup) surfaced in both workspace inboxes.
+ *
+ * Invariants these tests enforce:
+ *   1. assertDraftWorkspace throws when a row's workspace_id doesn't match
+ *      the resolved session workspace — this is the server-side tripwire
+ *      in the drafts list endpoint.
+ *   2. persistSkillEnvelope sets workspace_id on every inserted row from
+ *      the active session's mode, never inferring from the originating
+ *      record after the fact.
+ *   3. resolveWriteWorkspace refuses to fall back to a different mode's
+ *      workspace — writing a lettings draft into the sales workspace is
+ *      exactly the bleed we're fixing.
+ *
+ * Hermetic — stubbed Supabase, no network.
+ */
+
+import {
+  assertDraftWorkspace,
+  resolveSessionWorkspace,
+  resolveWriteWorkspace,
+} from '../../lib/agent-intelligence/workspace-resolution';
+import { persistDraftsForEnvelope } from '../../lib/agent-intelligence/draft-store';
+import type { AgenticSkillEnvelope } from '../../lib/agent-intelligence/envelope';
+
+type Row = Record<string, any>;
+
+function mockSupabase(state: {
+  agent_profiles?: Row[];
+  agent_workspaces?: Row[];
+  pending_drafts?: Row[];
+}) {
+  const data = {
+    agent_profiles: state.agent_profiles ?? [],
+    agent_workspaces: state.agent_workspaces ?? [],
+    pending_drafts: state.pending_drafts ?? [],
+  };
+
+  function qb(table: keyof typeof data) {
+    const filters: Row = {};
+    const builder: any = {
+      eq(col: string, val: any) { filters[col] = val; return builder; },
+      in(col: string, vals: any[]) { filters[`__in_${col}`] = vals; return builder; },
+      order() { return builder; },
+      limit() { return builder; },
+      select() { return builder; },
+      insert(row: Row | Row[]) {
+        const rows = Array.isArray(row) ? row : [row];
+        const inserted = rows.map((r, i) => {
+          const withId = { id: r.id || `row-${data[table].length + 1 + i}`, ...r };
+          data[table].push(withId);
+          return withId;
+        });
+        return {
+          select() {
+            return {
+              single: async () => ({ data: inserted[0], error: null }),
+              then(resolve: any) { return Promise.resolve({ data: inserted, error: null }).then(resolve); },
+            };
+          },
+        };
+      },
+      async single() {
+        const rows = data[table] as Row[];
+        const match = rows.find((r) => match_filters(r, filters)) ?? null;
+        return { data: match, error: null };
+      },
+      async maybeSingle() {
+        const rows = data[table] as Row[];
+        const match = rows.find((r) => match_filters(r, filters)) ?? null;
+        return { data: match, error: null };
+      },
+      then(resolve: any) {
+        const rows = (data[table] as Row[]).filter((r) => match_filters(r, filters));
+        return Promise.resolve({ data: rows, error: null }).then(resolve);
+      },
+    };
+    return builder;
+  }
+
+  function match_filters(r: Row, filters: Row): boolean {
+    return Object.entries(filters).every(([k, v]) =>
+      k.startsWith('__in_') ? (v as any[]).includes(r[k.slice(5)]) : r[k] === v,
+    );
+  }
+
+  return { from: (table: string) => qb(table as any), _data: data } as any;
+}
+
+const TENANT_ID = 'tenant-bridge';
+const AGENT_ID = 'profile-bridge';
+const USER_ID = 'user-bridge';
+const SALES_WORKSPACE = 'ws-sales';
+const LETTINGS_WORKSPACE = 'ws-lettings';
+
+function bridgeState() {
+  return {
+    agent_profiles: [
+      { id: AGENT_ID, user_id: USER_ID, tenant_id: TENANT_ID, last_active_workspace_id: SALES_WORKSPACE },
+    ],
+    agent_workspaces: [
+      { id: SALES_WORKSPACE, agent_id: AGENT_ID, tenant_id: TENANT_ID, mode: 'sales', is_default: true },
+      { id: LETTINGS_WORKSPACE, agent_id: AGENT_ID, tenant_id: TENANT_ID, mode: 'lettings', is_default: false },
+    ],
+  };
+}
+
+describe('assertDraftWorkspace (read-path tripwire)', () => {
+  it('passes silently when every row matches the session workspace', () => {
+    expect(() =>
+      assertDraftWorkspace(
+        [
+          { id: 'd1', workspace_id: SALES_WORKSPACE },
+          { id: 'd2', workspace_id: SALES_WORKSPACE },
+        ],
+        SALES_WORKSPACE,
+      ),
+    ).not.toThrow();
+  });
+
+  it('throws when ANY row leaks a different workspace_id', () => {
+    expect(() =>
+      assertDraftWorkspace(
+        [
+          { id: 'd1', workspace_id: SALES_WORKSPACE },
+          { id: 'd2-leaked', workspace_id: LETTINGS_WORKSPACE },
+        ],
+        SALES_WORKSPACE,
+      ),
+    ).toThrow(/Tripwire.*d2-leaked.*Cross-workspace leak/);
+  });
+
+  it('throws when workspace_id is NULL (pre-backfill rows must never leak)', () => {
+    expect(() =>
+      assertDraftWorkspace(
+        [{ id: 'd-null', workspace_id: null }],
+        SALES_WORKSPACE,
+      ),
+    ).toThrow(/Tripwire.*d-null/);
+  });
+});
+
+describe('resolveSessionWorkspace (mode hint vs persisted active)', () => {
+  it('uses the explicit mode hint when given, ignoring the persisted active workspace', async () => {
+    const supabase = mockSupabase(bridgeState());
+    const session = await resolveSessionWorkspace(supabase, USER_ID, 'lettings');
+    expect(session?.mode).toBe('lettings');
+    expect(session?.workspaceId).toBe(LETTINGS_WORKSPACE);
+  });
+
+  it('falls back to the persisted active workspace when no mode hint is supplied', async () => {
+    const supabase = mockSupabase(bridgeState());
+    const session = await resolveSessionWorkspace(supabase, USER_ID, null);
+    expect(session?.mode).toBe('sales');
+    expect(session?.workspaceId).toBe(SALES_WORKSPACE);
+  });
+
+  it('returns null for an unknown user (no profile)', async () => {
+    const supabase = mockSupabase(bridgeState());
+    const session = await resolveSessionWorkspace(supabase, 'unknown-user', null);
+    expect(session).toBeNull();
+  });
+});
+
+describe('resolveWriteWorkspace (write-path scope)', () => {
+  it('returns the matching workspace_id for the requested mode', async () => {
+    const supabase = mockSupabase(bridgeState());
+    const wsId = await resolveWriteWorkspace(supabase, USER_ID, 'lettings');
+    expect(wsId).toBe(LETTINGS_WORKSPACE);
+  });
+
+  it('refuses to fall back when the requested mode does not exist for this user', async () => {
+    const stateNoLettings = {
+      agent_profiles: bridgeState().agent_profiles,
+      agent_workspaces: [
+        { id: SALES_WORKSPACE, agent_id: AGENT_ID, tenant_id: TENANT_ID, mode: 'sales', is_default: true },
+      ],
+    };
+    const supabase = mockSupabase(stateNoLettings);
+    await expect(resolveWriteWorkspace(supabase, USER_ID, 'lettings')).rejects.toThrow(
+      /no workspace with mode=lettings/,
+    );
+  });
+});
+
+describe('persistSkillEnvelope (write-path workspace stamping)', () => {
+  it('stamps workspace_id on every inserted row from the agentContext mode', async () => {
+    const supabase = mockSupabase(bridgeState());
+    const envelope: AgenticSkillEnvelope = {
+      skill: 'draft_message',
+      summary: 'Drafted one email.',
+      coverage: 'ok',
+      drafts: [
+        {
+          id: 'tmp-1',
+          type: 'email',
+          subject: 'Test',
+          body: 'Body',
+          recipient: { name: 'Test', email: 'test@example.com', role: 'buyer' },
+          affected_record: { id: 'unit-1', kind: 'sales_unit', label: 'Unit 1' },
+          reasoning: 'because',
+        } as any,
+      ],
+      meta: {},
+    };
+    await persistDraftsForEnvelope(supabase, envelope, {
+      userId: USER_ID,
+      tenantId: TENANT_ID,
+      skill: 'draft_message',
+      workspaceId: LETTINGS_WORKSPACE,
+    });
+    const inserted = supabase._data.pending_drafts as Row[];
+    expect(inserted.length).toBe(1);
+    expect(inserted[0].workspace_id).toBe(LETTINGS_WORKSPACE);
+  });
+});

--- a/apps/unified-portal/tests/agent-intelligence/orchestration.test.ts
+++ b/apps/unified-portal/tests/agent-intelligence/orchestration.test.ts
@@ -31,6 +31,8 @@ interface MockState {
   pending_drafts: Row[];
   viewing_audit_log: Row[];
   developments?: Row[];
+  agent_profiles?: Row[];
+  agent_workspaces?: Row[];
   /** Tables that should throw on any write. */
   failingTables?: Set<string>;
 }
@@ -44,6 +46,17 @@ function makeSupabase(state: MockState) {
     pending_drafts: state.pending_drafts,
     viewing_audit_log: state.viewing_audit_log,
     developments: state.developments ?? [],
+    // Default workspace seed so resolveWriteWorkspace inside the voice-
+    // capture write path succeeds. Tests can override by supplying their
+    // own rows; otherwise auth-1 owns one sales workspace + one lettings
+    // workspace under tenant-1.
+    agent_profiles: state.agent_profiles ?? [
+      { id: 'profile-1', user_id: 'auth-1', tenant_id: 'tenant-1', last_active_workspace_id: 'ws-sales-1' },
+    ],
+    agent_workspaces: state.agent_workspaces ?? [
+      { id: 'ws-sales-1', agent_id: 'profile-1', tenant_id: 'tenant-1', mode: 'sales', is_default: true },
+      { id: 'ws-lettings-1', agent_id: 'profile-1', tenant_id: 'tenant-1', mode: 'lettings', is_default: false },
+    ],
   };
 
   function qb(table: string) {


### PR DESCRIPTION
## Summary
Fixes a critical data isolation bug where drafts from one workspace (e.g., Sales) were visible in another workspace's inbox (e.g., Lettings). The root cause was partitioning drafts by `draft_type` rather than `workspace_id` — the shared `buyer_followup` type appeared in both workspace filters, causing cross-workspace bleed.

## Key Changes

**Database Schema (Migrations 060–062)**
- Added `workspace_id` column to `pending_drafts` with foreign key to `agent_workspaces`
- Added `needs_workspace_review` flag for ambiguous rows during backfill
- Replaced user-scoped RLS policy with workspace-scoped policy that validates both `user_id` and `workspace_id` membership
- Backfilled all existing rows conservatively using draft type and `affected_record.kind` signals; rows that couldn't be mapped are flagged for manual review

**Workspace Resolution Layer** (`lib/agent-intelligence/workspace-resolution.ts`)
- `resolveSessionWorkspace()` — resolves the workspace for read operations, respecting explicit `mode` query param or falling back to agent's persisted `last_active_workspace_id`
- `resolveWriteWorkspace()` — resolves the workspace for write operations; throws if the requested mode doesn't exist (prevents fallback to wrong workspace)
- `assertDraftWorkspace()` — server-side tripwire that throws if any returned row's `workspace_id` doesn't match the session workspace (defence-in-depth against SQL/RLS regressions)

**API Routes**
- `/api/agent/intelligence/drafts` — now filters by `workspace_id` instead of `draft_type`; calls `assertDraftWorkspace()` on all returned rows
- `/api/agent/intelligence/drafts/[id]` — returns 404 for cross-workspace fetches (not 403, so workspace existence isn't leaked)
- `/api/agent/intelligence/send-draft` — validates draft belongs to session workspace before mutation
- `/api/agent/intelligence/execute-actions` — accepts `mode` in request body and resolves workspace at write time
- `/api/agent/intelligence/capability-chips` — scopes drafts count to active workspace

**Draft Persistence** (`lib/agent-intelligence/draft-store.ts`)
- `SkillPersistContext` now requires `workspaceId` (non-nullable)
- All draft inserts stamp `workspace_id` from the active session at write time, never inferred from originating record

**Write Paths**
- Voice capture, broadcast, and skill envelope persistence all call `resolveWriteWorkspace()` to stamp the correct workspace before inserting
- Removed `draftTypesForMode()` helper and related type constants — no longer needed at runtime

**Tests**
- Added comprehensive test suite (`drafts-workspace-isolation.test.ts`) covering read-path tripwire, session resolution, and write-path workspace stamping
- Updated existing tests to seed workspace tables

## Implementation Details
- The `mode` parameter is now the primary workspace selector; it comes from URL query params (`?mode=sales|lettings`) on read paths and request body on write paths
- Workspace resolution is centralized so all callers (drafts list, send, execute-actions, broadcast, voice capture) use the same logic
- The tripwire assertion in the read path will throw loudly if the SQL filter or RLS policy regresses, surfacing the bug immediately rather than silently filtering
- Drafts with ambiguous origins are excluded from both inboxes via the `workspace_id` JOIN, preventing bleed while humans triage them

https://claude.ai/code/session_01LqjcZrpUfcuAV7E8ztmLLs