### PR TITLE
feat(assistant-v2): Sprint 3 developer dashboard for snag intelligence

### DIFF
--- a/apps/unified-portal/app/developer/issues/[id]/IssueStandaloneClient.tsx
+++ b/apps/unified-portal/app/developer/issues/[id]/IssueStandaloneClient.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Client wrapper for /developer/issues/[id]. Owns the local detail
+ * state so the flag toggle and the new-note insert can refresh
+ * without a full page reload, while keeping the shared
+ * IssueDetailContent component identical to the drawer's body.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 6.6.
+ */
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Check, Copy, Flag, MoreHorizontal } from 'lucide-react';
+import { IssueDetailContent } from '@/components/issues/IssueDetailContent';
+import { IssueDetailResponse } from '@/components/issues/types';
+
+interface IssueStandaloneClientProps {
+  initialDetail: IssueDetailResponse;
+}
+
+export function IssueStandaloneClient({ initialDetail }: IssueStandaloneClientProps) {
+  const router = useRouter();
+  const [detail, setDetail] = useState<IssueDetailResponse>(initialDetail);
+  const [flagging, setFlagging] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/issues/${detail.report.id}`, { cache: 'no-store' });
+      if (!res.ok) return;
+      const json = (await res.json()) as IssueDetailResponse;
+      setDetail(json);
+    } catch {
+      // best-effort
+    }
+  }, [detail.report.id]);
+
+  const toggleFlag = async () => {
+    if (flagging) return;
+    setFlagging(true);
+    try {
+      const res = await fetch(`/api/issues/${detail.report.id}/flag`, { method: 'POST' });
+      if (!res.ok) return;
+      await refresh();
+      router.refresh();
+    } finally {
+      setFlagging(false);
+    }
+  };
+
+  const copyLink = async () => {
+    const url = window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      window.prompt('Copy link to issue', url);
+    }
+    setMenuOpen(false);
+  };
+
+  const flagged = detail.report.developer_flagged;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-end gap-1">
+        <button
+          type="button"
+          onClick={() => void toggleFlag()}
+          disabled={flagging}
+          aria-pressed={flagged}
+          title={flagged ? 'Remove flag' : 'Flag for attention'}
+          className={`w-10 h-10 flex items-center justify-center rounded-lg transition-colors disabled:opacity-50 ${
+            flagged
+              ? 'bg-brand-50 text-brand-600 hover:bg-brand-100'
+              : 'text-neutral-700 hover:bg-neutral-100'
+          }`}
+        >
+          <Flag className={`w-5 h-5 ${flagged ? 'fill-current' : ''}`} />
+        </button>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setMenuOpen((v) => !v)}
+            aria-label="More options"
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            className="w-10 h-10 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <MoreHorizontal className="w-5 h-5" />
+          </button>
+          {menuOpen ? (
+            <>
+              <button
+                type="button"
+                aria-hidden
+                tabIndex={-1}
+                onClick={() => setMenuOpen(false)}
+                className="fixed inset-0 z-10 bg-transparent cursor-default"
+              />
+              <div
+                role="menu"
+                className="absolute right-0 top-full mt-1 z-20 min-w-[12rem] rounded-lg border border-neutral-200 bg-white shadow-lg py-1"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => void copyLink()}
+                  className="w-full px-3 py-2 text-left text-body-sm text-neutral-800 hover:bg-neutral-50 flex items-center gap-2"
+                >
+                  {copied ? (
+                    <Check className="w-4 h-4 text-emerald-600" />
+                  ) : (
+                    <Copy className="w-4 h-4 text-neutral-500" />
+                  )}
+                  {copied ? 'Copied' : 'Copy link to issue'}
+                </button>
+              </div>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      <IssueDetailContent data={detail} onNoteAdded={() => void refresh()} />
+    </div>
+  );
+}

--- a/apps/unified-portal/app/developer/issues/[id]/page.tsx
+++ b/apps/unified-portal/app/developer/issues/[id]/page.tsx
@@ -1,0 +1,272 @@
+/**
+ * /developer/issues/[id]
+ *
+ * Assistant V2 Sprint 3. Server-rendered standalone detail page for an
+ * issue. Same shared component as the drawer renders the body so a
+ * link copied from the drawer's menu opens the identical view as a
+ * full page.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 6.6.
+ *
+ * Gates on FEATURE_DEVELOPER_DASHBOARD (404 when off). Verifies the
+ * caller is admin or site_team via snag-auth. snagger_external sees
+ * 404. Resolves all data server-side (issue, media with signed URLs,
+ * analysis, events, notes) and hands off to IssueStandalonePageClient
+ * which wraps the shared content with a header (back link, flag
+ * toggle, copy-link menu) and provides URL refresh after flag toggles.
+ */
+
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ChevronLeft } from 'lucide-react';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessDevelopment,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { SnagNoAccess } from '../../../snag/SnagNoAccess';
+import { IssueStandaloneClient } from './IssueStandaloneClient';
+import {
+  IssueAnalysis,
+  IssueDetailResponse,
+  IssueEvent,
+  IssueMedia,
+  IssueNote,
+  IssueReport,
+  IssueSeverity,
+  IssueSource,
+  IssueStatus,
+} from '@/components/issues/types';
+
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const BUCKET = 'assistant-media';
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function DeveloperIssueDetailPage({ params }: PageProps) {
+  if (!isDeveloperDashboardEnabled()) notFound();
+  if (!UUID_RE.test(params.id)) notFound();
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      if (err.code === 'unauthenticated') {
+        return <SnagNoAccess code="unauthenticated" />;
+      }
+      notFound();
+    }
+    throw err;
+  }
+  if (auth.role === 'snagger_external') notFound();
+
+  const detail = await loadDetail(params.id, auth.tenantId);
+  if (!detail) notFound();
+
+  try {
+    assertCanAccessDevelopment(auth, detail.report.development_id);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="px-6 py-4 border-b border-neutral-200 bg-white flex items-center gap-2">
+        <Link
+          href="/developer/issues"
+          className="inline-flex items-center gap-1 text-body-sm text-neutral-700 hover:text-neutral-900 px-2 py-1 -ml-2 rounded-md hover:bg-neutral-100"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          Back to issues
+        </Link>
+      </header>
+      <main className="px-6 py-6 max-w-3xl mx-auto">
+        <IssueStandaloneClient initialDetail={detail} />
+      </main>
+    </div>
+  );
+}
+
+async function loadDetail(
+  issueReportId: string,
+  tenantId: string,
+): Promise<IssueDetailResponse | null> {
+  const supabase = getSupabaseAdmin();
+
+  const { data: report } = await supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, user_id, title, description, room, status, priority, severity_label, severity_score, safety_risk, likely_trade, likely_system, source, logged_by_user_id, logged_by_role, linked_analysis_id, developer_flagged, developer_flagged_at, developer_flagged_by, created_at, updated_at, resolved_at',
+    )
+    .eq('id', issueReportId)
+    .maybeSingle();
+
+  if (!report || report.tenant_id !== tenantId) return null;
+
+  const unitId = report.unit_id as string | null;
+  const developmentId = report.development_id as string;
+
+  const [unitRes, devRes] = await Promise.all([
+    unitId
+      ? supabase
+          .from('units')
+          .select('id, unit_code, unit_number, address_line_1')
+          .eq('id', unitId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase.from('developments').select('id, name').eq('id', developmentId).maybeSingle(),
+  ]);
+  const unitRow = unitRes.data;
+  const unitDisplayName = unitRow
+    ? ((unitRow.unit_code as string | null) ??
+      (unitRow.unit_number as string | null) ??
+      (unitRow.address_line_1 as string | null) ??
+      'Unit')
+    : null;
+  const developmentName = devRes.data ? ((devRes.data.name as string | null) ?? null) : null;
+
+  const { data: joinRows } = await supabase
+    .from('issue_report_media')
+    .select('media_id')
+    .eq('issue_report_id', issueReportId);
+  const mediaIds = (joinRows ?? []).map((j) => j.media_id as string);
+
+  const mediaPayload: IssueMedia[] = [];
+  if (mediaIds.length > 0) {
+    const { data: mediaRows } = await supabase
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path, mime_type, width, height')
+      .in('id', mediaIds);
+    const expiresIso = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+    for (const m of mediaRows ?? []) {
+      if (m.tenant_id !== tenantId) continue;
+      const { data: signed } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(m.storage_path as string, SIGNED_URL_TTL_SECONDS);
+      let thumbUrl = signed?.signedUrl ?? '';
+      if (m.thumbnail_path) {
+        const { data: thumbSigned } = await supabase.storage
+          .from(BUCKET)
+          .createSignedUrl(m.thumbnail_path as string, SIGNED_URL_TTL_SECONDS);
+        if (thumbSigned?.signedUrl) thumbUrl = thumbSigned.signedUrl;
+      }
+      mediaPayload.push({
+        id: m.id as string,
+        storage_path: m.storage_path as string,
+        thumbnail_path: (m.thumbnail_path as string | null) ?? null,
+        mime_type: m.mime_type as string,
+        width: (m.width as number | null) ?? null,
+        height: (m.height as number | null) ?? null,
+        signed_url: signed?.signedUrl ?? '',
+        thumbnail_url: thumbUrl,
+        expires_at: expiresIso,
+      });
+    }
+  }
+
+  let analysis: IssueAnalysis | null = null;
+  const linkedAnalysisId = report.linked_analysis_id as string | null;
+  if (linkedAnalysisId) {
+    const { data: analysisRow } = await supabase
+      .from('assistant_media_analysis')
+      .select('*')
+      .eq('id', linkedAnalysisId)
+      .maybeSingle();
+    if (analysisRow) analysis = analysisRow as IssueAnalysis;
+  }
+
+  const [eventsRes, notesRes] = await Promise.all([
+    supabase
+      .from('issue_events')
+      .select('id, event_type, actor_type, actor_id, metadata, created_at')
+      .eq('issue_report_id', issueReportId)
+      .order('created_at', { ascending: true }),
+    supabase
+      .from('issue_notes')
+      .select('id, author_user_id, author_role, body, created_at')
+      .eq('issue_report_id', issueReportId)
+      .order('created_at', { ascending: false }),
+  ]);
+  const events = eventsRes.data ?? [];
+  const notes = notesRes.data ?? [];
+
+  const userIds = new Set<string>();
+  for (const e of events) {
+    const aid = e.actor_id as string | null;
+    if (aid) userIds.add(aid);
+  }
+  for (const n of notes) {
+    const aid = n.author_user_id as string | null;
+    if (aid) userIds.add(aid);
+  }
+  const emailByUserId = new Map<string, string>();
+  for (const id of userIds) {
+    const { data: u } = await supabase.auth.admin.getUserById(id);
+    if (u?.user?.email) emailByUserId.set(id, u.user.email);
+  }
+
+  const reportPayload: IssueReport = {
+    id: report.id as string,
+    tenant_id: report.tenant_id as string,
+    development_id: report.development_id as string,
+    unit_id: (report.unit_id as string | null) ?? null,
+    user_id: (report.user_id as string | null) ?? null,
+    title: report.title as string,
+    description: (report.description as string | null) ?? null,
+    room: (report.room as string | null) ?? null,
+    status: report.status as IssueStatus,
+    priority: (report.priority as string | null) ?? null,
+    severity_label: (report.severity_label as IssueSeverity | null) ?? null,
+    severity_score: (report.severity_score as number | null) ?? null,
+    safety_risk: (report.safety_risk as string | null) ?? null,
+    likely_trade: (report.likely_trade as string | null) ?? null,
+    likely_system: (report.likely_system as string | null) ?? null,
+    source: report.source as IssueSource,
+    logged_by_user_id: (report.logged_by_user_id as string | null) ?? null,
+    logged_by_role: (report.logged_by_role as string | null) ?? null,
+    linked_analysis_id: (report.linked_analysis_id as string | null) ?? null,
+    developer_flagged: !!report.developer_flagged,
+    developer_flagged_at: (report.developer_flagged_at as string | null) ?? null,
+    developer_flagged_by: (report.developer_flagged_by as string | null) ?? null,
+    created_at: report.created_at as string,
+    updated_at: (report.updated_at as string | null) ?? null,
+    resolved_at: (report.resolved_at as string | null) ?? null,
+    unit_display_name: unitDisplayName,
+    development_name: developmentName,
+  };
+
+  const eventsPayload: IssueEvent[] = events.map((e) => ({
+    id: e.id as string,
+    event_type: e.event_type as string,
+    actor_type: (e.actor_type as string | null) ?? null,
+    actor_id: (e.actor_id as string | null) ?? null,
+    actor_email: e.actor_id ? emailByUserId.get(e.actor_id as string) ?? null : null,
+    metadata: (e.metadata as Record<string, unknown> | null) ?? null,
+    created_at: e.created_at as string,
+  }));
+
+  const notesPayload: IssueNote[] = notes.map((n) => ({
+    id: n.id as string,
+    author_user_id: n.author_user_id as string,
+    author_role: n.author_role as string,
+    author_email: emailByUserId.get(n.author_user_id as string) ?? null,
+    body: n.body as string,
+    created_at: n.created_at as string,
+  }));
+
+  return {
+    report: reportPayload,
+    media: mediaPayload,
+    analysis,
+    events: eventsPayload,
+    notes: notesPayload,
+  };
+}

--- a/apps/unified-portal/app/developer/issues/page.tsx
+++ b/apps/unified-portal/app/developer/issues/page.tsx
@@ -1,0 +1,272 @@
+/**
+ * /developer/issues
+ *
+ * Assistant V2 Sprint 3. Developer-facing dashboard for snag intelligence.
+ * Server component that gates the route on FEATURE_DEVELOPER_DASHBOARD,
+ * verifies the caller is admin or site_team via the snag-auth pattern,
+ * fetches initial data (overview counts, list, developments) directly
+ * via Supabase, and hands off to IssuesDashboardClient for the chips
+ * and drawer.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 6.
+ */
+
+import { notFound } from 'next/navigation';
+import { isDeveloperDashboardEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { SnagNoAccess } from '../../snag/SnagNoAccess';
+import { IssuesDashboardClient } from '@/components/issues/IssuesDashboardClient';
+import {
+  DashboardInitialData,
+  IssueFilters,
+  IssueListRow,
+  IssueOverviewCounts,
+  IssueSeverity,
+  IssueSource,
+  IssueStatus,
+  PAGE_SIZE,
+} from '@/components/issues/types';
+import { parseFiltersFromSearchParams } from '@/components/issues/filter-url';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+export default async function DeveloperIssuesPage({ searchParams }: PageProps) {
+  if (!isDeveloperDashboardEnabled()) notFound();
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      if (err.code === 'unauthenticated') {
+        return <SnagNoAccess code="unauthenticated" />;
+      }
+      notFound();
+    }
+    throw err;
+  }
+  if (auth.role === 'snagger_external') notFound();
+
+  const filters = parseFiltersFromSearchParams(searchParams);
+  const initial = await loadInitialData(auth.tenantId, filters);
+
+  return <IssuesDashboardClient initial={initial} initialFilters={filters} />;
+}
+
+function deriveUnitDisplayName(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+async function loadInitialData(
+  tenantId: string,
+  filters: IssueFilters,
+): Promise<DashboardInitialData> {
+  const supabase = getSupabaseAdmin();
+  const now = Date.now();
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const overviewPromise = Promise.all([
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .in('status', ['open', 'reopened']),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .in('severity_label', ['high', 'urgent']),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .gte('created_at', sevenDaysAgo),
+    supabase
+      .from('issue_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .eq('status', 'resolved')
+      .gte('resolved_at', thirtyDaysAgo),
+  ]);
+
+  const developmentsPromise = supabase
+    .from('developments')
+    .select('id, name')
+    .eq('tenant_id', tenantId)
+    .order('name', { ascending: true });
+
+  const [overviewRes, developmentsRes, listResult] = await Promise.all([
+    overviewPromise,
+    developmentsPromise,
+    fetchList(tenantId, filters),
+  ]);
+
+  const [openR, highR, weekR, monthR] = overviewRes;
+  const overview: IssueOverviewCounts = {
+    open: openR.count ?? 0,
+    high_priority: highR.count ?? 0,
+    new_this_week: weekR.count ?? 0,
+    resolved_this_month: monthR.count ?? 0,
+  };
+
+  const developments = (developmentsRes.data ?? []).map((d) => ({
+    id: d.id as string,
+    name: (d.name as string | null) ?? 'Scheme',
+  }));
+
+  return {
+    overview,
+    list: listResult,
+    developments,
+  };
+}
+
+interface ListShape {
+  rows: IssueListRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+async function fetchList(tenantId: string, filters: IssueFilters): Promise<ListShape> {
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, source, severity_label, severity_score, status, priority, room, developer_flagged, logged_by_role, created_at, resolved_at',
+      { count: 'exact' },
+    )
+    .eq('tenant_id', tenantId);
+
+  if (filters.development_id) {
+    query = query.eq('development_id', filters.development_id);
+  }
+  if (filters.status.length > 0) {
+    query = query.in('status', filters.status as IssueStatus[]);
+  }
+  if (filters.severity.length > 0) {
+    query = query.in('severity_label', filters.severity as IssueSeverity[]);
+  }
+  if (filters.source.length > 0) {
+    query = query.in('source', filters.source as IssueSource[]);
+  }
+  if (filters.flagged) {
+    query = query.eq('developer_flagged', true);
+  }
+
+  if (filters.sort === 'created_at_asc') {
+    query = query.order('created_at', { ascending: true });
+  } else if (filters.sort === 'severity_desc') {
+    query = query
+      .order('severity_score', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
+  } else {
+    query = query.order('created_at', { ascending: false });
+  }
+  query = query.range(0, PAGE_SIZE - 1);
+
+  const { data: rowsData, count } = await query;
+  const reportRows = rowsData ?? [];
+  const issueIds = reportRows.map((r) => r.id as string);
+  const unitIds = Array.from(
+    new Set(
+      reportRows
+        .map((r) => r.unit_id as string | null)
+        .filter((v): v is string => !!v),
+    ),
+  );
+  const developmentIds = Array.from(
+    new Set(reportRows.map((r) => r.development_id as string).filter((v): v is string => !!v)),
+  );
+
+  const unitsById = new Map<string, { display_name: string }>();
+  if (unitIds.length > 0) {
+    const { data } = await supabase
+      .from('units')
+      .select('id, unit_code, unit_number, address_line_1')
+      .in('id', unitIds);
+    for (const u of data ?? []) {
+      unitsById.set(u.id as string, {
+        display_name: deriveUnitDisplayName({
+          unit_code: (u.unit_code as string | null) ?? null,
+          unit_number: (u.unit_number as string | null) ?? null,
+          address_line_1: (u.address_line_1 as string | null) ?? null,
+        }),
+      });
+    }
+  }
+
+  const developmentsById = new Map<string, { name: string | null }>();
+  if (developmentIds.length > 0) {
+    const { data } = await supabase
+      .from('developments')
+      .select('id, name')
+      .in('id', developmentIds);
+    for (const d of data ?? []) {
+      developmentsById.set(d.id as string, { name: (d.name as string | null) ?? null });
+    }
+  }
+
+  const mediaCounts = new Map<string, number>();
+  const noteCounts = new Map<string, number>();
+  if (issueIds.length > 0) {
+    const [mediaRes, notesRes] = await Promise.all([
+      supabase.from('issue_report_media').select('issue_report_id').in('issue_report_id', issueIds),
+      supabase.from('issue_notes').select('issue_report_id').in('issue_report_id', issueIds),
+    ]);
+    for (const j of mediaRes.data ?? []) {
+      const k = j.issue_report_id as string;
+      mediaCounts.set(k, (mediaCounts.get(k) ?? 0) + 1);
+    }
+    for (const j of notesRes.data ?? []) {
+      const k = j.issue_report_id as string;
+      noteCounts.set(k, (noteCounts.get(k) ?? 0) + 1);
+    }
+  }
+
+  const rows: IssueListRow[] = reportRows.map((r) => {
+    const unitId = r.unit_id as string | null;
+    const devId = r.development_id as string;
+    const unit = unitId ? unitsById.get(unitId) ?? null : null;
+    const dev = developmentsById.get(devId) ?? null;
+    return {
+      id: r.id as string,
+      title: r.title as string,
+      source: r.source as IssueSource,
+      severity_label: (r.severity_label as IssueSeverity | null) ?? null,
+      severity_score: (r.severity_score as number | null) ?? null,
+      status: r.status as IssueStatus,
+      priority: (r.priority as string | null) ?? null,
+      room: (r.room as string | null) ?? null,
+      unit_display_name: unit?.display_name ?? null,
+      development_name: dev?.name ?? null,
+      media_count: mediaCounts.get(r.id as string) ?? 0,
+      note_count: noteCounts.get(r.id as string) ?? 0,
+      developer_flagged: !!r.developer_flagged,
+      created_at: r.created_at as string,
+      resolved_at: (r.resolved_at as string | null) ?? null,
+      logged_by_role: (r.logged_by_role as string | null) ?? null,
+    };
+  });
+
+  return {
+    rows,
+    total: count ?? rows.length,
+    limit: PAGE_SIZE,
+    offset: 0,
+  };
+}

--- a/apps/unified-portal/app/developer/layout-sidebar.tsx
+++ b/apps/unified-portal/app/developer/layout-sidebar.tsx
@@ -10,8 +10,9 @@ import {
   FolderArchive, MessageSquare, Shield, Sparkles,
   Layers, ShieldCheck, GitBranch, Mail, Command,
   CalendarCheck, Building2, Wrench, Dumbbell, BookOpen as Welcome,
-  Plug, Megaphone, HardDrive, LogOut, UserPlus
+  Plug, Megaphone, HardDrive, LogOut, UserPlus, ClipboardList
 } from 'lucide-react';
+import { isDeveloperDashboardEnabled, isBuilderSnagAppEnabled } from '@/lib/feature-flags';
 import { ScopeSwitcher } from '@/components/developer/ScopeSwitcher';
 import { CommandPalette } from '@/components/ui/CommandPalette';
 import { useCurrentContext } from '@/contexts/CurrentContext';
@@ -29,57 +30,78 @@ interface NavSection {
   }>;
 }
 
-const btsNavSections: NavSection[] = [
-  {
-    title: 'Main',
-    items: [
-      { label: 'Overview', href: '/developer', icon: Home },
-      { label: 'Sales Pipeline', href: '/developer/pipeline', icon: GitBranch },
-      { label: 'OpenHouse Intelligence', href: '/developer/scheme-intelligence', icon: Sparkles },
-    ],
-  },
-  {
-    title: 'Developer Tools',
-    items: [
-      { label: 'Pre-Handover Portal', href: '/developer/pre-handover-settings', icon: CalendarCheck },
-      { label: 'Kitchen Selections', href: '/developer/kitchen-selections', icon: Layers },
-      { label: 'Compliance', href: '/developer/compliance', icon: ShieldCheck },
-      { label: 'Communications', href: '/developer/communications', icon: Mail },
-    ],
-  },
-  {
-    title: 'Management',
-    items: [
-      { label: 'Homeowners', href: '/developer/homeowners', icon: Users },
-      { label: 'Smart Archive', href: '/developer/archive', icon: FolderArchive },
-      { label: 'Data Hub', href: '/developer/data-hub', icon: HardDrive },
-      { label: 'Room Dimensions', href: '/developer/room-dimensions', icon: Ruler },
-    ],
-  },
-  {
-    title: 'Communication',
-    items: [
-      { label: 'Broadcasts', href: '/developer/broadcasts', icon: Megaphone },
-      { label: 'Noticeboard', href: '/developer/noticeboard', icon: MessageSquare },
-      { label: 'Moderation', href: '/developer/moderation', icon: Shield },
-    ],
-  },
-  {
-    title: 'Insights',
-    items: [
-      { label: 'Analytics', href: '/developer/analytics', icon: BarChart3 },
-      { label: 'AI Insights', href: '/developer/insights', icon: Lightbulb },
-      { label: 'Knowledge Base', href: '/developer/knowledge-base', icon: BookOpen },
-    ],
-  },
-  {
-    title: 'Settings',
-    items: [
-      { label: 'Integrations', href: '/developer/integrations', icon: Plug },
-      { label: 'Snagging Team', href: '/developer/snaggers', icon: UserPlus },
-    ],
-  },
-];
+function buildBtsNavSections(): NavSection[] {
+  const dashboardOn = isDeveloperDashboardEnabled();
+  const snagAppOn = isBuilderSnagAppEnabled();
+
+  const snaggingItems: NavSection['items'] = [];
+  if (dashboardOn) {
+    snaggingItems.push({ label: 'Issues', href: '/developer/issues', icon: ClipboardList });
+  }
+  if (snagAppOn) {
+    snaggingItems.push({ label: 'Team', href: '/developer/snaggers', icon: UserPlus });
+  }
+
+  const sections: NavSection[] = [
+    {
+      title: 'Main',
+      items: [
+        { label: 'Overview', href: '/developer', icon: Home },
+        { label: 'Sales Pipeline', href: '/developer/pipeline', icon: GitBranch },
+        { label: 'OpenHouse Intelligence', href: '/developer/scheme-intelligence', icon: Sparkles },
+      ],
+    },
+  ];
+
+  if (snaggingItems.length > 0) {
+    sections.push({ title: 'Snagging', items: snaggingItems });
+  }
+
+  sections.push(
+    {
+      title: 'Developer Tools',
+      items: [
+        { label: 'Pre-Handover Portal', href: '/developer/pre-handover-settings', icon: CalendarCheck },
+        { label: 'Kitchen Selections', href: '/developer/kitchen-selections', icon: Layers },
+        { label: 'Compliance', href: '/developer/compliance', icon: ShieldCheck },
+        { label: 'Communications', href: '/developer/communications', icon: Mail },
+      ],
+    },
+    {
+      title: 'Management',
+      items: [
+        { label: 'Homeowners', href: '/developer/homeowners', icon: Users },
+        { label: 'Smart Archive', href: '/developer/archive', icon: FolderArchive },
+        { label: 'Data Hub', href: '/developer/data-hub', icon: HardDrive },
+        { label: 'Room Dimensions', href: '/developer/room-dimensions', icon: Ruler },
+      ],
+    },
+    {
+      title: 'Communication',
+      items: [
+        { label: 'Broadcasts', href: '/developer/broadcasts', icon: Megaphone },
+        { label: 'Noticeboard', href: '/developer/noticeboard', icon: MessageSquare },
+        { label: 'Moderation', href: '/developer/moderation', icon: Shield },
+      ],
+    },
+    {
+      title: 'Insights',
+      items: [
+        { label: 'Analytics', href: '/developer/analytics', icon: BarChart3 },
+        { label: 'AI Insights', href: '/developer/insights', icon: Lightbulb },
+        { label: 'Knowledge Base', href: '/developer/knowledge-base', icon: BookOpen },
+      ],
+    },
+    {
+      title: 'Settings',
+      items: [
+        { label: 'Integrations', href: '/developer/integrations', icon: Plug },
+      ],
+    },
+  );
+
+  return sections;
+}
 
 function getBtrNavSections(developmentId: string): NavSection[] {
   return [
@@ -138,7 +160,7 @@ export function DeveloperLayoutWithSidebar({ children }: SidebarMenuProps) {
   const effectiveProjectType = contextProjectType || fetchedProjectType || 'bts';
 
   const navSections = useMemo(() => {
-    const sections = [...btsNavSections];
+    const sections = buildBtsNavSections();
     if (developmentId && (effectiveProjectType === 'btr' || effectiveProjectType === 'mixed')) {
       sections.push(...getBtrNavSections(developmentId));
     }

--- a/apps/unified-portal/components/issues/IssueDetailContent.tsx
+++ b/apps/unified-portal/components/issues/IssueDetailContent.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+/**
+ * Shared detail view used by both the drawer (IssueDetailDrawer) and
+ * the standalone page (/developer/issues/[id]). Spec section 6.5/6.6.
+ *
+ * Renders:
+ *   - title + unit/development/room subtitle
+ *   - source badge, status dot, severity label row
+ *   - photo grid (3 across, opens lightbox)
+ *   - resident message / snag notes
+ *   - AI assessment (collapsed by default when model_provider is
+ *     'placeholder')
+ *   - notes section with new-note input and existing list
+ *   - timeline of issue_events
+ *
+ * The component owns local state for which photo is in the lightbox,
+ * whether the AI assessment is expanded, and the optimistic notes
+ * append. Parent owns the issue payload and supplies a refresh hook
+ * (re-fetches /api/issues/[id] when the flag changes elsewhere).
+ */
+
+import { useMemo, useState } from 'react';
+import { Image as ImageIcon } from 'lucide-react';
+import {
+  IssueAnalysis,
+  IssueDetailResponse,
+  IssueNote,
+  severityLabel,
+  sourceLabel,
+  statusDotClass,
+  statusLabel,
+} from './types';
+import { IssueLightbox } from './IssueLightbox';
+import { IssueNotesSection } from './IssueNotesSection';
+import { IssueTimeline } from './IssueTimeline';
+
+interface IssueDetailContentProps {
+  data: IssueDetailResponse;
+  onNoteAdded?: (note: IssueNote) => void;
+}
+
+export function IssueDetailContent({ data, onNoteAdded }: IssueDetailContentProps) {
+  const { report, media, analysis, events } = data;
+  const [notes, setNotes] = useState<IssueNote[]>(data.notes);
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  const placeholderAnalysis = isPlaceholderAnalysis(analysis);
+  const [assessmentOpen, setAssessmentOpen] = useState<boolean>(!placeholderAnalysis && !!analysis);
+
+  const subtitleParts = [
+    report.unit_display_name,
+    report.development_name,
+    report.room,
+  ].filter(Boolean) as string[];
+  const subtitle = subtitleParts.join(' . ');
+
+  const handleNoteAdded = (note: IssueNote) => {
+    setNotes((curr) => [note, ...curr]);
+    onNoteAdded?.(note);
+  };
+
+  const residentMessage = report.description?.trim() ?? '';
+
+  const flaggedBadge = useMemo(() => {
+    if (!report.developer_flagged) return null;
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand-50 text-brand-700 text-caption">
+        Flagged
+      </span>
+    );
+  }, [report.developer_flagged]);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-heading-md text-neutral-900 break-words">{report.title}</h2>
+        {subtitle ? (
+          <p className="text-body-sm text-neutral-500">{subtitle}</p>
+        ) : null}
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-neutral-100 text-neutral-700 text-caption">
+            {sourceLabel(report.source)}
+          </span>
+          <span className="inline-flex items-center gap-1.5 text-caption text-neutral-700">
+            <span
+              aria-hidden
+              className={`w-2 h-2 rounded-full ${statusDotClass(report.status)}`}
+            />
+            {statusLabel(report.status)}
+          </span>
+          <span className="text-caption text-neutral-700">
+            Severity: {severityLabel(report.severity_label)}
+          </span>
+          {flaggedBadge}
+        </div>
+      </header>
+
+      {media.length > 0 ? (
+        <section className="space-y-2">
+          <h3 className="text-body-sm font-semibold text-neutral-900 flex items-center gap-1.5">
+            <ImageIcon className="w-3.5 h-3.5 text-neutral-500" />
+            Photos
+          </h3>
+          <div className="grid grid-cols-3 gap-2">
+            {media.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setLightboxSrc(m.signed_url || m.thumbnail_url)}
+                className="block aspect-square bg-neutral-100 border border-neutral-200 rounded-md overflow-hidden hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+              >
+                <img
+                  src={m.thumbnail_url || m.signed_url}
+                  alt=""
+                  className="w-full h-full object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {residentMessage ? (
+        <section className="space-y-2">
+          <h3 className="text-body-sm font-semibold text-neutral-900">
+            {report.source === 'homeowner_assistant' ? 'Resident message' : 'Snag notes'}
+          </h3>
+          <div className="rounded-lg border border-neutral-200 bg-white px-3 py-2 text-body-sm text-neutral-800 whitespace-pre-wrap break-words">
+            {residentMessage}
+          </div>
+        </section>
+      ) : null}
+
+      {analysis ? (
+        <AssessmentSection
+          analysis={analysis}
+          isPlaceholder={placeholderAnalysis}
+          open={assessmentOpen}
+          onToggle={() => setAssessmentOpen((v) => !v)}
+        />
+      ) : null}
+
+      <IssueNotesSection issueId={report.id} notes={notes} onAdded={handleNoteAdded} />
+
+      <IssueTimeline events={events} />
+
+      <IssueLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+    </div>
+  );
+}
+
+interface AssessmentSectionProps {
+  analysis: IssueAnalysis;
+  isPlaceholder: boolean;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function AssessmentSection({ analysis, isPlaceholder, open, onToggle }: AssessmentSectionProps) {
+  return (
+    <section className="space-y-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-2 text-left"
+      >
+        <h3 className="text-body-sm font-semibold text-neutral-900">
+          AI assessment
+          {isPlaceholder ? (
+            <span className="ml-2 text-caption font-normal text-neutral-500">
+              (placeholder)
+            </span>
+          ) : null}
+        </h3>
+        <span className="text-caption text-neutral-500">
+          {open ? 'Hide' : 'Show'}
+        </span>
+      </button>
+
+      {open ? (
+        <div className="rounded-lg border border-neutral-200 bg-white px-3 py-3 space-y-2">
+          {analysis.summary ? (
+            <p className="text-body-sm text-neutral-800 whitespace-pre-wrap">
+              {analysis.summary}
+            </p>
+          ) : null}
+
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-caption">
+            {analysis.severity_label ? (
+              <Field
+                label="Severity"
+                value={`${analysis.severity_label}${
+                  analysis.severity_score !== null && analysis.severity_score !== undefined
+                    ? ` (${analysis.severity_score})`
+                    : ''
+                }`}
+              />
+            ) : null}
+            {analysis.safety_risk ? (
+              <Field label="Safety risk" value={analysis.safety_risk} />
+            ) : null}
+            {analysis.likely_trade ? (
+              <Field label="Likely trade" value={analysis.likely_trade} />
+            ) : null}
+            {analysis.likely_system ? (
+              <Field label="System" value={analysis.likely_system} />
+            ) : null}
+            {analysis.suggested_priority ? (
+              <Field label="Priority" value={analysis.suggested_priority} />
+            ) : null}
+            {analysis.model_provider ? (
+              <Field
+                label="Model"
+                value={`${analysis.model_provider}${
+                  analysis.model_name ? ` . ${analysis.model_name}` : ''
+                }`}
+              />
+            ) : null}
+          </dl>
+
+          {analysis.reasoning || analysis.ai_reasoning ? (
+            <div>
+              <div className="text-caption font-semibold text-neutral-700 mb-0.5">
+                Reasoning
+              </div>
+              <p className="text-body-sm text-neutral-700 whitespace-pre-wrap">
+                {(analysis.reasoning as string) || (analysis.ai_reasoning as string)}
+              </p>
+            </div>
+          ) : null}
+
+          {analysis.recommended_action ? (
+            <div>
+              <div className="text-caption font-semibold text-neutral-700 mb-0.5">
+                Recommended action
+              </div>
+              <p className="text-body-sm text-neutral-700 whitespace-pre-wrap">
+                {analysis.recommended_action}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  value: string | null | undefined;
+}
+
+function Field({ label, value }: FieldProps) {
+  if (!value) return null;
+  return (
+    <div>
+      <dt className="text-neutral-500">{label}</dt>
+      <dd className="text-neutral-900">{value}</dd>
+    </div>
+  );
+}
+
+function isPlaceholderAnalysis(analysis: IssueAnalysis | null): boolean {
+  if (!analysis) return false;
+  const provider = analysis.model_provider;
+  return provider === 'placeholder';
+}

--- a/apps/unified-portal/components/issues/IssueDetailDrawer.tsx
+++ b/apps/unified-portal/components/issues/IssueDetailDrawer.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+/**
+ * Right-side detail drawer. Spec section 6.5.
+ *
+ * - 560px on desktop, full-screen on mobile.
+ * - Backdrop dims the list behind it on desktop; mobile is opaque.
+ * - Header has Close, Flag toggle, and a Menu (Copy link to issue).
+ * - Body delegates to IssueDetailContent (the shared component used by
+ *   /developer/issues/[id] as well).
+ * - The drawer syncs to ?issue=<id> via the parent (IssuesDashboardClient
+ *   manages the URL); this component just calls onClose to clear it.
+ *
+ * Fetches /api/issues/[id] when issueId changes. Re-fetches when the
+ * user toggles the flag or after a note is added (so the timeline
+ * picks up the new events).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, Copy, Flag, MoreHorizontal, X } from 'lucide-react';
+import { IssueDetailContent } from './IssueDetailContent';
+import { IssueDetailResponse } from './types';
+
+interface IssueDetailDrawerProps {
+  issueId: string | null;
+  onClose: () => void;
+  onFlagChanged?: (issueId: string, flagged: boolean) => void;
+  onNotesChanged?: (issueId: string) => void;
+}
+
+export function IssueDetailDrawer({
+  issueId,
+  onClose,
+  onFlagChanged,
+  onNotesChanged,
+}: IssueDetailDrawerProps) {
+  const [data, setData] = useState<IssueDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [flagging, setFlagging] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(async () => {
+    if (!issueId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/issues/${issueId}`, { cache: 'no-store' });
+      if (!res.ok) {
+        setError(res.status === 404 ? 'Issue not found.' : "Couldn't load this issue.");
+        return;
+      }
+      const json = (await res.json()) as IssueDetailResponse;
+      setData(json);
+    } catch {
+      setError("Couldn't load this issue.");
+    } finally {
+      setLoading(false);
+    }
+  }, [issueId]);
+
+  useEffect(() => {
+    if (!issueId) {
+      setData(null);
+      setError(null);
+      setMenuOpen(false);
+      setCopied(false);
+      return;
+    }
+    void load();
+  }, [issueId, load]);
+
+  useEffect(() => {
+    if (!issueId) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      document.body.style.overflow = prev;
+    };
+  }, [issueId, onClose]);
+
+  const flagged = data?.report.developer_flagged ?? false;
+
+  const toggleFlag = async () => {
+    if (!issueId || flagging) return;
+    setFlagging(true);
+    try {
+      const res = await fetch(`/api/issues/${issueId}/flag`, { method: 'POST' });
+      if (!res.ok) return;
+      const json = await res.json();
+      const nextFlagged = !!json.developer_flagged;
+      onFlagChanged?.(issueId, nextFlagged);
+      await load();
+    } finally {
+      setFlagging(false);
+    }
+  };
+
+  const copyLink = async () => {
+    if (!issueId) return;
+    const url = new URL(`/developer/issues/${issueId}`, window.location.origin).toString();
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      window.prompt('Copy link to issue', url);
+    }
+    setMenuOpen(false);
+  };
+
+  if (!issueId) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-modal flex justify-end"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Issue detail"
+    >
+      <button
+        type="button"
+        aria-label="Close issue detail"
+        onClick={onClose}
+        className="absolute inset-0 bg-neutral-900/40"
+      />
+
+      <div
+        ref={containerRef}
+        className="relative bg-white w-full sm:w-[560px] sm:max-w-[560px] h-full shadow-2xl flex flex-col overflow-hidden animate-fade-in"
+      >
+        <header className="flex items-center gap-1 px-4 py-3 border-b border-neutral-200 bg-white">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="w-10 h-10 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={() => void toggleFlag()}
+            disabled={flagging || !data}
+            aria-pressed={flagged}
+            title={flagged ? 'Remove flag' : 'Flag for attention'}
+            className={`w-10 h-10 flex items-center justify-center rounded-lg transition-colors disabled:opacity-50 ${
+              flagged
+                ? 'bg-brand-50 text-brand-600 hover:bg-brand-100'
+                : 'text-neutral-700 hover:bg-neutral-100'
+            }`}
+          >
+            <Flag className={`w-5 h-5 ${flagged ? 'fill-current' : ''}`} />
+          </button>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-label="More options"
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              className="w-10 h-10 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+            >
+              <MoreHorizontal className="w-5 h-5" />
+            </button>
+            {menuOpen ? (
+              <>
+                <button
+                  type="button"
+                  aria-hidden
+                  tabIndex={-1}
+                  onClick={() => setMenuOpen(false)}
+                  className="fixed inset-0 z-10 bg-transparent cursor-default"
+                />
+                <div
+                  role="menu"
+                  className="absolute right-0 top-full mt-1 z-20 min-w-[12rem] rounded-lg border border-neutral-200 bg-white shadow-lg py-1"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => void copyLink()}
+                    className="w-full px-3 py-2 text-left text-body-sm text-neutral-800 hover:bg-neutral-50 flex items-center gap-2"
+                  >
+                    {copied ? (
+                      <Check className="w-4 h-4 text-emerald-600" />
+                    ) : (
+                      <Copy className="w-4 h-4 text-neutral-500" />
+                    )}
+                    {copied ? 'Copied' : 'Copy link to issue'}
+                  </button>
+                </div>
+              </>
+            ) : null}
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {loading && !data ? (
+            <div className="text-body-sm text-neutral-500">Loading issue...</div>
+          ) : error ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-body-sm text-red-700">
+              {error}
+            </div>
+          ) : data ? (
+            <IssueDetailContent
+              data={data}
+              onNoteAdded={() => {
+                onNotesChanged?.(issueId);
+                void load();
+              }}
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueFilterBar.tsx
+++ b/apps/unified-portal/components/issues/IssueFilterBar.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+/**
+ * Filter bar for /developer/issues. Spec section 6.3.
+ *
+ * Single row of filter chips (status, source, severity, development,
+ * flagged toggle, search). Each chip opens a small sheet with the
+ * options for that filter; the Flagged chip is a single toggle.
+ *
+ * Search is a free text input that filters by title. The server route
+ * (/api/issues/list) does not currently accept a search param, so the
+ * input applies client-side over the loaded rows. A future enhancement
+ * could push the term server-side as ILIKE on title.
+ *
+ * Filter state lives in the parent (IssuesDashboardClient) and the URL.
+ * The bar is purely presentational and emits onChange events.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Check,
+  ChevronDown,
+  Flag,
+  Search,
+  X,
+  Building2,
+  AlertCircle,
+  Users,
+  CircleDot,
+} from 'lucide-react';
+import {
+  DevelopmentLite,
+  IssueFilters,
+  IssueSeverity,
+  IssueSource,
+  IssueStatus,
+  severityLabel,
+  sourceLabel,
+  statusLabel,
+} from './types';
+
+interface IssueFilterBarProps {
+  filters: IssueFilters;
+  developments: DevelopmentLite[];
+  onChange: (next: IssueFilters) => void;
+}
+
+type OpenSheet = 'status' | 'severity' | 'source' | 'development' | null;
+
+const STATUS_OPTIONS: IssueStatus[] = ['open', 'reopened', 'resolved', 'closed'];
+const SEVERITY_OPTIONS: IssueSeverity[] = ['urgent', 'high', 'medium', 'low'];
+const SOURCE_OPTIONS: IssueSource[] = [
+  'homeowner_assistant',
+  'site_team_snag',
+  'snagger_external',
+];
+
+export function IssueFilterBar({ filters, developments, onChange }: IssueFilterBarProps) {
+  const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+
+  useEffect(() => {
+    setSearchDraft(filters.search);
+  }, [filters.search]);
+
+  const setStatus = (next: IssueStatus[]) => {
+    onChange({ ...filters, status: next.length > 0 ? next : ['open', 'reopened'] });
+  };
+  const setSeverity = (next: IssueSeverity[]) => onChange({ ...filters, severity: next });
+  const setSource = (next: IssueSource[]) => onChange({ ...filters, source: next });
+  const setDevelopment = (id: string | null) => onChange({ ...filters, development_id: id });
+  const toggleFlagged = () => onChange({ ...filters, flagged: !filters.flagged });
+  const commitSearch = () => {
+    if (searchDraft !== filters.search) {
+      onChange({ ...filters, search: searchDraft });
+    }
+  };
+  const clearSearch = () => {
+    setSearchDraft('');
+    onChange({ ...filters, search: '' });
+  };
+
+  const statusChipLabel =
+    filters.status.length === 2 && filters.status.includes('open') && filters.status.includes('reopened')
+      ? 'Status: Open + Reopened'
+      : filters.status.length === 1
+      ? `Status: ${statusLabel(filters.status[0])}`
+      : `Status: ${filters.status.length} selected`;
+
+  const severityChipLabel =
+    filters.severity.length === 0
+      ? 'Severity: Any'
+      : filters.severity.length === 1
+      ? `Severity: ${severityLabel(filters.severity[0])}`
+      : `Severity: ${filters.severity.length} selected`;
+
+  const sourceChipLabel =
+    filters.source.length === 0
+      ? 'Source: Any'
+      : filters.source.length === 1
+      ? `Source: ${sourceLabel(filters.source[0])}`
+      : `Source: ${filters.source.length} selected`;
+
+  const developmentChipLabel = filters.development_id
+    ? `Scheme: ${developments.find((d) => d.id === filters.development_id)?.name ?? 'Selected'}`
+    : 'Scheme: All';
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <FilterChip
+          icon={CircleDot}
+          label={statusChipLabel}
+          active={
+            !(
+              filters.status.length === 2 &&
+              filters.status.includes('open') &&
+              filters.status.includes('reopened')
+            )
+          }
+          onClick={() => setOpenSheet('status')}
+        />
+        <FilterChip
+          icon={AlertCircle}
+          label={severityChipLabel}
+          active={filters.severity.length > 0}
+          onClick={() => setOpenSheet('severity')}
+        />
+        <FilterChip
+          icon={Users}
+          label={sourceChipLabel}
+          active={filters.source.length > 0}
+          onClick={() => setOpenSheet('source')}
+        />
+        <FilterChip
+          icon={Building2}
+          label={developmentChipLabel}
+          active={!!filters.development_id}
+          onClick={() => setOpenSheet('development')}
+        />
+        <button
+          type="button"
+          onClick={toggleFlagged}
+          aria-pressed={filters.flagged}
+          className={`inline-flex items-center gap-1.5 h-9 px-3 rounded-full border text-body-sm transition-colors ${
+            filters.flagged
+              ? 'bg-brand-500 border-brand-500 text-white hover:bg-brand-600'
+              : 'bg-white border-neutral-200 text-neutral-700 hover:border-neutral-300'
+          }`}
+        >
+          <Flag className="w-3.5 h-3.5" />
+          Flagged
+        </button>
+
+        <div className="ml-auto relative w-full sm:w-64">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400 pointer-events-none" />
+          <input
+            type="search"
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            onBlur={commitSearch}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitSearch();
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                clearSearch();
+              }
+            }}
+            placeholder="Search by title"
+            aria-label="Search by title"
+            className="w-full h-9 pl-9 pr-9 bg-white border border-neutral-200 rounded-full text-body-sm placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          />
+          {searchDraft ? (
+            <button
+              type="button"
+              onClick={clearSearch}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 inline-flex items-center justify-center rounded-full text-neutral-500 hover:bg-neutral-100"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {openSheet === 'status' ? (
+        <MultiSelectSheet
+          title="Filter by status"
+          options={STATUS_OPTIONS.map((s) => ({ value: s, label: statusLabel(s) }))}
+          selected={filters.status}
+          onCancel={() => setOpenSheet(null)}
+          onConfirm={(next) => {
+            setStatus(next as IssueStatus[]);
+            setOpenSheet(null);
+          }}
+        />
+      ) : null}
+
+      {openSheet === 'severity' ? (
+        <MultiSelectSheet
+          title="Filter by severity"
+          options={SEVERITY_OPTIONS.map((s) => ({ value: s, label: severityLabel(s) }))}
+          selected={filters.severity}
+          onCancel={() => setOpenSheet(null)}
+          onConfirm={(next) => {
+            setSeverity(next as IssueSeverity[]);
+            setOpenSheet(null);
+          }}
+        />
+      ) : null}
+
+      {openSheet === 'source' ? (
+        <MultiSelectSheet
+          title="Filter by source"
+          options={SOURCE_OPTIONS.map((s) => ({ value: s, label: sourceLabel(s) }))}
+          selected={filters.source}
+          onCancel={() => setOpenSheet(null)}
+          onConfirm={(next) => {
+            setSource(next as IssueSource[]);
+            setOpenSheet(null);
+          }}
+        />
+      ) : null}
+
+      {openSheet === 'development' ? (
+        <SingleSelectSheet
+          title="Filter by scheme"
+          options={[{ value: '', label: 'All schemes' }, ...developments.map((d) => ({ value: d.id, label: d.name }))]}
+          selected={filters.development_id ?? ''}
+          onCancel={() => setOpenSheet(null)}
+          onConfirm={(value) => {
+            setDevelopment(value ? value : null);
+            setOpenSheet(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface FilterChipProps {
+  icon: typeof Flag;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+function FilterChip({ icon: Icon, label, active, onClick }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 h-9 px-3 rounded-full border text-body-sm transition-colors ${
+        active
+          ? 'bg-brand-50 border-brand-500 text-neutral-900'
+          : 'bg-white border-neutral-200 text-neutral-700 hover:border-neutral-300'
+      }`}
+    >
+      <Icon className="w-3.5 h-3.5 text-neutral-500" />
+      <span className="truncate max-w-[12rem]">{label}</span>
+      <ChevronDown className="w-3.5 h-3.5 text-neutral-400" />
+    </button>
+  );
+}
+
+interface SheetOption {
+  value: string;
+  label: string;
+}
+
+interface MultiSelectSheetProps {
+  title: string;
+  options: SheetOption[];
+  selected: string[];
+  onCancel: () => void;
+  onConfirm: (next: string[]) => void;
+}
+
+function MultiSelectSheet({ title, options, selected, onCancel, onConfirm }: MultiSelectSheetProps) {
+  const [working, setWorking] = useState<string[]>(selected);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  const toggle = (value: string) => {
+    setWorking((curr) =>
+      curr.includes(value) ? curr.filter((v) => v !== value) : [...curr, value],
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-modal flex items-end sm:items-center justify-center bg-neutral-900/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div
+        ref={containerRef}
+        className="bg-white w-full sm:w-96 sm:rounded-2xl rounded-t-2xl max-h-[80vh] overflow-y-auto"
+      >
+        <header className="px-4 py-3 border-b border-neutral-200 flex items-center gap-2">
+          <h2 className="text-heading-sm text-neutral-900 flex-1">{title}</h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="w-10 h-10 -mr-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </header>
+        <ul className="divide-y divide-neutral-100">
+          {options.map((opt) => {
+            const isOn = working.includes(opt.value);
+            return (
+              <li key={opt.value}>
+                <button
+                  type="button"
+                  onClick={() => toggle(opt.value)}
+                  className={`w-full px-4 py-3 text-left flex items-center gap-3 min-h-[48px] hover:bg-neutral-50 ${
+                    isOn ? 'bg-brand-50' : ''
+                  }`}
+                >
+                  <span
+                    className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center ${
+                      isOn ? 'bg-brand-500 border-brand-500' : 'border-neutral-300 bg-white'
+                    }`}
+                  >
+                    {isOn ? <Check className="w-3.5 h-3.5 text-white" /> : null}
+                  </span>
+                  <span className="flex-1 text-body text-neutral-900">{opt.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        <div className="sticky bottom-0 bg-white border-t border-neutral-200 px-4 py-3 flex gap-2">
+          <button
+            type="button"
+            onClick={() => setWorking([])}
+            className="px-3 py-2 text-body-sm text-neutral-700 hover:bg-neutral-100 rounded-lg min-h-[40px]"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(working)}
+            className="ml-auto px-4 py-2 bg-brand-500 text-white rounded-lg text-body-sm font-medium hover:bg-brand-600 min-h-[40px]"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SingleSelectSheetProps {
+  title: string;
+  options: SheetOption[];
+  selected: string;
+  onCancel: () => void;
+  onConfirm: (next: string) => void;
+}
+
+function SingleSelectSheet({ title, options, selected, onCancel, onConfirm }: SingleSelectSheetProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-modal flex items-end sm:items-center justify-center bg-neutral-900/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="bg-white w-full sm:w-96 sm:rounded-2xl rounded-t-2xl max-h-[80vh] overflow-y-auto">
+        <header className="px-4 py-3 border-b border-neutral-200 flex items-center gap-2">
+          <h2 className="text-heading-sm text-neutral-900 flex-1">{title}</h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="w-10 h-10 -mr-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </header>
+        <ul className="divide-y divide-neutral-100">
+          {options.map((opt) => {
+            const isOn = selected === opt.value;
+            return (
+              <li key={opt.value || 'all'}>
+                <button
+                  type="button"
+                  onClick={() => onConfirm(opt.value)}
+                  className={`w-full px-4 py-3 text-left flex items-center gap-3 min-h-[48px] hover:bg-neutral-50 ${
+                    isOn ? 'bg-brand-50' : ''
+                  }`}
+                >
+                  <span className="flex-1 text-body text-neutral-900">{opt.label}</span>
+                  {isOn ? <Check className="w-5 h-5 text-brand-600" /> : null}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueLightbox.tsx
+++ b/apps/unified-portal/components/issues/IssueLightbox.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Full screen image overlay for the developer dashboard. Same pattern
+ * as components/assistant/MediaLightbox.tsx but takes a pre-signed
+ * URL directly rather than fetching via x-qr-token.
+ *
+ * Closes on Escape, backdrop click, and the X button. Body scroll is
+ * locked while open.
+ */
+
+import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+
+interface IssueLightboxProps {
+  src: string | null;
+  alt?: string;
+  onClose: () => void;
+}
+
+export function IssueLightbox({ src, alt, onClose }: IssueLightboxProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!src) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeButtonRef.current?.focus();
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      document.body.style.overflow = prev;
+    };
+  }, [src, onClose]);
+
+  if (!src) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Photo preview"
+      className="fixed inset-0 z-[1080] flex items-center justify-center bg-black/90 backdrop-blur-sm animate-fadeIn"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <button
+        ref={closeButtonRef}
+        type="button"
+        onClick={onClose}
+        aria-label="Close photo"
+        className="absolute top-4 right-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white/60 active:scale-[0.98] transition-all duration-150"
+      >
+        <X className="h-5 w-5" />
+      </button>
+      <img
+        src={src}
+        alt={alt ?? ''}
+        className="max-h-[90vh] max-w-[92vw] object-contain rounded-lg shadow-2xl"
+      />
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueListRow.tsx
+++ b/apps/unified-portal/components/issues/IssueListRow.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * Single row in the issue list. Spec section 6.4.
+ *
+ * Layout: severity bar (4px coloured) on the left, then title and
+ * subtitle stack, then metadata (media count, status dot, source,
+ * relative time, flag icon) on the right. Tap fires onOpen with the
+ * issue id, which opens the detail drawer.
+ */
+
+import { Flag, Image as ImageIcon } from 'lucide-react';
+import { SeverityIndicator } from './SeverityIndicator';
+import {
+  IssueListRow as IssueListRowType,
+  sourceLabel,
+  statusDotClass,
+  statusLabel,
+} from './types';
+
+interface IssueListRowProps {
+  row: IssueListRowType;
+  onOpen: (id: string) => void;
+}
+
+function relativeTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (isNaN(t)) return '';
+  const diff = Date.now() - t;
+  const min = Math.round(diff / (60 * 1000));
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.round(hr / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.round(months / 12);
+  return `${years}y ago`;
+}
+
+export function IssueListRow({ row, onOpen }: IssueListRowProps) {
+  const subtitleParts = [row.unit_display_name, row.development_name, row.room].filter(Boolean) as string[];
+  const subtitle = subtitleParts.join(' . ');
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(row.id)}
+      className="w-full flex items-stretch text-left bg-white border-b border-neutral-100 hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-colors"
+    >
+      <SeverityIndicator severity={row.severity_label} />
+      <div className="flex-1 min-w-0 px-4 py-3 flex items-center gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="text-body font-medium text-neutral-900 truncate">
+              {row.title}
+            </span>
+            {row.developer_flagged ? (
+              <Flag
+                aria-label="Flagged for attention"
+                className="w-3.5 h-3.5 text-brand-500 flex-shrink-0"
+              />
+            ) : null}
+          </div>
+          <div className="text-body-sm text-neutral-500 truncate mt-0.5">
+            {subtitle || 'No location'}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {row.media_count > 0 ? (
+            <span className="inline-flex items-center gap-1 text-caption text-neutral-600">
+              <ImageIcon className="w-3.5 h-3.5" />
+              {row.media_count}
+            </span>
+          ) : null}
+          <span className="inline-flex items-center gap-1.5 text-caption text-neutral-600">
+            <span
+              aria-hidden
+              className={`w-2 h-2 rounded-full ${statusDotClass(row.status)}`}
+            />
+            <span className="hidden sm:inline">{statusLabel(row.status)}</span>
+          </span>
+          <span className="hidden md:inline-flex items-center px-2 py-0.5 rounded-full bg-neutral-100 text-neutral-700 text-caption">
+            {sourceLabel(row.source)}
+          </span>
+          <span className="text-caption text-neutral-500 tabular-nums whitespace-nowrap">
+            {relativeTime(row.created_at)}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueNotesSection.tsx
+++ b/apps/unified-portal/components/issues/IssueNotesSection.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * Notes section in the issue detail. Spec section 6.5.
+ *
+ * - New-note textarea + Send button at the top.
+ * - List of existing notes newest-first below.
+ * - POST /api/issues/[id]/notes inserts the note and the parent
+ *   appends the new note to the list optimistically via onAdded.
+ */
+
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+import { IssueNote } from './types';
+
+interface IssueNotesSectionProps {
+  issueId: string;
+  notes: IssueNote[];
+  onAdded: (note: IssueNote) => void;
+}
+
+const MAX_NOTE_LEN = 2000;
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function authorDisplay(note: IssueNote): string {
+  if (note.author_email) return note.author_email;
+  if (note.author_role) return note.author_role.replace('_', ' ');
+  return 'Team member';
+}
+
+export function IssueNotesSection({ issueId, notes, onAdded }: IssueNotesSectionProps) {
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = draft.trim();
+  const canSend = trimmed.length > 0 && trimmed.length <= MAX_NOTE_LEN && !submitting;
+
+  const submit = async () => {
+    if (!canSend) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/issues/${issueId}/notes`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ body: trimmed }),
+      });
+      if (!res.ok) {
+        let message = "Couldn't save that note.";
+        try {
+          const json = await res.json();
+          if (typeof json?.error === 'string' && json.error.length < 200) message = json.error;
+        } catch {
+          // ignore
+        }
+        setError(message);
+        return;
+      }
+      const json = await res.json();
+      if (json?.note) {
+        onAdded(json.note as IssueNote);
+        setDraft('');
+      }
+    } catch {
+      setError("Couldn't save that note.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-body-sm font-semibold text-neutral-900">Notes</h3>
+
+      <div className="rounded-lg border border-neutral-200 bg-white">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.slice(0, MAX_NOTE_LEN))}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              e.preventDefault();
+              void submit();
+            }
+          }}
+          placeholder="Add a note for the team"
+          rows={3}
+          className="w-full resize-none rounded-t-lg px-3 py-2 text-body-sm text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
+        />
+        <div className="flex items-center justify-between px-3 py-2 border-t border-neutral-100">
+          <span className="text-caption text-neutral-500">
+            {trimmed.length}/{MAX_NOTE_LEN}
+          </span>
+          <button
+            type="button"
+            onClick={() => void submit()}
+            disabled={!canSend}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-brand-500 text-white rounded-md text-body-sm font-medium disabled:bg-neutral-200 disabled:text-neutral-400 hover:bg-brand-600 min-h-[36px]"
+          >
+            <Send className="w-3.5 h-3.5" />
+            {submitting ? 'Sending...' : 'Send'}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-body-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {notes.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-neutral-200 bg-neutral-50 px-4 py-6 text-center text-body-sm text-neutral-500">
+          No notes yet.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {notes.map((note) => (
+            <li
+              key={note.id}
+              className="rounded-lg border border-neutral-200 bg-white px-3 py-2"
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="text-body-sm font-medium text-neutral-900 truncate">
+                  {authorDisplay(note)}
+                </span>
+                <span className="text-caption text-neutral-500 ml-auto whitespace-nowrap">
+                  {formatTimestamp(note.created_at)}
+                </span>
+              </div>
+              <p className="mt-1 text-body-sm text-neutral-700 whitespace-pre-wrap break-words">
+                {note.body}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueOverviewCards.tsx
+++ b/apps/unified-portal/components/issues/IssueOverviewCards.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * Four overview cards at the top of /developer/issues.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md section 6.2.
+ *
+ * The High priority card gets a subtle amber treatment when count > 0;
+ * zero is neutral. Accents are thin coloured bars on the left edge,
+ * not gradients or emoji.
+ */
+
+import { IssueOverviewCounts } from './types';
+
+interface IssueOverviewCardsProps {
+  counts: IssueOverviewCounts;
+}
+
+interface CardSpec {
+  label: string;
+  value: number;
+  highlighted: boolean;
+}
+
+export function IssueOverviewCards({ counts }: IssueOverviewCardsProps) {
+  const cards: CardSpec[] = [
+    { label: 'Open', value: counts.open, highlighted: false },
+    {
+      label: 'High priority',
+      value: counts.high_priority,
+      highlighted: counts.high_priority > 0,
+    },
+    { label: 'New this week', value: counts.new_this_week, highlighted: false },
+    { label: 'Resolved this month', value: counts.resolved_this_month, highlighted: false },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {cards.map((card) => (
+        <div
+          key={card.label}
+          className={`relative bg-white border rounded-lg px-4 py-4 overflow-hidden ${
+            card.highlighted ? 'border-amber-200' : 'border-neutral-200'
+          }`}
+        >
+          <span
+            aria-hidden
+            className={`absolute left-0 top-0 bottom-0 w-1 ${
+              card.highlighted ? 'bg-amber-500' : 'bg-transparent'
+            }`}
+          />
+          <div className="text-caption uppercase tracking-wide text-neutral-500">
+            {card.label}
+          </div>
+          <div className="mt-2 text-3xl font-semibold text-neutral-900 tabular-nums">
+            {card.value.toLocaleString()}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueTimeline.tsx
+++ b/apps/unified-portal/components/issues/IssueTimeline.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+/**
+ * Timeline of issue_events. Spec section 6.5.
+ *
+ * Events to render:
+ *   - snag_logged: "Logged by [actor]"
+ *   - analysis_completed: "AI assessment completed"
+ *   - flagged: "Flagged by [developer name]"
+ *   - unflagged: "Flag removed"
+ *   - note_added: "Note added by [actor]"
+ *   - status_changed: "Status changed from X to Y by [actor]"
+ *
+ * Events arrive ordered ascending; we render newest-first to mirror
+ * the notes list.
+ */
+
+import {
+  Flag,
+  FlagOff,
+  MessageSquarePlus,
+  PenLine,
+  Sparkles,
+  ArrowRight,
+  CircleDot,
+} from 'lucide-react';
+import { IssueEvent } from './types';
+
+interface IssueTimelineProps {
+  events: IssueEvent[];
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function actorDisplay(event: IssueEvent): string {
+  if (event.actor_email) return event.actor_email;
+  if (event.actor_type) return event.actor_type.replace('_', ' ');
+  return 'system';
+}
+
+function describe(event: IssueEvent): { icon: typeof Flag; text: string } {
+  const actor = actorDisplay(event);
+  switch (event.event_type) {
+    case 'snag_logged':
+      return { icon: PenLine, text: `Logged by ${actor}` };
+    case 'analysis_completed':
+      return { icon: Sparkles, text: 'AI assessment completed' };
+    case 'flagged':
+      return { icon: Flag, text: `Flagged by ${actor}` };
+    case 'unflagged':
+      return { icon: FlagOff, text: 'Flag removed' };
+    case 'note_added':
+      return { icon: MessageSquarePlus, text: `Note added by ${actor}` };
+    case 'status_changed': {
+      const meta = event.metadata ?? {};
+      const from = typeof meta.from === 'string' ? meta.from : 'previous';
+      const to = typeof meta.to === 'string' ? meta.to : 'new';
+      return { icon: ArrowRight, text: `Status changed from ${from} to ${to} by ${actor}` };
+    }
+    default:
+      return { icon: CircleDot, text: event.event_type.replace('_', ' ') };
+  }
+}
+
+export function IssueTimeline({ events }: IssueTimelineProps) {
+  if (events.length === 0) {
+    return (
+      <section className="space-y-3">
+        <h3 className="text-body-sm font-semibold text-neutral-900">Timeline</h3>
+        <div className="rounded-lg border border-dashed border-neutral-200 bg-neutral-50 px-4 py-6 text-center text-body-sm text-neutral-500">
+          No activity yet.
+        </div>
+      </section>
+    );
+  }
+
+  const ordered = [...events].reverse();
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-body-sm font-semibold text-neutral-900">Timeline</h3>
+      <ol className="space-y-2">
+        {ordered.map((event) => {
+          const { icon: Icon, text } = describe(event);
+          return (
+            <li key={event.id} className="flex items-start gap-3">
+              <span className="mt-0.5 flex-shrink-0 w-7 h-7 rounded-full bg-neutral-100 flex items-center justify-center text-neutral-500">
+                <Icon className="w-3.5 h-3.5" />
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="text-body-sm text-neutral-900">{text}</div>
+                <div className="text-caption text-neutral-500">
+                  {formatTimestamp(event.created_at)}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
+++ b/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+/**
+ * Top-level client for /developer/issues. Spec section 6.2-6.5.
+ *
+ * Responsibilities:
+ *   - Overview card counts and filter state.
+ *   - List fetch with "Load more" pagination.
+ *   - URL <-> filter sync (bookmarkable filtered views, browser
+ *     back/forward stays in sync).
+ *   - Drawer open/close via the ?issue=<id> query param, so the
+ *     browser back button closes the drawer without leaving the page.
+ *
+ * Hydrated with server-rendered initial data so the first paint shows
+ * real counts and rows. Filters are derived from the URL on every
+ * render so back/forward updates the visible list.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { IssueOverviewCards } from './IssueOverviewCards';
+import { IssueFilterBar } from './IssueFilterBar';
+import { IssueListRow } from './IssueListRow';
+import { IssueDetailDrawer } from './IssueDetailDrawer';
+import {
+  DashboardInitialData,
+  IssueFilters,
+  IssueListResponse,
+  IssueListRow as IssueListRowType,
+  IssueOverviewCounts,
+  PAGE_SIZE,
+} from './types';
+import { buildFilterQuery, buildListApiQuery, parseFiltersFromSearchParams } from './filter-url';
+
+interface IssuesDashboardClientProps {
+  initial: DashboardInitialData;
+  initialFilters: IssueFilters;
+}
+
+export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboardClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [overview, setOverview] = useState<IssueOverviewCounts>(initial.overview);
+  const [rows, setRows] = useState<IssueListRowType[]>(initial.list.rows);
+  const [total, setTotal] = useState<number>(initial.list.total);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const drawerIssueId = searchParams?.get('issue') ?? null;
+  const developments = initial.developments;
+
+  const filters = useMemo(
+    () => (searchParams ? parseFiltersFromSearchParams(searchParams) : initialFilters),
+    [searchParams, initialFilters],
+  );
+  const filterKey = useMemo(() => stableKey(filters), [filters]);
+  const initialFilterKey = useMemo(() => stableKey(initialFilters), [initialFilters]);
+  const seenFilterKey = useRef<string>(initialFilterKey);
+
+  const fetchList = useCallback(
+    async (next: IssueFilters, offset: number, append: boolean) => {
+      const setBusy = append ? setLoadingMore : setLoading;
+      setBusy(true);
+      setError(null);
+      try {
+        const query = buildListApiQuery(next, PAGE_SIZE, offset);
+        const res = await fetch(`/api/issues/list?${query}`, { cache: 'no-store' });
+        if (!res.ok) {
+          setError("Couldn't load issues.");
+          return;
+        }
+        const json = (await res.json()) as IssueListResponse;
+        setRows((curr) => (append ? [...curr, ...json.rows] : json.rows));
+        setTotal(json.total);
+      } catch {
+        setError("Couldn't load issues.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  const refreshOverview = useCallback(async () => {
+    try {
+      const res = await fetch('/api/issues/overview', { cache: 'no-store' });
+      if (!res.ok) return;
+      const json = (await res.json()) as IssueOverviewCounts;
+      setOverview(json);
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  useEffect(() => {
+    if (filterKey === seenFilterKey.current) return;
+    seenFilterKey.current = filterKey;
+    void fetchList(filters, 0, false);
+  }, [filterKey, filters, fetchList]);
+
+  const handleFiltersChange = useCallback(
+    (next: IssueFilters) => {
+      const params = buildFilterQuery(next);
+      const issueId = searchParams?.get('issue');
+      if (issueId) params.set('issue', issueId);
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const openIssue = (id: string) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    params.set('issue', id);
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  const closeDrawer = useCallback(() => {
+    if (!drawerIssueId) return;
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      params.delete('issue');
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    }
+  }, [drawerIssueId, pathname, router, searchParams]);
+
+  const handleFlagChanged = (id: string, flagged: boolean) => {
+    setRows((curr) =>
+      curr.map((r) => (r.id === id ? { ...r, developer_flagged: flagged } : r)),
+    );
+  };
+
+  const handleNotesChanged = (id: string) => {
+    setRows((curr) =>
+      curr.map((r) => (r.id === id ? { ...r, note_count: r.note_count + 1 } : r)),
+    );
+  };
+
+  const loadMore = () => {
+    if (loadingMore || rows.length >= total) return;
+    void fetchList(filters, rows.length, true);
+  };
+
+  const refreshAll = useCallback(() => {
+    void refreshOverview();
+    void fetchList(filters, 0, false);
+  }, [fetchList, filters, refreshOverview]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const handler = () => {
+      if (!document.hidden) refreshAll();
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [refreshAll]);
+
+  const searchTerm = filters.search.trim().toLowerCase();
+  const filteredRows = searchTerm
+    ? rows.filter((r) => r.title.toLowerCase().includes(searchTerm))
+    : rows;
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-6">
+      <header className="flex items-baseline justify-between gap-3">
+        <div>
+          <h1 className="text-heading-md text-neutral-900">Issues</h1>
+          <p className="text-body-sm text-neutral-600 mt-1">
+            Operational visibility across homeowner and snagger reports.
+          </p>
+        </div>
+      </header>
+
+      <IssueOverviewCards counts={overview} />
+
+      <IssueFilterBar
+        filters={filters}
+        developments={developments}
+        onChange={handleFiltersChange}
+      />
+
+      {loading && rows.length === 0 ? (
+        <div className="bg-white border border-neutral-200 rounded-lg px-4 py-6 text-body-sm text-neutral-500">
+          Loading issues...
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-body-sm text-red-700">
+          {error}
+        </div>
+      ) : filteredRows.length === 0 ? (
+        <div className="bg-white border border-neutral-200 rounded-lg px-4 py-10 text-center text-body-sm text-neutral-500">
+          No issues match these filters.
+        </div>
+      ) : (
+        <div className="bg-white border border-neutral-200 rounded-lg overflow-hidden">
+          <ul>
+            {filteredRows.map((row) => (
+              <li key={row.id}>
+                <IssueListRow row={row} onOpen={openIssue} />
+              </li>
+            ))}
+          </ul>
+          {rows.length < total ? (
+            <div className="px-4 py-3 border-t border-neutral-100 flex justify-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="px-4 py-2 text-body-sm font-medium text-neutral-700 bg-neutral-50 border border-neutral-200 rounded-md hover:bg-neutral-100 disabled:opacity-60 min-h-[40px]"
+              >
+                {loadingMore ? 'Loading...' : 'Load more'}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <IssueDetailDrawer
+        issueId={drawerIssueId}
+        onClose={closeDrawer}
+        onFlagChanged={(id, flagged) => {
+          handleFlagChanged(id, flagged);
+          void refreshOverview();
+        }}
+        onNotesChanged={handleNotesChanged}
+      />
+    </div>
+  );
+}
+
+function stableKey(filters: IssueFilters): string {
+  return JSON.stringify({
+    status: [...filters.status].sort(),
+    severity: [...filters.severity].sort(),
+    source: [...filters.source].sort(),
+    development_id: filters.development_id,
+    flagged: filters.flagged,
+    search: filters.search,
+    sort: filters.sort,
+  });
+}

--- a/apps/unified-portal/components/issues/SeverityIndicator.tsx
+++ b/apps/unified-portal/components/issues/SeverityIndicator.tsx
@@ -1,0 +1,19 @@
+/**
+ * Coloured 4px vertical bar shown on the left of each issue list row.
+ * Severity colour mapping is fixed per spec section 6.4.
+ */
+
+import { IssueSeverity, severityBarClass } from './types';
+
+interface SeverityIndicatorProps {
+  severity: IssueSeverity | null;
+}
+
+export function SeverityIndicator({ severity }: SeverityIndicatorProps) {
+  return (
+    <span
+      aria-hidden
+      className={`block w-1 self-stretch flex-shrink-0 ${severityBarClass(severity)}`}
+    />
+  );
+}

--- a/apps/unified-portal/components/issues/filter-url.ts
+++ b/apps/unified-portal/components/issues/filter-url.ts
@@ -1,0 +1,130 @@
+/**
+ * URL <-> filter state codec for /developer/issues. The dashboard URL
+ * is the source of truth so a filtered view is bookmarkable. Initial
+ * page load parses query params; subsequent edits push a fresh URL.
+ */
+
+import {
+  DEFAULT_FILTERS,
+  IssueFilters,
+  IssueSeverity,
+  IssueSource,
+  IssueStatus,
+} from './types';
+
+const VALID_STATUS: IssueStatus[] = ['open', 'reopened', 'resolved', 'closed'];
+const VALID_SEVERITY: IssueSeverity[] = ['low', 'medium', 'high', 'urgent'];
+const VALID_SOURCE: IssueSource[] = [
+  'homeowner_assistant',
+  'site_team_snag',
+  'snagger_external',
+];
+const VALID_SORTS: IssueFilters['sort'][] = [
+  'created_at_desc',
+  'severity_desc',
+  'created_at_asc',
+];
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseCsv<T extends string>(value: string | null, allowed: T[]): T[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s): s is T => (allowed as string[]).includes(s));
+}
+
+export function parseFiltersFromSearchParams(
+  params: URLSearchParams | Record<string, string | string[] | undefined>,
+): IssueFilters {
+  const get = (key: string): string | null => {
+    if (params instanceof URLSearchParams) return params.get(key);
+    const v = params[key];
+    if (Array.isArray(v)) return v[0] ?? null;
+    return v ?? null;
+  };
+
+  const statusRaw = get('status');
+  const status = statusRaw === null ? DEFAULT_FILTERS.status : parseCsv(statusRaw, VALID_STATUS);
+  const severity = parseCsv(get('severity'), VALID_SEVERITY);
+  const source = parseCsv(get('source'), VALID_SOURCE);
+  const developmentRaw = get('development_id');
+  const development_id = developmentRaw && UUID_RE.test(developmentRaw) ? developmentRaw : null;
+  const flagged = get('flagged') === 'true';
+  const search = (get('search') ?? '').slice(0, 200);
+  const sortRaw = get('sort');
+  const sort = sortRaw && (VALID_SORTS as string[]).includes(sortRaw)
+    ? (sortRaw as IssueFilters['sort'])
+    : DEFAULT_FILTERS.sort;
+
+  return {
+    status: status.length > 0 ? status : DEFAULT_FILTERS.status,
+    severity,
+    source,
+    development_id,
+    flagged,
+    search,
+    sort,
+  };
+}
+
+function statusArraysEqual(a: IssueStatus[], b: IssueStatus[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+export function buildFilterQuery(filters: IssueFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (!statusArraysEqual(filters.status, DEFAULT_FILTERS.status)) {
+    params.set('status', filters.status.join(','));
+  }
+  if (filters.severity.length > 0) {
+    params.set('severity', filters.severity.join(','));
+  }
+  if (filters.source.length > 0) {
+    params.set('source', filters.source.join(','));
+  }
+  if (filters.development_id) {
+    params.set('development_id', filters.development_id);
+  }
+  if (filters.flagged) {
+    params.set('flagged', 'true');
+  }
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
+  if (filters.sort !== DEFAULT_FILTERS.sort) {
+    params.set('sort', filters.sort);
+  }
+  return params;
+}
+
+export function buildListApiQuery(filters: IssueFilters, limit: number, offset: number): string {
+  const params = new URLSearchParams();
+  params.set('limit', String(limit));
+  params.set('offset', String(offset));
+  if (filters.status.length > 0) {
+    params.set('status', filters.status.join(','));
+  }
+  if (filters.severity.length > 0) {
+    params.set('severity', filters.severity.join(','));
+  }
+  if (filters.source.length > 0) {
+    params.set('source', filters.source.join(','));
+  }
+  if (filters.development_id) {
+    params.set('development_id', filters.development_id);
+  }
+  if (filters.flagged) {
+    params.set('flagged', 'true');
+  }
+  if (filters.search) {
+    params.set('search', filters.search);
+  }
+  if (filters.sort) {
+    params.set('sort', filters.sort);
+  }
+  return params.toString();
+}

--- a/apps/unified-portal/components/issues/types.ts
+++ b/apps/unified-portal/components/issues/types.ts
@@ -1,0 +1,226 @@
+/**
+ * Shared types for the Sprint 3 developer dashboard. Matches the
+ * response shapes from /api/issues/list and /api/issues/[id].
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3.md sections 5.2 and 5.3.
+ */
+
+export type IssueSeverity = 'low' | 'medium' | 'high' | 'urgent';
+export type IssueStatus = 'open' | 'reopened' | 'resolved' | 'closed';
+export type IssueSource =
+  | 'homeowner_assistant'
+  | 'site_team_snag'
+  | 'snagger_external';
+
+export interface IssueListRow {
+  id: string;
+  title: string;
+  source: IssueSource;
+  severity_label: IssueSeverity | null;
+  severity_score: number | null;
+  status: IssueStatus;
+  priority: string | null;
+  room: string | null;
+  unit_display_name: string | null;
+  development_name: string | null;
+  media_count: number;
+  note_count: number;
+  developer_flagged: boolean;
+  created_at: string;
+  resolved_at: string | null;
+  logged_by_role: string | null;
+}
+
+export interface IssueListResponse {
+  rows: IssueListRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface IssueOverviewCounts {
+  open: number;
+  high_priority: number;
+  new_this_week: number;
+  resolved_this_month: number;
+}
+
+export interface IssueMedia {
+  id: string;
+  storage_path: string;
+  thumbnail_path: string | null;
+  mime_type: string;
+  width: number | null;
+  height: number | null;
+  signed_url: string;
+  thumbnail_url: string;
+  expires_at: string;
+}
+
+export interface IssueEvent {
+  id: string;
+  event_type: string;
+  actor_type: string | null;
+  actor_id: string | null;
+  actor_email: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface IssueNote {
+  id: string;
+  author_user_id: string;
+  author_role: string;
+  author_email: string | null;
+  body: string;
+  created_at: string;
+}
+
+export interface IssueReport {
+  id: string;
+  tenant_id: string;
+  development_id: string;
+  unit_id: string | null;
+  user_id: string | null;
+  title: string;
+  description: string | null;
+  room: string | null;
+  status: IssueStatus;
+  priority: string | null;
+  severity_label: IssueSeverity | null;
+  severity_score: number | null;
+  safety_risk: string | null;
+  likely_trade: string | null;
+  likely_system: string | null;
+  source: IssueSource;
+  logged_by_user_id: string | null;
+  logged_by_role: string | null;
+  linked_analysis_id: string | null;
+  developer_flagged: boolean;
+  developer_flagged_at: string | null;
+  developer_flagged_by: string | null;
+  created_at: string;
+  updated_at: string | null;
+  resolved_at: string | null;
+  unit_display_name: string | null;
+  development_name: string | null;
+}
+
+export interface IssueAnalysis {
+  id?: string;
+  model_provider?: string | null;
+  model_name?: string | null;
+  summary?: string | null;
+  severity_label?: string | null;
+  severity_score?: number | null;
+  safety_risk?: string | null;
+  likely_trade?: string | null;
+  likely_system?: string | null;
+  suggested_priority?: string | null;
+  ai_reasoning?: string | null;
+  reasoning?: string | null;
+  evidence?: Array<{ description?: string; confidence?: number } | string> | null;
+  recommended_action?: string | null;
+  created_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface IssueDetailResponse {
+  report: IssueReport;
+  media: IssueMedia[];
+  analysis: IssueAnalysis | null;
+  events: IssueEvent[];
+  notes: IssueNote[];
+}
+
+export interface DevelopmentLite {
+  id: string;
+  name: string;
+}
+
+export interface DashboardInitialData {
+  overview: IssueOverviewCounts;
+  list: IssueListResponse;
+  developments: DevelopmentLite[];
+}
+
+export interface IssueFilters {
+  status: IssueStatus[];
+  severity: IssueSeverity[];
+  source: IssueSource[];
+  development_id: string | null;
+  flagged: boolean;
+  search: string;
+  sort: 'created_at_desc' | 'severity_desc' | 'created_at_asc';
+}
+
+export const DEFAULT_FILTERS: IssueFilters = {
+  status: ['open', 'reopened'],
+  severity: [],
+  source: [],
+  development_id: null,
+  flagged: false,
+  search: '',
+  sort: 'created_at_desc',
+};
+
+export const PAGE_SIZE = 50;
+
+export function severityBarClass(severity: IssueSeverity | null): string {
+  switch (severity) {
+    case 'urgent':
+      return 'bg-red-600';
+    case 'high':
+      return 'bg-red-500';
+    case 'medium':
+      return 'bg-amber-500';
+    case 'low':
+      return 'bg-neutral-300';
+    default:
+      return 'bg-neutral-200';
+  }
+}
+
+export function statusDotClass(status: IssueStatus): string {
+  switch (status) {
+    case 'resolved':
+      return 'bg-green-500';
+    case 'reopened':
+      return 'bg-amber-500';
+    case 'closed':
+      return 'bg-neutral-400';
+    default:
+      return 'bg-neutral-500';
+  }
+}
+
+export function statusLabel(status: IssueStatus): string {
+  switch (status) {
+    case 'resolved':
+      return 'Resolved';
+    case 'reopened':
+      return 'Reopened';
+    case 'closed':
+      return 'Closed';
+    default:
+      return 'Open';
+  }
+}
+
+export function sourceLabel(source: IssueSource): string {
+  switch (source) {
+    case 'homeowner_assistant':
+      return 'Homeowner';
+    case 'site_team_snag':
+      return 'Site team';
+    case 'snagger_external':
+      return 'Snagger';
+    default:
+      return source;
+  }
+}
+
+export function severityLabel(severity: IssueSeverity | null): string {
+  if (!severity) return 'Unassessed';
+  return severity.charAt(0).toUpperCase() + severity.slice(1);
+}


### PR DESCRIPTION
Implements section 6 of `docs/specs/assistant-v2-sprint-3.md` — the developer-facing dashboard for snag intelligence. UI only; sits on top of the schema (PR #160) and server routes (PR #161) that already merged.

## Summary

Two new routes inside the existing `/developer` sidebar layout, plus a nav restructure that groups the Sprint 2 Snagging Team link and the new Issues page under a parent Snagging section.

### New routes
- `/developer/issues` — server component that hydrates a client dashboard. Overview cards (section 6.2), chip filter bar (section 6.3), list with "Load more" pagination (section 6.4), and a right-side detail drawer (section 6.5). 404 when `FEATURE_DEVELOPER_DASHBOARD` is off.
- `/developer/issues/[id]` — server-rendered standalone detail page (section 6.6). Renders the same body as the drawer, with a back link and a flag toggle in the page chrome. URL-shareable and refresh-safe. 404 when the flag is off.

Both pages call `resolveSnagAuth` from `lib/assistant/snag-auth.ts` and 404 for `snagger_external`. The standalone page also calls `assertCanAccessDevelopment` against the issue's development.

### Sidebar restructure (section 6.1)
`apps/unified-portal/app/developer/layout-sidebar.tsx` no longer ships a static `btsNavSections`. A new `buildBtsNavSections()` reads `isDeveloperDashboardEnabled()` and `isBuilderSnagAppEnabled()` (NEXT_PUBLIC_ variants on the client) and assembles a `Snagging` parent section with `Issues` and `Team` children, placed between OpenHouse Intelligence and the Developer Tools group. The whole section is omitted if both flags are off.

### Components organisation
All issue-specific UI lives under `apps/unified-portal/components/issues/`:

- `types.ts` — shared response shapes and the severity/status colour maps from section 6.4.
- `filter-url.ts` — URL ↔ filter codec so dashboard state is bookmarkable.
- `IssueOverviewCards.tsx` — section 6.2 cards with the High priority amber accent.
- `IssueFilterBar.tsx` — chip filters with multi/single-select sheets and the flagged toggle.
- `IssueListRow.tsx` — list row with `SeverityIndicator.tsx` bar, status dot, source badge, media count, and flag icon.
- `IssueDetailDrawer.tsx` — 560px desktop / full-screen mobile drawer.
- `IssueDetailContent.tsx` — **shared component** rendered both inside the drawer and on the standalone page (one source of truth per section 6.6).
- `IssueLightbox.tsx` — same pattern as Sprint 1's `MediaLightbox` but takes a pre-signed URL directly (no QR token).
- `IssueNotesSection.tsx` — new-note input + list (POST `/api/issues/[id]/notes`).
- `IssueTimeline.tsx` — renders `issue_events` with the verbatim copy from section 6.5.
- `IssuesDashboardClient.tsx` — wires everything together.

### Drawer URL state syncing
- Opening a row calls `router.push` to add `?issue=<id>` to the URL.
- Closing the drawer calls `router.back()` so the browser back button closes the drawer rather than leaving the page entirely.
- Filter changes use `router.replace` so they do not pollute history with one entry per chip click.
- Filter state is derived from `useSearchParams` every render, so browser back/forward through filter URLs keeps the visible list in sync.

### Reused components and helpers
- `lib/assistant/snag-auth.ts` (Sprint 2) — `resolveSnagAuth`, `assertCanAccessDevelopment`, `SnagAuthError`.
- `lib/feature-flags.ts` (Sprint 3) — `isDeveloperDashboardEnabled`, `isBuilderSnagAppEnabled`.
- `app/snag/SnagNoAccess.tsx` (Sprint 2) — surfaced when the caller is signed in but has no `site_team_members` row.
- Sprint 1's `MediaLightbox` pattern is reused but with a thin variant (`IssueLightbox.tsx`) that takes the signed URL directly rather than refetching via x-qr-token.

### Notes
- Search input in section 6.3 is rendered and applies client-side over loaded rows. The existing `/api/issues/list` route does not accept a search parameter, so a server-side ILIKE is left for a follow-up.
- Severity bar colours, status dot colours, and source badge styling match section 6.4 verbatim.
- Copy strings are the verbatim text from section 6.7. No em dashes, no emoji, Lucide icons only.

### Vercel build
Local `npm run build` is green and reports `/developer/issues` and `/developer/issues/[id]` as fresh routes. Will confirm the Vercel deploy is `READY` on the PR before squash-merging.

Spec reference: `docs/specs/assistant-v2-sprint-3.md` section 6.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3fBDhmbartbLozcB81YyB)_