### PR TITLE
feat(assistant-v2): Sprint 1 server routes and placeholder analysis

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -112,6 +112,12 @@ ENABLE_CHAT_HISTORY=true
 ENABLE_THEME_CUSTOMIZATION=true
 ENABLE_QR_ONBOARDING=true
 
+# Assistant V2 image upload (Sprint 1). Default off in production.
+# Enable per tenant during testing. When false the attachment button does
+# not render and the /api/assistant/* multimodal routes return 404.
+FEATURE_ASSISTANT_IMAGE_UPLOAD=false
+NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
+
 # ----------------------------------------------------------------
 # Rate Limiting
 # ----------------------------------------------------------------

--- a/apps/unified-portal/.env.example
+++ b/apps/unified-portal/.env.example
@@ -69,6 +69,16 @@ OPENAI_API_KEY=sk-your-openai-key-here
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 
 # ═══════════════════════════════════════════════════════════════════════════
+# FEATURE FLAGS
+# ═══════════════════════════════════════════════════════════════════════════
+# Assistant V2 image upload (Sprint 1). Default off in production.
+# Enable for the Longview Estates and Solas Renewables demo tenants only
+# during initial testing. When false, the attachment button does not render
+# and the /api/assistant/* multimodal routes return 404.
+FEATURE_ASSISTANT_IMAGE_UPLOAD=false
+NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
+
+# ═══════════════════════════════════════════════════════════════════════════
 # APPLICATION
 # ═══════════════════════════════════════════════════════════════════════════
 NODE_ENV=development

--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -1,0 +1,198 @@
+/**
+ * POST /api/assistant/chat/multimodal
+ *
+ * Assistant V2 Sprint 1. Entry point for chat messages that include
+ * media. The existing text-only chat route (/api/chat) stays untouched.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-1.md section 5.3.
+ *
+ * Sprint 1 scope:
+ *   1. Verify the caller's tenant via lib/assistant/media-auth.
+ *   2. Load the assistant_media rows referenced by media_ids and confirm
+ *      every row belongs to the verified tenant. Cross-tenant media in
+ *      the payload returns 403.
+ *   3. Run the placeholder mediaAnalysisService.analyse. This persists
+ *      one row in assistant_media_analysis with model_provider =
+ *      'placeholder'.
+ *   4. Return { message, analysis_id, action }. The decision engine and
+ *      issue-report creation are explicitly deferred to Sprint 1b.
+ *
+ * Gated on FEATURE_ASSISTANT_IMAGE_UPLOAD. With the flag off this route
+ * returns 404 before any work happens.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isAssistantImageUploadEnabled } from '@/lib/feature-flags';
+import {
+  resolveMediaAuth,
+  mediaAuthErrorToResponse,
+  featureDisabledResponse,
+  MediaAuthError,
+} from '@/lib/assistant/media-auth';
+import { analyse } from '@/lib/assistant/mediaAnalysisService';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_MEDIA_PER_MESSAGE = 6;
+const MAX_MESSAGE_LENGTH = 4000;
+
+interface MultimodalBody {
+  conversation_id?: unknown;
+  message_text?: unknown;
+  media_ids?: unknown;
+  unit_id?: unknown;
+  message_id?: unknown;
+}
+
+function isUuidArray(v: unknown): v is string[] {
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((s) => typeof s === 'string' && UUID_RE.test(s))
+  );
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAssistantImageUploadEnabled()) {
+    return featureDisabledResponse();
+  }
+
+  let body: MultimodalBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const conversationId = typeof body.conversation_id === 'string' ? body.conversation_id : '';
+  const messageText = typeof body.message_text === 'string' ? body.message_text : '';
+  const requestedUnitId = typeof body.unit_id === 'string' ? body.unit_id : null;
+  const providedMessageId = typeof body.message_id === 'string' ? body.message_id : null;
+
+  if (!UUID_RE.test(conversationId)) {
+    return NextResponse.json({ error: 'conversation_id is required' }, { status: 400 });
+  }
+  if (!isUuidArray(body.media_ids)) {
+    return NextResponse.json({ error: 'media_ids is required' }, { status: 400 });
+  }
+  const mediaIds: string[] = Array.from(new Set(body.media_ids));
+  if (mediaIds.length > MAX_MEDIA_PER_MESSAGE) {
+    return NextResponse.json(
+      { error: 'You can attach up to 6 photos per message.' },
+      { status: 400 },
+    );
+  }
+  if (messageText.length > MAX_MESSAGE_LENGTH) {
+    return NextResponse.json(
+      { error: 'Message text is too long.' },
+      { status: 400 },
+    );
+  }
+  if (providedMessageId && !UUID_RE.test(providedMessageId)) {
+    return NextResponse.json({ error: 'message_id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveMediaAuth(request, {
+      unitId: requestedUnitId,
+      requireUnit: true,
+    });
+  } catch (err) {
+    if (err instanceof MediaAuthError) return mediaAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (!auth.developmentId) {
+    return NextResponse.json(
+      { error: 'Unit is not linked to a development' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data: mediaRows, error: mediaErr } = await supabase
+    .from('assistant_media')
+    .select('id, tenant_id, unit_id, conversation_id, message_id')
+    .in('id', mediaIds);
+
+  if (mediaErr) {
+    console.error(
+      '[assistant-chat-multimodal] media_lookup_failed reason=%s',
+      mediaErr.message,
+    );
+    return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+  }
+
+  if (!mediaRows || mediaRows.length !== mediaIds.length) {
+    return NextResponse.json({ error: 'One or more media not found' }, { status: 404 });
+  }
+
+  for (const m of mediaRows) {
+    if (m.tenant_id !== auth.tenantId) {
+      console.warn(
+        '[assistant-chat-multimodal] CROSS_TENANT_MEDIA media_id=%s caller_tenant=%s media_tenant=%s',
+        m.id,
+        auth.tenantId,
+        m.tenant_id,
+      );
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (m.conversation_id && m.conversation_id !== conversationId) {
+      return NextResponse.json(
+        { error: 'Media belongs to a different conversation' },
+        { status: 400 },
+      );
+    }
+    if (auth.unitId && m.unit_id && m.unit_id !== auth.unitId) {
+      return NextResponse.json(
+        { error: 'Media belongs to a different unit' },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Use the message_id supplied in the body if any, otherwise reuse the
+  // message_id the upload route stamped on the media rows (they all share
+  // one in normal flows). Last resort, mint a fresh uuid.
+  const messageId =
+    providedMessageId ??
+    (mediaRows[0]?.message_id as string | null | undefined) ??
+    randomUUID();
+
+  let result;
+  try {
+    result = await analyse({
+      tenantId: auth.tenantId,
+      developmentId: auth.developmentId,
+      unitId: auth.unitId,
+      conversationId,
+      messageId,
+      userId: auth.userId,
+      userMessage: messageText,
+      mediaIds,
+    });
+  } catch (err) {
+    console.error(
+      '[assistant-chat-multimodal] analyse_failed reason=%s',
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json(
+      { error: 'Could not analyse the photo. Try again.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    message: result.residentMessage,
+    analysis_id: result.analysisId,
+    action: result.action,
+    message_id: messageId,
+    conversation_id: conversationId,
+  });
+}

--- a/apps/unified-portal/app/api/assistant/media/signed-url/route.ts
+++ b/apps/unified-portal/app/api/assistant/media/signed-url/route.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /api/assistant/media/signed-url
+ *
+ * Assistant V2 Sprint 1. Return a fresh signed URL pair (original +
+ * thumbnail) for an assistant_media row that the caller is authorised
+ * to read.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-1.md section 5.2.
+ *
+ * Auth. The caller's tenant is verified via lib/assistant/media-auth.
+ * The media row's tenant is then cross-checked against the verified
+ * tenant. Cross-tenant access is the named cross-tenant block in
+ * the acceptance criteria; it returns 403.
+ *
+ * Gated on FEATURE_ASSISTANT_IMAGE_UPLOAD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isAssistantImageUploadEnabled } from '@/lib/feature-flags';
+import {
+  resolveMediaAuth,
+  mediaAuthErrorToResponse,
+  featureDisabledResponse,
+  MediaAuthError,
+} from '@/lib/assistant/media-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const BUCKET = 'assistant-media';
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(request: NextRequest) {
+  if (!isAssistantImageUploadEnabled()) {
+    return featureDisabledResponse();
+  }
+
+  let body: { media_id?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const mediaId = typeof body.media_id === 'string' ? body.media_id : '';
+  if (!UUID_RE.test(mediaId)) {
+    return NextResponse.json({ error: 'media_id is required' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveMediaAuth(request);
+  } catch (err) {
+    if (err instanceof MediaAuthError) return mediaAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data: media, error: mediaErr } = await supabase
+    .from('assistant_media')
+    .select('id, tenant_id, unit_id, storage_path, thumbnail_path')
+    .eq('id', mediaId)
+    .maybeSingle();
+
+  if (mediaErr || !media) {
+    return NextResponse.json({ error: 'Media not found' }, { status: 404 });
+  }
+
+  if (media.tenant_id !== auth.tenantId) {
+    console.warn(
+      '[assistant-media-signed-url] CROSS_TENANT_ACCESS media_id=%s caller_tenant=%s media_tenant=%s caller_type=%s',
+      mediaId,
+      auth.tenantId,
+      media.tenant_id,
+      auth.callerType,
+    );
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  // Homeowner callers may only fetch media bound to their own unit. Admins
+  // (with a tenant-wide session) can fetch any media in their tenant; the
+  // developer dashboard is the named consumer in the spec.
+  if (auth.callerType === 'homeowner' && auth.unitId && media.unit_id !== auth.unitId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: signed, error: signedErr } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(media.storage_path as string, SIGNED_URL_TTL_SECONDS);
+  if (signedErr || !signed?.signedUrl) {
+    console.error(
+      '[assistant-media-signed-url] sign_failed media_id=%s reason=%s',
+      mediaId,
+      signedErr?.message,
+    );
+    return NextResponse.json({ error: 'Could not sign media URL' }, { status: 500 });
+  }
+
+  let thumbnailUrl = signed.signedUrl;
+  if (media.thumbnail_path) {
+    const { data: thumbSigned } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(media.thumbnail_path as string, SIGNED_URL_TTL_SECONDS);
+    if (thumbSigned?.signedUrl) thumbnailUrl = thumbSigned.signedUrl;
+  }
+
+  const expiresAt = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+
+  return NextResponse.json({
+    media_id: mediaId,
+    signed_url: signed.signedUrl,
+    thumbnail_url: thumbnailUrl,
+    expires_at: expiresAt,
+  });
+}

--- a/apps/unified-portal/app/api/assistant/media/upload/route.ts
+++ b/apps/unified-portal/app/api/assistant/media/upload/route.ts
@@ -1,0 +1,344 @@
+/**
+ * POST /api/assistant/media/upload
+ *
+ * Assistant V2 Sprint 1. Accepts a multipart upload of one to six image
+ * files, validates each, generates a server-side thumbnail, persists an
+ * assistant_media row per file, and returns signed URLs for both the
+ * original and the thumbnail.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-1.md sections 4 and 5.1.
+ *
+ * Auth. Two caller types supported via lib/assistant/media-auth:
+ *   - homeowner via x-qr-token header (tenant_id derived from the unit
+ *     bound to the token, not from the request body)
+ *   - admin via Supabase session cookie (tenant_id from the admins row)
+ *
+ * Storage paths follow:
+ *   {tenant_id}/{development_id}/{unit_id}/{conversation_id}/{media_id}.{ext}
+ *   {tenant_id}/{development_id}/{unit_id}/{conversation_id}/thumbnails/{media_id}.jpg
+ *
+ * All new behaviour is gated on FEATURE_ASSISTANT_IMAGE_UPLOAD. With the
+ * flag off the route returns 404 before any auth or DB work happens.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import sharp from 'sharp';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isAssistantImageUploadEnabled } from '@/lib/feature-flags';
+import {
+  resolveMediaAuth,
+  mediaAuthErrorToResponse,
+  featureDisabledResponse,
+  MediaAuthError,
+} from '@/lib/assistant/media-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const BUCKET = 'assistant-media';
+const MAX_FILES_PER_REQUEST = 6;
+const MAX_BYTES = 25 * 1024 * 1024;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const THUMBNAIL_LONGEST_EDGE = 800;
+const THUMBNAIL_JPEG_QUALITY = 80;
+const UPLOADS_PER_USER_PER_HOUR = 20;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ALLOWED_MIME = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+]);
+
+const EXT_FOR_MIME: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/heic': 'heic',
+};
+
+interface RateBucket {
+  count: number;
+  resetAt: number;
+}
+const uploadRateBuckets = new Map<string, RateBucket>();
+function checkUploadRate(key: string): boolean {
+  const now = Date.now();
+  const entry = uploadRateBuckets.get(key);
+  if (!entry || now > entry.resetAt) {
+    uploadRateBuckets.set(key, { count: 1, resetAt: now + 60 * 60 * 1000 });
+    return true;
+  }
+  if (entry.count >= UPLOADS_PER_USER_PER_HOUR) return false;
+  entry.count += 1;
+  return true;
+}
+
+interface UploadOutcome {
+  media_id: string;
+  signed_url: string;
+  thumbnail_url: string;
+  width: number | null;
+  height: number | null;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAssistantImageUploadEnabled()) {
+    return featureDisabledResponse();
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 });
+  }
+
+  const conversationId = String(form.get('conversation_id') ?? '');
+  const messageIdRaw = form.get('message_id');
+  const unitIdRaw = form.get('unit_id');
+  const requestedUnitId = typeof unitIdRaw === 'string' && unitIdRaw ? unitIdRaw : null;
+  const messageId =
+    typeof messageIdRaw === 'string' && messageIdRaw ? messageIdRaw : randomUUID();
+
+  if (!UUID_RE.test(conversationId)) {
+    return NextResponse.json({ error: 'conversation_id is required' }, { status: 400 });
+  }
+  if (!UUID_RE.test(messageId)) {
+    return NextResponse.json({ error: 'message_id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveMediaAuth(request, {
+      unitId: requestedUnitId,
+      requireUnit: true,
+    });
+  } catch (err) {
+    if (err instanceof MediaAuthError) return mediaAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (!auth.developmentId) {
+    return NextResponse.json(
+      { error: 'Unit is not linked to a development' },
+      { status: 400 },
+    );
+  }
+
+  const rateKey = `${auth.tenantId}:${auth.userId ?? auth.unitId ?? 'anon'}`;
+  if (!checkUploadRate(rateKey)) {
+    return NextResponse.json(
+      { error: 'Upload limit reached. Try again later.' },
+      { status: 429 },
+    );
+  }
+
+  const files = form.getAll('files').filter((v): v is File => v instanceof File);
+  if (files.length === 0) {
+    return NextResponse.json({ error: 'Attach at least one photo.' }, { status: 400 });
+  }
+  if (files.length > MAX_FILES_PER_REQUEST) {
+    return NextResponse.json(
+      { error: 'You can attach up to 6 photos per message.' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdmin();
+  const outcomes: UploadOutcome[] = [];
+  const writtenObjects: string[] = [];
+
+  try {
+    for (const file of files) {
+      if (file.size === 0) {
+        return NextResponse.json({ error: 'One of the files was empty.' }, { status: 400 });
+      }
+      if (file.size > MAX_BYTES) {
+        return NextResponse.json(
+          { error: 'That photo is too large. Try one under 25 MB.' },
+          { status: 400 },
+        );
+      }
+      const mimeType = (file.type || '').toLowerCase();
+      if (!ALLOWED_MIME.has(mimeType)) {
+        return NextResponse.json(
+          { error: "That file type isn't supported. Try a JPG, PNG, or HEIC." },
+          { status: 400 },
+        );
+      }
+
+      const buffer = Buffer.from(await file.arrayBuffer());
+
+      // Read dimensions; HEIC files may not have parseable metadata via sharp
+      // without libheif. We capture whatever sharp gives us and never fail
+      // the upload over missing dimensions alone.
+      let width: number | null = null;
+      let height: number | null = null;
+      try {
+        const meta = await sharp(buffer).metadata();
+        width = typeof meta.width === 'number' ? meta.width : null;
+        height = typeof meta.height === 'number' ? meta.height : null;
+      } catch {
+        // Leave dimensions null; the analysis pipeline reads pixels itself.
+      }
+
+      // Thumbnail: max 800px on the longest edge, JPEG q80, EXIF stripped.
+      // sharp().jpeg() strips metadata by default (does not call
+      // withMetadata()), which is what we want.
+      let thumbnailBuffer: Buffer | null = null;
+      try {
+        thumbnailBuffer = await sharp(buffer)
+          .rotate()
+          .resize({
+            width: THUMBNAIL_LONGEST_EDGE,
+            height: THUMBNAIL_LONGEST_EDGE,
+            fit: 'inside',
+            withoutEnlargement: true,
+          })
+          .jpeg({ quality: THUMBNAIL_JPEG_QUALITY })
+          .toBuffer();
+      } catch (thumbErr) {
+        // HEIC without libheif at runtime will land here. The original is
+        // still useful for Sprint 1b analysis, so we proceed but log it.
+        console.warn(
+          '[assistant-media-upload] thumbnail_failed mime=%s reason=%s',
+          mimeType,
+          thumbErr instanceof Error ? thumbErr.message : String(thumbErr),
+        );
+      }
+
+      const mediaId = randomUUID();
+      const ext = EXT_FOR_MIME[mimeType] ?? 'bin';
+      const basePath = `${auth.tenantId}/${auth.developmentId}/${auth.unitId}/${conversationId}`;
+      const originalPath = `${basePath}/${mediaId}.${ext}`;
+      const thumbnailPath = thumbnailBuffer
+        ? `${basePath}/thumbnails/${mediaId}.jpg`
+        : null;
+
+      const { error: originalErr } = await supabase.storage
+        .from(BUCKET)
+        .upload(originalPath, buffer, {
+          contentType: mimeType,
+          upsert: false,
+        });
+      if (originalErr) {
+        console.error(
+          '[assistant-media-upload] storage_failed path=%s reason=%s',
+          originalPath,
+          originalErr.message,
+        );
+        return NextResponse.json(
+          { error: 'Could not save that photo. Try again.' },
+          { status: 500 },
+        );
+      }
+      writtenObjects.push(originalPath);
+
+      if (thumbnailBuffer && thumbnailPath) {
+        const { error: thumbErr } = await supabase.storage
+          .from(BUCKET)
+          .upload(thumbnailPath, thumbnailBuffer, {
+            contentType: 'image/jpeg',
+            upsert: false,
+          });
+        if (thumbErr) {
+          console.warn(
+            '[assistant-media-upload] thumbnail_upload_failed path=%s reason=%s',
+            thumbnailPath,
+            thumbErr.message,
+          );
+        } else {
+          writtenObjects.push(thumbnailPath);
+        }
+      }
+
+      const { error: insertErr } = await supabase
+        .from('assistant_media')
+        .insert({
+          id: mediaId,
+          tenant_id: auth.tenantId,
+          development_id: auth.developmentId,
+          unit_id: auth.unitId,
+          user_id: auth.userId,
+          conversation_id: conversationId,
+          message_id: messageId,
+          media_type: 'image',
+          storage_path: originalPath,
+          thumbnail_path: thumbnailPath,
+          mime_type: mimeType,
+          file_size_bytes: file.size,
+          width,
+          height,
+        });
+      if (insertErr) {
+        console.error(
+          '[assistant-media-upload] insert_failed media_id=%s reason=%s',
+          mediaId,
+          insertErr.message,
+        );
+        return NextResponse.json(
+          { error: 'Could not save that photo. Try again.' },
+          { status: 500 },
+        );
+      }
+
+      const { data: signed, error: signedErr } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(originalPath, SIGNED_URL_TTL_SECONDS);
+      if (signedErr || !signed?.signedUrl) {
+        console.error(
+          '[assistant-media-upload] sign_failed path=%s reason=%s',
+          originalPath,
+          signedErr?.message,
+        );
+        return NextResponse.json(
+          { error: 'Could not finalize the upload. Try again.' },
+          { status: 500 },
+        );
+      }
+
+      let thumbnailUrl = signed.signedUrl;
+      if (thumbnailPath) {
+        const { data: thumbSigned } = await supabase.storage
+          .from(BUCKET)
+          .createSignedUrl(thumbnailPath, SIGNED_URL_TTL_SECONDS);
+        if (thumbSigned?.signedUrl) thumbnailUrl = thumbSigned.signedUrl;
+      }
+
+      outcomes.push({
+        media_id: mediaId,
+        signed_url: signed.signedUrl,
+        thumbnail_url: thumbnailUrl,
+        width,
+        height,
+      });
+    }
+  } catch (err) {
+    // Best-effort rollback of storage objects written before the failure.
+    // The DB rows (if any) stay; they have RLS off and storage_path nulled
+    // would be more disruptive than leaving an orphan that future cleanup
+    // will catch. Storage objects are the larger waste.
+    for (const path of writtenObjects) {
+      await supabase.storage.from(BUCKET).remove([path]).catch(() => null);
+    }
+    console.error(
+      '[assistant-media-upload] unexpected reason=%s',
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json(
+      { error: 'Could not upload the photo. Try again.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    message_id: messageId,
+    conversation_id: conversationId,
+    unit_id: auth.unitId,
+    media: outcomes,
+  });
+}

--- a/apps/unified-portal/lib/assistant/media-auth.ts
+++ b/apps/unified-portal/lib/assistant/media-auth.ts
@@ -1,0 +1,189 @@
+/**
+ * Tenant verification for Assistant V2 media routes (Sprint 1).
+ *
+ * Two caller types are supported and must be told apart from the request
+ * itself. Never trust a client-supplied tenant_id.
+ *
+ * 1. Homeowner (resident). Authenticates with an x-qr-token header. We
+ *    validate the signed QR token, derive the units.id from it, then look
+ *    up tenant_id and development_id from the units row. The caller-supplied
+ *    unit_id (if any) must match the token-bound unit, otherwise 403.
+ *
+ * 2. Installer / developer / admin. Authenticates with a Supabase admin
+ *    session cookie. We resolve tenant_id from the admins row. The caller-
+ *    supplied unit_id (if any) must belong to that tenant, otherwise 403.
+ *
+ * Both code paths return the same MediaAuthContext shape so route handlers
+ * stay short. Routes that need a unit_id (uploads, multimodal chat) ask
+ * for it explicitly; routes that don't (signed-url) skip the unit check.
+ *
+ * This is deliberately a thin, additive helper. It does not replace the
+ * existing care-session or admin-session helpers. It exists because the
+ * three new assistant routes need a single auth boundary that handles both
+ * homeowner and admin callers, and embedding that logic in each route
+ * would invite drift.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { validateQRToken } from '@openhouse/api/qr-tokens';
+import { getSupabaseAdmin, getServerSession } from '@/lib/supabase-server';
+import type { AdminSession } from '@/lib/supabase-server';
+
+export type MediaCallerType = 'homeowner' | 'admin';
+
+export interface MediaAuthContext {
+  callerType: MediaCallerType;
+  tenantId: string;
+  developmentId: string | null;
+  unitId: string | null;
+  userId: string | null;
+  adminSession: AdminSession | null;
+}
+
+export type MediaAuthErrorCode =
+  | 'unauthenticated'
+  | 'forbidden'
+  | 'invalid_unit'
+  | 'cross_tenant_unit';
+
+export class MediaAuthError extends Error {
+  constructor(public code: MediaAuthErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = 'MediaAuthError';
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface UnitRow {
+  id: string;
+  tenant_id: string | null;
+  development_id: string | null;
+}
+
+async function loadUnit(unitId: string): Promise<UnitRow | null> {
+  if (!UUID_RE.test(unitId)) return null;
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('units')
+    .select('id, tenant_id, development_id')
+    .eq('id', unitId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data as UnitRow;
+}
+
+/**
+ * Resolve and verify the caller. If a unit_id is provided, the returned
+ * context's tenant_id and development_id are taken from the unit (cross-
+ * checked against the caller's verified tenant). If no unit_id is given,
+ * tenant_id falls back to the caller's verified tenant and development_id
+ * is null.
+ *
+ * Throws MediaAuthError; the route should convert to a response via
+ * mediaAuthErrorToResponse.
+ */
+export async function resolveMediaAuth(
+  request: NextRequest,
+  opts: { unitId?: string | null; requireUnit?: boolean } = {},
+): Promise<MediaAuthContext> {
+  const { unitId: requestedUnitId = null, requireUnit = false } = opts;
+
+  if (requestedUnitId && !UUID_RE.test(requestedUnitId)) {
+    throw new MediaAuthError('invalid_unit');
+  }
+
+  const qrToken = request.headers.get('x-qr-token');
+
+  if (qrToken) {
+    const payload = await validateQRToken(qrToken).catch(() => null);
+    if (!payload?.supabaseUnitId) {
+      throw new MediaAuthError('unauthenticated');
+    }
+
+    const unit = await loadUnit(payload.supabaseUnitId);
+    if (!unit || !unit.tenant_id) {
+      throw new MediaAuthError('invalid_unit');
+    }
+
+    if (requestedUnitId && requestedUnitId !== unit.id) {
+      throw new MediaAuthError('cross_tenant_unit');
+    }
+
+    if (requireUnit && !unit.id) {
+      throw new MediaAuthError('invalid_unit');
+    }
+
+    return {
+      callerType: 'homeowner',
+      tenantId: unit.tenant_id,
+      developmentId: unit.development_id,
+      unitId: unit.id,
+      userId: null,
+      adminSession: null,
+    };
+  }
+
+  const session = await getServerSession();
+  if (!session) {
+    throw new MediaAuthError('unauthenticated');
+  }
+  if (!session.tenantId) {
+    throw new MediaAuthError('forbidden');
+  }
+
+  if (!requestedUnitId) {
+    if (requireUnit) {
+      throw new MediaAuthError('invalid_unit');
+    }
+    return {
+      callerType: 'admin',
+      tenantId: session.tenantId,
+      developmentId: null,
+      unitId: null,
+      userId: session.id,
+      adminSession: session,
+    };
+  }
+
+  const unit = await loadUnit(requestedUnitId);
+  if (!unit || !unit.tenant_id) {
+    throw new MediaAuthError('invalid_unit');
+  }
+  if (unit.tenant_id !== session.tenantId) {
+    throw new MediaAuthError('cross_tenant_unit');
+  }
+
+  return {
+    callerType: 'admin',
+    tenantId: unit.tenant_id,
+    developmentId: unit.development_id,
+    unitId: unit.id,
+    userId: session.id,
+    adminSession: session,
+  };
+}
+
+/**
+ * Map a MediaAuthError to a NextResponse. Cross-tenant attempts are
+ * surfaced as 403 (not 404) because the spec's acceptance criteria
+ * require an explicit 403 to confirm tenant isolation.
+ */
+export function mediaAuthErrorToResponse(err: MediaAuthError): NextResponse {
+  if (err.code === 'unauthenticated') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (err.code === 'invalid_unit') {
+    return NextResponse.json({ error: 'Unit not found' }, { status: 404 });
+  }
+  return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+}
+
+/**
+ * Return a fresh 404 NextResponse when the feature flag is off. Routes
+ * call this as the very first line so the surface area of the disabled
+ * feature is exactly zero (no parse, no auth, no DB).
+ */
+export function featureDisabledResponse(): NextResponse {
+  return NextResponse.json({ error: 'Not found' }, { status: 404 });
+}

--- a/apps/unified-portal/lib/assistant/mediaAnalysisService.ts
+++ b/apps/unified-portal/lib/assistant/mediaAnalysisService.ts
@@ -1,0 +1,217 @@
+/**
+ * mediaAnalysisService. Sprint 1 placeholder.
+ *
+ * Real multimodal analysis lands in Sprint 1b. Only the body of `analyse`
+ * changes then. The exported interface (MediaAnalysisInput, StructuredAnalysis,
+ * MediaAnalysisResult) and the persistence shape stay stable so the routes,
+ * UI, and downstream consumers do not need to move when the real model is
+ * wired in.
+ *
+ * For now the service returns a safe stub:
+ *   - residentMessage is the canonical placeholder copy from the spec
+ *   - structured fields are all neutral defaults
+ *   - action is always 'answer_only' (no issue creation, no escalation)
+ *   - a row is persisted to assistant_media_analysis with
+ *     model_provider = 'placeholder' so the UI and dashboards can be wired
+ *     end to end against real database state.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+
+export type AssistantAction =
+  | 'answer_only'
+  | 'ask_for_more_info'
+  | 'log_issue_memory'
+  | 'create_issue_report'
+  | 'escalate_issue'
+  | 'flag_for_human_review';
+
+export type SeverityLabel = 'low' | 'medium' | 'high' | 'urgent';
+export type EscalationLevel = 'none' | 'developer_notify' | 'urgent';
+
+export interface MediaAnalysisInput {
+  tenantId: string;
+  developmentId: string;
+  unitId: string | null;
+  conversationId: string;
+  messageId: string;
+  userId: string | null;
+  userMessage: string;
+  mediaIds: string[];
+}
+
+export interface StructuredAnalysis {
+  issue_type: string | null;
+  issue_category: string | null;
+  room: string | null;
+  visible_features: string[];
+  severity_score: number | null;
+  severity_label: SeverityLabel | null;
+  confidence_score: number | null;
+  safety_risk: boolean;
+  safety_risk_type: string | null;
+  likely_trade: string | null;
+  likely_system: string | null;
+  potential_causes: string[];
+  recommended_action: string | null;
+  resident_guidance: string | null;
+  needs_more_info: boolean;
+  more_info_requested: string[];
+  should_create_issue: boolean;
+  should_escalate: boolean;
+  escalation_level: EscalationLevel | null;
+  requires_human_review: boolean;
+  warranty_relevant: boolean;
+  similar_issue_check_required: boolean;
+  developer_summary: string;
+}
+
+export interface MediaAnalysisResult {
+  analysisId: string;
+  residentMessage: string;
+  developerSummary: string;
+  structured: StructuredAnalysis;
+  action: AssistantAction;
+}
+
+/**
+ * Resident-facing placeholder copy. Kept in one place so when Sprint 1b
+ * lands the real model the copy can be removed in a single edit rather
+ * than hunted across the codebase.
+ *
+ * No em dashes. No emoji. Calm, peer-to-peer tone.
+ */
+const PLACEHOLDER_RESIDENT_MESSAGE =
+  "Thanks for the photo. I've saved it against your home. Full analysis isn't enabled yet, but a member of the team can review it if needed.";
+
+const PLACEHOLDER_DEVELOPER_SUMMARY =
+  'Placeholder analysis. Real model wiring pending Sprint 1b.';
+
+function neutralStructured(): StructuredAnalysis {
+  return {
+    issue_type: null,
+    issue_category: null,
+    room: null,
+    visible_features: [],
+    severity_score: null,
+    severity_label: null,
+    confidence_score: null,
+    safety_risk: false,
+    safety_risk_type: null,
+    likely_trade: null,
+    likely_system: null,
+    potential_causes: [],
+    recommended_action: 'placeholder',
+    resident_guidance: null,
+    needs_more_info: false,
+    more_info_requested: [],
+    should_create_issue: false,
+    should_escalate: false,
+    escalation_level: 'none',
+    requires_human_review: false,
+    warranty_relevant: false,
+    similar_issue_check_required: false,
+    developer_summary: PLACEHOLDER_DEVELOPER_SUMMARY,
+  };
+}
+
+interface InsertAnalysisRow extends StructuredAnalysis {
+  tenant_id: string;
+  development_id: string;
+  unit_id: string | null;
+  user_id: string | null;
+  conversation_id: string;
+  message_id: string;
+  input_media_ids: string[];
+  raw_model_output: Record<string, unknown>;
+  model_provider: string;
+  model_name: string;
+  model_version: string | null;
+  prompt_version: string | null;
+  processing_time_ms: number | null;
+}
+
+async function insertAnalysis(row: InsertAnalysisRow): Promise<{ id: string }> {
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('assistant_media_analysis')
+    .insert({
+      tenant_id: row.tenant_id,
+      development_id: row.development_id,
+      unit_id: row.unit_id,
+      user_id: row.user_id,
+      conversation_id: row.conversation_id,
+      message_id: row.message_id,
+      analysis_scope: 'single_message',
+      input_media_ids: row.input_media_ids,
+      issue_type: row.issue_type,
+      issue_category: row.issue_category,
+      room: row.room,
+      visible_features: row.visible_features,
+      severity_score: row.severity_score,
+      severity_label: row.severity_label,
+      confidence_score: row.confidence_score,
+      safety_risk: row.safety_risk,
+      safety_risk_type: row.safety_risk_type,
+      likely_trade: row.likely_trade,
+      likely_system: row.likely_system,
+      potential_causes: row.potential_causes,
+      recommended_action: row.recommended_action,
+      resident_guidance: row.resident_guidance,
+      needs_more_info: row.needs_more_info,
+      more_info_requested: row.more_info_requested,
+      should_create_issue: row.should_create_issue,
+      should_escalate: row.should_escalate,
+      escalation_level: row.escalation_level,
+      requires_human_review: row.requires_human_review,
+      warranty_relevant: row.warranty_relevant,
+      similar_issue_check_required: row.similar_issue_check_required,
+      developer_summary: row.developer_summary,
+      raw_model_output: row.raw_model_output,
+      model_provider: row.model_provider,
+      model_name: row.model_name,
+      model_version: row.model_version,
+      prompt_version: row.prompt_version,
+      processing_time_ms: row.processing_time_ms,
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    throw new Error(
+      `[mediaAnalysisService] failed to persist analysis row: ${error?.message ?? 'no row returned'}`,
+    );
+  }
+
+  return { id: data.id as string };
+}
+
+export async function analyse(input: MediaAnalysisInput): Promise<MediaAnalysisResult> {
+  const startedAt = Date.now();
+  const structured = neutralStructured();
+
+  const analysisRow = await insertAnalysis({
+    tenant_id: input.tenantId,
+    development_id: input.developmentId,
+    unit_id: input.unitId,
+    user_id: input.userId,
+    conversation_id: input.conversationId,
+    message_id: input.messageId,
+    input_media_ids: input.mediaIds,
+    raw_model_output: { placeholder: true },
+    model_provider: 'placeholder',
+    model_name: 'placeholder-v1',
+    model_version: null,
+    prompt_version: 'placeholder-v1',
+    processing_time_ms: Date.now() - startedAt,
+    ...structured,
+  });
+
+  return {
+    analysisId: analysisRow.id,
+    residentMessage: PLACEHOLDER_RESIDENT_MESSAGE,
+    developerSummary: structured.developer_summary,
+    structured,
+    action: 'answer_only',
+  };
+}

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -19,10 +19,32 @@ export function isAssistantOSEnabled(): boolean {
   return true;
 }
 
+/**
+ * Assistant V2 image upload (Sprint 1).
+ *
+ * Default off. When false:
+ *   - the homeowner chat input does not render the attachment button
+ *   - the three new server routes under /api/assistant/* return 404
+ *
+ * Server reads FEATURE_ASSISTANT_IMAGE_UPLOAD. Client reads
+ * NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD (must be set separately
+ * for the bundler to inline the value).
+ */
+export function isAssistantImageUploadEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD === 'true';
+  }
+  return (
+    process.env.FEATURE_ASSISTANT_IMAGE_UPLOAD === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD === 'true'
+  );
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
     purchaserVideos: isPurchaserVideosFeatureEnabled(),
     assistantOS: isAssistantOSEnabled(),
+    assistantImageUpload: isAssistantImageUploadEnabled(),
   };
 }

--- a/apps/unified-portal/package.json
+++ b/apps/unified-portal/package.json
@@ -56,6 +56,7 @@
     "recharts": "^2.13.3",
     "recharts-scale": "^0.4.5",
     "resend": "^6.9.3",
+    "sharp": "^0.34.5",
     "swr": "^2.2.5",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,6 +1129,7 @@
         "recharts": "^2.13.3",
         "recharts-scale": "^0.4.5",
         "resend": "^6.9.3",
+        "sharp": "^0.34.5",
         "swr": "^2.2.5",
         "tailwind-merge": "^2.2.0",
         "tailwindcss": "^3.4.1",
@@ -5193,7 +5194,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5214,7 +5214,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5235,7 +5234,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5256,7 +5254,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5277,7 +5274,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5298,7 +5294,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5319,7 +5314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5340,7 +5334,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5361,7 +5354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5382,7 +5374,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5403,7 +5394,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },


### PR DESCRIPTION
## Summary

Implements the server side of Assistant V2 Sprint 1 per
[`docs/specs/assistant-v2-sprint-1.md`](docs/specs/assistant-v2-sprint-1.md)
sections 4 through 6. UI work lands in a separate session on branch
`assistant-v2/ui`. All new behaviour is gated on
`FEATURE_ASSISTANT_IMAGE_UPLOAD` and defaults off; with the flag off the
new routes return 404 before any auth or DB work happens.

## What landed

1. **Feature flag.** `FEATURE_ASSISTANT_IMAGE_UPLOAD` (server) and
   `NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD` (client) added to the
   env example files and exposed via `lib/feature-flags.ts`.

2. **Three new routes under `apps/unified-portal/app/api/assistant/`:**
   - `POST /media/upload`: multipart upload of 1 to 6 image files,
     mime and size validation (25 MB cap, JPG/PNG/WebP/HEIC), server
     side thumbnail via `sharp` (800px longest edge, JPEG q80, EXIF
     stripped), one `assistant_media` row per file, one-hour signed
     URLs returned.
   - `POST /media/signed-url`: returns fresh one-hour signed URLs for
     an `assistant_media` row after verifying the caller's tenant.
   - `POST /chat/multimodal`: verifies tenant, cross-checks every
     referenced `assistant_media` row against the caller's tenant,
     runs the placeholder analysis, persists one
     `assistant_media_analysis` row, returns the placeholder
     response. Decision engine and issue report creation are
     explicitly deferred to Sprint 1b.

3. **Shared helpers in `apps/unified-portal/lib/assistant/`:**
   - `media-auth.ts`: single resolver for both homeowner
     (`x-qr-token` header) and admin (Supabase session cookie)
     callers. `tenant_id` is always derived from the verified
     context, never from a client-supplied field. Cross-tenant
     access attempts return 403 from the route, matching acceptance
     criterion 7 in the spec.
   - `mediaAnalysisService.ts`: placeholder `analyse()` that writes
     a neutral row with `model_provider = 'placeholder'`. The
     exported interface stays stable so Sprint 1b only needs to
     swap the function body.

## Storage path structure

Exactly as in section 4 of the spec:

```
{tenant_id}/{development_id}/{unit_id}/{conversation_id}/{media_id}.{ext}
{tenant_id}/{development_id}/{unit_id}/{conversation_id}/thumbnails/{media_id}.jpg
```

## Out of scope

- Chat UI (separate session, branch `assistant-v2/ui`).
- Real multimodal model call (Sprint 1b).
- Decision engine, issue report creation, escalation (Sprint 1b).
- Schema migrations (already applied; see acceptance criterion 3 in
  the spec).

## Notes

- No existing route is modified.
- The text-only `/api/chat` flow is untouched.
- All writes to the new tables go through the service-role Supabase
  client since the new tables ship with `service_role_bypass` RLS.
- No em dashes in code, copy, or this PR text.

## Test plan

- [ ] Local build (`npm run build`) succeeds.
- [ ] With `FEATURE_ASSISTANT_IMAGE_UPLOAD=false`, all three routes
      return 404.
- [ ] With the flag on and a valid `x-qr-token`, `POST /media/upload`
      writes `assistant_media` rows and returns signed URLs.
- [ ] `POST /chat/multimodal` writes one
      `assistant_media_analysis` row with `model_provider =
      'placeholder'` and returns the placeholder resident message.
- [ ] `POST /media/signed-url` with a `media_id` from another tenant
      returns 403.
- [ ] Thumbnails appear in storage at the expected
      `.../thumbnails/{media_id}.jpg` path.

Spec: `docs/specs/assistant-v2-sprint-1.md`.

Generated with [Claude Code](https://claude.com/claude-code)