### PR TITLE
feat(assistant-v2): unit grouped view for issues dashboard

### DIFF
--- a/apps/unified-portal/components/issues/IssueUnitCard.tsx
+++ b/apps/unified-portal/components/issues/IssueUnitCard.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+/**
+ * Single unit card on the "By unit" view of /developer/issues.
+ *
+ * Spec sections 2.2 + 5 of docs/specs/assistant-v2-sprint-3-1.md.
+ *
+ * Renders the unit header, up to 3 most recent issues, and a footer
+ * "Show all N" link if the unit has more than 3 issues in its open
+ * count. Tapping the footer expands the card inline, fetching the
+ * full list via /api/issues/list?unit_id=<id> with current filters.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { IssueListRow } from './IssueListRow';
+import { IssueUnitCardHeader } from './IssueUnitCardHeader';
+import {
+  IssueFilters,
+  IssueListResponse,
+  IssueListRow as IssueListRowType,
+  IssueUnitGroup,
+} from './types';
+import { buildListApiQuery } from './filter-url';
+
+interface IssueUnitCardProps {
+  unit: IssueUnitGroup;
+  filters: IssueFilters;
+  onOpenIssue: (id: string) => void;
+}
+
+const EXPANDED_PAGE_SIZE = 200;
+
+function extractUnitNumber(displayName: string): string | null {
+  const match = displayName.match(/\d+[A-Za-z]?$/);
+  return match ? match[0] : null;
+}
+
+export function IssueUnitCard({ unit, filters, onOpenIssue }: IssueUnitCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [allRows, setAllRows] = useState<IssueListRowType[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const unitNumber = extractUnitNumber(unit.unit_display_name);
+  const subtitleParts = [unit.development_name, unitNumber].filter(
+    (v): v is string => Boolean(v),
+  );
+  const subtitle = subtitleParts.join(' . ');
+
+  const totalCount = unit.open_count;
+  const topIssues = unit.issues;
+  const hasMore = totalCount > topIssues.length;
+
+  const loadAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams(
+        buildListApiQuery(filters, EXPANDED_PAGE_SIZE, 0),
+      );
+      params.set('unit_id', unit.unit_id);
+      params.set('limit', String(EXPANDED_PAGE_SIZE));
+      params.set('offset', '0');
+      const res = await fetch(`/api/issues/list?${params.toString()}`, {
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        setError("Couldn't load issues for this unit.");
+        return;
+      }
+      const json = (await res.json()) as IssueListResponse;
+      setAllRows(json.rows);
+    } catch {
+      setError("Couldn't load issues for this unit.");
+    } finally {
+      setLoading(false);
+    }
+  }, [filters, unit.unit_id]);
+
+  useEffect(() => {
+    if (expanded && allRows === null && !loading) {
+      void loadAll();
+    }
+  }, [expanded, allRows, loading, loadAll]);
+
+  // Invalidate fetched expanded rows when filters change so the next
+  // expansion pulls fresh data matching the current filter combination.
+  useEffect(() => {
+    setAllRows(null);
+  }, [filters]);
+
+  const rowsToRender = expanded && allRows ? allRows : topIssues;
+
+  return (
+    <div className="bg-white border border-neutral-200 rounded-lg overflow-hidden hover:shadow-card-hover transition-shadow">
+      <div className="px-4 py-3 border-b border-neutral-100">
+        <IssueUnitCardHeader
+          title={unit.unit_display_name}
+          subtitle={subtitle}
+          openCount={unit.open_count}
+          urgentHighCount={unit.urgent_high_count}
+          worstSeverity={unit.worst_severity}
+        />
+      </div>
+
+      {expanded && loading && !allRows ? (
+        <div className="px-4 py-6 text-body-sm text-neutral-500">
+          Loading issues...
+        </div>
+      ) : expanded && error ? (
+        <div className="px-4 py-4 text-body-sm text-red-700 bg-red-50 border-b border-red-100">
+          {error}
+        </div>
+      ) : null}
+
+      {rowsToRender.length > 0 ? (
+        <ul>
+          {rowsToRender.map((row) => (
+            <li key={row.id}>
+              <IssueListRow row={row} onOpen={onOpenIssue} />
+            </li>
+          ))}
+        </ul>
+      ) : !loading ? (
+        <div className="px-4 py-6 text-body-sm text-neutral-500">
+          No issues for this unit.
+        </div>
+      ) : null}
+
+      {hasMore || expanded ? (
+        <div className="px-4 py-2 border-t border-neutral-100 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="inline-flex items-center gap-1 text-body-sm text-neutral-600 hover:text-neutral-900 px-2 py-1 rounded-md min-h-[36px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+          >
+            {expanded ? (
+              <>
+                Show less
+                <ChevronUp className="w-4 h-4" />
+              </>
+            ) : (
+              <>
+                Show all {totalCount}
+                <ChevronDown className="w-4 h-4" />
+              </>
+            )}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueUnitCardHeader.tsx
+++ b/apps/unified-portal/components/issues/IssueUnitCardHeader.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * Header for a unit card on /developer/issues "By unit" view.
+ *
+ * Spec sections 2.2 + 5 of docs/specs/assistant-v2-sprint-3-1.md.
+ *
+ * Layout:
+ *   - Left: title (unit display name) and subtitle
+ *     ("Development name . unit number" when present).
+ *   - Right: open chip (always shown) and an urgent/high chip when
+ *     urgent_high_count > 0.
+ */
+
+import { IssueSeverity } from './types';
+import { IssueUnitCountChip } from './IssueUnitCountChip';
+
+interface IssueUnitCardHeaderProps {
+  title: string;
+  subtitle: string;
+  openCount: number;
+  urgentHighCount: number;
+  worstSeverity: IssueSeverity | null;
+}
+
+function urgentChipLabel(severity: IssueSeverity | null): string {
+  if (severity === 'urgent') return 'urgent';
+  if (severity === 'high') return 'high';
+  return 'urgent';
+}
+
+export function IssueUnitCardHeader({
+  title,
+  subtitle,
+  openCount,
+  urgentHighCount,
+  worstSeverity,
+}: IssueUnitCardHeaderProps) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex-1 min-w-0">
+        <div className="text-body font-semibold text-neutral-900 truncate">
+          {title}
+        </div>
+        {subtitle ? (
+          <div className="text-body-sm text-neutral-500 truncate mt-0.5">
+            {subtitle}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        <IssueUnitCountChip
+          variant="open"
+          count={openCount}
+          label="open"
+          worstSeverity={worstSeverity}
+        />
+        {urgentHighCount > 0 ? (
+          <IssueUnitCountChip
+            variant="urgent_high"
+            count={urgentHighCount}
+            label={urgentChipLabel(worstSeverity)}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueUnitCountChip.tsx
+++ b/apps/unified-portal/components/issues/IssueUnitCountChip.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * Small severity-coded count chip used on unit cards.
+ *
+ * Spec sections 2.2 + 5 + 7 of docs/specs/assistant-v2-sprint-3-1.md.
+ *
+ * Variants:
+ *   - open: neutral-100 bg, neutral-700 text, severity-coloured dot prefix.
+ *   - urgent_high: red-50 bg, red-700 text, no dot.
+ *
+ * Dot colour (open variant) by worst severity:
+ *   urgent -> red-600
+ *   high   -> red-500
+ *   medium -> amber-500
+ *   low / null -> neutral-500
+ */
+
+import { IssueSeverity } from './types';
+
+type ChipVariant = 'open' | 'urgent_high';
+
+interface IssueUnitCountChipProps {
+  variant: ChipVariant;
+  count: number;
+  label: string;
+  worstSeverity?: IssueSeverity | null;
+}
+
+function dotClass(severity: IssueSeverity | null | undefined): string {
+  switch (severity) {
+    case 'urgent':
+      return 'bg-red-600';
+    case 'high':
+      return 'bg-red-500';
+    case 'medium':
+      return 'bg-amber-500';
+    default:
+      return 'bg-neutral-500';
+  }
+}
+
+export function IssueUnitCountChip({
+  variant,
+  count,
+  label,
+  worstSeverity,
+}: IssueUnitCountChipProps) {
+  const containerClass =
+    variant === 'urgent_high'
+      ? 'bg-red-50 text-red-700'
+      : 'bg-neutral-100 text-neutral-700';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-caption font-medium ${containerClass}`}
+    >
+      {variant === 'open' ? (
+        <span
+          aria-hidden
+          className={`w-1.5 h-1.5 rounded-full ${dotClass(worstSeverity ?? null)}`}
+        />
+      ) : null}
+      <span className="tabular-nums">{count}</span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueUnitGrid.tsx
+++ b/apps/unified-portal/components/issues/IssueUnitGrid.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+/**
+ * Responsive grid of unit cards on /developer/issues "By unit" view.
+ *
+ * Spec sections 2.2 + 5 of docs/specs/assistant-v2-sprint-3-1.md.
+ *
+ * Layout: 1 col on mobile, 2 cols at md, 3 cols at lg. Renders an
+ * IssueUnitCard per unit returned by the server. Empty state when the
+ * filter combination produces no matching units.
+ */
+
+import { IssueUnitCard } from './IssueUnitCard';
+import { IssueFilters, IssueUnitGroup } from './types';
+
+interface IssueUnitGridProps {
+  units: IssueUnitGroup[];
+  filters: IssueFilters;
+  onOpenIssue: (id: string) => void;
+}
+
+export function IssueUnitGrid({ units, filters, onOpenIssue }: IssueUnitGridProps) {
+  if (units.length === 0) {
+    return (
+      <div className="bg-white border border-neutral-200 rounded-lg px-4 py-10 text-center text-body-sm text-neutral-600">
+        No units have issues matching these filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+      {units.map((unit) => (
+        <IssueUnitCard
+          key={unit.unit_id}
+          unit={unit}
+          filters={filters}
+          onOpenIssue={onOpenIssue}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssueViewToggle.tsx
+++ b/apps/unified-portal/components/issues/IssueViewToggle.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * View toggle for /developer/issues. Spec section 2.1 + 5.
+ *
+ * Segmented control with two options: "By unit" (default) and "Activity".
+ * Active option has a brand-colour pill fill; inactive options are neutral.
+ * Sits below the page heading and above the overview cards.
+ */
+
+import { LayoutGrid, ListOrdered } from 'lucide-react';
+import { IssueDashboardView } from './types';
+
+interface IssueViewToggleProps {
+  value: IssueDashboardView;
+  onChange: (next: IssueDashboardView) => void;
+}
+
+interface ToggleOption {
+  value: IssueDashboardView;
+  label: string;
+  icon: typeof LayoutGrid;
+}
+
+const OPTIONS: ToggleOption[] = [
+  { value: 'unit', label: 'By unit', icon: LayoutGrid },
+  { value: 'activity', label: 'Activity', icon: ListOrdered },
+];
+
+export function IssueViewToggle({ value, onChange }: IssueViewToggleProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Issue view"
+      className="inline-flex items-center gap-1 p-1 bg-neutral-100 rounded-full"
+    >
+      {OPTIONS.map((opt) => {
+        const isActive = opt.value === value;
+        const Icon = opt.icon;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(opt.value)}
+            className={`inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-body-sm font-medium transition-colors min-h-[36px] ${
+              isActive
+                ? 'bg-brand-500 text-white shadow-sm'
+                : 'text-neutral-700 hover:text-neutral-900'
+            }`}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
+++ b/apps/unified-portal/components/issues/IssuesDashboardClient.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 /**
- * Top-level client for /developer/issues. Spec section 6.2-6.5.
+ * Top-level client for /developer/issues.
+ *
+ * Sprint 3 spec: docs/specs/assistant-v2-sprint-3.md section 6.2 to 6.5.
+ * Sprint 3.1 adds the view toggle and unit-grouped view:
+ *   docs/specs/assistant-v2-sprint-3-1.md sections 2 + 5.
  *
  * Responsibilities:
  *   - Overview card counts and filter state.
- *   - List fetch with "Load more" pagination.
+ *   - View toggle ("By unit" default, "Activity") synced to ?view= in URL.
+ *   - Unit-grouped fetch when view=unit, flat list when view=activity.
  *   - URL <-> filter sync (bookmarkable filtered views, browser
  *     back/forward stays in sync).
  *   - Drawer open/close via the ?issue=<id> query param, so the
@@ -22,12 +27,17 @@ import { IssueOverviewCards } from './IssueOverviewCards';
 import { IssueFilterBar } from './IssueFilterBar';
 import { IssueListRow } from './IssueListRow';
 import { IssueDetailDrawer } from './IssueDetailDrawer';
+import { IssueViewToggle } from './IssueViewToggle';
+import { IssueUnitGrid } from './IssueUnitGrid';
 import {
   DashboardInitialData,
+  IssueDashboardView,
   IssueFilters,
   IssueListResponse,
   IssueListRow as IssueListRowType,
   IssueOverviewCounts,
+  IssueUnitGroup,
+  IssueUnitListResponse,
   PAGE_SIZE,
 } from './types';
 import { buildFilterQuery, buildListApiQuery, parseFiltersFromSearchParams } from './filter-url';
@@ -35,6 +45,12 @@ import { buildFilterQuery, buildListApiQuery, parseFiltersFromSearchParams } fro
 interface IssuesDashboardClientProps {
   initial: DashboardInitialData;
   initialFilters: IssueFilters;
+}
+
+const DEFAULT_VIEW: IssueDashboardView = 'unit';
+
+function parseView(raw: string | null): IssueDashboardView {
+  return raw === 'activity' ? 'activity' : 'unit';
 }
 
 export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboardClientProps) {
@@ -45,10 +61,13 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
   const [overview, setOverview] = useState<IssueOverviewCounts>(initial.overview);
   const [rows, setRows] = useState<IssueListRowType[]>(initial.list.rows);
   const [total, setTotal] = useState<number>(initial.list.total);
+  const [units, setUnits] = useState<IssueUnitGroup[]>([]);
+  const [unitsLoaded, setUnitsLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const view = parseView(searchParams?.get('view') ?? null);
   const drawerIssueId = searchParams?.get('issue') ?? null;
   const developments = initial.developments;
 
@@ -59,6 +78,7 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
   const filterKey = useMemo(() => stableKey(filters), [filters]);
   const initialFilterKey = useMemo(() => stableKey(initialFilters), [initialFilters]);
   const seenFilterKey = useRef<string>(initialFilterKey);
+  const seenUnitFilterKey = useRef<string | null>(null);
 
   const fetchList = useCallback(
     async (next: IssueFilters, offset: number, append: boolean) => {
@@ -84,6 +104,29 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
     [],
   );
 
+  const fetchUnits = useCallback(async (next: IssueFilters) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams(buildListApiQuery(next, PAGE_SIZE, 0));
+      params.set('group_by_unit', 'true');
+      const res = await fetch(`/api/issues/list?${params.toString()}`, {
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        setError("Couldn't load issues.");
+        return;
+      }
+      const json = (await res.json()) as IssueUnitListResponse;
+      setUnits(json.units);
+      setUnitsLoaded(true);
+    } catch {
+      setError("Couldn't load issues.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   const refreshOverview = useCallback(async () => {
     try {
       const res = await fetch('/api/issues/overview', { cache: 'no-store' });
@@ -95,21 +138,48 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
     }
   }, []);
 
+  // Refresh the activity list when filters change.
   useEffect(() => {
+    if (view !== 'activity') return;
     if (filterKey === seenFilterKey.current) return;
     seenFilterKey.current = filterKey;
     void fetchList(filters, 0, false);
-  }, [filterKey, filters, fetchList]);
+  }, [view, filterKey, filters, fetchList]);
+
+  // Refresh the unit grid when entering the view or when filters change.
+  useEffect(() => {
+    if (view !== 'unit') return;
+    if (unitsLoaded && filterKey === seenUnitFilterKey.current) return;
+    seenUnitFilterKey.current = filterKey;
+    void fetchUnits(filters);
+  }, [view, unitsLoaded, filterKey, filters, fetchUnits]);
 
   const handleFiltersChange = useCallback(
     (next: IssueFilters) => {
       const params = buildFilterQuery(next);
+      const currentView = searchParams?.get('view');
+      if (currentView) params.set('view', currentView);
       const issueId = searchParams?.get('issue');
       if (issueId) params.set('issue', issueId);
       const qs = params.toString();
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     },
     [pathname, router, searchParams],
+  );
+
+  const handleViewChange = useCallback(
+    (next: IssueDashboardView) => {
+      if (next === view) return;
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      if (next === DEFAULT_VIEW) {
+        params.delete('view');
+      } else {
+        params.set('view', next);
+      }
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [pathname, router, searchParams, view],
   );
 
   const openIssue = (id: string) => {
@@ -134,11 +204,27 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
     setRows((curr) =>
       curr.map((r) => (r.id === id ? { ...r, developer_flagged: flagged } : r)),
     );
+    setUnits((curr) =>
+      curr.map((u) => ({
+        ...u,
+        issues: u.issues.map((r) =>
+          r.id === id ? { ...r, developer_flagged: flagged } : r,
+        ),
+      })),
+    );
   };
 
   const handleNotesChanged = (id: string) => {
     setRows((curr) =>
       curr.map((r) => (r.id === id ? { ...r, note_count: r.note_count + 1 } : r)),
+    );
+    setUnits((curr) =>
+      curr.map((u) => ({
+        ...u,
+        issues: u.issues.map((r) =>
+          r.id === id ? { ...r, note_count: r.note_count + 1 } : r,
+        ),
+      })),
     );
   };
 
@@ -149,8 +235,12 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
 
   const refreshAll = useCallback(() => {
     void refreshOverview();
-    void fetchList(filters, 0, false);
-  }, [fetchList, filters, refreshOverview]);
+    if (view === 'unit') {
+      void fetchUnits(filters);
+    } else {
+      void fetchList(filters, 0, false);
+    }
+  }, [fetchList, fetchUnits, filters, refreshOverview, view]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -177,6 +267,8 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
         </div>
       </header>
 
+      <IssueViewToggle value={view} onChange={handleViewChange} />
+
       <IssueOverviewCards counts={overview} />
 
       <IssueFilterBar
@@ -185,7 +277,19 @@ export function IssuesDashboardClient({ initial, initialFilters }: IssuesDashboa
         onChange={handleFiltersChange}
       />
 
-      {loading && rows.length === 0 ? (
+      {view === 'unit' ? (
+        loading && !unitsLoaded ? (
+          <div className="bg-white border border-neutral-200 rounded-lg px-4 py-6 text-body-sm text-neutral-500">
+            Loading issues...
+          </div>
+        ) : error ? (
+          <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-body-sm text-red-700">
+            {error}
+          </div>
+        ) : (
+          <IssueUnitGrid units={units} filters={filters} onOpenIssue={openIssue} />
+        )
+      ) : loading && rows.length === 0 ? (
         <div className="bg-white border border-neutral-200 rounded-lg px-4 py-6 text-body-sm text-neutral-500">
           Loading issues...
         </div>

--- a/apps/unified-portal/components/issues/types.ts
+++ b/apps/unified-portal/components/issues/types.ts
@@ -38,6 +38,26 @@ export interface IssueListResponse {
   offset: number;
 }
 
+export interface IssueUnitGroup {
+  unit_id: string;
+  unit_display_name: string;
+  development_id: string | null;
+  development_name: string | null;
+  open_count: number;
+  urgent_high_count: number;
+  worst_severity: IssueSeverity | null;
+  issues: IssueListRow[];
+}
+
+export interface IssueUnitListResponse {
+  units: IssueUnitGroup[];
+  total_units: number;
+  limit: number;
+  offset: number;
+}
+
+export type IssueDashboardView = 'unit' | 'activity';
+
 export interface IssueOverviewCounts {
   open: number;
   high_priority: number;


### PR DESCRIPTION
Implements section 5 of `docs/specs/assistant-v2-sprint-3-1.md`. Adds the view toggle and unit grouped view to `/developer/issues`, with the unit view as the default on first page load.

## New components (apps/unified-portal/components/issues/)

- `IssueViewToggle.tsx` — pill-shaped segmented control with brand-colour fill on the active option. Two options: "By unit" (default) and "Activity". Sits below the page heading, above the overview cards.
- `IssueUnitGrid.tsx` — responsive grid (1 col mobile, 2 at md, 3 at lg) of unit cards. Renders the empty state "No units have issues matching these filters." in neutral-600 when the server returns zero units.
- `IssueUnitCard.tsx` — single card per unit: header, top 3 issue rows, and a "Show all N" footer when more issues exist for that unit. Tapping the footer expands the card inline and fetches `/api/issues/list?unit_id=<id>&limit=200` plus the current filters; "Show less" collapses it back.
- `IssueUnitCardHeader.tsx` — title (unit display name), subtitle (development name + unit number), open chip on the right plus a conditional urgent/high chip when `urgent_high_count > 0`.
- `IssueUnitCountChip.tsx` — small severity-coded pill. Variants: `open` (neutral-100 bg, neutral-700 text, severity-coloured dot per the spec) and `urgent_high` (red-50 bg, red-700 text, no dot).

## IssuesDashboardClient changes

- Reads `?view=` from `useSearchParams`, defaulting to `unit`.
- When `view === 'unit'`, fetches `/api/issues/list?group_by_unit=true` with all current filter params and renders `IssueUnitGrid`.
- When `view === 'activity'`, behaves exactly as today (flat list fetch + render).
- Syncs view changes to the URL via `router.push`. Filters, search query, and the drawer's `?issue=` param are preserved across view changes.
- Row clicks (from either view) open the existing `IssueDetailDrawer` with both `?view=unit` and `?issue=<id>` in the URL so browser back closes the drawer without losing the view.
- Optimistic flag and note-count updates now also patch the unit grid's `issues` arrays.

## Unchanged

- `IssueOverviewCards`, `IssueFilterBar`, `IssueListRow`, `IssueDetailDrawer`, `IssueLightbox`, and `SeverityIndicator` are reused as-is.
- No new server routes, no schema changes. The grouped fetch goes against the Sprint 3.1 server route merged in PR #166.

## Spec compliance

- Copy from section 5.1: "By unit", "Activity", "Show all N", "Show less", "No units have issues matching these filters.", subtitle separator " . ".
- No em dashes anywhere.
- Brand palette tokens (`brand-500`, `brand-600`) and Lucide React icons only.
- Mobile: single column unit grid; full-screen drawer behaviour from Sprint 3 is unchanged.
- Default view on first page load is "By unit". Per-user persistence remains out of scope.

## Build

`npm run build` passes locally and `/developer/issues` compiles at 12.3 kB. Vercel build is verified green on the deployed preview before this PR is marked ready for squash-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTuMpf9rv1DygKwi9yMxbB)_