### PR TITLE
feat(assistant-v2): Sprint 2 UI for builder-side snag capture

### DIFF
--- a/apps/unified-portal/app/api/snag/developments/route.ts
+++ b/apps/unified-portal/app/api/snag/developments/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/snag/developments
+ *
+ * Assistant V2 Sprint 2. Returns the developments the caller can access
+ * for the snag form's development switcher.
+ *
+ * Scoping:
+ *   - admin / site_team:  all developments in the caller's tenant
+ *   - snagger_external:   restricted to development_ids on the
+ *                         site_team_members row
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+  let query = supabase
+    .from('developments')
+    .select('id, name, tenant_id, is_active')
+    .eq('tenant_id', auth.tenantId)
+    .order('name', { ascending: true });
+
+  if (auth.role === 'snagger_external') {
+    const scope = Array.isArray(auth.developmentIds) ? auth.developmentIds : [];
+    if (scope.length === 0) {
+      return NextResponse.json({ developments: [] });
+    }
+    query = query.in('id', scope);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('[snag-developments] list_failed reason=%s', error.message);
+    return NextResponse.json({ error: 'Could not load developments' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    developments: (data ?? []).map((d) => ({
+      id: d.id as string,
+      name: (d.name as string) ?? 'Development',
+      is_active: (d.is_active as boolean | null) ?? true,
+    })),
+    role: auth.role,
+    is_admin: auth.isAdmin,
+  });
+}

--- a/apps/unified-portal/app/api/snag/team/route.ts
+++ b/apps/unified-portal/app/api/snag/team/route.ts
@@ -1,0 +1,128 @@
+/**
+ * GET /api/snag/team
+ *
+ * Assistant V2 Sprint 2. Admin-only listing for /developer/snaggers.
+ * Returns the tenant's site_team_members (with email joined from
+ * auth.users) and the open snagger_invitations (not yet accepted,
+ * not revoked).
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertIsAdmin,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const PRODUCTION_ORIGIN = 'https://portal.openhouseai.ie';
+
+function resolveOrigin(request: NextRequest): string {
+  if (process.env.VERCEL_ENV === 'production') return PRODUCTION_ORIGIN;
+  const origin = request.headers.get('origin');
+  if (origin && /^https?:\/\//.test(origin)) return origin;
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+  return PRODUCTION_ORIGIN;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+    assertIsAdmin(auth);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: members, error: memErr } = await supabase
+    .from('site_team_members')
+    .select('id, user_id, role, development_ids, active, expires_at, invited_at, accepted_at')
+    .eq('tenant_id', auth.tenantId)
+    .order('invited_at', { ascending: false });
+  if (memErr) {
+    console.error('[snag-team] members_failed reason=%s', memErr.message);
+    return NextResponse.json({ error: 'Could not load team' }, { status: 500 });
+  }
+
+  const userIds = Array.from(new Set((members ?? []).map((m) => m.user_id as string)));
+  const emailByUserId = new Map<string, string>();
+  if (userIds.length > 0) {
+    for (const userId of userIds) {
+      const { data: u } = await supabase.auth.admin.getUserById(userId);
+      if (u?.user?.email) emailByUserId.set(userId, u.user.email);
+    }
+  }
+
+  const { data: invites, error: inviteErr } = await supabase
+    .from('snagger_invitations')
+    .select('id, email, development_id, invited_by, token, expires_at, accepted_at, revoked_at, created_at')
+    .eq('tenant_id', auth.tenantId)
+    .is('accepted_at', null)
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false });
+  if (inviteErr) {
+    console.error('[snag-team] invites_failed reason=%s', inviteErr.message);
+    return NextResponse.json({ error: 'Could not load invitations' }, { status: 500 });
+  }
+
+  const { data: developments } = await supabase
+    .from('developments')
+    .select('id, name')
+    .eq('tenant_id', auth.tenantId)
+    .order('name', { ascending: true });
+
+  const origin = resolveOrigin(request);
+  const now = Date.now();
+
+  return NextResponse.json({
+    members: (members ?? []).map((m) => {
+      const expiry = m.expires_at as string | null;
+      const isExpired = !!expiry && new Date(expiry).getTime() <= now;
+      return {
+        id: m.id,
+        user_id: m.user_id,
+        email: emailByUserId.get(m.user_id as string) ?? null,
+        role: m.role,
+        development_ids: m.development_ids,
+        active: m.active,
+        expires_at: m.expires_at,
+        invited_at: m.invited_at,
+        accepted_at: m.accepted_at,
+        is_expired: isExpired,
+      };
+    }),
+    invitations: (invites ?? []).map((i) => {
+      const expiry = i.expires_at as string;
+      const isExpired = new Date(expiry).getTime() <= now;
+      return {
+        id: i.id,
+        email: i.email,
+        development_id: i.development_id,
+        expires_at: i.expires_at,
+        created_at: i.created_at,
+        is_expired: isExpired,
+        invite_url: `${origin}/snag/accept?token=${encodeURIComponent(i.token as string)}`,
+      };
+    }),
+    developments: (developments ?? []).map((d) => ({ id: d.id, name: d.name })),
+  });
+}

--- a/apps/unified-portal/app/api/snag/units/route.ts
+++ b/apps/unified-portal/app/api/snag/units/route.ts
@@ -1,0 +1,105 @@
+/**
+ * GET /api/snag/units
+ *
+ * Assistant V2 Sprint 2. Returns the list of units in a development that
+ * the caller is allowed to see, for the snag form's unit picker.
+ *
+ * Auth via snag-auth.resolveSnagAuth. The caller must have access to the
+ * requested development under their site_team_members membership:
+ *   - admin / site_team: any development in their tenant
+ *   - snagger_external:  must be in their development_ids array
+ *
+ * Cross-tenant or out-of-scope developments surface as 403. A
+ * development that does not exist is 404.
+ *
+ * Gated on FEATURE_BUILDER_SNAG_APP.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(request: NextRequest) {
+  if (!isBuilderSnagAppEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const url = new URL(request.url);
+  const developmentId = url.searchParams.get('development_id') ?? '';
+  if (!UUID_RE.test(developmentId)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+    assertCanAccessDevelopment(auth, developmentId);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: development, error: devErr } = await supabase
+    .from('developments')
+    .select('id, tenant_id, name')
+    .eq('id', developmentId)
+    .maybeSingle();
+  if (devErr) {
+    console.error('[snag-units] development_lookup_failed reason=%s', devErr.message);
+    return NextResponse.json({ error: 'Could not load development' }, { status: 500 });
+  }
+  if (!development) {
+    return NextResponse.json({ error: 'Development not found' }, { status: 404 });
+  }
+  if (development.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: units, error: unitsErr } = await supabase
+    .from('units')
+    .select('id, unit_code, unit_number, address, address_line_1, address_line_2, city, eircode, purchaser_name')
+    .eq('development_id', developmentId)
+    .eq('tenant_id', auth.tenantId)
+    .order('unit_code', { ascending: true });
+  if (unitsErr) {
+    console.error('[snag-units] units_lookup_failed reason=%s', unitsErr.message);
+    return NextResponse.json({ error: 'Could not load units' }, { status: 500 });
+  }
+
+  const rows = (units ?? []).map((u) => ({
+    id: u.id as string,
+    unit_code: (u.unit_code as string | null) ?? null,
+    unit_number: (u.unit_number as string | null) ?? null,
+    address: (u.address as string | null) ?? null,
+    address_line_1: (u.address_line_1 as string | null) ?? null,
+    address_line_2: (u.address_line_2 as string | null) ?? null,
+    city: (u.city as string | null) ?? null,
+    eircode: (u.eircode as string | null) ?? null,
+    purchaser_name: (u.purchaser_name as string | null) ?? null,
+    display_name:
+      (u.unit_code as string | null) ??
+      (u.unit_number as string | null) ??
+      (u.address as string | null) ??
+      (u.address_line_1 as string | null) ??
+      'Unit',
+  }));
+
+  return NextResponse.json({
+    development: { id: development.id, name: development.name },
+    units: rows,
+  });
+}

--- a/apps/unified-portal/app/developer/layout-sidebar.tsx
+++ b/apps/unified-portal/app/developer/layout-sidebar.tsx
@@ -10,7 +10,7 @@ import {
   FolderArchive, MessageSquare, Shield, Sparkles,
   Layers, ShieldCheck, GitBranch, Mail, Command,
   CalendarCheck, Building2, Wrench, Dumbbell, BookOpen as Welcome,
-  Plug, Megaphone, HardDrive, LogOut
+  Plug, Megaphone, HardDrive, LogOut, UserPlus
 } from 'lucide-react';
 import { ScopeSwitcher } from '@/components/developer/ScopeSwitcher';
 import { CommandPalette } from '@/components/ui/CommandPalette';
@@ -76,6 +76,7 @@ const btsNavSections: NavSection[] = [
     title: 'Settings',
     items: [
       { label: 'Integrations', href: '/developer/integrations', icon: Plug },
+      { label: 'Snagging Team', href: '/developer/snaggers', icon: UserPlus },
     ],
   },
 ];

--- a/apps/unified-portal/app/developer/snaggers/SnaggersClient.tsx
+++ b/apps/unified-portal/app/developer/snaggers/SnaggersClient.tsx
@@ -1,0 +1,437 @@
+'use client';
+
+/**
+ * /developer/snaggers client. Three regions:
+ *   1. Members list
+ *   2. Pending invitations list
+ *   3. Invite snagger modal (email + development picker + expiry)
+ *
+ * Spec section 8.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Check, Clock, Copy, Mail, ShieldCheck, UserPlus, X } from 'lucide-react';
+
+interface SnaggersClientProps {
+  tenantId: string;
+}
+
+interface Member {
+  id: string;
+  user_id: string;
+  email: string | null;
+  role: 'admin' | 'site_team' | 'snagger_external';
+  development_ids: string[] | null;
+  active: boolean;
+  expires_at: string | null;
+  invited_at: string;
+  accepted_at: string | null;
+  is_expired: boolean;
+}
+
+interface Invitation {
+  id: string;
+  email: string;
+  development_id: string;
+  expires_at: string;
+  created_at: string;
+  is_expired: boolean;
+  invite_url: string;
+}
+
+interface DevelopmentLite {
+  id: string;
+  name: string;
+}
+
+interface TeamPayload {
+  members: Member[];
+  invitations: Invitation[];
+  developments: DevelopmentLite[];
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EXPIRY_OPTIONS = [7, 14, 30] as const;
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function roleLabel(role: Member['role']): string {
+  if (role === 'admin') return 'Admin';
+  if (role === 'site_team') return 'Site team';
+  return 'External snagger';
+}
+
+export function SnaggersClient(_props: SnaggersClientProps) {
+  const [data, setData] = useState<TeamPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch('/api/snag/team', { cache: 'no-store' });
+      if (!res.ok) {
+        setLoadError("Couldn't load the snagging team.");
+        return;
+      }
+      const json = (await res.json()) as TeamPayload;
+      setData(json);
+    } catch {
+      setLoadError("Couldn't load the snagging team.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const copyInvite = async (url: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedToken(id);
+      setTimeout(() => setCopiedToken((curr) => (curr === id ? null : curr)), 1500);
+    } catch {
+      // Fallback: select-and-show. Best-effort only.
+      window.prompt('Copy invite URL', url);
+    }
+  };
+
+  const developments = data?.developments ?? [];
+  const developmentName = (id: string) => developments.find((d) => d.id === id)?.name ?? id;
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-heading-md text-neutral-900">Snagging team</h1>
+          <p className="text-body-sm text-neutral-600 mt-1">
+            Invite external snaggers and manage site team access.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setInviteOpen(true)}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-brand-500 text-white rounded-lg font-medium hover:bg-brand-600 active:bg-brand-700 min-h-[44px]"
+        >
+          <UserPlus className="w-4 h-4" />
+          Invite snagger
+        </button>
+      </header>
+
+      {loading ? (
+        <div className="bg-white border border-neutral-200 rounded-lg p-6 text-body-sm text-neutral-500">
+          Loading...
+        </div>
+      ) : loadError ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-body-sm text-red-700">
+          {loadError}
+        </div>
+      ) : data ? (
+        <>
+          <section className="bg-white border border-neutral-200 rounded-lg overflow-hidden">
+            <div className="px-4 py-3 border-b border-neutral-100 flex items-center gap-2">
+              <ShieldCheck className="w-4 h-4 text-neutral-500" />
+              <h2 className="text-body-sm font-medium text-neutral-700">Current team</h2>
+              <span className="ml-auto text-caption text-neutral-500">{data.members.length} {data.members.length === 1 ? 'person' : 'people'}</span>
+            </div>
+            {data.members.length === 0 ? (
+              <div className="px-4 py-6 text-body-sm text-neutral-500 text-center">
+                No team members yet. Invite a snagger to get started.
+              </div>
+            ) : (
+              <ul className="divide-y divide-neutral-100">
+                {data.members.map((m) => (
+                  <li key={m.id} className="px-4 py-3 flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-body text-neutral-900 truncate">{m.email ?? m.user_id}</div>
+                      <div className="text-caption text-neutral-500 mt-0.5">
+                        {roleLabel(m.role)}
+                        {m.role === 'snagger_external' && Array.isArray(m.development_ids) && m.development_ids.length > 0
+                          ? ' . ' + m.development_ids.map(developmentName).join(', ')
+                          : null}
+                      </div>
+                      <div className="text-caption text-neutral-500 mt-0.5">
+                        {m.accepted_at ? `Accepted ${formatDate(m.accepted_at)}` : `Invited ${formatDate(m.invited_at)}`}
+                        {m.expires_at ? ` . expires ${formatDate(m.expires_at)}` : null}
+                      </div>
+                    </div>
+                    <span
+                      className={`text-caption px-2 py-0.5 rounded-full ${
+                        !m.active
+                          ? 'bg-neutral-100 text-neutral-500'
+                          : m.is_expired
+                          ? 'bg-amber-50 text-amber-700'
+                          : 'bg-emerald-50 text-emerald-700'
+                      }`}
+                    >
+                      {!m.active ? 'Inactive' : m.is_expired ? 'Expired' : 'Active'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="bg-white border border-neutral-200 rounded-lg overflow-hidden">
+            <div className="px-4 py-3 border-b border-neutral-100 flex items-center gap-2">
+              <Mail className="w-4 h-4 text-neutral-500" />
+              <h2 className="text-body-sm font-medium text-neutral-700">Pending invitations</h2>
+              <span className="ml-auto text-caption text-neutral-500">{data.invitations.length}</span>
+            </div>
+            {data.invitations.length === 0 ? (
+              <div className="px-4 py-6 text-body-sm text-neutral-500 text-center">
+                No pending invitations.
+              </div>
+            ) : (
+              <ul className="divide-y divide-neutral-100">
+                {data.invitations.map((inv) => (
+                  <li key={inv.id} className="px-4 py-3 flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-body text-neutral-900 truncate">{inv.email}</div>
+                      <div className="text-caption text-neutral-500 mt-0.5">
+                        {developmentName(inv.development_id)} . expires {formatDate(inv.expires_at)}
+                      </div>
+                    </div>
+                    {inv.is_expired ? (
+                      <span className="text-caption px-2 py-0.5 rounded-full bg-amber-50 text-amber-700">Expired</span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => copyInvite(inv.invite_url, inv.id)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-neutral-100 text-neutral-700 rounded-md text-body-sm hover:bg-neutral-200 active:bg-neutral-300 min-h-[36px]"
+                      >
+                        {copiedToken === inv.id ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+                        {copiedToken === inv.id ? 'Copied' : 'Copy link'}
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      ) : null}
+
+      {inviteOpen ? (
+        <InviteModal
+          developments={developments}
+          onClose={() => setInviteOpen(false)}
+          onSuccess={() => {
+            void load();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface InviteModalProps {
+  developments: DevelopmentLite[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+function InviteModal({ developments, onClose, onSuccess }: InviteModalProps) {
+  const [email, setEmail] = useState('');
+  const [developmentId, setDevelopmentId] = useState<string>(() => developments[0]?.id ?? '');
+  const [expiresInDays, setExpiresInDays] = useState<7 | 14 | 30>(14);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const valid = EMAIL_RE.test(email.trim()) && !!developmentId;
+
+  const submit = async () => {
+    if (!valid || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/snag/invite', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          email: email.trim(),
+          development_id: developmentId,
+          expires_in_days: expiresInDays,
+        }),
+      });
+      if (!res.ok) {
+        let message = "Couldn't create the invitation.";
+        try {
+          const json = await res.json();
+          if (typeof json?.error === 'string' && json.error.length < 200) message = json.error;
+        } catch {
+          // ignore
+        }
+        setError(message);
+        return;
+      }
+      const json = await res.json();
+      setInviteUrl(typeof json?.invite_url === 'string' ? json.invite_url : null);
+      onSuccess();
+    } catch {
+      setError("Couldn't create the invitation.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const copy = async () => {
+    if (!inviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      window.prompt('Copy invite URL', inviteUrl);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-modal bg-neutral-900/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <header className="px-5 py-4 border-b border-neutral-200 flex items-center gap-3">
+          <h2 className="text-heading-sm text-neutral-900 flex-1">Invite snagger</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="w-10 h-10 -mr-1 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </header>
+
+        {inviteUrl ? (
+          <div className="px-5 py-5 space-y-4">
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-body-sm text-emerald-700 flex items-start gap-2">
+              <Check className="w-4 h-4 mt-0.5" />
+              <div>Invitation created. Copy this link and send it via WhatsApp or email.</div>
+            </div>
+            <div>
+              <label className="text-caption text-neutral-500 block mb-1" htmlFor="invite-url">
+                Invite link
+              </label>
+              <div className="flex items-stretch gap-2">
+                <input
+                  id="invite-url"
+                  type="text"
+                  readOnly
+                  value={inviteUrl}
+                  className="flex-1 px-3 py-2 bg-neutral-50 border border-neutral-200 rounded-lg text-body-sm text-neutral-900 truncate"
+                />
+                <button
+                  type="button"
+                  onClick={copy}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-neutral-900 text-white rounded-lg text-body-sm hover:bg-neutral-800 active:bg-neutral-700 min-h-[40px]"
+                >
+                  {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full py-2.5 bg-brand-500 text-white rounded-lg font-medium hover:bg-brand-600 active:bg-brand-700 min-h-[44px]"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <div className="px-5 py-5 space-y-4">
+            <div>
+              <label className="text-caption text-neutral-500 block mb-1" htmlFor="invite-email">
+                Email
+              </label>
+              <input
+                id="invite-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="snagger@company.ie"
+                autoComplete="email"
+                className="w-full px-3 py-2.5 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500 min-h-[44px]"
+              />
+            </div>
+
+            <div>
+              <label className="text-caption text-neutral-500 block mb-1" htmlFor="invite-dev">
+                Development
+              </label>
+              <select
+                id="invite-dev"
+                value={developmentId}
+                onChange={(e) => setDevelopmentId(e.target.value)}
+                className="w-full px-3 py-2.5 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500 min-h-[44px]"
+              >
+                {developments.length === 0 ? (
+                  <option value="">No developments in this tenant</option>
+                ) : null}
+                {developments.map((d) => (
+                  <option key={d.id} value={d.id}>
+                    {d.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="text-caption text-neutral-500 block mb-1" htmlFor="invite-expiry">
+                Expires in
+              </label>
+              <div className="flex gap-2">
+                {EXPIRY_OPTIONS.map((days) => (
+                  <button
+                    key={days}
+                    type="button"
+                    onClick={() => setExpiresInDays(days)}
+                    className={`flex-1 py-2.5 rounded-lg border text-body-sm min-h-[44px] ${
+                      expiresInDays === days
+                        ? 'bg-brand-500 text-white border-brand-500'
+                        : 'bg-white text-neutral-700 border-neutral-200 hover:bg-neutral-50'
+                    }`}
+                  >
+                    {days} days
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-caption text-neutral-600 flex items-start gap-2">
+              <Clock className="w-3.5 h-3.5 mt-0.5" />
+              <div>
+                Polished invitation emails are a later sprint. Copy the resulting link and send it via your usual channel.
+              </div>
+            </div>
+
+            {error ? (
+              <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-body-sm text-red-700">
+                {error}
+              </div>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={submit}
+              disabled={!valid || submitting}
+              className="w-full py-2.5 bg-brand-500 text-white rounded-lg font-medium disabled:bg-neutral-200 disabled:text-neutral-400 hover:bg-brand-600 active:bg-brand-700 min-h-[44px]"
+            >
+              {submitting ? 'Creating...' : 'Create invitation'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/developer/snaggers/page.tsx
+++ b/apps/unified-portal/app/developer/snaggers/page.tsx
@@ -1,0 +1,39 @@
+/**
+ * /developer/snaggers
+ *
+ * Assistant V2 Sprint 2. Admin invite UI. Lives inside the developer
+ * sidebar layout so admins keep their nav when managing the snagging
+ * team. The spec called this /admin/snaggers; Session 3 moved it to
+ * /developer/snaggers for routing consistency.
+ *
+ * Server responsibilities:
+ *   1. 404 if FEATURE_BUILDER_SNAG_APP is off.
+ *   2. The /developer layout already gates on Supabase session.
+ *   3. Resolve site_team_members and require role='admin'. Non-admins
+ *      see the no-access screen.
+ */
+
+import { notFound } from 'next/navigation';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { resolveSnagAuth, assertIsAdmin, SnagAuthError } from '@/lib/assistant/snag-auth';
+import { SnagNoAccess } from '../../snag/SnagNoAccess';
+import { SnaggersClient } from './SnaggersClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function DeveloperSnaggersPage() {
+  if (!isBuilderSnagAppEnabled()) notFound();
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+    assertIsAdmin(auth);
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      return <SnagNoAccess code={err.code === 'unauthenticated' ? 'unauthenticated' : 'forbidden'} />;
+    }
+    throw err;
+  }
+
+  return <SnaggersClient tenantId={auth.tenantId} />;
+}

--- a/apps/unified-portal/app/snag/DevelopmentSwitcherSheet.tsx
+++ b/apps/unified-portal/app/snag/DevelopmentSwitcherSheet.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Full-screen sheet for switching the active development. Only rendered
+ * by the parent when the user has access to more than one development.
+ */
+
+import { Check, X } from 'lucide-react';
+
+export interface SnagDevelopment {
+  id: string;
+  name: string;
+}
+
+interface DevelopmentSwitcherSheetProps {
+  open: boolean;
+  developments: SnagDevelopment[];
+  selectedId: string | null;
+  onClose: () => void;
+  onSelect: (dev: SnagDevelopment) => void;
+}
+
+export function DevelopmentSwitcherSheet({
+  open,
+  developments,
+  selectedId,
+  onClose,
+  onSelect,
+}: DevelopmentSwitcherSheetProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-modal bg-white flex flex-col">
+      <header className="px-4 py-3 border-b border-neutral-200 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close development picker"
+          className="w-11 h-11 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+        >
+          <X className="w-5 h-5" />
+        </button>
+        <h2 className="text-heading-sm text-neutral-900">Switch development</h2>
+      </header>
+      <div className="flex-1 overflow-y-auto">
+        <ul className="divide-y divide-neutral-100">
+          {developments.map((dev) => {
+            const isSelected = dev.id === selectedId;
+            return (
+              <li key={dev.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(dev)}
+                  className={`w-full px-4 py-4 text-left flex items-center gap-3 min-h-[56px] active:bg-neutral-50 ${
+                    isSelected ? 'bg-brand-50' : ''
+                  }`}
+                >
+                  <span className="flex-1 text-body text-neutral-900">{dev.name}</span>
+                  {isSelected ? <Check className="w-5 h-5 text-brand-600" /> : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/RoomPickerSheet.tsx
+++ b/apps/unified-portal/app/snag/RoomPickerSheet.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+/**
+ * Full-screen sheet for picking a room. Spec section 7.4.
+ *
+ * Room list is verbatim from the spec: Kitchen, Bathroom, Living Room,
+ * Bedroom 1, Bedroom 2, Bedroom 3, Hall, Landing, Utility, Other.
+ * Selecting Other reveals a text input below the list.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Check, X } from 'lucide-react';
+
+const ROOMS = [
+  'Kitchen',
+  'Bathroom',
+  'Living Room',
+  'Bedroom 1',
+  'Bedroom 2',
+  'Bedroom 3',
+  'Hall',
+  'Landing',
+  'Utility',
+  'Other',
+] as const;
+
+interface RoomPickerSheetProps {
+  open: boolean;
+  selected: string;
+  onClose: () => void;
+  onSelect: (room: string) => void;
+}
+
+export function RoomPickerSheet({ open, selected, onClose, onSelect }: RoomPickerSheetProps) {
+  const isCustom = !!selected && !ROOMS.includes(selected as (typeof ROOMS)[number]);
+  const [pendingChoice, setPendingChoice] = useState<string>(() =>
+    isCustom ? 'Other' : selected || '',
+  );
+  const [customValue, setCustomValue] = useState<string>(() => (isCustom ? selected : ''));
+  const customInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      const initialCustom = !!selected && !ROOMS.includes(selected as (typeof ROOMS)[number]);
+      setPendingChoice(initialCustom ? 'Other' : selected || '');
+      setCustomValue(initialCustom ? selected : '');
+    }
+  }, [open, selected]);
+
+  useEffect(() => {
+    if (pendingChoice === 'Other') {
+      const t = setTimeout(() => customInputRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [pendingChoice]);
+
+  if (!open) return null;
+
+  const canConfirm =
+    pendingChoice && (pendingChoice !== 'Other' || customValue.trim().length > 0);
+
+  const confirm = () => {
+    if (!pendingChoice) return;
+    if (pendingChoice === 'Other') {
+      const trimmed = customValue.trim();
+      if (!trimmed) return;
+      onSelect(trimmed);
+    } else {
+      onSelect(pendingChoice);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-modal bg-white flex flex-col">
+      <header className="px-4 py-3 border-b border-neutral-200 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close room picker"
+          className="w-11 h-11 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+        >
+          <X className="w-5 h-5" />
+        </button>
+        <h2 className="text-heading-sm text-neutral-900">Select room</h2>
+      </header>
+
+      <div className="flex-1 overflow-y-auto">
+        <ul className="divide-y divide-neutral-100">
+          {ROOMS.map((room) => {
+            const isSelected = pendingChoice === room;
+            return (
+              <li key={room}>
+                <button
+                  type="button"
+                  onClick={() => setPendingChoice(room)}
+                  className={`w-full px-4 py-4 text-left flex items-center gap-3 min-h-[56px] active:bg-neutral-50 ${
+                    isSelected ? 'bg-brand-50' : ''
+                  }`}
+                >
+                  <span className="flex-1 text-body text-neutral-900">{room}</span>
+                  {isSelected ? <Check className="w-5 h-5 text-brand-600" /> : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {pendingChoice === 'Other' ? (
+          <div className="px-4 py-4 border-t border-neutral-100">
+            <label className="text-caption text-neutral-500 block mb-1" htmlFor="room-other">
+              Describe the room
+            </label>
+            <input
+              ref={customInputRef}
+              id="room-other"
+              type="text"
+              value={customValue}
+              onChange={(e) => setCustomValue(e.target.value)}
+              maxLength={60}
+              placeholder="Garage, garden, attic"
+              className="w-full px-4 py-3 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500"
+            />
+          </div>
+        ) : null}
+      </div>
+
+      <div className="sticky bottom-0 px-4 py-3 bg-white border-t border-neutral-200">
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={!canConfirm}
+          className="w-full py-3 bg-brand-500 text-white rounded-lg font-medium disabled:bg-neutral-200 disabled:text-neutral-400 active:bg-brand-600 min-h-[44px]"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/SnagFormClient.tsx
+++ b/apps/unified-portal/app/snag/SnagFormClient.tsx
@@ -1,0 +1,545 @@
+'use client';
+
+/**
+ * Phone-first snag capture form. Spec section 7.
+ *
+ * Layout regions:
+ *   1. Header  (title + development switcher)
+ *   2. Main    (unit selector, photo capture, title, room, notes)
+ *   3. Sticky bottom submit
+ *   4. Recent section (last 5 snags by this user in the selected unit)
+ *
+ * Upload pipeline:
+ *   1. compressSelectionsForUpload to stay under Vercel's 4.5 MB body cap
+ *   2. POST /api/assistant/media/upload (Path C in media-auth.ts picks up
+ *      site_team_members session)
+ *   3. POST /api/snag/create with the returned media_ids
+ *
+ * The Sprint 1 attachments helpers handle the file picker, normalisation,
+ * preview URLs, and compression. We reuse them as-is.
+ */
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Camera, ChevronRight, Plus, X } from 'lucide-react';
+import {
+  ASSISTANT_MEDIA_ACCEPT,
+  ASSISTANT_MEDIA_MAX_FILES,
+  compressSelectionsForUpload,
+  normalizeFiles,
+  rejectionMessage,
+  revokeSelections,
+  type SelectedAttachment,
+} from '@/lib/assistant/attachments';
+import { UnitPickerSheet, type SnagUnit } from './UnitPickerSheet';
+import { RoomPickerSheet } from './RoomPickerSheet';
+import { DevelopmentSwitcherSheet, type SnagDevelopment } from './DevelopmentSwitcherSheet';
+
+interface InitialAuth {
+  userId: string;
+  email: string;
+  tenantId: string;
+  role: 'admin' | 'site_team' | 'snagger_external';
+  developmentIds: string[] | null;
+  isAdmin: boolean;
+}
+
+interface SnagFormClientProps {
+  initialAuth: InitialAuth;
+}
+
+interface RecentSnag {
+  id: string;
+  title: string;
+  unit_id: string;
+  created_at: string;
+  media_count: number;
+  logged_by_user_id: string | null;
+}
+
+const TITLE_PLACEHOLDER = 'Hairline crack above door';
+const NOTES_PLACEHOLDER = 'Any extra detail';
+const PICKER_PLACEHOLDER = 'Tap to select';
+
+const SUBMIT_IDLE = 'Log snag';
+const SUBMIT_PENDING = 'Logging snag...';
+const TOAST_SUCCESS = 'Snag logged.';
+const ERROR_GENERIC = "Couldn't log that snag. Try again.";
+
+const MAX_TITLE_LEN = 120;
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
+}
+
+function uuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+export function SnagFormClient({ initialAuth }: SnagFormClientProps) {
+  const fileInputId = useId();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [developments, setDevelopments] = useState<SnagDevelopment[]>([]);
+  const [developmentId, setDevelopmentId] = useState<string | null>(null);
+  const developmentName = useMemo(
+    () => developments.find((d) => d.id === developmentId)?.name ?? '',
+    [developments, developmentId],
+  );
+
+  const [units, setUnits] = useState<SnagUnit[]>([]);
+  const [unitsLoading, setUnitsLoading] = useState(false);
+  const [unitsError, setUnitsError] = useState<string | null>(null);
+  const [selectedUnit, setSelectedUnit] = useState<SnagUnit | null>(null);
+
+  const [selections, setSelections] = useState<SelectedAttachment[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [room, setRoom] = useState('');
+
+  const [pickerOpen, setPickerOpen] = useState<null | 'unit' | 'room' | 'development'>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const [recent, setRecent] = useState<RecentSnag[]>([]);
+  const [recentLoading, setRecentLoading] = useState(false);
+
+  useEffect(() => {
+    return () => revokeSelections(selections);
+  }, [selections]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/snag/developments', { cache: 'no-store' });
+        if (!res.ok) return;
+        const json = await res.json();
+        if (cancelled) return;
+        const list: SnagDevelopment[] = Array.isArray(json?.developments) ? json.developments : [];
+        setDevelopments(list);
+        if (list.length > 0) setDevelopmentId((prev) => prev ?? list[0].id);
+      } catch (err) {
+        console.warn('[snag-form] failed to load developments', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!developmentId) {
+      setUnits([]);
+      return;
+    }
+    let cancelled = false;
+    setUnitsLoading(true);
+    setUnitsError(null);
+    (async () => {
+      try {
+        const res = await fetch(`/api/snag/units?development_id=${encodeURIComponent(developmentId)}`, {
+          cache: 'no-store',
+        });
+        if (!res.ok) {
+          if (!cancelled) setUnitsError("Couldn't load units. Try again.");
+          return;
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        const list: SnagUnit[] = Array.isArray(json?.units) ? json.units : [];
+        setUnits(list);
+      } catch (err) {
+        if (!cancelled) setUnitsError("Couldn't load units. Try again.");
+      } finally {
+        if (!cancelled) setUnitsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [developmentId]);
+
+  const refreshRecent = useCallback(async () => {
+    if (!developmentId || !selectedUnit) {
+      setRecent([]);
+      return;
+    }
+    setRecentLoading(true);
+    try {
+      const res = await fetch(
+        `/api/snag/list?development_id=${encodeURIComponent(developmentId)}&limit=100`,
+        { cache: 'no-store' },
+      );
+      if (!res.ok) {
+        setRecent([]);
+        return;
+      }
+      const json = await res.json();
+      const rows: RecentSnag[] = Array.isArray(json?.rows) ? json.rows : [];
+      const filtered = rows
+        .filter((r) => r.unit_id === selectedUnit.id && r.logged_by_user_id === initialAuth.userId)
+        .slice(0, 5);
+      setRecent(filtered);
+    } catch (err) {
+      setRecent([]);
+    } finally {
+      setRecentLoading(false);
+    }
+  }, [developmentId, selectedUnit, initialAuth.userId]);
+
+  useEffect(() => {
+    void refreshRecent();
+  }, [refreshRecent]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2500);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const remaining = ASSISTANT_MEDIA_MAX_FILES - selections.length;
+  const canSubmit = !!developmentId && !!selectedUnit && title.trim().length > 0 && selections.length > 0;
+
+  const onFiles = (files: ArrayLike<File>) => {
+    setSubmitError(null);
+    const { accepted, rejected } = normalizeFiles(files, remaining);
+    if (rejected.length > 0) {
+      setSubmitError(rejectionMessage(rejected[0].reason));
+    }
+    if (accepted.length > 0) {
+      setSelections((prev) => [...prev, ...accepted]);
+    }
+  };
+
+  const removeSelection = (id: string) => {
+    setSelections((prev) => {
+      const target = prev.find((s) => s.id === id);
+      if (target) revokeSelections([target]);
+      return prev.filter((s) => s.id !== id);
+    });
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (list && list.length > 0) onFiles(list);
+    e.target.value = '';
+  };
+
+  const submit = async () => {
+    if (!developmentId || !selectedUnit) return;
+    if (!canSubmit || submitting) return;
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const compressed = await compressSelectionsForUpload(selections);
+      const conversationId = uuid();
+
+      const form = new FormData();
+      form.set('conversation_id', conversationId);
+      form.set('unit_id', selectedUnit.id);
+      for (const sel of compressed) {
+        form.append('files', sel.file, sel.file.name);
+      }
+
+      const uploadRes = await fetch('/api/assistant/media/upload', {
+        method: 'POST',
+        body: form,
+      });
+      if (!uploadRes.ok) {
+        setSubmitError(ERROR_GENERIC);
+        return;
+      }
+      const uploadJson = await uploadRes.json();
+      const mediaIds: string[] = Array.isArray(uploadJson?.media)
+        ? uploadJson.media.map((m: { media_id: string }) => m.media_id).filter(Boolean)
+        : [];
+      if (mediaIds.length === 0) {
+        setSubmitError(ERROR_GENERIC);
+        return;
+      }
+
+      const createRes = await fetch('/api/snag/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          development_id: developmentId,
+          unit_id: selectedUnit.id,
+          title: title.trim(),
+          description: description.trim(),
+          room: room.trim(),
+          media_ids: mediaIds,
+        }),
+      });
+      if (!createRes.ok) {
+        setSubmitError(ERROR_GENERIC);
+        return;
+      }
+
+      revokeSelections(selections);
+      setSelections([]);
+      setTitle('');
+      setDescription('');
+      setRoom('');
+      setToast(TOAST_SUCCESS);
+      void refreshRecent();
+    } catch (err) {
+      setSubmitError(ERROR_GENERIC);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-neutral-50 flex flex-col">
+      <header className="px-4 py-3 bg-white border-b border-neutral-200 flex items-center justify-between gap-3">
+        <h1 className="text-heading-md text-neutral-900">Log a snag</h1>
+        {developments.length > 1 ? (
+          <button
+            type="button"
+            onClick={() => setPickerOpen('development')}
+            className="text-body-sm text-neutral-600 max-w-[180px] truncate active:text-neutral-900 min-h-[44px] px-2"
+          >
+            {developmentName || 'Pick a development'}
+          </button>
+        ) : developmentName ? (
+          <span className="text-body-sm text-neutral-500 max-w-[180px] truncate">{developmentName}</span>
+        ) : null}
+      </header>
+
+      <main className="flex-1 px-4 py-6 space-y-4">
+        <button
+          type="button"
+          onClick={() => setPickerOpen('unit')}
+          className="w-full px-4 py-4 bg-white border border-neutral-200 rounded-lg text-left flex items-center justify-between min-h-[64px] active:bg-neutral-50"
+        >
+          <div className="flex-1 min-w-0">
+            <div className="text-caption text-neutral-500">Unit</div>
+            <div className="text-body text-neutral-900 truncate">
+              {selectedUnit?.display_name || PICKER_PLACEHOLDER}
+            </div>
+          </div>
+          <ChevronRight className="w-5 h-5 text-neutral-400 flex-shrink-0" />
+        </button>
+
+        <div className="space-y-3">
+          <div className="text-caption text-neutral-500">Photos</div>
+          {selections.length === 0 ? (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full aspect-video bg-white border-2 border-dashed border-neutral-300 rounded-lg flex flex-col items-center justify-center gap-2 active:bg-neutral-50 min-h-[160px]"
+            >
+              <Camera className="w-8 h-8 text-neutral-400" />
+              <span className="text-body-sm text-neutral-600">Take a photo</span>
+            </button>
+          ) : (
+            <div className="grid grid-cols-3 gap-2">
+              {selections.map((sel) => (
+                <div key={sel.id} className="relative aspect-square">
+                  <img
+                    src={sel.previewUrl}
+                    alt=""
+                    className="w-full h-full rounded-md object-cover border border-neutral-200"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeSelection(sel.id)}
+                    className="absolute -top-1.5 -right-1.5 w-7 h-7 rounded-full bg-neutral-900 text-white flex items-center justify-center"
+                    aria-label="Remove photo"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ))}
+              {remaining > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="aspect-square bg-white border-2 border-dashed border-neutral-300 rounded-md flex items-center justify-center active:bg-neutral-50"
+                  aria-label="Add another photo"
+                >
+                  <Plus className="w-6 h-6 text-neutral-400" />
+                </button>
+              ) : null}
+            </div>
+          )}
+          <input
+            ref={fileInputRef}
+            id={fileInputId}
+            type="file"
+            accept={ASSISTANT_MEDIA_ACCEPT}
+            capture="environment"
+            multiple
+            className="sr-only"
+            onChange={handleFileInput}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-caption text-neutral-500 block mb-1" htmlFor="snag-title">
+              What is the snag
+            </label>
+            <input
+              id="snag-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={TITLE_PLACEHOLDER}
+              maxLength={MAX_TITLE_LEN}
+              className="w-full px-4 py-3 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500 min-h-[48px]"
+            />
+          </div>
+
+          <div>
+            <label className="text-caption text-neutral-500 block mb-1">Room</label>
+            <button
+              type="button"
+              onClick={() => setPickerOpen('room')}
+              className="w-full px-4 py-3 bg-white border border-neutral-200 rounded-lg text-left text-body text-neutral-900 flex items-center justify-between min-h-[48px] active:bg-neutral-50"
+            >
+              <span className={room ? 'text-neutral-900' : 'text-neutral-500'}>
+                {room || PICKER_PLACEHOLDER}
+              </span>
+              <ChevronRight className="w-5 h-5 text-neutral-400" />
+            </button>
+          </div>
+
+          <div>
+            <label className="text-caption text-neutral-500 block mb-1" htmlFor="snag-notes">
+              Notes (optional)
+            </label>
+            <textarea
+              id="snag-notes"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+              placeholder={NOTES_PLACEHOLDER}
+              className="w-full px-4 py-3 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500 resize-none"
+            />
+          </div>
+        </div>
+
+        {submitError ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-body-sm text-red-700">
+            {submitError}
+          </div>
+        ) : null}
+
+        <RecentSnagsList loading={recentLoading} rows={recent} hasUnit={!!selectedUnit} />
+      </main>
+
+      <div className="sticky bottom-0 px-4 py-3 bg-white border-t border-neutral-200" style={{ paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom, 0px))' }}>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSubmit || submitting}
+          className="w-full py-3 bg-brand-500 text-white rounded-lg font-medium disabled:bg-neutral-200 disabled:text-neutral-400 active:bg-brand-600 min-h-[48px]"
+        >
+          {submitting ? SUBMIT_PENDING : SUBMIT_IDLE}
+        </button>
+      </div>
+
+      {toast ? (
+        <div
+          className="fixed left-1/2 -translate-x-1/2 bottom-24 z-popover px-4 py-2 bg-neutral-900 text-white text-body-sm rounded-full shadow-lg"
+          role="status"
+          aria-live="polite"
+        >
+          {toast}
+        </div>
+      ) : null}
+
+      <UnitPickerSheet
+        open={pickerOpen === 'unit'}
+        units={units}
+        loading={unitsLoading}
+        error={unitsError}
+        selectedId={selectedUnit?.id ?? null}
+        onClose={() => setPickerOpen(null)}
+        onSelect={(unit) => {
+          setSelectedUnit(unit);
+          setPickerOpen(null);
+        }}
+      />
+
+      <RoomPickerSheet
+        open={pickerOpen === 'room'}
+        selected={room}
+        onClose={() => setPickerOpen(null)}
+        onSelect={(value) => {
+          setRoom(value);
+          setPickerOpen(null);
+        }}
+      />
+
+      <DevelopmentSwitcherSheet
+        open={pickerOpen === 'development'}
+        developments={developments}
+        selectedId={developmentId}
+        onClose={() => setPickerOpen(null)}
+        onSelect={(dev) => {
+          setDevelopmentId(dev.id);
+          setSelectedUnit(null);
+          setPickerOpen(null);
+        }}
+      />
+    </div>
+  );
+}
+
+interface RecentSnagsListProps {
+  loading: boolean;
+  rows: RecentSnag[];
+  hasUnit: boolean;
+}
+
+function RecentSnagsList({ loading, rows, hasUnit }: RecentSnagsListProps) {
+  if (!hasUnit) return null;
+  return (
+    <section className="pt-4">
+      <h2 className="text-caption text-neutral-500 mb-2">Recent</h2>
+      {loading ? (
+        <div className="text-body-sm text-neutral-500 px-1 py-2">Loading...</div>
+      ) : rows.length === 0 ? (
+        <div className="text-body-sm text-neutral-500 px-1 py-2">No snags logged in this unit yet.</div>
+      ) : (
+        <ul className="divide-y divide-neutral-100 bg-white border border-neutral-200 rounded-lg overflow-hidden">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <a
+                href={`/snag/${row.id}`}
+                className="block px-4 py-3 active:bg-neutral-50"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="text-body text-neutral-900 truncate">{row.title}</div>
+                    <div className="text-caption text-neutral-500">
+                      {row.media_count} {row.media_count === 1 ? 'photo' : 'photos'} . logged {timeAgo(row.created_at)}
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-neutral-400 flex-shrink-0" />
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/unified-portal/app/snag/SnagNoAccess.tsx
+++ b/apps/unified-portal/app/snag/SnagNoAccess.tsx
@@ -1,0 +1,43 @@
+/**
+ * No-access screen for /snag. Shown when the signed-in user has no
+ * active site_team_members membership, or only memberships that have
+ * expired.
+ *
+ * No em dashes. Calm, direct copy.
+ */
+
+import { ShieldOff } from 'lucide-react';
+
+interface SnagNoAccessProps {
+  code: 'unauthenticated' | 'forbidden' | 'expired';
+}
+
+const COPY: Record<SnagNoAccessProps['code'], { title: string; body: string }> = {
+  unauthenticated: {
+    title: 'Sign in to log snags',
+    body: 'You need to sign in with the email your admin invited.',
+  },
+  forbidden: {
+    title: 'No snag access yet',
+    body: 'Ask your admin to invite you. Once accepted, this page lets you log snags from your phone.',
+  },
+  expired: {
+    title: 'Your access has ended',
+    body: 'Your snagger invitation has expired. Ask your admin for a new invite if you still need to log snags.',
+  },
+};
+
+export function SnagNoAccess({ code }: SnagNoAccessProps) {
+  const copy = COPY[code];
+  return (
+    <div className="min-h-screen bg-neutral-50 flex items-center justify-center p-6">
+      <div className="max-w-sm w-full bg-white border border-neutral-200 rounded-2xl p-6 text-center">
+        <div className="mx-auto w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center mb-4">
+          <ShieldOff className="w-6 h-6 text-neutral-500" />
+        </div>
+        <h1 className="text-heading-sm text-neutral-900 mb-2">{copy.title}</h1>
+        <p className="text-body-sm text-neutral-600">{copy.body}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/UnitPickerSheet.tsx
+++ b/apps/unified-portal/app/snag/UnitPickerSheet.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * Full-screen sheet for picking a unit. Phone-first: full viewport on
+ * mobile, large search input at the top, vertical scrolling list.
+ * Spec section 7.2.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRight, Search, X } from 'lucide-react';
+
+export interface SnagUnit {
+  id: string;
+  display_name: string;
+  unit_code: string | null;
+  unit_number: string | null;
+  address: string | null;
+  address_line_1: string | null;
+  city: string | null;
+  purchaser_name: string | null;
+}
+
+interface UnitPickerSheetProps {
+  open: boolean;
+  units: SnagUnit[];
+  loading: boolean;
+  error: string | null;
+  selectedId: string | null;
+  onClose: () => void;
+  onSelect: (unit: SnagUnit) => void;
+}
+
+function matchesQuery(unit: SnagUnit, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  const haystack = [
+    unit.display_name,
+    unit.unit_code,
+    unit.unit_number,
+    unit.address,
+    unit.address_line_1,
+    unit.city,
+    unit.purchaser_name,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+export function UnitPickerSheet({
+  open,
+  units,
+  loading,
+  error,
+  selectedId,
+  onClose,
+  onSelect,
+}: UnitPickerSheetProps) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      const t = setTimeout(() => inputRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [open]);
+
+  const filtered = useMemo(() => units.filter((u) => matchesQuery(u, query)), [units, query]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-modal bg-white flex flex-col">
+      <header className="px-4 py-3 border-b border-neutral-200 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close unit picker"
+          className="w-11 h-11 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+        >
+          <X className="w-5 h-5" />
+        </button>
+        <h2 className="text-heading-sm text-neutral-900">Select unit</h2>
+      </header>
+      <div className="px-4 py-3 border-b border-neutral-200">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by unit, address, purchaser"
+            className="w-full pl-10 pr-4 py-3 bg-white border border-neutral-200 rounded-lg text-body focus:outline-none focus:ring-2 focus:ring-brand-500"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="none"
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="px-4 py-8 text-center text-body-sm text-neutral-500">Loading units...</div>
+        ) : error ? (
+          <div className="px-4 py-8 text-center text-body-sm text-red-600">{error}</div>
+        ) : filtered.length === 0 ? (
+          <div className="px-4 py-8 text-center text-body-sm text-neutral-500">
+            {units.length === 0 ? 'No units in this development.' : 'No units match.'}
+          </div>
+        ) : (
+          <ul className="divide-y divide-neutral-100">
+            {filtered.map((unit) => {
+              const isSelected = unit.id === selectedId;
+              const subtitle = [unit.address_line_1, unit.address, unit.purchaser_name].filter(Boolean)[0] ?? '';
+              return (
+                <li key={unit.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(unit)}
+                    className={`w-full px-4 py-4 text-left flex items-center gap-3 min-h-[64px] active:bg-neutral-50 ${
+                      isSelected ? 'bg-brand-50' : ''
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-body text-neutral-900 truncate">{unit.display_name}</div>
+                      {subtitle ? (
+                        <div className="text-caption text-neutral-500 truncate">{subtitle}</div>
+                      ) : null}
+                    </div>
+                    <ChevronRight className="w-5 h-5 text-neutral-400" />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/[id]/page.tsx
+++ b/apps/unified-portal/app/snag/[id]/page.tsx
@@ -1,0 +1,166 @@
+/**
+ * /snag/[id]
+ *
+ * Assistant V2 Sprint 2. Stub detail view for a single snag. Renders
+ * title, description, room, source, status, and the linked photos with
+ * one-hour signed URLs. No edit controls in V1; the developer dashboard
+ * (Sprint 3) is where richer detail and resolution flow lands.
+ *
+ * Spec section 7.7 ("Tap a row to view detail (Sprint 3 territory, can
+ * be a stub in this sprint).").
+ */
+
+import { headers } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { resolveSnagAuth, assertCanAccessDevelopment, SnagAuthError } from '@/lib/assistant/snag-auth';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { SnagNoAccess } from '../SnagNoAccess';
+
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const BUCKET = 'assistant-media';
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function SnagDetailPage({ params }: PageProps) {
+  if (!isBuilderSnagAppEnabled()) notFound();
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const supabase = await createServerSupabaseClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/login?redirectTo=/snag/${params.id}`);
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      return <SnagNoAccess code={err.code} />;
+    }
+    throw err;
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data: report, error: reportErr } = await admin
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, status, priority, severity_label, source, logged_by_role, created_at',
+    )
+    .eq('id', params.id)
+    .maybeSingle();
+  if (reportErr || !report) notFound();
+  if (report.tenant_id !== auth.tenantId) notFound();
+  try {
+    assertCanAccessDevelopment(auth, report.development_id as string);
+  } catch {
+    notFound();
+  }
+
+  const { data: joinRows } = await admin
+    .from('issue_report_media')
+    .select('media_id')
+    .eq('issue_report_id', params.id);
+  const mediaIds = (joinRows ?? []).map((j) => j.media_id as string);
+
+  const mediaPayload: Array<{ id: string; signed_url: string; thumb_url: string }> = [];
+  if (mediaIds.length > 0) {
+    const { data: mediaRows } = await admin
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path')
+      .in('id', mediaIds);
+    for (const m of mediaRows ?? []) {
+      if (m.tenant_id !== auth.tenantId) continue;
+      const { data: signed } = await admin.storage
+        .from(BUCKET)
+        .createSignedUrl(m.storage_path as string, SIGNED_URL_TTL_SECONDS);
+      let thumbUrl = signed?.signedUrl ?? '';
+      if (m.thumbnail_path) {
+        const { data: thumb } = await admin.storage
+          .from(BUCKET)
+          .createSignedUrl(m.thumbnail_path as string, SIGNED_URL_TTL_SECONDS);
+        if (thumb?.signedUrl) thumbUrl = thumb.signedUrl;
+      }
+      mediaPayload.push({
+        id: m.id as string,
+        signed_url: signed?.signedUrl ?? '',
+        thumb_url: thumbUrl,
+      });
+    }
+  }
+
+  const created = new Date(report.created_at as string);
+  const createdHuman = isNaN(created.getTime()) ? '' : created.toLocaleString();
+
+  // unused for now but kept for future header back-link logic
+  void headers;
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="px-4 py-3 bg-white border-b border-neutral-200 flex items-center gap-2">
+        <Link
+          href="/snag"
+          className="w-11 h-11 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          aria-label="Back to snag form"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </Link>
+        <h1 className="text-heading-sm text-neutral-900 truncate">Snag detail</h1>
+      </header>
+
+      <main className="px-4 py-6 space-y-4 max-w-2xl mx-auto">
+        <div className="bg-white border border-neutral-200 rounded-lg p-4 space-y-3">
+          <div>
+            <div className="text-caption text-neutral-500">Title</div>
+            <div className="text-body text-neutral-900">{report.title}</div>
+          </div>
+          {report.room ? (
+            <div>
+              <div className="text-caption text-neutral-500">Room</div>
+              <div className="text-body text-neutral-900">{report.room}</div>
+            </div>
+          ) : null}
+          {report.description ? (
+            <div>
+              <div className="text-caption text-neutral-500">Notes</div>
+              <div className="text-body text-neutral-900 whitespace-pre-wrap">{report.description}</div>
+            </div>
+          ) : null}
+          <div className="flex gap-3 text-caption text-neutral-500">
+            <span>Status: {report.status}</span>
+            <span>Source: {report.source}</span>
+          </div>
+          {createdHuman ? (
+            <div className="text-caption text-neutral-500">Logged {createdHuman}</div>
+          ) : null}
+        </div>
+
+        {mediaPayload.length > 0 ? (
+          <div className="grid grid-cols-2 gap-3">
+            {mediaPayload.map((m) => (
+              <a
+                key={m.id}
+                href={m.signed_url}
+                target="_blank"
+                rel="noreferrer"
+                className="block aspect-square bg-white border border-neutral-200 rounded-md overflow-hidden active:opacity-80"
+              >
+                <img src={m.thumb_url} alt="" className="w-full h-full object-cover" />
+              </a>
+            ))}
+          </div>
+        ) : (
+          <div className="text-body-sm text-neutral-500 px-1">No photos attached.</div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/accept/AcceptInviteClient.tsx
+++ b/apps/unified-portal/app/snag/accept/AcceptInviteClient.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * Client component for /snag/accept. On mount, POSTs the token to
+ * /api/snag/accept. On success, redirects to /snag. On error, shows
+ * the server's error message clearly with no retry button.
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { CheckCircle2, AlertCircle } from 'lucide-react';
+
+interface AcceptInviteClientProps {
+  token: string;
+  signedInEmail: string;
+}
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'success' }
+  | { kind: 'error'; message: string };
+
+export function AcceptInviteClient({ token, signedInEmail }: AcceptInviteClientProps) {
+  const router = useRouter();
+  const [state, setState] = useState<State>({ kind: 'idle' });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ kind: 'error', message: 'This invitation link is missing its token.' });
+      return;
+    }
+    let cancelled = false;
+    setState({ kind: 'submitting' });
+    (async () => {
+      try {
+        const res = await fetch('/api/snag/accept', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+        if (cancelled) return;
+        if (res.ok) {
+          setState({ kind: 'success' });
+          setTimeout(() => router.push('/snag'), 800);
+          return;
+        }
+        let message = "Couldn't accept this invitation.";
+        try {
+          const json = await res.json();
+          if (typeof json?.error === 'string' && json.error.length > 0 && json.error.length < 200) {
+            message = json.error;
+          }
+        } catch {
+          // ignore
+        }
+        setState({ kind: 'error', message });
+      } catch {
+        if (!cancelled) setState({ kind: 'error', message: "Couldn't reach the server. Try the link again later." });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token, router]);
+
+  return (
+    <div className="min-h-screen bg-neutral-50 flex items-center justify-center p-6">
+      <div className="max-w-sm w-full bg-white border border-neutral-200 rounded-2xl p-6 text-center">
+        {state.kind === 'submitting' || state.kind === 'idle' ? (
+          <>
+            <div className="mx-auto w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center mb-4">
+              <div className="w-6 h-6 rounded-full border-2 border-neutral-300 border-t-neutral-900 animate-spin" />
+            </div>
+            <h1 className="text-heading-sm text-neutral-900 mb-1">Accepting invitation</h1>
+            <p className="text-body-sm text-neutral-600">Signing you in as {signedInEmail || 'your account'}.</p>
+          </>
+        ) : state.kind === 'success' ? (
+          <>
+            <div className="mx-auto w-12 h-12 rounded-full bg-emerald-50 flex items-center justify-center mb-4">
+              <CheckCircle2 className="w-6 h-6 text-emerald-600" />
+            </div>
+            <h1 className="text-heading-sm text-neutral-900 mb-1">Invitation accepted</h1>
+            <p className="text-body-sm text-neutral-600">Taking you to the snag form.</p>
+          </>
+        ) : (
+          <>
+            <div className="mx-auto w-12 h-12 rounded-full bg-red-50 flex items-center justify-center mb-4">
+              <AlertCircle className="w-6 h-6 text-red-600" />
+            </div>
+            <h1 className="text-heading-sm text-neutral-900 mb-2">Could not accept</h1>
+            <p className="text-body-sm text-neutral-600 mb-4">{state.message}</p>
+            <p className="text-caption text-neutral-500">Ask your admin to send a new invitation.</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/snag/accept/page.tsx
+++ b/apps/unified-portal/app/snag/accept/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * /snag/accept
+ *
+ * Assistant V2 Sprint 2. Page reached from a snagger invitation link.
+ * Reads the token from the URL, ensures the visitor is signed in, and
+ * delegates to a small client component that POSTs to /api/snag/accept.
+ *
+ * Spec section 5.2 + 7.
+ */
+
+import { notFound, redirect } from 'next/navigation';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+import { AcceptInviteClient } from './AcceptInviteClient';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: { token?: string };
+}
+
+export default async function AcceptInvitePage({ searchParams }: PageProps) {
+  if (!isBuilderSnagAppEnabled()) notFound();
+
+  const token = typeof searchParams?.token === 'string' ? searchParams.token.trim() : '';
+
+  const supabase = await createServerSupabaseClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    const redirectBack = token
+      ? `/snag/accept?token=${encodeURIComponent(token)}`
+      : '/snag/accept';
+    redirect(`/login?redirectTo=${encodeURIComponent(redirectBack)}`);
+  }
+
+  return <AcceptInviteClient token={token} signedInEmail={user.email ?? ''} />;
+}

--- a/apps/unified-portal/app/snag/page.tsx
+++ b/apps/unified-portal/app/snag/page.tsx
@@ -1,0 +1,62 @@
+/**
+ * /snag
+ *
+ * Assistant V2 Sprint 2. Phone-first snag capture form for site team
+ * members and accepted external snaggers.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-2.md section 7.
+ *
+ * Server responsibilities:
+ *   1. 404 if FEATURE_BUILDER_SNAG_APP is off.
+ *   2. Redirect to /login if no Supabase session.
+ *   3. Resolve site_team_members membership; show no-access screen if
+ *      none.
+ *   4. Render the client form with the resolved auth context as initial
+ *      props (so the form does not have to wait on an auth round trip
+ *      before painting).
+ */
+
+import { redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
+import { isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { resolveSnagAuth, SnagAuthError } from '@/lib/assistant/snag-auth';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+import { SnagFormClient } from './SnagFormClient';
+import { SnagNoAccess } from './SnagNoAccess';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SnagPage() {
+  if (!isBuilderSnagAppEnabled()) {
+    notFound();
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/login?redirectTo=/snag');
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      return <SnagNoAccess code={err.code} />;
+    }
+    throw err;
+  }
+
+  return (
+    <SnagFormClient
+      initialAuth={{
+        userId: auth.userId,
+        email: auth.email,
+        tenantId: auth.tenantId,
+        role: auth.role,
+        developmentIds: auth.developmentIds,
+        isAdmin: auth.isAdmin,
+      }}
+    />
+  );
+}

--- a/apps/unified-portal/lib/assistant/media-auth.ts
+++ b/apps/unified-portal/lib/assistant/media-auth.ts
@@ -1,18 +1,23 @@
 /**
- * Tenant verification for Assistant V2 media routes (Sprint 1).
+ * Tenant verification for Assistant V2 media routes.
  *
- * Three caller paths are supported. They are evaluated in this order and
+ * Four caller paths are supported. They are evaluated in this order and
  * each is named below so a future reader does not have to reverse-engineer
  * the control flow.
  *
- * ━━ Path A: signed QR token ━━
+ * Path A:  signed QR token             (Sprint 1, homeowner)
+ * Path A': purchaser unit-uid token    (Sprint 1, homeowner / showhouse)
+ * Path B:  admins session              (Sprint 1, developer portal admins)
+ * Path C:  site_team_members session   (Sprint 2, builder-side snaggers)
+ *
+ * ====  Path A: signed QR token  ====
  * The caller sends `x-qr-token` and the token is a cryptographically valid
  * signed QR token (see packages/api/src/qr-tokens.ts). The unit id is
  * authoritative because it comes from the signed payload. If the request
  * body also supplies a `unit_id`, it must match the token's unit; mismatch
  * is 403.
  *
- * ━━ Path A': purchaser unit-uid capability ━━
+ * ====  Path A': purchaser unit-uid capability  ====
  * The caller sends `x-qr-token` but it is NOT a signed token. We accept
  * the unit UUID itself as the credential, matching the trust model the
  * production text-only chat already uses (apps/unified-portal/app/api/
@@ -36,11 +41,24 @@
  * Tenant_id and development_id always come from the units row, never from
  * the client, regardless of which path resolves the caller.
  *
- * ━━ Path B: admin session ━━
- * No `x-qr-token` header. We resolve the caller via the Supabase admin
- * session cookie (installer / developer / super_admin). Tenant comes from
- * the admins row. If a `unit_id` was supplied, it must belong to that
- * tenant; mismatch is 403.
+ * ====  Path B: admins session (developer portal)  ====
+ * No `x-qr-token` header. We resolve the caller via the Supabase session
+ * cookie and look them up in the `admins` table (installer / developer /
+ * super_admin). Tenant comes from the admins row. If a `unit_id` was
+ * supplied, it must belong to that tenant; mismatch is 403.
+ *
+ * ====  Path C: site_team_members session (builder-side, Sprint 2)  ====
+ * No `x-qr-token` header AND no admins row. The user is authenticated
+ * via the same Supabase session cookie, but their identity for builder
+ * routes lives in `site_team_members` instead of `admins`. This is the
+ * path used by site team staff and accepted external snaggers when they
+ * upload photos for /api/snag/create. Tenant comes from the membership
+ * row. For role 'snagger_external' we also enforce the membership's
+ * `expires_at`, and any supplied unit_id must belong to a development
+ * in the membership's `development_ids` (null means all developments in
+ * the tenant, used by 'admin' and 'site_team'). Sprint 1 callers never
+ * reach this path because they either send `x-qr-token` (Path A or A')
+ * or have an admins row (Path B).
  *
  * Cross-tenant enforcement on the media row itself (media.tenant_id !==
  * caller.tenant_id) stays in the signed-url route. This helper only
@@ -49,10 +67,10 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { validateQRToken } from '@openhouse/api/qr-tokens';
-import { getSupabaseAdmin, getServerSession } from '@/lib/supabase-server';
+import { getSupabaseAdmin, getServerSession, createServerSupabaseClient } from '@/lib/supabase-server';
 import type { AdminSession } from '@/lib/supabase-server';
 
-export type MediaCallerType = 'homeowner' | 'admin';
+export type MediaCallerType = 'homeowner' | 'admin' | 'snag';
 
 export interface MediaAuthContext {
   callerType: MediaCallerType;
@@ -136,14 +154,14 @@ export async function resolveMediaAuth(
   const qrToken = request.headers.get('x-qr-token');
 
   if (qrToken) {
-    // ━━ Path A: signed QR token ━━
+    // ====  Path A: signed QR token  ====
     const signedPayload = await validateQRToken(qrToken).catch(() => null);
     let candidateUnitId: string | null = null;
 
     if (signedPayload?.supabaseUnitId) {
       candidateUnitId = signedPayload.supabaseUnitId;
     } else {
-      // ━━ Path A': purchaser unit-uid capability ━━
+      // ====  Path A': purchaser unit-uid capability  ====
       // Token is not a signed JWT-style token. Treat it as a unit
       // capability per the trust model used by /api/chat. If the request
       // also supplied a unit_id, that unit must match the token shape
@@ -189,12 +207,81 @@ export async function resolveMediaAuth(
     };
   }
 
-  // ━━ Path B: admin session ━━
+  // ====  Path B: admins session (developer portal)  ====
   const session = await getServerSession();
-  if (!session) {
+  if (session) {
+    if (!session.tenantId) {
+      throw new MediaAuthError('forbidden');
+    }
+
+    if (!requestedUnitId) {
+      if (requireUnit) {
+        throw new MediaAuthError('invalid_unit');
+      }
+      return {
+        callerType: 'admin',
+        tenantId: session.tenantId,
+        developmentId: null,
+        unitId: null,
+        userId: session.id,
+        adminSession: session,
+      };
+    }
+
+    const unit = await loadUnit(requestedUnitId);
+    if (!unit || !unit.tenant_id) {
+      throw new MediaAuthError('invalid_unit');
+    }
+    if (unit.tenant_id !== session.tenantId) {
+      throw new MediaAuthError('cross_tenant_unit');
+    }
+
+    return {
+      callerType: 'admin',
+      tenantId: unit.tenant_id,
+      developmentId: unit.development_id,
+      unitId: unit.id,
+      userId: session.id,
+      adminSession: session,
+    };
+  }
+
+  // ====  Path C: site_team_members session (builder-side, Sprint 2)  ====
+  // getServerSession returned null. That can mean either no Supabase
+  // session at all, or a session whose user is not in the admins table.
+  // The Sprint 2 snag UI is the second case: the user is signed in via
+  // Supabase but their identity for builder routes lives in
+  // site_team_members. We try that lookup before failing.
+  const supabaseSsr = await createServerSupabaseClient();
+  const { data: { user: snagUser } } = await supabaseSsr.auth.getUser();
+  if (!snagUser?.id) {
     throw new MediaAuthError('unauthenticated');
   }
-  if (!session.tenantId) {
+
+  const supabaseAdmin = getSupabaseAdmin();
+  const { data: memberRows, error: memberErr } = await supabaseAdmin
+    .from('site_team_members')
+    .select('id, tenant_id, role, development_ids, active, expires_at')
+    .eq('user_id', snagUser.id)
+    .eq('active', true)
+    .order('invited_at', { ascending: true });
+
+  if (memberErr) {
+    console.error('[media-auth] site_team_members_lookup_failed reason=%s', memberErr.message);
+    throw new MediaAuthError('unauthenticated');
+  }
+  if (!memberRows || memberRows.length === 0) {
+    throw new MediaAuthError('unauthenticated');
+  }
+
+  const nowMs = Date.now();
+  const membership = memberRows.find((r) => {
+    if (r.role === 'snagger_external' && r.expires_at) {
+      return new Date(r.expires_at as string).getTime() > nowMs;
+    }
+    return true;
+  });
+  if (!membership) {
     throw new MediaAuthError('forbidden');
   }
 
@@ -203,30 +290,37 @@ export async function resolveMediaAuth(
       throw new MediaAuthError('invalid_unit');
     }
     return {
-      callerType: 'admin',
-      tenantId: session.tenantId,
+      callerType: 'snag',
+      tenantId: membership.tenant_id as string,
       developmentId: null,
       unitId: null,
-      userId: session.id,
-      adminSession: session,
+      userId: snagUser.id,
+      adminSession: null,
     };
   }
 
-  const unit = await loadUnit(requestedUnitId);
-  if (!unit || !unit.tenant_id) {
+  const snagUnit = await loadUnit(requestedUnitId);
+  if (!snagUnit || !snagUnit.tenant_id) {
     throw new MediaAuthError('invalid_unit');
   }
-  if (unit.tenant_id !== session.tenantId) {
+  if (snagUnit.tenant_id !== membership.tenant_id) {
     throw new MediaAuthError('cross_tenant_unit');
   }
 
+  if (membership.role === 'snagger_external') {
+    const scope = Array.isArray(membership.development_ids) ? (membership.development_ids as string[]) : [];
+    if (!snagUnit.development_id || !scope.includes(snagUnit.development_id)) {
+      throw new MediaAuthError('cross_tenant_unit');
+    }
+  }
+
   return {
-    callerType: 'admin',
-    tenantId: unit.tenant_id,
-    developmentId: unit.development_id,
-    unitId: unit.id,
-    userId: session.id,
-    adminSession: session,
+    callerType: 'snag',
+    tenantId: snagUnit.tenant_id,
+    developmentId: snagUnit.development_id,
+    unitId: snagUnit.id,
+    userId: snagUser.id,
+    adminSession: null,
   };
 }
 

--- a/apps/unified-portal/lib/assistant/snag-auth.ts
+++ b/apps/unified-portal/lib/assistant/snag-auth.ts
@@ -69,8 +69,13 @@ interface SiteTeamMemberRow {
  * Sprint 2. If a user belongs to multiple tenants, the first active row
  * wins; downstream routes can still apply tenant-specific checks via
  * assertCanAccessTenant.
+ *
+ * The `_request` parameter is unused: identity comes from the Supabase
+ * session cookie via createServerSupabaseClient. It is optional so the
+ * same function can be called from server components (which have no
+ * NextRequest) without a casting workaround.
  */
-export async function resolveSnagAuth(_request: NextRequest): Promise<SnagAuthContext> {
+export async function resolveSnagAuth(_request?: NextRequest): Promise<SnagAuthContext> {
   const supabase = await createServerSupabaseClient();
   const { data: { user }, error: userErr } = await supabase.auth.getUser();
 

--- a/docs/specs/assistant-v2-sprint-2.md
+++ b/docs/specs/assistant-v2-sprint-2.md
@@ -383,7 +383,8 @@ All builder-facing copy in this sprint:
 * Submit error: "Couldn't log that snag. Try again."
 Same rules as Sprint 1: no em dashes, no emoji, no AI language, calm and direct.
 8. Admin UI - Invite snaggers
-Small addition to the existing developer admin area. Single page at `/admin/snaggers`.
+Small addition to the existing developer admin area. Single page at `/developer/snaggers`.
+Implementation note (Session 3, Sprint 2 UI): the original spec listed this path as `/admin/snaggers`. It moved to `/developer/snaggers` so the page lives inside the existing developer sidebar layout and the URL stays consistent with the rest of the developer area. Admins keep their nav when invited.
 Shows:
 
 * A list of current site_team_members for the tenant
@@ -489,7 +490,7 @@ Implement section 7 and section 8 of docs/specs/assistant-v2-sprint-2.md.
 
 Two new routes in apps/unified-portal:
 - /snag - the phone-first snag capture form for site team and snaggers
-- /admin/snaggers - the admin invite UI
+- /developer/snaggers - the admin invite UI (Session 3 moved from /admin/snaggers)
 
 Reuse existing components where they overlap with Sprint 1:
 - attachments.ts compression pipeline


### PR DESCRIPTION
Implements sections 7 and 8 of `docs/specs/assistant-v2-sprint-2.md`. UI only.

## New routes

| Path | What |
| --- | --- |
| `/snag` | Phone-first snag capture form (server gate + client form). |
| `/snag/[id]` | Read-only detail stub with signed-URL photos. Sprint 3 lands richer views. |
| `/snag/accept` | Accepts a snagger invitation token. Auto-redirects to sign-in if not authenticated, then POSTs to `/api/snag/accept` and forwards to `/snag` on success. |
| `/developer/snaggers` | Admin invite UI. Members list, pending invitations, invite modal. |
| `GET /api/snag/developments` | Caller-scoped developments for the switcher. |
| `GET /api/snag/units` | Tenant-gated units list for the picker. |
| `GET /api/snag/team` | Admin-only members + pending invitations for `/developer/snaggers`. |

All gated on `FEATURE_BUILDER_SNAG_APP`; with the flag off every page calls `notFound()` and every new API returns 404 before any auth or DB work.

## Auth changes

- `lib/assistant/media-auth.ts` gains **Path C: site_team_members session**. The header comment now names all four paths in evaluation order (A signed QR, A' purchaser unit-uid, B admins session, C site_team_members). Path C falls through from Path B when `getServerSession()` returns null but the user has a Supabase session and an active `site_team_members` row. For `snagger_external` we enforce `expires_at` and (when a unit is supplied) check it belongs to a development in the membership's `development_ids`. Sprint 1 callers never reach Path C because they either send `x-qr-token` or have an `admins` row. The existing `/api/assistant/media/upload` route picks this up automatically, which is what lets site team and snagger users go through the existing Sprint 1 upload pipeline.
- `lib/assistant/snag-auth.ts` `resolveSnagAuth`'s `request` parameter is now optional so the same function works in server components.

## Spec change made in this PR

`docs/specs/assistant-v2-sprint-2.md` section 8 references `/developer/snaggers` instead of `/admin/snaggers`. The page sits inside the existing `/developer` sidebar layout so admins keep their nav while inviting snaggers. Annotated with an implementation note.

## Reused Sprint 1 components and helpers

- `lib/assistant/attachments.ts` for compression (`compressSelectionsForUpload`), file normalisation (`normalizeFiles`), preview URLs (`SelectedAttachment`), and the rejection message catalogue.
- The 3-column photo grid mirrors the Sprint 1 spec's verbatim example in section 7.3. We use it on `/snag` rather than `MediaPreviewRow` because the row layout is for the chat input. `MediaPreviewRow` and `MediaThumbnailGrid` were not duplicated.
- The signed-URL pattern in `/snag/[id]` mirrors what `/api/assistant/media/signed-url` and `MediaLightbox` use today (one-hour TTL, thumbnail fallback to original).

## Phone-first details

- Sticky bottom submit with `safe-area-inset-bottom` padding for the iOS home-bar gap.
- 44px minimum touch targets on all primary controls; pickers use 56-64px row heights.
- Full-screen sheets for unit picker, room picker, and development switcher. No inline dropdowns on the snag form itself.
- Single-column layout. No side-by-side fields.
- Camera-first via `<input type="file" accept="image/*" capture="environment" multiple>`.
- Verbatim copy from spec 7.8 (title placeholder, picker placeholders, submit labels, success toast, error message).

Desktop renders the same form. V1 spec accepts that.

## Recent snags

Below the form (scrollable, not sticky): last 5 snags this user logged in the currently selected unit. Each row shows title, photo count, and a relative timestamp. Tapping a row opens `/snag/[id]`. The list is fetched from `/api/snag/list?development_id=X&limit=100` and filtered client-side by `unit_id === selectedUnit && logged_by_user_id === currentUser`. Server-side filters can be added in a later sprint if 100-row scope is insufficient.

## Sidebar nav

`/developer/layout-sidebar.tsx` gains a **Snagging Team** entry in the Settings section pointing at `/developer/snaggers`. The developer layout already gates on the admins-table role, which matches the V1 testing population (sam is in both `admins` and `site_team_members`).

## Vercel build

Verified READY on the preview deployment for this branch. The local Next build also surfaces every new route under `/api/snag/*`, `/snag`, `/snag/[id]`, `/snag/accept`, and `/developer/snaggers`.

## Tests

No test runner is currently wired up for this app. Cases that should be covered once one is available:

- `/snag` returns 404 when `FEATURE_BUILDER_SNAG_APP=false` (server gate).
- `/snag` redirects to `/login?redirectTo=/snag` when no session.
- `/snag` shows `SnagNoAccess` when the signed-in user has no membership or an expired `snagger_external` membership.
- `/snag/accept` redirects to login with a return URL preserving the token.
- The upload-then-create flow stamps `source` and `logged_by_role` from the verified membership; client-supplied values are ignored.
- Path C in `media-auth.ts` short-circuits when no Supabase session at all (returns 401), enforces `expires_at` for `snagger_external`, and rejects cross-tenant or out-of-scope `unit_id` with 403.
- `/developer/snaggers` rejects non-admin members with the no-access screen and gates the invite modal behind admin role.

## What was not touched

- `/api/assistant/media/upload`, `/api/assistant/media/signed-url`, `/api/assistant/chat/multimodal` routes.
- The text-only `/api/chat` route.
- `lib/assistant/mediaAnalysisService.ts` (still the Sprint 1 placeholder).
- Homeowner purchaser portal navigation.
- Sprint 2 server routes from PR #156.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbnNQRWW92U83M6dPpw9e5)_