### PR TITLE
fix(assistant-v2): compress photos client-side before upload

### DIFF
--- a/apps/unified-portal/lib/assistant/attachments.ts
+++ b/apps/unified-portal/lib/assistant/attachments.ts
@@ -21,6 +21,21 @@
  * server (POST /api/assistant/media/upload). We pre-filter so the homeowner
  * sees a fast inline error before a 5 MB upload, but the server is the
  * source of truth.
+ *
+ * Client-side compression. The upload route runs on Vercel serverless,
+ * which caps the request body at roughly 4.5 MB regardless of our
+ * application code. iPhone photos are typically 10 to 15 MB, which
+ * triggers a 413 Payload Too Large from the platform before our handler
+ * even runs. The fix here is a client-side resize and re-encode:
+ * decode the image, draw to a canvas sized to at most 2000 pixels on
+ * the longest edge, export as JPEG at quality 0.85. This keeps the
+ * post-compression body comfortably under the 4.5 MB cap while leaving
+ * enough resolution for the Sprint 1b multimodal analysis pass.
+ *
+ * The longer-term plan is direct-to-Supabase signed upload URLs, which
+ * lets the homeowner bypass our serverless function entirely and push
+ * the original bytes to storage. Until that lands, compression is the
+ * pragmatic fix. See compressForUpload below for the implementation.
  */
 
 import { nanoid } from 'nanoid';
@@ -129,6 +144,133 @@ export function rejectionMessage(reason: AttachmentRejectionReason): string {
     default:
       return "That photo could not be added.";
   }
+}
+
+/**
+ * Compression threshold. Files at or below this size go to the upload
+ * route as-is. Anything larger gets routed through the canvas resize
+ * step. 1.5 MB is comfortably under Vercel's 4.5 MB body cap with
+ * headroom for the multipart envelope, and below this size most photos
+ * are already optimised (screenshots, social-app exports).
+ */
+const COMPRESSION_THRESHOLD_BYTES = 1_500_000;
+
+/**
+ * Resize target. 2000 px on the longest edge is plenty for the Sprint 1b
+ * multimodal analysis pass and produces JPEG outputs in the 500 KB to
+ * 1.5 MB range for a typical iPhone photo.
+ */
+const COMPRESSION_MAX_EDGE = 2000;
+const COMPRESSION_JPEG_QUALITY = 0.85;
+
+/**
+ * Decode a file into an HTMLImageElement. Throws if the browser cannot
+ * decode the bytes (HEIC on Chrome and Firefox is the known case). The
+ * caller is responsible for catching and falling back to the original
+ * upload.
+ */
+function decodeImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const url = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('decode_failed'));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    canvas.toBlob(resolve, type, quality);
+  });
+}
+
+function replaceExtension(name: string, newExt: string): string {
+  const dot = name.lastIndexOf('.');
+  const base = dot > 0 ? name.slice(0, dot) : name;
+  return `${base}.${newExt}`;
+}
+
+/**
+ * Compress a single file for upload. Skips the resize when the original
+ * is already under the threshold or when the browser cannot decode the
+ * format (HEIC on Chrome and Firefox). In the no-op cases the original
+ * File object is returned unchanged so the rest of the pipeline can
+ * stay file-shaped.
+ *
+ * On a decode failure the original is still returned; the server allow
+ * list and the 25 MB cap remain the safety net. If the original exceeds
+ * Vercel's body cap the upload will fail with a 413, which surfaces as
+ * the generic "Couldn't upload that photo" error rather than crashing
+ * the client.
+ */
+export async function compressForUpload(file: File): Promise<File> {
+  if (file.size <= COMPRESSION_THRESHOLD_BYTES) return file;
+  if (typeof document === 'undefined') return file;
+
+  let img: HTMLImageElement;
+  try {
+    img = await decodeImage(file);
+  } catch {
+    // HEIC on non-Safari browsers, or any other undecodable input.
+    // Fall back to the original; the server will validate and the
+    // upload will either succeed or surface the generic error.
+    return file;
+  }
+
+  const naturalWidth = img.naturalWidth || img.width;
+  const naturalHeight = img.naturalHeight || img.height;
+  if (!naturalWidth || !naturalHeight) return file;
+
+  const longestEdge = Math.max(naturalWidth, naturalHeight);
+  const scale = longestEdge > COMPRESSION_MAX_EDGE ? COMPRESSION_MAX_EDGE / longestEdge : 1;
+  const targetWidth = Math.max(1, Math.round(naturalWidth * scale));
+  const targetHeight = Math.max(1, Math.round(naturalHeight * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetWidth;
+  canvas.height = targetHeight;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return file;
+  ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+  const blob = await canvasToBlob(canvas, 'image/jpeg', COMPRESSION_JPEG_QUALITY);
+  if (!blob || blob.size >= file.size) {
+    // The re-encode came out larger than the original (rare, but can
+    // happen for already heavily-compressed sources). Keep the
+    // original.
+    return file;
+  }
+
+  const newName = replaceExtension(file.name, 'jpg');
+  return new File([blob], newName, { type: 'image/jpeg', lastModified: file.lastModified });
+}
+
+/**
+ * Compress an array of selections sequentially. Sequential rather than
+ * parallel because decoding multiple 12 MP photos at once on a low-end
+ * Android WebView can spike memory enough to OOM the tab. The wall-clock
+ * cost is modest (typically under three seconds for six photos).
+ */
+export async function compressSelectionsForUpload(
+  selections: SelectedAttachment[],
+): Promise<SelectedAttachment[]> {
+  const out: SelectedAttachment[] = [];
+  for (const sel of selections) {
+    const compressed = await compressForUpload(sel.file);
+    if (compressed === sel.file) {
+      out.push(sel);
+    } else {
+      out.push({ ...sel, file: compressed });
+    }
+  }
+  return out;
 }
 
 /**

--- a/apps/unified-portal/lib/assistant/multimodal-client.ts
+++ b/apps/unified-portal/lib/assistant/multimodal-client.ts
@@ -4,14 +4,18 @@
  * Client side orchestration for sending a chat message that includes
  * attached images. Sprint 1 of Assistant V2, section 7.3 of the spec.
  *
- * Two network calls, in order:
- *   1. POST /api/assistant/media/upload  (multipart, one to six files)
- *   2. POST /api/assistant/chat/multimodal  (json, message text + media ids)
+ * Pipeline:
+ *   1. Compress each selected file via the canvas resize step (only
+ *      kicks in for files larger than the threshold). Required because
+ *      Vercel's serverless body cap is 4.5 MB and iPhone photos sail
+ *      past that; see attachments.ts for the architectural notes.
+ *   2. POST /api/assistant/media/upload  (multipart, one to six files)
+ *   3. POST /api/assistant/chat/multimodal  (json, message text + media ids)
  *
  * The caller passes an onStatus callback so the UI can swap the rotating
- * status strip ("Uploading photos" then "Reviewing your home information"
- * then "Preparing the response"). Each label transitions only when the
- * corresponding network call resolves. No fake progress.
+ * status strip ("Preparing photos" then "Uploading photos" then
+ * "Reviewing your home information" then "Preparing the response"). Each
+ * label transitions only when its phase actually starts. No fake progress.
  *
  * Errors:
  *   - Any 4xx or 5xx surfaces a SendMultimodalError with a resident-facing
@@ -19,9 +23,10 @@
  *     7.5 of the spec.
  */
 
-import type { SelectedAttachment } from './attachments';
+import { compressSelectionsForUpload, type SelectedAttachment } from './attachments';
 
 export type MultimodalStatus =
+  | 'compressing'
   | 'uploading'
   | 'reviewing'
   | 'preparing';
@@ -67,12 +72,18 @@ const CHAT_FAILED_MESSAGE =
 export async function sendMultimodal(input: SendMultimodalInput): Promise<SendMultimodalResult> {
   const { conversationId, unitId, qrToken, messageText, selections, onStatus } = input;
 
+  onStatus?.('compressing');
+  // compressSelectionsForUpload is a no-op for files already under the
+  // threshold and for browsers that cannot decode the source format
+  // (HEIC on Chrome and Firefox), so this is always safe to call.
+  const compressed = await compressSelectionsForUpload(selections);
+
   onStatus?.('uploading');
 
   const form = new FormData();
   form.set('conversation_id', conversationId);
   form.set('unit_id', unitId);
-  for (const sel of selections) {
+  for (const sel of compressed) {
     form.append('files', sel.file, sel.file.name);
   }
 
@@ -164,6 +175,8 @@ export async function sendMultimodal(input: SendMultimodalInput): Promise<SendMu
 
 export function statusToLabel(status: MultimodalStatus): string {
   switch (status) {
+    case 'compressing':
+      return 'Preparing photos';
     case 'uploading':
       return 'Uploading photos';
     case 'reviewing':

--- a/docs/specs/assistant-v2-sprint-1.md
+++ b/docs/specs/assistant-v2-sprint-1.md
@@ -520,11 +520,20 @@ When the send button is pressed with attached media:
 ```
 
 Status messages rotate through:
+- "Preparing photos"
 - "Uploading photos"
 - "Reviewing your home information"
 - "Preparing the response"
 
-Each step transitions when the corresponding network call resolves. Do not show fake progress.
+Each step transitions when its phase actually starts. Do not show fake progress.
+
+"Preparing photos" covers the client-side compression step. iPhone photos
+are typically 10 to 15 MB and Vercel's serverless body cap is roughly
+4.5 MB, so the client resizes each photo to at most 2000 pixels on the
+longest edge and re-encodes as JPEG at quality 0.85 before the upload
+network call begins. Files already below 1.5 MB skip the step entirely.
+The longer-term plan is direct-to-Supabase signed upload URLs, which
+removes the need for the client-side step.
 
 2. Call `POST /api/assistant/media/upload` to upload all files. Collect returned media IDs.
 3. Call `POST /api/assistant/chat/multimodal` with the message text and media IDs.


### PR DESCRIPTION
## Summary

`/api/assistant/media/upload` was returning **413 Payload Too Large**
for typical iPhone photos. Vercel's serverless functions cap the
request body at roughly **4.5 MB** at the platform layer (before our
handler ever runs); iPhone photos are typically 10 to 15 MB.

The proper architectural fix is direct-to-Supabase signed upload URLs
(homeowner PUTs the original bytes straight to storage, our route only
writes the metadata). That is larger work and should not block testing
the rest of Sprint 1. This PR is the pragmatic interim: compress on
the client before upload, target max 2000 px on the longest edge at
JPEG quality 0.85.

## What landed

**`lib/assistant/attachments.ts`** gains:

- `compressForUpload(file: File): Promise<File>`
  - Skips compression for files at or below **1.5 MB**.
  - Decodes via `Image` + `URL.createObjectURL`, draws to a canvas
    sized to at most **2000 px** on the longest edge, exports as
    **JPEG quality 0.85** via `canvas.toBlob`.
  - Returns the original `File` unchanged when the browser cannot
    decode the source (HEIC on Chrome and Firefox). The server's
    25 MB allow-list and Vercel's 4.5 MB cap remain the safety net;
    failures surface as the generic "Couldn't upload that photo"
    inline error.
  - Preserves the original filename, swapping the extension to `.jpg`
    when the format changes, and keeps `lastModified` so server-side
    logging stays readable.
  - If the re-encoded blob is larger than the original (rare, for
    already-compressed sources), keeps the original.

- `compressSelectionsForUpload(selections)` runs the above sequentially
  across an array. Sequential rather than parallel because decoding
  multiple 12 MP photos at once on a low-end Android WebView can spike
  memory hard enough to OOM the tab. Wall-clock cost is modest
  (typically under three seconds for six photos).

**`lib/assistant/multimodal-client.ts`** adds a new `'compressing'`
status. Pipeline becomes:

```
compressing  ->  uploading  ->  reviewing  ->  preparing
```

`statusToLabel('compressing')` returns `"Preparing photos"`. Each label
still transitions only when its phase actually starts; no fake
progress.

**`docs/specs/assistant-v2-sprint-1.md`** section 7.3 is updated to add
`"Preparing photos"` at the top of the rotating status list and to
document the underlying Vercel body cap and the future direct-upload
plan.

## What did not change

- Server route is untouched. The 25 MB cap in
  `/api/assistant/media/upload` stays as the correct safety net; the
  only real-world inputs over that limit are screen recordings and
  burst-mode panoramas, both out of scope for Sprint 1.
- The 4.5 MB Vercel limit is a platform setting; we did not change
  infrastructure.
- Section 7.5 copy (errors, aria labels, placeholder reply) is unchanged.
- No em dashes in code, copy, commit message, or this PR.

## Test plan (manual on the preview)

- [ ] Upload a single typical iPhone photo (~12 MB JPEG). Confirm
      `POST /api/assistant/media/upload` returns 200 instead of 413.
- [ ] Confirm the status strip shows `Preparing photos` first, then
      transitions to `Uploading photos` once compression finishes.
- [ ] Upload a small screenshot (under 1.5 MB). Confirm `Preparing
      photos` is brief or instant (file goes through unchanged).
- [ ] On Chrome / Firefox, attempt a HEIC upload. Confirm it falls
      back gracefully: either succeeds if under 4.5 MB, or surfaces
      the generic upload-failed error if over it. Browser should not
      crash.
- [ ] Confirm `assistant_media.file_size_bytes` reflects the
      compressed size for large originals.
- [ ] Confirm the `mime_type` recorded is `image/jpeg` for compressed
      files, original type for skipped files.

## Refs

- 413 root cause: Vercel serverless body cap (approx 4.5 MB).
- Spec: `docs/specs/assistant-v2-sprint-1.md`.
- Follow-up: direct-to-Supabase signed upload URLs (issue to file).

Generated with [Claude Code](https://claude.com/claude-code)