### PR TITLE
feat(assistant-v2): Sprint 2 server routes for builder-side snags

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -118,6 +118,18 @@ ENABLE_QR_ONBOARDING=true
 FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 
+# Assistant V2 builder-side snag app (Sprint 2). Default off in production.
+# Enable per tenant during testing. When false the /snag and
+# /admin/snaggers routes 404 and all /api/snag/* server routes return 404.
+FEATURE_BUILDER_SNAG_APP=false
+NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
+
+# Internal key used to authorise the fire-and-forget enrichment fetch
+# from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
+# random opaque secret set per environment. Without it, enrichment is
+# skipped (snag still gets created). Generate with: openssl rand -hex 32
+INTERNAL_ENRICHMENT_KEY=
+
 # ----------------------------------------------------------------
 # Rate Limiting
 # ----------------------------------------------------------------

--- a/apps/unified-portal/.env.example
+++ b/apps/unified-portal/.env.example
@@ -78,6 +78,19 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=
 FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 
+# Assistant V2 builder-side snag app (Sprint 2). Default off in production.
+# Enable per tenant during testing. When false, the /snag and
+# /admin/snaggers routes 404 and all /api/snag/* server routes return 404
+# before any auth or DB work.
+FEATURE_BUILDER_SNAG_APP=false
+NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
+
+# Internal key used to authorise the fire-and-forget enrichment fetch
+# from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
+# random opaque secret set per environment. Without it, enrichment is
+# skipped (snag still gets created). Generate with: openssl rand -hex 32
+INTERNAL_ENRICHMENT_KEY=
+
 # ═══════════════════════════════════════════════════════════════════════════
 # APPLICATION
 # ═══════════════════════════════════════════════════════════════════════════

--- a/apps/unified-portal/app/api/snag/[id]/route.ts
+++ b/apps/unified-portal/app/api/snag/[id]/route.ts
@@ -1,0 +1,158 @@
+/**
+ * GET /api/snag/[id]
+ *
+ * Assistant V2 Sprint 2. Returns a single snag with its linked media
+ * (one-hour signed URLs) and the full event timeline.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 5.5.
+ *
+ * Caller must be able to access the report's development_id under their
+ * site_team_members membership; cross-tenant or out-of-scope reports
+ * surface as 403.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const BUCKET = 'assistant-media';
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, user_id, title, description, room, status, priority, severity_label, severity_score, safety_risk, likely_trade, likely_system, source, logged_by_user_id, logged_by_role, linked_analysis_id, created_at, updated_at',
+    )
+    .eq('id', issueReportId)
+    .maybeSingle();
+
+  if (reportErr) {
+    console.error('[snag-detail] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load snag' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Snag not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  try {
+    assertCanAccessDevelopment(auth, report.development_id as string);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const { data: joinRows, error: joinErr } = await supabase
+    .from('issue_report_media')
+    .select('media_id')
+    .eq('issue_report_id', issueReportId);
+  if (joinErr) {
+    console.error('[snag-detail] join_lookup_failed reason=%s', joinErr.message);
+    return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+  }
+
+  const mediaIds = (joinRows ?? []).map((j) => j.media_id as string);
+  let mediaPayload: Array<{
+    id: string;
+    storage_path: string;
+    thumbnail_path: string | null;
+    mime_type: string;
+    width: number | null;
+    height: number | null;
+    signed_url: string;
+    thumbnail_url: string;
+    expires_at: string;
+  }> = [];
+
+  if (mediaIds.length > 0) {
+    const { data: mediaRows, error: mediaErr } = await supabase
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path, mime_type, width, height')
+      .in('id', mediaIds);
+    if (mediaErr) {
+      console.error('[snag-detail] media_lookup_failed reason=%s', mediaErr.message);
+      return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+    }
+
+    const expiresIso = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    for (const m of mediaRows ?? []) {
+      if (m.tenant_id !== auth.tenantId) {
+        continue;
+      }
+      const { data: signed } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(m.storage_path as string, SIGNED_URL_TTL_SECONDS);
+      let thumbUrl = signed?.signedUrl ?? '';
+      if (m.thumbnail_path) {
+        const { data: thumbSigned } = await supabase.storage
+          .from(BUCKET)
+          .createSignedUrl(m.thumbnail_path as string, SIGNED_URL_TTL_SECONDS);
+        if (thumbSigned?.signedUrl) thumbUrl = thumbSigned.signedUrl;
+      }
+      mediaPayload.push({
+        id: m.id as string,
+        storage_path: m.storage_path as string,
+        thumbnail_path: (m.thumbnail_path as string | null) ?? null,
+        mime_type: m.mime_type as string,
+        width: (m.width as number | null) ?? null,
+        height: (m.height as number | null) ?? null,
+        signed_url: signed?.signedUrl ?? '',
+        thumbnail_url: thumbUrl,
+        expires_at: expiresIso,
+      });
+    }
+  }
+
+  const { data: events, error: eventsErr } = await supabase
+    .from('issue_events')
+    .select('id, event_type, actor_type, actor_id, metadata, created_at')
+    .eq('issue_report_id', issueReportId)
+    .order('created_at', { ascending: true });
+  if (eventsErr) {
+    console.error('[snag-detail] events_lookup_failed reason=%s', eventsErr.message);
+  }
+
+  return NextResponse.json({
+    report,
+    media: mediaPayload,
+    events: events ?? [],
+  });
+}

--- a/apps/unified-portal/app/api/snag/accept/route.ts
+++ b/apps/unified-portal/app/api/snag/accept/route.ts
@@ -1,0 +1,155 @@
+/**
+ * POST /api/snag/accept
+ *
+ * Assistant V2 Sprint 2. Public route that consumes a snagger invitation
+ * token and grants the authenticated user a site_team_members row with
+ * role snagger_external.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 5.2.
+ *
+ * The route still requires the caller to have an active Supabase session.
+ * The invitation's email must match the session user's email.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP. With the flag off the route returns
+ * 404 before any auth or DB work.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { snagFeatureDisabledResponse } from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface AcceptBody {
+  token?: unknown;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let body: AcceptBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const token = typeof body.token === 'string' ? body.token.trim() : '';
+  if (!token) {
+    return NextResponse.json({ error: 'token is required' }, { status: 400 });
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+
+  if (userErr || !user?.id || !user.email) {
+    return NextResponse.json(
+      { error: 'Sign in before accepting an invitation' },
+      { status: 401 },
+    );
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data: invitation, error: lookupErr } = await admin
+    .from('snagger_invitations')
+    .select('id, tenant_id, development_id, email, expires_at, accepted_at, revoked_at')
+    .eq('token', token)
+    .maybeSingle();
+
+  if (lookupErr) {
+    console.error('[snag-accept] lookup_failed reason=%s', lookupErr.message);
+    return NextResponse.json({ error: 'Could not load invitation' }, { status: 500 });
+  }
+  if (!invitation) {
+    return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+  }
+  if (invitation.revoked_at) {
+    return NextResponse.json({ error: 'Invitation has been revoked' }, { status: 410 });
+  }
+  if (invitation.accepted_at) {
+    return NextResponse.json({ error: 'Invitation has already been accepted' }, { status: 410 });
+  }
+  if (new Date(invitation.expires_at as string).getTime() <= Date.now()) {
+    return NextResponse.json({ error: 'Invitation has expired' }, { status: 410 });
+  }
+
+  const inviteEmail = String(invitation.email).trim().toLowerCase();
+  const sessionEmail = user.email.trim().toLowerCase();
+  if (inviteEmail !== sessionEmail) {
+    console.warn(
+      '[snag-accept] EMAIL_MISMATCH invitation_id=%s invite_email=%s session_email=%s',
+      invitation.id,
+      inviteEmail,
+      sessionEmail,
+    );
+    return NextResponse.json(
+      { error: 'This invitation was issued to a different email address' },
+      { status: 403 },
+    );
+  }
+
+  const { data: existing, error: existingErr } = await admin
+    .from('site_team_members')
+    .select('id, role, active, expires_at')
+    .eq('user_id', user.id)
+    .eq('tenant_id', invitation.tenant_id)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (existingErr) {
+    console.error('[snag-accept] existing_lookup_failed reason=%s', existingErr.message);
+    return NextResponse.json({ error: 'Could not check existing membership' }, { status: 500 });
+  }
+
+  if (existing) {
+    const { error: updateInviteErr } = await admin
+      .from('snagger_invitations')
+      .update({ accepted_at: new Date().toISOString(), accepted_by_user_id: user.id })
+      .eq('id', invitation.id);
+    if (updateInviteErr) {
+      console.error('[snag-accept] invitation_update_failed reason=%s', updateInviteErr.message);
+    }
+    return NextResponse.json({
+      success: true,
+      already_member: true,
+      tenant_id: invitation.tenant_id,
+      development_ids: [invitation.development_id],
+    });
+  }
+
+  const { error: memberErr } = await admin
+    .from('site_team_members')
+    .insert({
+      tenant_id: invitation.tenant_id,
+      user_id: user.id,
+      role: 'snagger_external',
+      development_ids: [invitation.development_id],
+      active: true,
+      invited_by: null,
+      accepted_at: new Date().toISOString(),
+      expires_at: invitation.expires_at,
+    });
+
+  if (memberErr) {
+    console.error('[snag-accept] member_insert_failed reason=%s', memberErr.message);
+    return NextResponse.json({ error: 'Could not create membership' }, { status: 500 });
+  }
+
+  const { error: updateInviteErr } = await admin
+    .from('snagger_invitations')
+    .update({ accepted_at: new Date().toISOString(), accepted_by_user_id: user.id })
+    .eq('id', invitation.id);
+  if (updateInviteErr) {
+    console.error('[snag-accept] invitation_update_failed reason=%s', updateInviteErr.message);
+  }
+
+  return NextResponse.json({
+    success: true,
+    tenant_id: invitation.tenant_id,
+    development_ids: [invitation.development_id],
+  });
+}

--- a/apps/unified-portal/app/api/snag/create/route.ts
+++ b/apps/unified-portal/app/api/snag/create/route.ts
@@ -1,0 +1,284 @@
+/**
+ * POST /api/snag/create
+ *
+ * Assistant V2 Sprint 2. The main builder-side snag creation route.
+ * A site team member or accepted external snagger logs a snag with one
+ * or more photos attached.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 5.3.
+ *
+ * Flow:
+ *   1. Verify caller's identity and active membership via resolveSnagAuth.
+ *   2. Validate body shape and the development_id / unit_id / media_ids
+ *      payload.
+ *   3. Verify development_id belongs to caller's tenant and (for
+ *      snagger_external) is in their development_ids array.
+ *   4. Verify unit_id belongs to same tenant and same development.
+ *   5. Verify every media_id belongs to caller's tenant.
+ *   6. Insert issue_reports with source, logged_by_user_id, logged_by_role.
+ *   7. Insert issue_report_media rows linking each media to the issue.
+ *   8. Insert one issue_events row with event_type 'snag_logged'.
+ *   9. Fire-and-forget POST to /api/snag/enrich/[issue_report_id] so
+ *      assistant_media_analysis runs asynchronously.
+ *  10. Return the new issue_report_id immediately.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_MEDIA_PER_SNAG = 6;
+const MAX_TITLE_LEN = 200;
+const MAX_DESCRIPTION_LEN = 4000;
+const MAX_ROOM_LEN = 120;
+
+interface CreateBody {
+  development_id?: unknown;
+  unit_id?: unknown;
+  title?: unknown;
+  description?: unknown;
+  room?: unknown;
+  media_ids?: unknown;
+}
+
+function isUuidArray(v: unknown): v is string[] {
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    v.every((s) => typeof s === 'string' && UUID_RE.test(s))
+  );
+}
+
+function resolveOrigin(request: NextRequest): string {
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
+}
+
+/**
+ * Fire-and-forget. Never throws into the request handler. If the
+ * INTERNAL_ENRICHMENT_KEY is unset the call is skipped with a single
+ * warning so local dev still works.
+ */
+function triggerEnrichment(request: NextRequest, issueReportId: string): void {
+  const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
+  if (!internalKey) {
+    console.warn(
+      '[snag-create] enrichment_skipped reason=INTERNAL_ENRICHMENT_KEY_unset issue=%s',
+      issueReportId,
+    );
+    return;
+  }
+
+  const origin = resolveOrigin(request);
+  const url = `${origin}/api/snag/enrich/${encodeURIComponent(issueReportId)}`;
+
+  try {
+    void fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-key': internalKey,
+      },
+      body: JSON.stringify({}),
+    }).catch((err) => {
+      console.warn(
+        '[snag-create] enrichment_fetch_rejected issue=%s reason=%s',
+        issueReportId,
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  } catch (err) {
+    console.warn(
+      '[snag-create] enrichment_fetch_threw issue=%s reason=%s',
+      issueReportId,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let body: CreateBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const developmentId = typeof body.development_id === 'string' ? body.development_id : '';
+  const unitId = typeof body.unit_id === 'string' ? body.unit_id : '';
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
+  const room = typeof body.room === 'string' ? body.room.trim() : '';
+
+  if (!UUID_RE.test(developmentId)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  if (!UUID_RE.test(unitId)) {
+    return NextResponse.json({ error: 'unit_id must be a uuid' }, { status: 400 });
+  }
+  if (!title) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+  if (title.length > MAX_TITLE_LEN) {
+    return NextResponse.json({ error: 'title is too long' }, { status: 400 });
+  }
+  if (description.length > MAX_DESCRIPTION_LEN) {
+    return NextResponse.json({ error: 'description is too long' }, { status: 400 });
+  }
+  if (room.length > MAX_ROOM_LEN) {
+    return NextResponse.json({ error: 'room is too long' }, { status: 400 });
+  }
+  if (!isUuidArray(body.media_ids)) {
+    return NextResponse.json({ error: 'media_ids must be a non-empty array of uuids' }, { status: 400 });
+  }
+  const mediaIds = Array.from(new Set(body.media_ids));
+  if (mediaIds.length > MAX_MEDIA_PER_SNAG) {
+    return NextResponse.json(
+      { error: `You can attach up to ${MAX_MEDIA_PER_SNAG} photos per snag.` },
+      { status: 400 },
+    );
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+    assertCanAccessDevelopment(auth, developmentId);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: development, error: devErr } = await supabase
+    .from('developments')
+    .select('id, tenant_id')
+    .eq('id', developmentId)
+    .maybeSingle();
+  if (devErr) {
+    console.error('[snag-create] development_lookup_failed reason=%s', devErr.message);
+    return NextResponse.json({ error: 'Could not load development' }, { status: 500 });
+  }
+  if (!development || development.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: unit, error: unitErr } = await supabase
+    .from('units')
+    .select('id, tenant_id, development_id')
+    .eq('id', unitId)
+    .maybeSingle();
+  if (unitErr) {
+    console.error('[snag-create] unit_lookup_failed reason=%s', unitErr.message);
+    return NextResponse.json({ error: 'Could not load unit' }, { status: 500 });
+  }
+  if (!unit) {
+    return NextResponse.json({ error: 'Unit not found' }, { status: 404 });
+  }
+  if (unit.tenant_id !== auth.tenantId || unit.development_id !== developmentId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: mediaRows, error: mediaErr } = await supabase
+    .from('assistant_media')
+    .select('id, tenant_id, unit_id')
+    .in('id', mediaIds);
+  if (mediaErr) {
+    console.error('[snag-create] media_lookup_failed reason=%s', mediaErr.message);
+    return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+  }
+  if (!mediaRows || mediaRows.length !== mediaIds.length) {
+    return NextResponse.json({ error: 'One or more media not found' }, { status: 404 });
+  }
+  for (const m of mediaRows) {
+    if (m.tenant_id !== auth.tenantId) {
+      console.warn(
+        '[snag-create] CROSS_TENANT_MEDIA media_id=%s caller_tenant=%s media_tenant=%s',
+        m.id,
+        auth.tenantId,
+        m.tenant_id,
+      );
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+
+  const source = auth.role === 'snagger_external' ? 'snagger_external' : 'site_team_snag';
+
+  const { data: issueRow, error: insertErr } = await supabase
+    .from('issue_reports')
+    .insert({
+      tenant_id: auth.tenantId,
+      development_id: developmentId,
+      unit_id: unitId,
+      user_id: auth.userId,
+      title,
+      description: description || null,
+      room: room || null,
+      status: 'open',
+      priority: 'normal',
+      source,
+      logged_by_user_id: auth.userId,
+      logged_by_role: auth.role,
+    })
+    .select('id')
+    .single();
+
+  if (insertErr || !issueRow) {
+    console.error('[snag-create] issue_insert_failed reason=%s', insertErr?.message ?? 'no row');
+    return NextResponse.json({ error: 'Could not log snag' }, { status: 500 });
+  }
+
+  const issueReportId = issueRow.id as string;
+
+  const mediaJoinRows = mediaIds.map((mediaId) => ({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    media_id: mediaId,
+  }));
+  const { error: joinErr } = await supabase.from('issue_report_media').insert(mediaJoinRows);
+  if (joinErr) {
+    console.error('[snag-create] issue_media_join_failed reason=%s', joinErr.message);
+    return NextResponse.json({ error: 'Could not link media to snag' }, { status: 500 });
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: 'snag_logged',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: { source, media_count: mediaIds.length },
+  });
+  if (eventErr) {
+    console.error('[snag-create] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  triggerEnrichment(request, issueReportId);
+
+  return NextResponse.json({ issue_report_id: issueReportId });
+}

--- a/apps/unified-portal/app/api/snag/enrich/[issue_report_id]/route.ts
+++ b/apps/unified-portal/app/api/snag/enrich/[issue_report_id]/route.ts
@@ -1,0 +1,164 @@
+/**
+ * POST /api/snag/enrich/[issue_report_id]
+ *
+ * Assistant V2 Sprint 2. Internal-only enrichment route. Called as a
+ * fire-and-forget fetch from /api/snag/create immediately after the
+ * snag is persisted.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 6.
+ *
+ * Auth. Two acceptable proofs:
+ *   - x-internal-key header matching process.env.INTERNAL_ENRICHMENT_KEY
+ *   - Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>
+ *
+ * On a Sprint 1 placeholder, mediaAnalysisService.analyse persists a
+ * neutral assistant_media_analysis row. This route additionally links
+ * that row back to the issue via issue_reports.linked_analysis_id and
+ * appends an issue_events row with event_type 'analysis_completed' so
+ * the timeline reflects the enrichment.
+ *
+ * When the real model lands in Sprint 1b, mediaAnalysisService.analyse
+ * is swapped in place. This route does not change.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID, timingSafeEqual } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { snagFeatureDisabledResponse } from '@/lib/assistant/snag-auth';
+import { analyse } from '@/lib/assistant/mediaAnalysisService';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface RouteParams {
+  params: { issue_report_id: string };
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+function isInternalCaller(request: NextRequest): boolean {
+  const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
+  const headerKey = request.headers.get('x-internal-key');
+  if (internalKey && headerKey && safeEqual(headerKey, internalKey)) {
+    return true;
+  }
+  const auth = request.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    const token = auth.slice(7);
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (serviceKey && safeEqual(token, serviceKey)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  if (!isInternalCaller(request)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const issueReportId = params.issue_report_id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'issue_report_id must be a uuid' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, development_id, unit_id, user_id, title, description, logged_by_user_id, linked_analysis_id')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[snag-enrich] report_lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load snag' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Snag not found' }, { status: 404 });
+  }
+  if (report.linked_analysis_id) {
+    return NextResponse.json({ ok: true, already_enriched: true, analysis_id: report.linked_analysis_id });
+  }
+
+  const { data: joinRows, error: joinErr } = await supabase
+    .from('issue_report_media')
+    .select('media_id')
+    .eq('issue_report_id', issueReportId);
+  if (joinErr) {
+    console.error('[snag-enrich] media_lookup_failed reason=%s', joinErr.message);
+    return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+  }
+  const mediaIds = (joinRows ?? []).map((j) => j.media_id as string);
+
+  const userMessageParts = [report.title as string];
+  if (report.description) userMessageParts.push(report.description as string);
+  const userMessage = userMessageParts.join('\n\n');
+
+  let result;
+  try {
+    result = await analyse({
+      tenantId: report.tenant_id as string,
+      developmentId: report.development_id as string,
+      unitId: (report.unit_id as string | null) ?? null,
+      conversationId: issueReportId,
+      messageId: randomUUID(),
+      userId: (report.logged_by_user_id as string | null) ?? (report.user_id as string | null) ?? null,
+      userMessage,
+      mediaIds,
+    });
+  } catch (err) {
+    console.error(
+      '[snag-enrich] analyse_failed issue=%s reason=%s',
+      issueReportId,
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json({ error: 'Could not enrich snag' }, { status: 500 });
+  }
+
+  const { error: updateErr } = await supabase
+    .from('issue_reports')
+    .update({ linked_analysis_id: result.analysisId, updated_at: new Date().toISOString() })
+    .eq('id', issueReportId);
+  if (updateErr) {
+    console.error('[snag-enrich] report_update_failed reason=%s', updateErr.message);
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: report.tenant_id,
+    issue_report_id: issueReportId,
+    event_type: 'analysis_completed',
+    actor_type: 'system',
+    actor_id: null,
+    metadata: {
+      analysis_id: result.analysisId,
+      model_provider: 'placeholder',
+      action: result.action,
+    },
+  });
+  if (eventErr) {
+    console.error('[snag-enrich] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    issue_report_id: issueReportId,
+    analysis_id: result.analysisId,
+    action: result.action,
+  });
+}

--- a/apps/unified-portal/app/api/snag/invite/route.ts
+++ b/apps/unified-portal/app/api/snag/invite/route.ts
@@ -1,0 +1,151 @@
+/**
+ * POST /api/snag/invite
+ *
+ * Assistant V2 Sprint 2. Admin-only route that creates a snagger
+ * invitation and returns a one-time signup URL.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 5.1.
+ *
+ * Email sending is out of scope for V1. The admin copies the link and
+ * sends it themselves via whatever channel they already use. Polished
+ * invitation emails are a later sprint.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP. With the flag off the route returns
+ * 404 before any auth or DB work.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertIsAdmin,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_EXPIRES_DAYS = 1;
+const MAX_EXPIRES_DAYS = 90;
+const PRODUCTION_ORIGIN = 'https://portal.openhouseai.ie';
+
+interface InviteBody {
+  email?: unknown;
+  development_id?: unknown;
+  expires_in_days?: unknown;
+}
+
+function resolveOrigin(request: NextRequest): string {
+  if (process.env.VERCEL_ENV === 'production') {
+    return PRODUCTION_ORIGIN;
+  }
+  const origin = request.headers.get('origin');
+  if (origin && /^https?:\/\//.test(origin)) {
+    return origin;
+  }
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+  return PRODUCTION_ORIGIN;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let body: InviteBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  const developmentId = typeof body.development_id === 'string' ? body.development_id : '';
+  const expiresInDays = typeof body.expires_in_days === 'number' ? Math.round(body.expires_in_days) : NaN;
+
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 });
+  }
+  if (!UUID_RE.test(developmentId)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  if (!Number.isFinite(expiresInDays) || expiresInDays < MIN_EXPIRES_DAYS || expiresInDays > MAX_EXPIRES_DAYS) {
+    return NextResponse.json(
+      { error: `expires_in_days must be between ${MIN_EXPIRES_DAYS} and ${MAX_EXPIRES_DAYS}` },
+      { status: 400 },
+    );
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+    assertIsAdmin(auth);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: development, error: devErr } = await supabase
+    .from('developments')
+    .select('id, tenant_id')
+    .eq('id', developmentId)
+    .maybeSingle();
+
+  if (devErr) {
+    console.error('[snag-invite] development_lookup_failed reason=%s', devErr.message);
+    return NextResponse.json({ error: 'Could not load development' }, { status: 500 });
+  }
+  if (!development) {
+    return NextResponse.json({ error: 'Development not found' }, { status: 404 });
+  }
+  if (development.tenant_id !== auth.tenantId) {
+    console.warn(
+      '[snag-invite] CROSS_TENANT_DEVELOPMENT caller_tenant=%s dev_tenant=%s',
+      auth.tenantId,
+      development.tenant_id,
+    );
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const token = randomUUID();
+  const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: inviteRow, error: insertErr } = await supabase
+    .from('snagger_invitations')
+    .insert({
+      tenant_id: auth.tenantId,
+      development_id: developmentId,
+      email,
+      invited_by: auth.userId,
+      token,
+      expires_at: expiresAt,
+    })
+    .select('id, token, expires_at')
+    .single();
+
+  if (insertErr || !inviteRow) {
+    console.error('[snag-invite] insert_failed reason=%s', insertErr?.message ?? 'no row');
+    return NextResponse.json({ error: 'Could not create invitation' }, { status: 500 });
+  }
+
+  const origin = resolveOrigin(request);
+  const inviteUrl = `${origin}/snag/accept?token=${encodeURIComponent(inviteRow.token as string)}`;
+
+  return NextResponse.json({
+    invitation_id: inviteRow.id,
+    invite_url: inviteUrl,
+    expires_at: inviteRow.expires_at,
+  });
+}

--- a/apps/unified-portal/app/api/snag/list/route.ts
+++ b/apps/unified-portal/app/api/snag/list/route.ts
@@ -1,0 +1,134 @@
+/**
+ * GET /api/snag/list
+ *
+ * Assistant V2 Sprint 2. Returns a paginated list of snags accessible
+ * to the caller, with the media count attached to each row.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 5.4.
+ *
+ * Access scoping:
+ *   - admin / site_team: every issue_reports row in their tenant
+ *   - snagger_external:  only rows whose development_id is in their
+ *                        development_ids array
+ *
+ * Optional query params:
+ *   - development_id (uuid)
+ *   - status (text)
+ *   - limit (1-100, default 25)
+ *   - offset (default 0)
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const url = new URL(request.url);
+  const developmentIdParam = url.searchParams.get('development_id');
+  const statusParam = url.searchParams.get('status');
+  const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
+
+  if (developmentIdParam && !UUID_RE.test(developmentIdParam)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  if (developmentIdParam) {
+    try {
+      assertCanAccessDevelopment(auth, developmentIdParam);
+    } catch (err) {
+      if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+      throw err;
+    }
+  }
+
+  let limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+  let offset = offsetParam ? parseInt(offsetParam, 10) : 0;
+  if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT;
+  if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+  if (!Number.isFinite(offset) || offset < 0) offset = 0;
+
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, status, priority, severity_label, source, logged_by_user_id, logged_by_role, created_at, updated_at',
+      { count: 'exact' },
+    )
+    .eq('tenant_id', auth.tenantId);
+
+  if (developmentIdParam) {
+    query = query.eq('development_id', developmentIdParam);
+  } else if (auth.role === 'snagger_external') {
+    const allowed = Array.isArray(auth.developmentIds) ? auth.developmentIds : [];
+    if (allowed.length === 0) {
+      return NextResponse.json({ rows: [], total: 0, limit, offset });
+    }
+    query = query.in('development_id', allowed);
+  }
+
+  if (statusParam) {
+    query = query.eq('status', statusParam);
+  }
+
+  query = query.order('created_at', { ascending: false }).range(offset, offset + limit - 1);
+
+  const { data: rows, error: listErr, count } = await query;
+  if (listErr) {
+    console.error('[snag-list] list_failed reason=%s', listErr.message);
+    return NextResponse.json({ error: 'Could not load snags' }, { status: 500 });
+  }
+  const reportRows = rows ?? [];
+  const ids = reportRows.map((r) => r.id as string);
+
+  const mediaCounts = new Map<string, number>();
+  if (ids.length > 0) {
+    const { data: joinRows, error: joinErr } = await supabase
+      .from('issue_report_media')
+      .select('issue_report_id')
+      .in('issue_report_id', ids);
+    if (joinErr) {
+      console.error('[snag-list] media_count_failed reason=%s', joinErr.message);
+    } else {
+      for (const j of joinRows ?? []) {
+        const k = j.issue_report_id as string;
+        mediaCounts.set(k, (mediaCounts.get(k) ?? 0) + 1);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    rows: reportRows.map((r) => ({ ...r, media_count: mediaCounts.get(r.id as string) ?? 0 })),
+    total: count ?? reportRows.length,
+    limit,
+    offset,
+  });
+}

--- a/apps/unified-portal/lib/assistant/snag-auth.ts
+++ b/apps/unified-portal/lib/assistant/snag-auth.ts
@@ -1,0 +1,176 @@
+/**
+ * Tenant verification for Assistant V2 Sprint 2 snag routes.
+ *
+ * Builder-side callers always come through a Supabase session cookie.
+ * Unlike Sprint 1's media-auth (which also handles homeowner x-qr-token
+ * paths), there is no token-based path here. The flow is:
+ *
+ *   1. Read the Supabase auth user from the session cookie.
+ *   2. Load the caller's active site_team_members row.
+ *   3. For snagger_external, also enforce expires_at.
+ *
+ * tenant_id, role, and development_ids always come from site_team_members,
+ * never from the client. The caller can supply a development_id in the
+ * request body for resource-scoped routes, but it is then cross-checked
+ * against the verified membership and rejected with 403 on mismatch.
+ *
+ * Routes use the helpers in this file:
+ *   - resolveSnagAuth(request)               basic identity resolution
+ *   - assertCanAccessDevelopment(auth, id)   per-route resource check
+ *   - assertCanAccessTenant(auth, id)        per-route resource check
+ *   - assertIsAdmin(auth)                    admin-only route guard
+ *   - snagAuthErrorToResponse(err)           uniform error mapping
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+
+export type SnagRole = 'admin' | 'site_team' | 'snagger_external';
+
+export interface SnagAuthContext {
+  userId: string;
+  email: string;
+  tenantId: string;
+  role: SnagRole;
+  developmentIds: string[] | null;
+  isAdmin: boolean;
+  membershipId: string;
+  expiresAt: string | null;
+}
+
+export type SnagAuthErrorCode =
+  | 'unauthenticated'
+  | 'forbidden'
+  | 'expired';
+
+export class SnagAuthError extends Error {
+  constructor(public code: SnagAuthErrorCode, message?: string) {
+    super(message ?? code);
+    this.name = 'SnagAuthError';
+  }
+}
+
+interface SiteTeamMemberRow {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  role: SnagRole;
+  development_ids: string[] | null;
+  active: boolean;
+  expires_at: string | null;
+}
+
+/**
+ * Resolve the caller's identity and membership. Returns the first active
+ * site_team_members row for the authenticated user, after enforcing
+ * snagger_external expiry. Throws SnagAuthError on any failure.
+ *
+ * Multi-tenant membership is theoretically possible but not exercised in
+ * Sprint 2. If a user belongs to multiple tenants, the first active row
+ * wins; downstream routes can still apply tenant-specific checks via
+ * assertCanAccessTenant.
+ */
+export async function resolveSnagAuth(_request: NextRequest): Promise<SnagAuthContext> {
+  const supabase = await createServerSupabaseClient();
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+
+  if (userErr || !user?.id || !user.email) {
+    throw new SnagAuthError('unauthenticated');
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data: rows, error: memErr } = await admin
+    .from('site_team_members')
+    .select('id, tenant_id, user_id, role, development_ids, active, expires_at')
+    .eq('user_id', user.id)
+    .eq('active', true)
+    .order('invited_at', { ascending: true });
+
+  if (memErr) {
+    console.error('[snag-auth] membership_lookup_failed reason=%s', memErr.message);
+    throw new SnagAuthError('forbidden');
+  }
+  if (!rows || rows.length === 0) {
+    throw new SnagAuthError('forbidden');
+  }
+
+  const now = Date.now();
+  const usable = (rows as SiteTeamMemberRow[]).find((r) => {
+    if (r.role === 'snagger_external' && r.expires_at) {
+      return new Date(r.expires_at).getTime() > now;
+    }
+    return true;
+  });
+
+  if (!usable) {
+    throw new SnagAuthError('expired');
+  }
+
+  return {
+    userId: usable.user_id,
+    email: user.email,
+    tenantId: usable.tenant_id,
+    role: usable.role,
+    developmentIds: usable.development_ids,
+    isAdmin: usable.role === 'admin',
+    membershipId: usable.id,
+    expiresAt: usable.expires_at,
+  };
+}
+
+export function assertCanAccessTenant(auth: SnagAuthContext, tenantId: string): void {
+  if (auth.tenantId !== tenantId) {
+    throw new SnagAuthError('forbidden');
+  }
+}
+
+/**
+ * Verify the caller's membership permits access to the supplied
+ * development. admin and site_team see all developments in their tenant.
+ * snagger_external is scoped to the development_ids array.
+ *
+ * This does NOT confirm tenant_id of the development; the caller must
+ * have already established that the development belongs to auth.tenantId
+ * via assertCanAccessTenant or an explicit tenant lookup.
+ */
+export function assertCanAccessDevelopment(
+  auth: SnagAuthContext,
+  developmentId: string,
+): void {
+  if (auth.role === 'admin' || auth.role === 'site_team') {
+    return;
+  }
+  if (auth.role === 'snagger_external') {
+    const allowed = Array.isArray(auth.developmentIds) && auth.developmentIds.includes(developmentId);
+    if (!allowed) {
+      throw new SnagAuthError('forbidden');
+    }
+    return;
+  }
+  throw new SnagAuthError('forbidden');
+}
+
+export function assertIsAdmin(auth: SnagAuthContext): void {
+  if (!auth.isAdmin) {
+    throw new SnagAuthError('forbidden');
+  }
+}
+
+export function snagAuthErrorToResponse(err: SnagAuthError): NextResponse {
+  if (err.code === 'unauthenticated') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (err.code === 'expired') {
+    return NextResponse.json({ error: 'Membership expired' }, { status: 403 });
+  }
+  return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+}
+
+/**
+ * Return a fresh 404 NextResponse when the feature flag is off. Routes
+ * call this as the very first line so the surface area of the disabled
+ * feature is exactly zero (no parse, no auth, no DB).
+ */
+export function snagFeatureDisabledResponse(): NextResponse {
+  return NextResponse.json({ error: 'Not found' }, { status: 404 });
+}

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -40,11 +40,33 @@ export function isAssistantImageUploadEnabled(): boolean {
   );
 }
 
+/**
+ * Assistant V2 builder-side snag app (Sprint 2).
+ *
+ * Default off. When false:
+ *   - the /snag and /admin/snaggers routes render as 404 (Session 3)
+ *   - all /api/snag/* server routes return 404 before any auth or DB work
+ *
+ * Server reads FEATURE_BUILDER_SNAG_APP. Client reads
+ * NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP (must be set separately for the
+ * bundler to inline the value at build time).
+ */
+export function isBuilderSnagAppEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP === 'true';
+  }
+  return (
+    process.env.FEATURE_BUILDER_SNAG_APP === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP === 'true'
+  );
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
     purchaserVideos: isPurchaserVideosFeatureEnabled(),
     assistantOS: isAssistantOSEnabled(),
     assistantImageUpload: isAssistantImageUploadEnabled(),
+    builderSnagApp: isBuilderSnagAppEnabled(),
   };
 }


### PR DESCRIPTION
Implements sections 5 and 6 of `docs/specs/assistant-v2-sprint-2.md`. Server-side only, no UI.

## New routes (under `apps/unified-portal/app/api/snag/`)

| Method | Path | Purpose |
| --- | --- | --- |
| POST | `/api/snag/invite` | Admin creates a `snagger_invitations` row and returns a signup URL (spec 5.1). |
| POST | `/api/snag/accept` | Authenticated user redeems token, creates a `site_team_members` row with role `snagger_external` (spec 5.2). |
| POST | `/api/snag/create` | Main snag creation. Inserts `issue_reports`, `issue_report_media`, `issue_events`, then fire-and-forgets enrichment (spec 5.3). |
| GET | `/api/snag/list` | Paginated list scoped to caller's accessible developments, with media count (spec 5.4). |
| GET | `/api/snag/[id]` | Single snag detail with one-hour signed media URLs and event timeline (spec 5.5). |
| POST | `/api/snag/enrich/[issue_report_id]` | Internal route. Calls `mediaAnalysisService.analyse()`, links the resulting `assistant_media_analysis` row back via `linked_analysis_id`, and appends an `analysis_completed` event (spec 6). |

## Auth helper

New `apps/unified-portal/lib/assistant/snag-auth.ts`, patterned after `media-auth.ts`. Exports:

- `resolveSnagAuth(request)` reads the Supabase session, loads the active `site_team_members` row, enforces `expires_at` for `snagger_external`, returns `{ userId, email, tenantId, role, developmentIds, isAdmin, membershipId, expiresAt }`.
- `assertCanAccessTenant(auth, tenantId)`, `assertCanAccessDevelopment(auth, developmentId)`, `assertIsAdmin(auth)` for per-route resource checks. `snagger_external` is restricted to its `development_ids` array.
- `SnagAuthError` and `snagAuthErrorToResponse(err)` for uniform mapping to 401 / 403 responses.
- `snagFeatureDisabledResponse()` for the flag-off 404 short-circuit.

Tenant ID and role always derive from the verified membership row. Client-supplied `tenant_id` or `logged_by_role` are never trusted; the create route stamps both from `auth`.

## Feature flag and env

- `apps/unified-portal/lib/feature-flags.ts` gains `isBuilderSnagAppEnabled()` covering both server (`FEATURE_BUILDER_SNAG_APP`) and client (`NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP`) variants.
- `apps/unified-portal/.env.example` and `.env.production.example` document the new env vars: `FEATURE_BUILDER_SNAG_APP`, `NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP`, and `INTERNAL_ENRICHMENT_KEY`.
- All six routes return 404 before any auth or DB work when the flag is false.

## INTERNAL_ENRICHMENT_KEY (action required before testing)

The fire-and-forget fetch from `/create` to `/enrich/[issue_report_id]` authenticates with `x-internal-key`. The enrich route also accepts `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>` as a fallback. Both are `timingSafeEqual` compared.

**Before testing in Vercel:**
1. Generate a random secret: `openssl rand -hex 32`
2. Add `INTERNAL_ENRICHMENT_KEY` to Vercel env (Production AND Preview) and redeploy.

If unset, `/create` still works but logs `enrichment_skipped reason=INTERNAL_ENRICHMENT_KEY_unset` and the snag is left without an analysis row. This keeps local dev frictionless.

## Background enrichment

`/create` triggers a non-awaited `fetch()` to `/enrich/[issue_report_id]`. The call is wrapped in `try/void fetch().catch()` so a synchronous throw or async rejection is logged but never blocks the response. The snag is committed before the enrichment is scheduled, so the user gets `issue_report_id` immediately regardless of model latency.

## What was not touched

- The Sprint 1 multimodal route (`/api/assistant/chat/multimodal`), signed-url route (`/api/assistant/media/signed-url`), and upload route (`/api/assistant/media/upload`) are unchanged.
- `lib/assistant/mediaAnalysisService.ts` is unchanged. It is still the Sprint 1 placeholder; Sprint 1b will swap the body and both builder-side and homeowner-side surfaces will pick up the real model automatically.
- The text-only `/api/chat` route is unchanged.
- The homeowner multimodal path continues to write `source = 'homeowner_assistant'` via the column default.

## Tests

No test runner is currently wired up for this app (same situation Sprint 1 documented). Cases that should be covered once one is available:

- Feature-flag-off returns 404 on every `/api/snag/*` route without touching auth or DB.
- `resolveSnagAuth` returns 401 with no session, 403 with no active membership, 403 with expired `snagger_external` membership.
- `/invite` rejects non-admin callers with 403 and cross-tenant `development_id` with 403.
- `/accept` returns 410 for expired / revoked / already-accepted tokens, 403 on email mismatch, idempotent when user already a member of the tenant.
- `/create` rejects out-of-scope `development_id` for `snagger_external` with 403, rejects cross-tenant `media_ids` with 403, stamps `source` and `logged_by_role` from the verified auth.
- `/list` filters to `development_ids` for `snagger_external`, returns the right media count per row.
- `/[id]` returns 403 when the report's `development_id` is outside the caller's access.
- `/enrich/[id]` rejects callers without `x-internal-key` or the service-role JWT, is idempotent if `linked_analysis_id` is already set.

## Spec cross-reference

Sections 5.1, 5.2, 5.3, 5.4, 5.5, and 6 of `docs/specs/assistant-v2-sprint-2.md`.

## Out of scope (Session 3)

UI for `/snag` and `/admin/snaggers`. That lands on the `assistant-v2/snag-ui` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbnNQRWW92U83M6dPpw9e5)_