### PR TITLE
feat(assistant-v2): Sprint 3 server routes for developer dashboard

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -124,6 +124,13 @@ NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 FEATURE_BUILDER_SNAG_APP=false
 NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
 
+# Assistant V2 developer dashboard for snag intelligence (Sprint 3).
+# Default off in production. Enable per tenant during testing. When false
+# the /developer/issues routes 404 and all /api/issues/* server routes
+# return 404 before any auth or DB work.
+FEATURE_DEVELOPER_DASHBOARD=false
+NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
 # from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
 # random opaque secret set per environment. Without it, enrichment is

--- a/apps/unified-portal/.env.example
+++ b/apps/unified-portal/.env.example
@@ -85,6 +85,15 @@ NEXT_PUBLIC_FEATURE_ASSISTANT_IMAGE_UPLOAD=false
 FEATURE_BUILDER_SNAG_APP=false
 NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
 
+# Assistant V2 developer dashboard for snag intelligence (Sprint 3).
+# Default off in production. Enable per tenant during testing. When false,
+# the /developer/issues routes 404 and all /api/issues/* server routes
+# return 404 before any auth or DB work. Independent of
+# FEATURE_BUILDER_SNAG_APP: the dashboard reads issue_reports regardless of
+# how snags got there.
+FEATURE_DEVELOPER_DASHBOARD=false
+NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
 # from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
 # random opaque secret set per environment. Without it, enrichment is

--- a/apps/unified-portal/app/api/issues/[id]/flag/route.ts
+++ b/apps/unified-portal/app/api/issues/[id]/flag/route.ts
@@ -1,0 +1,121 @@
+/**
+ * POST /api/issues/[id]/flag
+ *
+ * Assistant V2 Sprint 3. Toggles the developer flag on an issue and
+ * appends a flagged or unflagged event to the timeline.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 5.4.
+ *
+ * When setting developer_flagged to true we also write
+ * developer_flagged_at and developer_flagged_by. When toggling off we
+ * clear both. An issue_events row is inserted in either case with
+ * event_type 'flagged' or 'unflagged'.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403.
+ *
+ * Gated on FEATURE_DEVELOPER_DASHBOARD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isDeveloperDashboardEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, development_id, developer_flagged')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[issues-flag] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  try {
+    assertCanAccessDevelopment(auth, report.development_id as string);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const currentlyFlagged = !!report.developer_flagged;
+  const nextFlagged = !currentlyFlagged;
+  const nowIso = new Date().toISOString();
+
+  const { error: updateErr } = await supabase
+    .from('issue_reports')
+    .update({
+      developer_flagged: nextFlagged,
+      developer_flagged_at: nextFlagged ? nowIso : null,
+      developer_flagged_by: nextFlagged ? auth.userId : null,
+      updated_at: nowIso,
+    })
+    .eq('id', issueReportId);
+  if (updateErr) {
+    console.error('[issues-flag] update_failed reason=%s', updateErr.message);
+    return NextResponse.json({ error: 'Could not update flag' }, { status: 500 });
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: nextFlagged ? 'flagged' : 'unflagged',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: {},
+  });
+  if (eventErr) {
+    console.error('[issues-flag] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({
+    issue_report_id: issueReportId,
+    developer_flagged: nextFlagged,
+    developer_flagged_at: nextFlagged ? nowIso : null,
+    developer_flagged_by: nextFlagged ? auth.userId : null,
+  });
+}

--- a/apps/unified-portal/app/api/issues/[id]/notes/route.ts
+++ b/apps/unified-portal/app/api/issues/[id]/notes/route.ts
@@ -1,0 +1,131 @@
+/**
+ * POST /api/issues/[id]/notes
+ *
+ * Assistant V2 Sprint 3. Append a note to an issue and record a
+ * note_added event on the timeline.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 5.5.
+ *
+ * Unlike the other dashboard routes, this one allows ALL authenticated
+ * roles including snagger_external. Notes are context, not status
+ * mutations, so a snagger can leave a note from the snagger-side surface
+ * even if they cannot open the dashboard.
+ *
+ * Body must be non-empty and at most 2000 chars. The note insert and the
+ * issue_events insert are recorded with the caller's role and user id.
+ * The event metadata includes the new note_id for the timeline.
+ *
+ * Gated on FEATURE_DEVELOPER_DASHBOARD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_NOTE_LEN = 2000;
+
+interface RouteParams {
+  params: { id: string };
+}
+
+interface NoteBody {
+  body?: unknown;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isDeveloperDashboardEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let payload: NoteBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const rawBody = typeof payload.body === 'string' ? payload.body.trim() : '';
+  if (!rawBody) {
+    return NextResponse.json({ error: 'body is required' }, { status: 400 });
+  }
+  if (rawBody.length > MAX_NOTE_LEN) {
+    return NextResponse.json({ error: 'body is too long' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, development_id')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[issues-notes] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  try {
+    assertCanAccessDevelopment(auth, report.development_id as string);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const { data: noteRow, error: insertErr } = await supabase
+    .from('issue_notes')
+    .insert({
+      tenant_id: auth.tenantId,
+      issue_report_id: issueReportId,
+      author_user_id: auth.userId,
+      author_role: auth.role,
+      body: rawBody,
+    })
+    .select('id, tenant_id, issue_report_id, author_user_id, author_role, body, created_at')
+    .single();
+  if (insertErr || !noteRow) {
+    console.error('[issues-notes] insert_failed reason=%s', insertErr?.message ?? 'no row');
+    return NextResponse.json({ error: 'Could not save note' }, { status: 500 });
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: 'note_added',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: { note_id: noteRow.id },
+  });
+  if (eventErr) {
+    console.error('[issues-notes] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({ note: noteRow });
+}

--- a/apps/unified-portal/app/api/issues/[id]/route.ts
+++ b/apps/unified-portal/app/api/issues/[id]/route.ts
@@ -1,0 +1,256 @@
+/**
+ * GET /api/issues/[id]
+ *
+ * Assistant V2 Sprint 3. Full issue detail for the developer dashboard
+ * drawer and standalone page.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 5.3.
+ *
+ * Returns:
+ *   - the issue row with unit display_name and development name joined
+ *   - media with one-hour signed URLs (and thumbnails)
+ *   - the linked assistant_media_analysis row, or null
+ *   - the full event timeline from issue_events, ordered ascending
+ *   - all notes from issue_notes, ordered descending, with author emails
+ *
+ * Access scoping. The caller must access the issue's development under
+ * their site_team_members membership. snagger_external is rejected with
+ * 403 before any DB lookup.
+ *
+ * Gated on FEATURE_DEVELOPER_DASHBOARD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const BUCKET = 'assistant-media';
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  if (!isDeveloperDashboardEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, user_id, title, description, room, status, priority, severity_label, severity_score, safety_risk, likely_trade, likely_system, source, logged_by_user_id, logged_by_role, linked_analysis_id, developer_flagged, developer_flagged_at, developer_flagged_by, created_at, updated_at, resolved_at',
+    )
+    .eq('id', issueReportId)
+    .maybeSingle();
+
+  if (reportErr) {
+    console.error('[issues-detail] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  try {
+    assertCanAccessDevelopment(auth, report.development_id as string);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const unitId = report.unit_id as string | null;
+  const developmentId = report.development_id as string;
+
+  const [unitRes, devRes] = await Promise.all([
+    unitId
+      ? supabase
+          .from('units')
+          .select('id, unit_code, unit_number, address_line_1')
+          .eq('id', unitId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase.from('developments').select('id, name').eq('id', developmentId).maybeSingle(),
+  ]);
+  if (unitRes.error) {
+    console.error('[issues-detail] unit_lookup_failed reason=%s', unitRes.error.message);
+  }
+  if (devRes.error) {
+    console.error('[issues-detail] development_lookup_failed reason=%s', devRes.error.message);
+  }
+
+  const unitRow = unitRes.data;
+  const unitDisplayName = unitRow
+    ? ((unitRow.unit_code as string | null) ??
+      (unitRow.unit_number as string | null) ??
+      (unitRow.address_line_1 as string | null) ??
+      'Unit')
+    : null;
+  const developmentName = devRes.data ? ((devRes.data.name as string | null) ?? null) : null;
+
+  const { data: joinRows, error: joinErr } = await supabase
+    .from('issue_report_media')
+    .select('media_id')
+    .eq('issue_report_id', issueReportId);
+  if (joinErr) {
+    console.error('[issues-detail] join_lookup_failed reason=%s', joinErr.message);
+    return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+  }
+  const mediaIds = (joinRows ?? []).map((j) => j.media_id as string);
+  let mediaPayload: Array<{
+    id: string;
+    storage_path: string;
+    thumbnail_path: string | null;
+    mime_type: string;
+    width: number | null;
+    height: number | null;
+    signed_url: string;
+    thumbnail_url: string;
+    expires_at: string;
+  }> = [];
+
+  if (mediaIds.length > 0) {
+    const { data: mediaRows, error: mediaErr } = await supabase
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path, mime_type, width, height')
+      .in('id', mediaIds);
+    if (mediaErr) {
+      console.error('[issues-detail] media_lookup_failed reason=%s', mediaErr.message);
+      return NextResponse.json({ error: 'Could not load media' }, { status: 500 });
+    }
+    const expiresIso = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    for (const m of mediaRows ?? []) {
+      if (m.tenant_id !== auth.tenantId) continue;
+      const { data: signed } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(m.storage_path as string, SIGNED_URL_TTL_SECONDS);
+      let thumbUrl = signed?.signedUrl ?? '';
+      if (m.thumbnail_path) {
+        const { data: thumbSigned } = await supabase.storage
+          .from(BUCKET)
+          .createSignedUrl(m.thumbnail_path as string, SIGNED_URL_TTL_SECONDS);
+        if (thumbSigned?.signedUrl) thumbUrl = thumbSigned.signedUrl;
+      }
+      mediaPayload.push({
+        id: m.id as string,
+        storage_path: m.storage_path as string,
+        thumbnail_path: (m.thumbnail_path as string | null) ?? null,
+        mime_type: m.mime_type as string,
+        width: (m.width as number | null) ?? null,
+        height: (m.height as number | null) ?? null,
+        signed_url: signed?.signedUrl ?? '',
+        thumbnail_url: thumbUrl,
+        expires_at: expiresIso,
+      });
+    }
+  }
+
+  let analysis: Record<string, unknown> | null = null;
+  const linkedAnalysisId = report.linked_analysis_id as string | null;
+  if (linkedAnalysisId) {
+    const { data: analysisRow, error: analysisErr } = await supabase
+      .from('assistant_media_analysis')
+      .select('*')
+      .eq('id', linkedAnalysisId)
+      .maybeSingle();
+    if (analysisErr) {
+      console.error('[issues-detail] analysis_lookup_failed reason=%s', analysisErr.message);
+    } else if (analysisRow) {
+      analysis = analysisRow as Record<string, unknown>;
+    }
+  }
+
+  const [eventsRes, notesRes] = await Promise.all([
+    supabase
+      .from('issue_events')
+      .select('id, event_type, actor_type, actor_id, metadata, created_at')
+      .eq('issue_report_id', issueReportId)
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('issue_notes')
+      .select('id, author_user_id, author_role, body, created_at')
+      .eq('issue_report_id', issueReportId)
+      .order('created_at', { ascending: false }),
+  ]);
+  if (eventsRes.error) {
+    console.error('[issues-detail] events_lookup_failed reason=%s', eventsRes.error.message);
+  }
+  if (notesRes.error) {
+    console.error('[issues-detail] notes_lookup_failed reason=%s', notesRes.error.message);
+  }
+  const events = eventsRes.data ?? [];
+  const notes = notesRes.data ?? [];
+
+  const userIds = new Set<string>();
+  for (const e of events) {
+    const aid = e.actor_id as string | null;
+    if (aid) userIds.add(aid);
+  }
+  for (const n of notes) {
+    const aid = n.author_user_id as string | null;
+    if (aid) userIds.add(aid);
+  }
+  const emailByUserId = new Map<string, string>();
+  for (const id of userIds) {
+    const { data: u } = await supabase.auth.admin.getUserById(id);
+    if (u?.user?.email) emailByUserId.set(id, u.user.email);
+  }
+
+  return NextResponse.json({
+    report: {
+      ...report,
+      unit_display_name: unitDisplayName,
+      development_name: developmentName,
+    },
+    media: mediaPayload,
+    analysis,
+    events: events.map((e) => ({
+      id: e.id,
+      event_type: e.event_type,
+      actor_type: e.actor_type,
+      actor_id: e.actor_id,
+      actor_email: e.actor_id ? emailByUserId.get(e.actor_id as string) ?? null : null,
+      metadata: e.metadata,
+      created_at: e.created_at,
+    })),
+    notes: notes.map((n) => ({
+      id: n.id,
+      author_user_id: n.author_user_id,
+      author_role: n.author_role,
+      author_email: emailByUserId.get(n.author_user_id as string) ?? null,
+      body: n.body,
+      created_at: n.created_at,
+    })),
+  });
+}

--- a/apps/unified-portal/app/api/issues/list/route.ts
+++ b/apps/unified-portal/app/api/issues/list/route.ts
@@ -1,0 +1,264 @@
+/**
+ * GET /api/issues/list
+ *
+ * Assistant V2 Sprint 3. Paginated list of issues for the developer
+ * dashboard.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 5.2.
+ *
+ * Query params (all optional):
+ *   - development_id  uuid, single
+ *   - status          comma-separated, defaults to 'open,reopened'
+ *   - severity        comma-separated: low,medium,high,urgent
+ *   - source          comma-separated: homeowner_assistant,site_team_snag,snagger_external
+ *   - flagged         boolean; if 'true' returns only developer-flagged rows
+ *   - sort            'created_at_desc' (default), 'severity_desc', 'created_at_asc'
+ *   - limit           default 50, max 200
+ *   - offset          default 0
+ *
+ * Each row joins unit display_name and development name so the dashboard
+ * does not need extra fetches per row. Media URLs are NOT included; media
+ * is fetched on the detail view.
+ *
+ * Scoped to the caller's tenant. snagger_external is rejected with 403
+ * before any DB work because the dashboard is developer-side only.
+ *
+ * Gated on FEATURE_DEVELOPER_DASHBOARD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const DEFAULT_STATUS = ['open', 'reopened'];
+const VALID_STATUSES = new Set(['open', 'reopened', 'resolved', 'closed']);
+const VALID_SEVERITIES = new Set(['low', 'medium', 'high', 'urgent']);
+const VALID_SOURCES = new Set(['homeowner_assistant', 'site_team_snag', 'snagger_external']);
+const VALID_SORTS = new Set(['created_at_desc', 'severity_desc', 'created_at_asc']);
+
+function parseCsv(value: string | null, allowed: Set<string>): string[] | null {
+  if (!value) return null;
+  const items = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const item of items) {
+    if (!allowed.has(item)) return null;
+  }
+  return items.length > 0 ? items : null;
+}
+
+function deriveUnitDisplayName(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+export async function GET(request: NextRequest) {
+  if (!isDeveloperDashboardEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const developmentIdParam = url.searchParams.get('development_id');
+  const statusParam = url.searchParams.get('status');
+  const severityParam = url.searchParams.get('severity');
+  const sourceParam = url.searchParams.get('source');
+  const flaggedParam = url.searchParams.get('flagged');
+  const sortParam = url.searchParams.get('sort') ?? 'created_at_desc';
+  const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
+
+  if (developmentIdParam && !UUID_RE.test(developmentIdParam)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  const statuses = statusParam ? parseCsv(statusParam, VALID_STATUSES) : DEFAULT_STATUS;
+  if (statusParam && !statuses) {
+    return NextResponse.json({ error: 'invalid status filter' }, { status: 400 });
+  }
+  const severities = parseCsv(severityParam, VALID_SEVERITIES);
+  if (severityParam && !severities) {
+    return NextResponse.json({ error: 'invalid severity filter' }, { status: 400 });
+  }
+  const sources = parseCsv(sourceParam, VALID_SOURCES);
+  if (sourceParam && !sources) {
+    return NextResponse.json({ error: 'invalid source filter' }, { status: 400 });
+  }
+  if (!VALID_SORTS.has(sortParam)) {
+    return NextResponse.json({ error: 'invalid sort' }, { status: 400 });
+  }
+
+  let limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+  let offset = offsetParam ? parseInt(offsetParam, 10) : 0;
+  if (!Number.isFinite(limit) || limit <= 0) limit = DEFAULT_LIMIT;
+  if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+  if (!Number.isFinite(offset) || offset < 0) offset = 0;
+
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, source, severity_label, severity_score, status, priority, room, developer_flagged, logged_by_role, created_at, resolved_at',
+      { count: 'exact' },
+    )
+    .eq('tenant_id', auth.tenantId);
+
+  if (developmentIdParam) {
+    query = query.eq('development_id', developmentIdParam);
+  }
+  if (statuses && statuses.length > 0) {
+    query = query.in('status', statuses);
+  }
+  if (severities && severities.length > 0) {
+    query = query.in('severity_label', severities);
+  }
+  if (sources && sources.length > 0) {
+    query = query.in('source', sources);
+  }
+  if (flaggedParam === 'true') {
+    query = query.eq('developer_flagged', true);
+  }
+
+  if (sortParam === 'created_at_asc') {
+    query = query.order('created_at', { ascending: true });
+  } else if (sortParam === 'severity_desc') {
+    query = query
+      .order('severity_score', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
+  } else {
+    query = query.order('created_at', { ascending: false });
+  }
+  query = query.range(offset, offset + limit - 1);
+
+  const { data: rows, error: listErr, count } = await query;
+  if (listErr) {
+    console.error('[issues-list] list_failed reason=%s', listErr.message);
+    return NextResponse.json({ error: 'Could not load issues' }, { status: 500 });
+  }
+  const reportRows = rows ?? [];
+  const issueIds = reportRows.map((r) => r.id as string);
+
+  const unitIds = Array.from(
+    new Set(reportRows.map((r) => r.unit_id as string | null).filter((v): v is string => !!v)),
+  );
+  const developmentIds = Array.from(
+    new Set(reportRows.map((r) => r.development_id as string).filter((v): v is string => !!v)),
+  );
+
+  const unitsById = new Map<string, { display_name: string }>();
+  if (unitIds.length > 0) {
+    const { data: unitRows, error: unitErr } = await supabase
+      .from('units')
+      .select('id, unit_code, unit_number, address_line_1')
+      .in('id', unitIds);
+    if (unitErr) {
+      console.error('[issues-list] unit_lookup_failed reason=%s', unitErr.message);
+    } else {
+      for (const u of unitRows ?? []) {
+        unitsById.set(u.id as string, {
+          display_name: deriveUnitDisplayName({
+            unit_code: (u.unit_code as string | null) ?? null,
+            unit_number: (u.unit_number as string | null) ?? null,
+            address_line_1: (u.address_line_1 as string | null) ?? null,
+          }),
+        });
+      }
+    }
+  }
+
+  const developmentsById = new Map<string, { name: string | null }>();
+  if (developmentIds.length > 0) {
+    const { data: devRows, error: devErr } = await supabase
+      .from('developments')
+      .select('id, name')
+      .in('id', developmentIds);
+    if (devErr) {
+      console.error('[issues-list] development_lookup_failed reason=%s', devErr.message);
+    } else {
+      for (const d of devRows ?? []) {
+        developmentsById.set(d.id as string, { name: (d.name as string | null) ?? null });
+      }
+    }
+  }
+
+  const mediaCounts = new Map<string, number>();
+  const noteCounts = new Map<string, number>();
+  if (issueIds.length > 0) {
+    const [mediaRes, notesRes] = await Promise.all([
+      supabase.from('issue_report_media').select('issue_report_id').in('issue_report_id', issueIds),
+      supabase.from('issue_notes').select('issue_report_id').in('issue_report_id', issueIds),
+    ]);
+    if (mediaRes.error) {
+      console.error('[issues-list] media_count_failed reason=%s', mediaRes.error.message);
+    } else {
+      for (const j of mediaRes.data ?? []) {
+        const k = j.issue_report_id as string;
+        mediaCounts.set(k, (mediaCounts.get(k) ?? 0) + 1);
+      }
+    }
+    if (notesRes.error) {
+      console.error('[issues-list] note_count_failed reason=%s', notesRes.error.message);
+    } else {
+      for (const j of notesRes.data ?? []) {
+        const k = j.issue_report_id as string;
+        noteCounts.set(k, (noteCounts.get(k) ?? 0) + 1);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    rows: reportRows.map((r) => {
+      const unitId = r.unit_id as string | null;
+      const devId = r.development_id as string;
+      const unit = unitId ? unitsById.get(unitId) ?? null : null;
+      const dev = developmentsById.get(devId) ?? null;
+      return {
+        id: r.id,
+        title: r.title,
+        source: r.source,
+        severity_label: r.severity_label,
+        severity_score: r.severity_score,
+        status: r.status,
+        priority: r.priority,
+        room: r.room,
+        unit_display_name: unit?.display_name ?? null,
+        development_name: dev?.name ?? null,
+        media_count: mediaCounts.get(r.id as string) ?? 0,
+        note_count: noteCounts.get(r.id as string) ?? 0,
+        developer_flagged: r.developer_flagged,
+        created_at: r.created_at,
+        resolved_at: r.resolved_at,
+        logged_by_role: r.logged_by_role,
+      };
+    }),
+    total: count ?? reportRows.length,
+    limit,
+    offset,
+  });
+}

--- a/apps/unified-portal/app/api/issues/overview/route.ts
+++ b/apps/unified-portal/app/api/issues/overview/route.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /api/issues/overview
+ *
+ * Assistant V2 Sprint 3. Returns the four overview card counts for the
+ * developer dashboard.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 5.1.
+ *
+ * Counts returned:
+ *   - open                 status in ('open', 'reopened')
+ *   - high_priority        severity_label in ('high', 'urgent')
+ *   - new_this_week        created_at in the last 7 days
+ *   - resolved_this_month  status = 'resolved' and resolved_at in last 30 days
+ *
+ * Scoped to the caller's tenant. admin and site_team see every development
+ * in their tenant. snagger_external is rejected with 403 before any DB work
+ * because the dashboard is developer-side only.
+ *
+ * Gated on FEATURE_DEVELOPER_DASHBOARD.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  if (!isDeveloperDashboardEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const tenantId = auth.tenantId;
+
+  const now = Date.now();
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [openResult, highResult, weekResult, monthResult] = await Promise.all([
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .in('status', ['open', 'reopened']),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .in('severity_label', ['high', 'urgent']),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .gte('created_at', sevenDaysAgo),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .eq('status', 'resolved')
+      .gte('resolved_at', thirtyDaysAgo),
+  ]);
+
+  for (const r of [openResult, highResult, weekResult, monthResult]) {
+    if (r.error) {
+      console.error('[issues-overview] count_failed reason=%s', r.error.message);
+      return NextResponse.json({ error: 'Could not load overview' }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({
+    open: openResult.count ?? 0,
+    high_priority: highResult.count ?? 0,
+    new_this_week: weekResult.count ?? 0,
+    resolved_this_month: monthResult.count ?? 0,
+  });
+}

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -61,6 +61,27 @@ export function isBuilderSnagAppEnabled(): boolean {
   );
 }
 
+/**
+ * Assistant V2 developer dashboard for snag intelligence (Sprint 3).
+ *
+ * Default off. When false:
+ *   - the /developer/issues routes render as 404 (Session 3)
+ *   - all /api/issues/* server routes return 404 before any auth or DB work
+ *
+ * Server reads FEATURE_DEVELOPER_DASHBOARD. Client reads
+ * NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD (must be set separately for the
+ * bundler to inline the value at build time).
+ */
+export function isDeveloperDashboardEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD === 'true';
+  }
+  return (
+    process.env.FEATURE_DEVELOPER_DASHBOARD === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD === 'true'
+  );
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
@@ -68,5 +89,6 @@ export function getFeatureFlags() {
     assistantOS: isAssistantOSEnabled(),
     assistantImageUpload: isAssistantImageUploadEnabled(),
     builderSnagApp: isBuilderSnagAppEnabled(),
+    developerDashboard: isDeveloperDashboardEnabled(),
   };
 }


### PR DESCRIPTION
Implements section 5 of `docs/specs/assistant-v2-sprint-3.md`. Adds five new server routes that surface snag intelligence to the developer-side dashboard. Read-mostly for the developer side; status mutations stay on the snagger-side `/snag/[id]` view.

## New routes

| Method | Route | Spec |
|--------|-------|------|
| GET | `/api/issues/overview` | 5.1 — four card counts (open, high_priority, new_this_week, resolved_this_month) |
| GET | `/api/issues/list` | 5.2 — paginated list with filters (development_id, status, severity, source, flagged) and sort (created_at_desc, severity_desc, created_at_asc) |
| GET | `/api/issues/[id]` | 5.3 — full issue detail with media (1-hour signed URLs), linked `assistant_media_analysis`, events, notes |
| POST | `/api/issues/[id]/flag` | 5.4 — toggles `developer_flagged`, writes flagged/unflagged event |
| POST | `/api/issues/[id]/notes` | 5.5 — adds an `issue_notes` row, writes note_added event |

## Feature flag

Adds `FEATURE_DEVELOPER_DASHBOARD` (and its `NEXT_PUBLIC_*` companion) following the exact pattern used by `isBuilderSnagAppEnabled()`. Default false. When off, every route returns 404 before any auth or DB work. Wired through:
- `apps/unified-portal/lib/feature-flags.ts` — `isDeveloperDashboardEnabled()` exported and included in `getFeatureFlags()`
- `apps/unified-portal/.env.example`
- `.env.production.example`

## Auth and access scoping

All routes use the existing `resolveSnagAuth` helper from `apps/unified-portal/lib/assistant/snag-auth.ts`. `snagger_external` is rejected with 403 on every route EXCEPT `POST /[id]/notes`, where any authenticated role may add a note because notes are context, not status mutations.

`tenant_id` and accessible developments are always derived from the verified `site_team_members` row; nothing is trusted from the request. `/[id]`, `/[id]/flag`, and `/[id]/notes` additionally call `assertCanAccessDevelopment` after fetching the issue to enforce cross-tenant and out-of-scope checks.

All DB writes use the service-role client (`getSupabaseAdmin`), matching the `service_role_bypass` RLS policy applied in PR #160.

## Scope discipline

No Sprint 1 or Sprint 2 routes were modified. No UI work in this PR; the dashboard surfaces (`/developer/issues` list + drawer, `/developer/issues/[id]` standalone page) land in Session 3.

## Test coverage notes

No test runner exists yet for these routes (same situation as Sprints 1 and 2). Cases that should be covered when one lands:

- Each route returns 404 when `FEATURE_DEVELOPER_DASHBOARD=false`.
- Each non-notes route returns 403 when caller is `snagger_external`.
- `/list` returns rows scoped to the caller's tenant only; cross-tenant rows never leak.
- `/list` default status filter is `open,reopened`; explicit `status=resolved` overrides.
- `/list` invalid filter values (severity, source, sort) return 400.
- `/overview` counts match direct SQL counts on `issue_reports`.
- `/[id]/flag` toggles `developer_flagged` and inserts exactly one event per call (alternating `flagged`/`unflagged`).
- `/[id]/notes` rejects empty body and bodies over 2000 chars with 400.
- `/[id]/notes` accepted from `snagger_external` when they have access to the issue's development.

## Build

Local `npm run build` passes. Vercel preview deployment for this branch should also be green by the time this PR is reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6YkKpdkksYLJPhbQqDrnQ)_