### PR TITLE
fix(assistant-v2): server-side title search for issues dashboard

### DIFF
--- a/apps/unified-portal/app/api/issues/list/route.ts
+++ b/apps/unified-portal/app/api/issues/list/route.ts
@@ -12,6 +12,8 @@
  *   - severity        comma-separated: low,medium,high,urgent
  *   - source          comma-separated: homeowner_assistant,site_team_snag,snagger_external
  *   - flagged         boolean; if 'true' returns only developer-flagged rows
+ *   - q               case-insensitive title substring match; trimmed,
+ *                     non-empty after trim, max 200 chars
  *   - sort            'created_at_desc' (default), 'severity_desc', 'created_at_asc'
  *   - limit           default 50, max 200
  *   - offset          default 0
@@ -47,6 +49,11 @@ const VALID_STATUSES = new Set(['open', 'reopened', 'resolved', 'closed']);
 const VALID_SEVERITIES = new Set(['low', 'medium', 'high', 'urgent']);
 const VALID_SOURCES = new Set(['homeowner_assistant', 'site_team_snag', 'snagger_external']);
 const VALID_SORTS = new Set(['created_at_desc', 'severity_desc', 'created_at_asc']);
+const MAX_SEARCH_LEN = 200;
+
+function escapeIlikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
 
 function parseCsv(value: string | null, allowed: Set<string>): string[] | null {
   if (!value) return null;
@@ -90,6 +97,7 @@ export async function GET(request: NextRequest) {
   const severityParam = url.searchParams.get('severity');
   const sourceParam = url.searchParams.get('source');
   const flaggedParam = url.searchParams.get('flagged');
+  const qParam = url.searchParams.get('q');
   const sortParam = url.searchParams.get('sort') ?? 'created_at_desc';
   const limitParam = url.searchParams.get('limit');
   const offsetParam = url.searchParams.get('offset');
@@ -111,6 +119,18 @@ export async function GET(request: NextRequest) {
   }
   if (!VALID_SORTS.has(sortParam)) {
     return NextResponse.json({ error: 'invalid sort' }, { status: 400 });
+  }
+
+  let searchTerm: string | null = null;
+  if (qParam !== null) {
+    const trimmed = qParam.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: 'q must not be empty' }, { status: 400 });
+    }
+    if (trimmed.length > MAX_SEARCH_LEN) {
+      return NextResponse.json({ error: 'q exceeds 200 characters' }, { status: 400 });
+    }
+    searchTerm = trimmed;
   }
 
   let limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
@@ -143,6 +163,9 @@ export async function GET(request: NextRequest) {
   }
   if (flaggedParam === 'true') {
     query = query.eq('developer_flagged', true);
+  }
+  if (searchTerm) {
+    query = query.ilike('title', `%${escapeIlikePattern(searchTerm)}%`);
   }
 
   if (sortParam === 'created_at_asc') {

--- a/apps/unified-portal/components/issues/IssueFilterBar.tsx
+++ b/apps/unified-portal/components/issues/IssueFilterBar.tsx
@@ -8,9 +8,9 @@
  * options for that filter; the Flagged chip is a single toggle.
  *
  * Search is a free text input that filters by title. The server route
- * (/api/issues/list) does not currently accept a search param, so the
- * input applies client-side over the loaded rows. A future enhancement
- * could push the term server-side as ILIKE on title.
+ * (/api/issues/list) accepts the term as a `q` query param and applies
+ * an ILIKE on title. Input is debounced 300ms so each keystroke does
+ * not hit the API.
  *
  * Filter state lives in the parent (IssuesDashboardClient) and the URL.
  * The bar is purely presentational and emits onChange events.
@@ -55,13 +55,34 @@ const SOURCE_OPTIONS: IssueSource[] = [
   'snagger_external',
 ];
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 export function IssueFilterBar({ filters, developments, onChange }: IssueFilterBarProps) {
   const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
   const [searchDraft, setSearchDraft] = useState(filters.search);
+  const filtersRef = useRef(filters);
+  const onChangeRef = useRef(onChange);
+  const lastCommittedRef = useRef(filters.search);
+
+  useEffect(() => {
+    filtersRef.current = filters;
+    onChangeRef.current = onChange;
+  });
 
   useEffect(() => {
     setSearchDraft(filters.search);
+    lastCommittedRef.current = filters.search;
   }, [filters.search]);
+
+  useEffect(() => {
+    const normalized = searchDraft.trim();
+    if (normalized === lastCommittedRef.current.trim()) return;
+    const handle = window.setTimeout(() => {
+      lastCommittedRef.current = normalized;
+      onChangeRef.current({ ...filtersRef.current, search: normalized });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [searchDraft]);
 
   const setStatus = (next: IssueStatus[]) => {
     onChange({ ...filters, status: next.length > 0 ? next : ['open', 'reopened'] });
@@ -70,13 +91,9 @@ export function IssueFilterBar({ filters, developments, onChange }: IssueFilterB
   const setSource = (next: IssueSource[]) => onChange({ ...filters, source: next });
   const setDevelopment = (id: string | null) => onChange({ ...filters, development_id: id });
   const toggleFlagged = () => onChange({ ...filters, flagged: !filters.flagged });
-  const commitSearch = () => {
-    if (searchDraft !== filters.search) {
-      onChange({ ...filters, search: searchDraft });
-    }
-  };
   const clearSearch = () => {
     setSearchDraft('');
+    lastCommittedRef.current = '';
     onChange({ ...filters, search: '' });
   };
 
@@ -158,16 +175,13 @@ export function IssueFilterBar({ filters, developments, onChange }: IssueFilterB
             type="search"
             value={searchDraft}
             onChange={(e) => setSearchDraft(e.target.value)}
-            onBlur={commitSearch}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                commitSearch();
-              } else if (e.key === 'Escape') {
+              if (e.key === 'Escape') {
                 e.preventDefault();
                 clearSearch();
               }
             }}
+            maxLength={200}
             placeholder="Search by title"
             aria-label="Search by title"
             className="w-full h-9 pl-9 pr-9 bg-white border border-neutral-200 rounded-full text-body-sm placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-brand-500"

--- a/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
+++ b/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
@@ -161,10 +161,10 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
     return () => document.removeEventListener('visibilitychange', handler);
   }, [refreshAll]);
 
-  const searchTerm = filters.search.trim().toLowerCase();
-  const filteredRows = searchTerm
-    ? rows.filter((r) => r.title.toLowerCase().includes(searchTerm))
-    : rows;
+  const hasActiveSearch = filters.search.trim().length > 0;
+  const emptyMessage = hasActiveSearch
+    ? 'No issues match this search and filters.'
+    : 'No issues match these filters.';
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -193,14 +193,14 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
         <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-body-sm text-red-700">
           {error}
         </div>
-      ) : filteredRows.length === 0 ? (
+      ) : rows.length === 0 ? (
         <div className="bg-white border border-neutral-200 rounded-lg px-4 py-10 text-center text-body-sm text-neutral-500">
-          No issues match these filters.
+          {emptyMessage}
         </div>
       ) : (
         <div className="bg-white border border-neutral-200 rounded-lg overflow-hidden">
           <ul>
-            {filteredRows.map((row) => (
+            {rows.map((row) => (
               <li key={row.id}>
                 <IssueListRow row={row} onOpen={openIssue} />
               </li>

--- a/apps/unified-portal/components/issues/filter-url.ts
+++ b/apps/unified-portal/components/issues/filter-url.ts
@@ -51,7 +51,7 @@ export function parseFiltersFromSearchParams(
   const developmentRaw = get('development_id');
   const development_id = developmentRaw && UUID_RE.test(developmentRaw) ? developmentRaw : null;
   const flagged = get('flagged') === 'true';
-  const search = (get('search') ?? '').slice(0, 200);
+  const search = (get('q') ?? '').slice(0, 200);
   const sortRaw = get('sort');
   const sort = sortRaw && (VALID_SORTS as string[]).includes(sortRaw)
     ? (sortRaw as IssueFilters['sort'])
@@ -92,8 +92,9 @@ export function buildFilterQuery(filters: IssueFilters): URLSearchParams {
   if (filters.flagged) {
     params.set('flagged', 'true');
   }
-  if (filters.search) {
-    params.set('search', filters.search);
+  const trimmedSearch = filters.search.trim();
+  if (trimmedSearch) {
+    params.set('q', trimmedSearch);
   }
   if (filters.sort !== DEFAULT_FILTERS.sort) {
     params.set('sort', filters.sort);
@@ -120,8 +121,9 @@ export function buildListApiQuery(filters: IssueFilters, limit: number, offset: 
   if (filters.flagged) {
     params.set('flagged', 'true');
   }
-  if (filters.search) {
-    params.set('search', filters.search);
+  const trimmedSearch = filters.search.trim();
+  if (trimmedSearch) {
+    params.set('q', trimmedSearch);
   }
   if (filters.sort) {
     params.set('sort', filters.sort);


### PR DESCRIPTION
Follow-up to #162. That PR shipped the `/developer/issues` dashboard but the title search input filtered client-side over already-loaded rows only, so a title living past page 1 of pagination would not surface. The end of #162 flagged this as a known gap, with the server-side ILIKE left for a follow-up. This PR closes that gap.

## Summary

- `/api/issues/list` accepts a new optional `q` query param. When present it sanitizes the input (trim, reject empty after trim, reject longer than 200 chars), escapes `%` `_` `\` to prevent wildcard injection, and applies `query.ilike('title', '%<escaped>%')` on `issue_reports.title`.
- The dashboard URL param renamed from `search` to `q` so a searched view stays bookmarkable. `buildListApiQuery` forwards `q` to the API.
- Client-side row filtering removed. The server filter is now the only filter, so results past the first page are found correctly.
- The search input debounces 300ms after the last keystroke before pushing a new URL. Escape still clears immediately.
- Empty-state copy now reads "No issues match this search and filters." when a search is active, otherwise the existing "No issues match these filters."

No changes to any other route or component beyond what the wire-up required.

## Build

Local `npm run build` is green. Will confirm the Vercel deploy reports `READY` on this PR before squash-merging.

## Test plan

- [ ] Type a title that lives on a deeper page; it appears (was the regression).
- [ ] Clear the input; list returns to unfiltered.
- [ ] Reload the URL with `?q=` present; the search is restored and the input prefilled.
- [ ] Combine `q` with status / severity / source / development / flagged filters; intersection is correct.
- [ ] Title containing `%` or `_` is matched literally, not as a wildcard.
- [ ] API rejects `q` of 201 chars and a whitespace-only `q` with 400.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WGQ9gqeWb6pccY2Yj3JY4J)_