### PR TITLE
fix(assistant-v2): register brand palette in tailwind config so primary buttons render

### DIFF
--- a/apps/unified-portal/tailwind.config.ts
+++ b/apps/unified-portal/tailwind.config.ts
@@ -44,6 +44,19 @@ const config: Config = {
           900: '#8B6428',  // Dark gold
           950: '#6B4E1C',  // Very dark gold
         },
+        brand: {
+          50: '#FDF8E8',   // Very light gold tint
+          100: '#FAF0D1',  // Light gold cream
+          200: '#F5E2AA',  // Soft gold
+          300: '#EED07C',  // Warm gold
+          400: '#E5BC4E',  // Medium gold
+          500: '#D4AF37',  // Primary premium gold
+          600: '#C9A961',  // Darker gold
+          700: '#B8934C',  // Deep gold
+          800: '#A67C3A',  // Rich gold
+          900: '#8B6428',  // Dark gold
+          950: '#6B4E1C',  // Very dark gold
+        },
         grey: {
           50: '#F9FAFB',
           100: '#F3F4F6',


### PR DESCRIPTION
## Root cause

`apps/unified-portal/app/globals.css` defines `--brand-50` through `--brand-950` as CSS custom properties (aliased to `--gold-*`), but `apps/unified-portal/tailwind.config.ts` had no `brand` entry under `theme.extend.colors`. Tailwind therefore generated no CSS for any `*-brand-*` utility. Every `bg-brand-500`, `text-brand-500`, `border-brand-500`, `hover:bg-brand-600`, `active:bg-brand-700`, `focus:ring-brand-500`, `ring-brand-*`, and the rest were unrecognised class names and dropped at build time.

Primary buttons reach for `bg-brand-500 text-white`. With `bg-brand-500` dropped, the background fell through to the parent white container; `text-white` remained; the button and its icon rendered as white-on-white. The disabled state used `bg-neutral-200` + `text-neutral-400` which are real Tailwind defaults (and `globals.css` already forces `text-neutral-400` to dark via `!important`), which is why disabled looked fine but the active button vanished.

## Fix

Register a `brand` colour palette in `apps/unified-portal/tailwind.config.ts`, symmetric with the existing `gold` palette in the same file, using identical hex values. One change, 13 lines, no component code touched.

Proof the fix landed: `.next/static/css/d87e7f33c8e95412.css` now contains `.bg-brand-500{...background-color:rgb(212 175 55...)}` and all other `*-brand-*` utilities resolve.

## Affected components (visible buttons that were invisible)

| File:line | Element |
| --- | --- |
| components/issues/IssueNotesSection.tsx:108 | Send (notes) |
| components/issues/IssueFilterBar.tsx:164 | Filter chip selected state |
| components/issues/IssueFilterBar.tsx:349 | Filter sheet checkbox selected state |
| components/issues/IssueFilterBar.tsx:371 | Apply filters button |
| app/developer/snaggers/SnaggersClient.tsx:123 | Invite snagger |
| app/developer/snaggers/SnaggersClient.tsx:346 | Done (after invite created) |
| app/developer/snaggers/SnaggersClient.tsx:401 | Expiry day selector (selected state) |
| app/developer/snaggers/SnaggersClient.tsx:428 | Create invitation |
| app/snag/SnagFormClient.tsx:452 | Submit snag (snagger-side) |
| app/snag/RoomPickerSheet.tsx:133 | Confirm (sheet) |
| components/ui/premium/Button.tsx:49 | `primary` variant (whole component) |

Cosmetic regressions also restored by the same fix: `bg-brand-50` tints on flag toggles, severity badges, and selected list rows; `text-brand-600` icons; `border-brand-500` selected-state borders; `focus:ring-brand-500` focus indicators across forms and the dashboard.

## Why option A (config fix) over option B (per-component substitution)

Option B would have meant rewriting roughly 60 `*-brand-*` occurrences across about 14 files to `*-gold-*`. That is high-touch, easy to miss instances, and would have discarded the `brand` semantic token that `globals.css` already maintains as an alias of `gold`. The brand layer exists so the palette can be retargeted in one place when the brand changes. Option A keeps that semantic intact and makes the design system work as it was originally written.

No component code was changed. The whole point of option A is that the components were already correct; only the config was wrong.

## Test plan

- [ ] Vercel preview build reaches READY.
- [ ] `/developer/issues` Send button in the notes drawer is visible with gold background.
- [ ] `/developer/snaggers` Invite snagger button is visible top right.
- [ ] Filter chips on `/developer/issues` show gold fill when selected.
- [ ] `<Button variant="primary">` callers (if used in preview) show gold background.

---
_Generated by [Claude Code](https://claude.ai/code/session_013mt98sSoRUFtKRQPK9iQ3M)_