### PR TITLE
feat(assistant-v2): Sprint 3.5a server routes for homeowner issues

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -131,10 +131,24 @@ NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
 FEATURE_DEVELOPER_DASHBOARD=false
 NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
 
+# Assistant V2 homeowner issues surface (Sprint 3.5a). Default off in
+# production. Enable per tenant during testing. When false, the new
+# /api/homeowners/* and /api/settings/notifications routes return 404
+# before any auth or DB work, the sidebar badge does not render, the
+# Reported Issues card on the homeowner detail page does not render, and
+# the aftercare email notification does not fire. The Recent Conversations
+# card removal is a privacy fix and is unconditional regardless of flag
+# state.
+FEATURE_HOMEOWNER_ISSUES=false
+NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
-# from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
-# random opaque secret set per environment. Without it, enrichment is
-# skipped (snag still gets created). Generate with: openssl rand -hex 32
+# from /api/snag/create to /api/snag/enrich/[issue_report_id] and the
+# aftercare email fetch from /api/assistant/chat/multimodal to
+# /api/notifications/homeowner-issue. Must be a random opaque secret set
+# per environment. Without it, enrichment and homeowner-issue email
+# notifications are skipped (the issue still gets created). Generate
+# with: openssl rand -hex 32
 INTERNAL_ENRICHMENT_KEY=
 
 # ----------------------------------------------------------------

--- a/apps/unified-portal/.env.example
+++ b/apps/unified-portal/.env.example
@@ -94,10 +94,24 @@ NEXT_PUBLIC_FEATURE_BUILDER_SNAG_APP=false
 FEATURE_DEVELOPER_DASHBOARD=false
 NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
 
+# Assistant V2 homeowner issues surface (Sprint 3.5a). Default off in
+# production. Enable per tenant during testing. When false, the new
+# /api/homeowners/* and /api/settings/notifications routes return 404
+# before any auth or DB work, the sidebar badge does not render, the
+# Reported Issues card on the homeowner detail page does not render, and
+# the aftercare email notification does not fire. The Recent Conversations
+# card removal is a privacy fix and is unconditional regardless of flag
+# state.
+FEATURE_HOMEOWNER_ISSUES=false
+NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
-# from /api/snag/create to /api/snag/enrich/[issue_report_id]. Must be a
-# random opaque secret set per environment. Without it, enrichment is
-# skipped (snag still gets created). Generate with: openssl rand -hex 32
+# from /api/snag/create to /api/snag/enrich/[issue_report_id] and the
+# aftercare email fetch from /api/assistant/chat/multimodal to
+# /api/notifications/homeowner-issue. Must be a random opaque secret set
+# per environment. Without it, enrichment and homeowner-issue email
+# notifications are skipped (the issue still gets created). Generate
+# with: openssl rand -hex 32
 INTERNAL_ENRICHMENT_KEY=
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -4,7 +4,8 @@
  * Assistant V2 Sprint 1. Entry point for chat messages that include
  * media. The existing text-only chat route (/api/chat) stays untouched.
  *
- * Spec: docs/specs/assistant-v2-sprint-1.md section 5.3.
+ * Spec: docs/specs/assistant-v2-sprint-1.md section 5.3,
+ * docs/specs/assistant-v2-sprint-3-5a.md section 5.1 and 5.8.
  *
  * Sprint 1 scope:
  *   1. Verify the caller's tenant via lib/assistant/media-auth.
@@ -17,14 +18,24 @@
  *   4. Return { message, analysis_id, action }. The decision engine and
  *      issue-report creation are explicitly deferred to Sprint 1b.
  *
+ * Sprint 3.5a addition:
+ *   5. When analyse returns action = 'create_issue_report', insert an
+ *      issue_reports row with source = 'homeowner_assistant' and
+ *      status = 'homeowner_new' (per spec section 5.1), link the
+ *      analysis to it, and fire a non-blocking notification to the
+ *      tenant's aftercare email. Currently the placeholder analysis
+ *      never returns this action, so this path is dormant until Sprint
+ *      1b replaces the placeholder with real multimodal reasoning.
+ *
  * Gated on FEATURE_ASSISTANT_IMAGE_UPLOAD. With the flag off this route
  * returns 404 before any work happens.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
+import { waitUntil } from '@vercel/functions';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { isAssistantImageUploadEnabled } from '@/lib/feature-flags';
+import { isAssistantImageUploadEnabled, isHomeownerIssuesEnabled } from '@/lib/feature-flags';
 import {
   resolveMediaAuth,
   mediaAuthErrorToResponse,
@@ -55,6 +66,78 @@ function isUuidArray(v: unknown): v is string[] {
     v.length > 0 &&
     v.every((s) => typeof s === 'string' && UUID_RE.test(s))
   );
+}
+
+function resolveOrigin(request: NextRequest): string {
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
+}
+
+/**
+ * Fire-and-forget notification of an aftercare email for a new
+ * homeowner-raised issue. Mirrors the enrichment trigger pattern in
+ * /api/snag/create: kept alive by waitUntil so the lambda is not torn
+ * down before the outbound fetch leaves, but never blocks the response
+ * to the homeowner. The INTERNAL_ENRICHMENT_KEY env var is reused so
+ * there is one internal secret to rotate, not two.
+ *
+ * If INTERNAL_ENRICHMENT_KEY is unset the call is skipped with a single
+ * warning so the issue still gets created.
+ */
+function triggerHomeownerIssueNotification(request: NextRequest, issueReportId: string): void {
+  const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
+  if (!internalKey) {
+    console.warn(
+      '[assistant-chat-multimodal] notification_skipped reason=INTERNAL_ENRICHMENT_KEY_unset issue=%s',
+      issueReportId,
+    );
+    return;
+  }
+
+  const origin = resolveOrigin(request);
+  const url = `${origin}/api/notifications/homeowner-issue`;
+
+  try {
+    waitUntil(
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-internal-key': internalKey,
+        },
+        body: JSON.stringify({ issue_report_id: issueReportId }),
+      })
+        .then((res) => {
+          if (!res.ok) {
+            console.warn(
+              '[assistant-chat-multimodal] notification_fetch_non_ok issue=%s status=%s',
+              issueReportId,
+              res.status,
+            );
+          }
+        })
+        .catch((err) => {
+          console.warn(
+            '[assistant-chat-multimodal] notification_fetch_rejected issue=%s reason=%s',
+            issueReportId,
+            err instanceof Error ? err.message : String(err),
+          );
+        }),
+    );
+  } catch (err) {
+    console.warn(
+      '[assistant-chat-multimodal] notification_fetch_threw issue=%s reason=%s',
+      issueReportId,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -188,11 +271,94 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Sprint 3.5a section 5.1. When the AI determines the upload represents
+  // an actual issue (not a curiosity question, not "look at my kitchen"),
+  // create an issue_reports row in the homeowner_new state and fire the
+  // aftercare email notification. The placeholder mediaAnalysisService
+  // currently never returns 'create_issue_report', so this branch is
+  // dormant until Sprint 1b replaces the placeholder with real reasoning.
+  let createdIssueReportId: string | null = null;
+  if (result.action === 'create_issue_report' && auth.unitId && auth.developmentId) {
+    const titleSource =
+      result.structured.developer_summary?.trim() ||
+      result.structured.issue_type?.trim() ||
+      'Photo from homeowner';
+    const title = titleSource.length > 200 ? `${titleSource.slice(0, 197)}...` : titleSource;
+
+    const { data: issueRow, error: issueErr } = await supabase
+      .from('issue_reports')
+      .insert({
+        tenant_id: auth.tenantId,
+        development_id: auth.developmentId,
+        unit_id: auth.unitId,
+        user_id: auth.userId,
+        title,
+        description: messageText || result.structured.developer_summary || null,
+        room: result.structured.room ?? null,
+        status: 'homeowner_new',
+        priority: 'normal',
+        source: 'homeowner_assistant',
+        severity_label: result.structured.severity_label,
+        severity_score: result.structured.severity_score,
+        safety_risk: result.structured.safety_risk,
+        likely_trade: result.structured.likely_trade,
+        likely_system: result.structured.likely_system,
+        linked_analysis_id: result.analysisId,
+        logged_by_user_id: auth.userId,
+        logged_by_role: 'homeowner',
+      })
+      .select('id')
+      .single();
+
+    if (issueErr || !issueRow) {
+      console.error(
+        '[assistant-chat-multimodal] issue_insert_failed reason=%s',
+        issueErr?.message ?? 'no row',
+      );
+    } else {
+      createdIssueReportId = issueRow.id as string;
+
+      const mediaJoinRows = mediaIds.map((mediaId) => ({
+        tenant_id: auth.tenantId,
+        issue_report_id: createdIssueReportId,
+        media_id: mediaId,
+      }));
+      const { error: joinErr } = await supabase.from('issue_report_media').insert(mediaJoinRows);
+      if (joinErr) {
+        console.error(
+          '[assistant-chat-multimodal] issue_media_join_failed reason=%s',
+          joinErr.message,
+        );
+      }
+
+      const { error: eventErr } = await supabase.from('issue_events').insert({
+        tenant_id: auth.tenantId,
+        issue_report_id: createdIssueReportId,
+        event_type: 'homeowner_issue_created',
+        actor_type: 'homeowner',
+        actor_id: auth.userId,
+        metadata: {
+          source: 'homeowner_assistant',
+          analysis_id: result.analysisId,
+          media_count: mediaIds.length,
+        },
+      });
+      if (eventErr) {
+        console.error('[assistant-chat-multimodal] event_insert_failed reason=%s', eventErr.message);
+      }
+
+      if (isHomeownerIssuesEnabled()) {
+        triggerHomeownerIssueNotification(request, createdIssueReportId);
+      }
+    }
+  }
+
   return NextResponse.json({
     message: result.residentMessage,
     analysis_id: result.analysisId,
     action: result.action,
     message_id: messageId,
     conversation_id: conversationId,
+    issue_report_id: createdIssueReportId,
   });
 }

--- a/apps/unified-portal/app/api/homeowners/[id]/issues/route.ts
+++ b/apps/unified-portal/app/api/homeowners/[id]/issues/route.ts
@@ -1,0 +1,286 @@
+/**
+ * GET /api/homeowners/[id]/issues
+ *
+ * Assistant V2 Sprint 3.5a. Returns every issue raised on or against a
+ * given homeowner's unit, with the linked AI analysis and a one-hour
+ * signed URL for the first attached photo per row. Feeds the Reported
+ * Issues card on the homeowner detail page.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.3.
+ *
+ * The [id] path parameter is a purchaser_agreement.id, NOT an
+ * issue_report.id. We look up the purchaser_agreement, derive the
+ * unit_id, look up the unit to confirm it belongs to the caller's
+ * tenant via assertCanAccessTenant, and then query issue_reports
+ * scoped to that unit and tenant.
+ *
+ * Result ordering: status priority first (homeowner_new, then open,
+ * then reopened, then resolved), then created_at desc within each
+ * status bucket so the most recent rows surface at the top of each
+ * group. The site team is meant to triage homeowner_new rows before
+ * anything else.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403.
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  assertCanAccessTenant,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const BUCKET = 'assistant-media';
+
+const STATUS_PRIORITY: Record<string, number> = {
+  homeowner_new: 0,
+  open: 1,
+  reopened: 2,
+  resolved: 3,
+};
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const purchaserAgreementId = params.id;
+  if (!UUID_RE.test(purchaserAgreementId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: agreement, error: agreementErr } = await supabase
+    .from('purchaser_agreements')
+    .select('id, unit_id, development_id')
+    .eq('id', purchaserAgreementId)
+    .maybeSingle();
+  if (agreementErr) {
+    console.error('[homeowners-issues] agreement_lookup_failed reason=%s', agreementErr.message);
+    return NextResponse.json({ error: 'Could not load homeowner' }, { status: 500 });
+  }
+  if (!agreement) {
+    return NextResponse.json({ error: 'Homeowner not found' }, { status: 404 });
+  }
+
+  const unitId = agreement.unit_id as string | null;
+  if (!unitId) {
+    return NextResponse.json({ error: 'Homeowner is not linked to a unit' }, { status: 400 });
+  }
+
+  const { data: unit, error: unitErr } = await supabase
+    .from('units')
+    .select('id, tenant_id, development_id')
+    .eq('id', unitId)
+    .maybeSingle();
+  if (unitErr) {
+    console.error('[homeowners-issues] unit_lookup_failed reason=%s', unitErr.message);
+    return NextResponse.json({ error: 'Could not load unit' }, { status: 500 });
+  }
+  if (!unit || !unit.tenant_id) {
+    return NextResponse.json({ error: 'Unit not found' }, { status: 404 });
+  }
+  try {
+    assertCanAccessTenant(auth, unit.tenant_id as string);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const { data: rows, error: listErr } = await supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, source, status, priority, severity_label, severity_score, safety_risk, likely_trade, likely_system, resolution_type, linked_analysis_id, logged_by_role, created_at, updated_at, resolved_at',
+    )
+    .eq('tenant_id', auth.tenantId)
+    .eq('unit_id', unitId);
+
+  if (listErr) {
+    console.error('[homeowners-issues] list_failed reason=%s', listErr.message);
+    return NextResponse.json({ error: 'Could not load issues' }, { status: 500 });
+  }
+
+  const issueRows = rows ?? [];
+  issueRows.sort((a, b) => {
+    const aPriority = STATUS_PRIORITY[a.status as string] ?? 99;
+    const bPriority = STATUS_PRIORITY[b.status as string] ?? 99;
+    if (aPriority !== bPriority) return aPriority - bPriority;
+    return new Date(b.created_at as string).getTime() - new Date(a.created_at as string).getTime();
+  });
+
+  const issueIds = issueRows.map((r) => r.id as string);
+  const analysisIds = Array.from(
+    new Set(issueRows.map((r) => r.linked_analysis_id as string | null).filter((v): v is string => !!v)),
+  );
+
+  const analysisById = new Map<string, Record<string, unknown>>();
+  if (analysisIds.length > 0) {
+    const { data: analysisRows, error: analysisErr } = await supabase
+      .from('assistant_media_analysis')
+      .select('*')
+      .in('id', analysisIds);
+    if (analysisErr) {
+      console.error('[homeowners-issues] analysis_lookup_failed reason=%s', analysisErr.message);
+    } else {
+      for (const a of analysisRows ?? []) {
+        analysisById.set(a.id as string, a as Record<string, unknown>);
+      }
+    }
+  }
+
+  const firstMediaByIssue = new Map<string, string>();
+  if (issueIds.length > 0) {
+    const { data: joinRows, error: joinErr } = await supabase
+      .from('issue_report_media')
+      .select('issue_report_id, media_id, created_at')
+      .in('issue_report_id', issueIds)
+      .order('created_at', { ascending: true });
+    if (joinErr) {
+      console.error('[homeowners-issues] media_join_lookup_failed reason=%s', joinErr.message);
+    } else {
+      for (const j of joinRows ?? []) {
+        const issueId = j.issue_report_id as string;
+        if (!firstMediaByIssue.has(issueId)) {
+          firstMediaByIssue.set(issueId, j.media_id as string);
+        }
+      }
+    }
+  }
+
+  const mediaIds = Array.from(new Set(firstMediaByIssue.values()));
+  const mediaById = new Map<
+    string,
+    {
+      id: string;
+      storage_path: string;
+      thumbnail_path: string | null;
+      mime_type: string;
+      width: number | null;
+      height: number | null;
+      tenant_id: string;
+    }
+  >();
+  if (mediaIds.length > 0) {
+    const { data: mediaRows, error: mediaErr } = await supabase
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path, mime_type, width, height')
+      .in('id', mediaIds);
+    if (mediaErr) {
+      console.error('[homeowners-issues] media_lookup_failed reason=%s', mediaErr.message);
+    } else {
+      for (const m of mediaRows ?? []) {
+        if (m.tenant_id !== auth.tenantId) continue;
+        mediaById.set(m.id as string, {
+          id: m.id as string,
+          storage_path: m.storage_path as string,
+          thumbnail_path: (m.thumbnail_path as string | null) ?? null,
+          mime_type: m.mime_type as string,
+          width: (m.width as number | null) ?? null,
+          height: (m.height as number | null) ?? null,
+          tenant_id: m.tenant_id as string,
+        });
+      }
+    }
+  }
+
+  const expiresIso = new Date(Date.now() + SIGNED_URL_TTL_SECONDS * 1000).toISOString();
+
+  const issues = await Promise.all(
+    issueRows.map(async (r) => {
+      const issueId = r.id as string;
+      const mediaId = firstMediaByIssue.get(issueId);
+      let media: {
+        id: string;
+        signed_url: string;
+        thumbnail_url: string;
+        mime_type: string;
+        width: number | null;
+        height: number | null;
+        expires_at: string;
+      } | null = null;
+      if (mediaId) {
+        const m = mediaById.get(mediaId);
+        if (m) {
+          const { data: signed } = await supabase.storage
+            .from(BUCKET)
+            .createSignedUrl(m.storage_path, SIGNED_URL_TTL_SECONDS);
+          let thumbUrl = signed?.signedUrl ?? '';
+          if (m.thumbnail_path) {
+            const { data: thumbSigned } = await supabase.storage
+              .from(BUCKET)
+              .createSignedUrl(m.thumbnail_path, SIGNED_URL_TTL_SECONDS);
+            if (thumbSigned?.signedUrl) thumbUrl = thumbSigned.signedUrl;
+          }
+          media = {
+            id: m.id,
+            signed_url: signed?.signedUrl ?? '',
+            thumbnail_url: thumbUrl,
+            mime_type: m.mime_type,
+            width: m.width,
+            height: m.height,
+            expires_at: expiresIso,
+          };
+        }
+      }
+
+      const linkedAnalysisId = r.linked_analysis_id as string | null;
+      const analysis = linkedAnalysisId ? analysisById.get(linkedAnalysisId) ?? null : null;
+
+      return {
+        id: issueId,
+        title: r.title,
+        description: r.description,
+        room: r.room,
+        source: r.source,
+        status: r.status,
+        priority: r.priority,
+        severity_label: r.severity_label,
+        severity_score: r.severity_score,
+        safety_risk: r.safety_risk,
+        likely_trade: r.likely_trade,
+        likely_system: r.likely_system,
+        resolution_type: r.resolution_type,
+        logged_by_role: r.logged_by_role,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+        resolved_at: r.resolved_at,
+        analysis,
+        first_media: media,
+      };
+    }),
+  );
+
+  return NextResponse.json({
+    purchaser_agreement_id: purchaserAgreementId,
+    unit_id: unitId,
+    issues,
+  });
+}

--- a/apps/unified-portal/app/api/homeowners/issues-count/route.ts
+++ b/apps/unified-portal/app/api/homeowners/issues-count/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/homeowners/issues-count
+ *
+ * Assistant V2 Sprint 3.5a. Returns the count of homeowner_new issues
+ * across the caller's tenant. Powers the sidebar notification badge
+ * next to the Homeowners nav link.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.2.
+ *
+ * The query hits the partial index issue_reports_homeowner_new_idx on
+ * (status) WHERE status = 'homeowner_new'. The combination of the index
+ * and the tenant_id equality filter keeps the count cheap even at
+ * scale; this route is called on every dashboard page load.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403; the homeowner surfaces are developer-side only.
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role === 'snagger_external') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { count, error } = await supabase
+    .from('issue_reports')
+    .select('id', { count: 'exact', head: true })
+    .eq('tenant_id', auth.tenantId)
+    .eq('status', 'homeowner_new');
+
+  if (error) {
+    console.error('[homeowners-issues-count] count_failed reason=%s', error.message);
+    return NextResponse.json({ error: 'Could not load count' }, { status: 500 });
+  }
+
+  return NextResponse.json({ count: count ?? 0 });
+}

--- a/apps/unified-portal/app/api/homeowners/issues/[issue_id]/escalate/route.ts
+++ b/apps/unified-portal/app/api/homeowners/issues/[issue_id]/escalate/route.ts
@@ -1,0 +1,168 @@
+/**
+ * POST /api/homeowners/issues/[issue_id]/escalate
+ *
+ * Assistant V2 Sprint 3.5a. Promote a homeowner-raised issue into the
+ * operational snag workflow. The source moves to 'homeowner_escalated'
+ * (the trail back to the homeowner is preserved) and the status moves
+ * to 'open' so the row appears in the regular /developer/issues
+ * dashboard and the unit grouped view.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.5.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403. The issue's source must be 'homeowner_assistant'
+ * (you cannot re-escalate an already-escalated issue).
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_NOTE_LEN = 2000;
+
+interface RouteParams {
+  params: { issue_id: string };
+}
+
+interface EscalateBody {
+  note?: unknown;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.issue_id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'issue_id must be a uuid' }, { status: 400 });
+  }
+
+  let payload: EscalateBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  let noteText: string | null = null;
+  if (payload.note !== undefined && payload.note !== null) {
+    if (typeof payload.note !== 'string') {
+      return NextResponse.json({ error: 'note must be a string' }, { status: 400 });
+    }
+    const trimmed = payload.note.trim();
+    if (trimmed.length > MAX_NOTE_LEN) {
+      return NextResponse.json({ error: 'note is too long' }, { status: 400 });
+    }
+    if (trimmed.length > 0) {
+      noteText = trimmed;
+    }
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, source, status')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[homeowners-issues-escalate] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (report.source !== 'homeowner_assistant') {
+    return NextResponse.json(
+      { error: 'This action only applies to unescalated homeowner issues.' },
+      { status: 400 },
+    );
+  }
+
+  let noteId: string | null = null;
+  if (noteText) {
+    const { data: noteRow, error: noteErr } = await supabase
+      .from('issue_notes')
+      .insert({
+        tenant_id: auth.tenantId,
+        issue_report_id: issueReportId,
+        author_user_id: auth.userId,
+        author_role: auth.role,
+        body: noteText,
+      })
+      .select('id')
+      .single();
+    if (noteErr || !noteRow) {
+      console.error(
+        '[homeowners-issues-escalate] note_insert_failed reason=%s',
+        noteErr?.message ?? 'no row',
+      );
+      return NextResponse.json({ error: 'Could not save note' }, { status: 500 });
+    }
+    noteId = noteRow.id as string;
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error: updateErr } = await supabase
+    .from('issue_reports')
+    .update({
+      source: 'homeowner_escalated',
+      status: 'open',
+      updated_at: nowIso,
+    })
+    .eq('id', issueReportId)
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, source, status, priority, severity_label, severity_score, resolution_type, logged_by_role, created_at, updated_at, resolved_at',
+    )
+    .single();
+  if (updateErr || !updated) {
+    console.error(
+      '[homeowners-issues-escalate] update_failed reason=%s',
+      updateErr?.message ?? 'no row',
+    );
+    return NextResponse.json({ error: 'Could not escalate issue' }, { status: 500 });
+  }
+
+  const eventMetadata: Record<string, unknown> = {};
+  if (noteId) eventMetadata.note_id = noteId;
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: 'escalated_from_homeowner',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: eventMetadata,
+  });
+  if (eventErr) {
+    console.error('[homeowners-issues-escalate] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({ issue: updated, note_id: noteId });
+}

--- a/apps/unified-portal/app/api/homeowners/issues/[issue_id]/resolve/route.ts
+++ b/apps/unified-portal/app/api/homeowners/issues/[issue_id]/resolve/route.ts
@@ -1,0 +1,160 @@
+/**
+ * POST /api/homeowners/issues/[issue_id]/resolve
+ *
+ * Assistant V2 Sprint 3.5a. The reply-and-resolve action for an
+ * unescalated homeowner-raised issue. The site team writes a reply,
+ * the reply is stored as an issue_notes row, and the issue moves to
+ * resolved with resolution_type='direct_reply'.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.4.
+ *
+ * In V1 the reply is captured as a note but not sent back to the
+ * homeowner. Sprint 1b will add the messaging loop; this route's
+ * shape stays the same when that happens, the UI just gains the
+ * delivery affordance.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403. The issue's source must be 'homeowner_assistant'
+ * (escalated and snagger-side issues use different routes).
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_REPLY_LEN = 2000;
+
+interface RouteParams {
+  params: { issue_id: string };
+}
+
+interface ResolveBody {
+  reply_body?: unknown;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.issue_id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'issue_id must be a uuid' }, { status: 400 });
+  }
+
+  let payload: ResolveBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const replyBody = typeof payload.reply_body === 'string' ? payload.reply_body.trim() : '';
+  if (!replyBody) {
+    return NextResponse.json({ error: 'reply_body is required' }, { status: 400 });
+  }
+  if (replyBody.length > MAX_REPLY_LEN) {
+    return NextResponse.json({ error: 'reply_body is too long' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, source, status')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[homeowners-issues-resolve] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (report.source !== 'homeowner_assistant') {
+    return NextResponse.json(
+      { error: 'This action only applies to unescalated homeowner issues.' },
+      { status: 400 },
+    );
+  }
+
+  const { data: noteRow, error: noteErr } = await supabase
+    .from('issue_notes')
+    .insert({
+      tenant_id: auth.tenantId,
+      issue_report_id: issueReportId,
+      author_user_id: auth.userId,
+      author_role: auth.role,
+      body: replyBody,
+    })
+    .select('id')
+    .single();
+  if (noteErr || !noteRow) {
+    console.error(
+      '[homeowners-issues-resolve] note_insert_failed reason=%s',
+      noteErr?.message ?? 'no row',
+    );
+    return NextResponse.json({ error: 'Could not save reply' }, { status: 500 });
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error: updateErr } = await supabase
+    .from('issue_reports')
+    .update({
+      status: 'resolved',
+      resolution_type: 'direct_reply',
+      resolved_at: nowIso,
+      updated_at: nowIso,
+    })
+    .eq('id', issueReportId)
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, source, status, priority, severity_label, severity_score, resolution_type, logged_by_role, created_at, updated_at, resolved_at',
+    )
+    .single();
+  if (updateErr || !updated) {
+    console.error(
+      '[homeowners-issues-resolve] update_failed reason=%s',
+      updateErr?.message ?? 'no row',
+    );
+    return NextResponse.json({ error: 'Could not resolve issue' }, { status: 500 });
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: 'resolved_by_reply',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: { resolution_type: 'direct_reply', note_id: noteRow.id },
+  });
+  if (eventErr) {
+    console.error('[homeowners-issues-resolve] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({ issue: updated, note_id: noteRow.id });
+}

--- a/apps/unified-portal/app/api/homeowners/issues/[issue_id]/warranty/route.ts
+++ b/apps/unified-portal/app/api/homeowners/issues/[issue_id]/warranty/route.ts
@@ -1,0 +1,160 @@
+/**
+ * POST /api/homeowners/issues/[issue_id]/warranty
+ *
+ * Assistant V2 Sprint 3.5a. Mark a homeowner-raised issue for warranty
+ * referral. A required documentation note is captured as an
+ * issue_notes row, the issue moves to resolved with
+ * resolution_type='warranty_referral', and the resolved_at timestamp
+ * is set.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.6.
+ *
+ * The note is required (unlike escalate where it is optional)
+ * because warranty referrals need documentation. The issue closes on
+ * the dashboard but is filterable by resolution_type='warranty_referral'
+ * for future reporting.
+ *
+ * Access scoping. admin and site_team only. snagger_external is
+ * rejected with 403. The issue's source must be 'homeowner_assistant'.
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_NOTE_LEN = 2000;
+
+interface RouteParams {
+  params: { issue_id: string };
+}
+
+interface WarrantyBody {
+  note?: unknown;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const issueReportId = params.issue_id;
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'issue_id must be a uuid' }, { status: 400 });
+  }
+
+  let payload: WarrantyBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const noteText = typeof payload.note === 'string' ? payload.note.trim() : '';
+  if (!noteText) {
+    return NextResponse.json({ error: 'note is required' }, { status: 400 });
+  }
+  if (noteText.length > MAX_NOTE_LEN) {
+    return NextResponse.json({ error: 'note is too long' }, { status: 400 });
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select('id, tenant_id, source, status')
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[homeowners-issues-warranty] lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+  if (report.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+  if (report.source !== 'homeowner_assistant') {
+    return NextResponse.json(
+      { error: 'This action only applies to unescalated homeowner issues.' },
+      { status: 400 },
+    );
+  }
+
+  const { data: noteRow, error: noteErr } = await supabase
+    .from('issue_notes')
+    .insert({
+      tenant_id: auth.tenantId,
+      issue_report_id: issueReportId,
+      author_user_id: auth.userId,
+      author_role: auth.role,
+      body: noteText,
+    })
+    .select('id')
+    .single();
+  if (noteErr || !noteRow) {
+    console.error(
+      '[homeowners-issues-warranty] note_insert_failed reason=%s',
+      noteErr?.message ?? 'no row',
+    );
+    return NextResponse.json({ error: 'Could not save note' }, { status: 500 });
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data: updated, error: updateErr } = await supabase
+    .from('issue_reports')
+    .update({
+      status: 'resolved',
+      resolution_type: 'warranty_referral',
+      resolved_at: nowIso,
+      updated_at: nowIso,
+    })
+    .eq('id', issueReportId)
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, source, status, priority, severity_label, severity_score, resolution_type, logged_by_role, created_at, updated_at, resolved_at',
+    )
+    .single();
+  if (updateErr || !updated) {
+    console.error(
+      '[homeowners-issues-warranty] update_failed reason=%s',
+      updateErr?.message ?? 'no row',
+    );
+    return NextResponse.json({ error: 'Could not mark for warranty' }, { status: 500 });
+  }
+
+  const { error: eventErr } = await supabase.from('issue_events').insert({
+    tenant_id: auth.tenantId,
+    issue_report_id: issueReportId,
+    event_type: 'marked_for_warranty',
+    actor_type: auth.role,
+    actor_id: auth.userId,
+    metadata: { resolution_type: 'warranty_referral', note_id: noteRow.id },
+  });
+  if (eventErr) {
+    console.error('[homeowners-issues-warranty] event_insert_failed reason=%s', eventErr.message);
+  }
+
+  return NextResponse.json({ issue: updated, note_id: noteRow.id });
+}

--- a/apps/unified-portal/app/api/notifications/homeowner-issue/route.ts
+++ b/apps/unified-portal/app/api/notifications/homeowner-issue/route.ts
@@ -1,0 +1,391 @@
+/**
+ * POST /api/notifications/homeowner-issue
+ *
+ * Assistant V2 Sprint 3.5a. Internal-only route triggered by
+ * /api/assistant/chat/multimodal immediately after a new
+ * homeowner-raised issue is created. Looks up the tenant's aftercare
+ * email and dispatches a notification with the issue summary, the
+ * homeowner's details, a thumbnail signed URL, and a deep link to the
+ * dashboard.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.8.
+ *
+ * Auth. Reuses the INTERNAL_ENRICHMENT_KEY env var (same secret used
+ * by /api/snag/enrich) to avoid introducing a second internal-only
+ * credential. The header check uses crypto.timingSafeEqual so the
+ * route is not vulnerable to timing oracle attacks. As a secondary
+ * acceptable proof, an Authorization: Bearer with the Supabase
+ * service-role key is also accepted, mirroring the enrich route.
+ *
+ * Email send. The codebase already has a Resend integration via
+ * lib/resend.ts (used by onboarding-submission, new-signup, and the
+ * agent-intelligence send-draft path). We reuse the same getResendClient
+ * helper which transparently falls back to a stub in environments where
+ * RESEND_API_KEY is not configured. The stub logs the would-be send
+ * and returns synthetic ids, so this route is exercisable end-to-end
+ * in dev and preview without sending real mail.
+ *
+ * If the tenant has no aftercare_email configured, the route logs a
+ * single info-level message and returns 200 without dispatching. That
+ * is a deliberate config choice, not an error.
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES. With the flag off the route is
+ * 404 before any auth or DB work.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import { snagFeatureDisabledResponse } from '@/lib/assistant/snag-auth';
+import { getResendClient } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
+const BUCKET = 'assistant-media';
+
+interface NotifyBody {
+  issue_report_id?: unknown;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+function isInternalCaller(request: NextRequest): boolean {
+  const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
+  const headerKey = request.headers.get('x-internal-key');
+  if (internalKey && headerKey && safeEqual(headerKey, internalKey)) {
+    return true;
+  }
+  const auth = request.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    const token = auth.slice(7);
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (serviceKey && safeEqual(token, serviceKey)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function deriveUnitDisplayName(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+function resolveDashboardOrigin(request: NextRequest): string {
+  if (process.env.NEXT_PUBLIC_DEVELOPER_PORTAL_URL) {
+    return process.env.NEXT_PUBLIC_DEVELOPER_PORTAL_URL.replace(/\/+$/, '');
+  }
+  const host = request.headers.get('host');
+  if (host) {
+    const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+    return `${proto}://${host}`;
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return 'http://localhost:3000';
+}
+
+export async function POST(request: NextRequest) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  if (!isInternalCaller(request)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let payload: NotifyBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const issueReportId = typeof payload.issue_report_id === 'string' ? payload.issue_report_id : '';
+  if (!UUID_RE.test(issueReportId)) {
+    return NextResponse.json({ error: 'issue_report_id must be a uuid' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: report, error: reportErr } = await supabase
+    .from('issue_reports')
+    .select(
+      'id, tenant_id, development_id, unit_id, title, description, room, source, status, linked_analysis_id, created_at',
+    )
+    .eq('id', issueReportId)
+    .maybeSingle();
+  if (reportErr) {
+    console.error('[homeowner-issue-notify] report_lookup_failed reason=%s', reportErr.message);
+    return NextResponse.json({ error: 'Could not load issue' }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ error: 'Issue not found' }, { status: 404 });
+  }
+
+  const tenantId = report.tenant_id as string;
+
+  const { data: settings, error: settingsErr } = await supabase
+    .from('tenant_settings')
+    .select('aftercare_email')
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+  if (settingsErr) {
+    console.error('[homeowner-issue-notify] settings_lookup_failed reason=%s', settingsErr.message);
+    return NextResponse.json({ error: 'Could not load settings' }, { status: 500 });
+  }
+  const aftercareEmail = (settings?.aftercare_email as string | null) ?? null;
+  if (!aftercareEmail || aftercareEmail.trim().length === 0) {
+    console.info('[homeowner-issue-notify] aftercare_email_unset tenant=%s issue=%s', tenantId, issueReportId);
+    return NextResponse.json({ ok: true, skipped: 'aftercare_email_unset' });
+  }
+
+  const unitId = report.unit_id as string | null;
+  const developmentId = report.development_id as string;
+
+  const [unitRes, devRes] = await Promise.all([
+    unitId
+      ? supabase
+          .from('units')
+          .select('id, unit_code, unit_number, address_line_1, purchaser_name, purchaser_email')
+          .eq('id', unitId)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase.from('developments').select('id, name').eq('id', developmentId).maybeSingle(),
+  ]);
+
+  if (unitRes.error) {
+    console.error('[homeowner-issue-notify] unit_lookup_failed reason=%s', unitRes.error.message);
+  }
+  if (devRes.error) {
+    console.error('[homeowner-issue-notify] development_lookup_failed reason=%s', devRes.error.message);
+  }
+
+  const unitRow = unitRes.data;
+  const unitDisplayName = unitRow
+    ? deriveUnitDisplayName({
+        unit_code: (unitRow.unit_code as string | null) ?? null,
+        unit_number: (unitRow.unit_number as string | null) ?? null,
+        address_line_1: (unitRow.address_line_1 as string | null) ?? null,
+      })
+    : 'Unit';
+  const developmentName = devRes.data ? ((devRes.data.name as string | null) ?? null) : null;
+
+  let purchaserAgreementId: string | null = null;
+  let homeownerName: string | null = unitRow ? ((unitRow.purchaser_name as string | null) ?? null) : null;
+  if (unitId) {
+    const { data: agreementRow, error: agreementErr } = await supabase
+      .from('purchaser_agreements')
+      .select('id, purchaser_name')
+      .eq('unit_id', unitId)
+      .order('agreed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (agreementErr) {
+      console.error(
+        '[homeowner-issue-notify] purchaser_lookup_failed reason=%s',
+        agreementErr.message,
+      );
+    } else if (agreementRow) {
+      purchaserAgreementId = agreementRow.id as string;
+      if (!homeownerName) {
+        homeownerName = (agreementRow.purchaser_name as string | null) ?? null;
+      }
+    }
+  }
+  if (!homeownerName) {
+    homeownerName = 'a homeowner';
+  }
+
+  let assessmentSummary: string | null = null;
+  const linkedAnalysisId = report.linked_analysis_id as string | null;
+  if (linkedAnalysisId) {
+    const { data: analysisRow, error: analysisErr } = await supabase
+      .from('assistant_media_analysis')
+      .select('developer_summary, severity_label')
+      .eq('id', linkedAnalysisId)
+      .maybeSingle();
+    if (analysisErr) {
+      console.error(
+        '[homeowner-issue-notify] analysis_lookup_failed reason=%s',
+        analysisErr.message,
+      );
+    } else if (analysisRow) {
+      const summary =
+        typeof analysisRow.developer_summary === 'string'
+          ? analysisRow.developer_summary.trim()
+          : '';
+      if (summary && !/^placeholder/i.test(summary)) {
+        assessmentSummary = summary;
+      }
+    }
+  }
+
+  let photoUrl: string | null = null;
+  const { data: joinRow, error: joinErr } = await supabase
+    .from('issue_report_media')
+    .select('media_id, created_at')
+    .eq('issue_report_id', issueReportId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (joinErr) {
+    console.error('[homeowner-issue-notify] media_join_lookup_failed reason=%s', joinErr.message);
+  } else if (joinRow) {
+    const mediaId = joinRow.media_id as string;
+    const { data: mediaRow, error: mediaErr } = await supabase
+      .from('assistant_media')
+      .select('id, tenant_id, storage_path, thumbnail_path')
+      .eq('id', mediaId)
+      .maybeSingle();
+    if (mediaErr) {
+      console.error('[homeowner-issue-notify] media_lookup_failed reason=%s', mediaErr.message);
+    } else if (mediaRow && mediaRow.tenant_id === tenantId) {
+      const path = (mediaRow.thumbnail_path as string | null) ?? (mediaRow.storage_path as string);
+      const { data: signed, error: signedErr } = await supabase.storage
+        .from(BUCKET)
+        .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+      if (signedErr) {
+        console.error('[homeowner-issue-notify] signed_url_failed reason=%s', signedErr.message);
+      } else if (signed?.signedUrl) {
+        photoUrl = signed.signedUrl;
+      }
+    }
+  }
+
+  const origin = resolveDashboardOrigin(request);
+  const dashboardLink = purchaserAgreementId
+    ? `${origin}/developer/homeowners/${purchaserAgreementId}`
+    : `${origin}/developer/homeowners`;
+
+  const subject = `New issue raised by ${homeownerName} at ${unitDisplayName}`;
+
+  const titleLine = (report.title as string | null) ?? 'Photo from homeowner';
+  const descriptionLine = (report.description as string | null) ?? '';
+  const roomLine = (report.room as string | null) ?? '';
+
+  const assessmentBlock = assessmentSummary
+    ? assessmentSummary
+    : 'Assessment pending. The AI analysis has not produced a full assessment for this upload yet.';
+
+  const textLines = [
+    `${homeownerName} raised an issue at ${unitDisplayName}${developmentName ? `, ${developmentName}` : ''}.`,
+    '',
+    `Title: ${titleLine}`,
+  ];
+  if (roomLine) textLines.push(`Room: ${roomLine}`);
+  if (descriptionLine) {
+    textLines.push('');
+    textLines.push(`Description:`);
+    textLines.push(descriptionLine);
+  }
+  textLines.push('');
+  textLines.push(`Assessment: ${assessmentBlock}`);
+  if (photoUrl) {
+    textLines.push('');
+    textLines.push(`Photo: ${photoUrl}`);
+  }
+  textLines.push('');
+  textLines.push(`Open in dashboard: ${dashboardLink}`);
+
+  const text = textLines.join('\n');
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+      <div style="background: #111; padding: 20px;">
+        <h1 style="color: #fff; margin: 0; font-size: 18px;">New homeowner issue</h1>
+      </div>
+      <div style="padding: 24px; background: #fff; color: #111;">
+        <p style="margin: 0 0 16px 0;">
+          <strong>${escapeHtml(homeownerName)}</strong> raised an issue at
+          <strong>${escapeHtml(unitDisplayName)}</strong>${developmentName ? `, ${escapeHtml(developmentName)}` : ''}.
+        </p>
+        <table style="width: 100%; border-collapse: collapse; margin: 8px 0 16px 0;">
+          <tr>
+            <td style="padding: 4px 0; color: #555; width: 30%;">Title</td>
+            <td style="padding: 4px 0;"><strong>${escapeHtml(titleLine)}</strong></td>
+          </tr>
+          ${
+            roomLine
+              ? `<tr><td style="padding: 4px 0; color: #555;">Room</td><td style="padding: 4px 0;">${escapeHtml(roomLine)}</td></tr>`
+              : ''
+          }
+          ${
+            descriptionLine
+              ? `<tr><td style="padding: 4px 0; color: #555; vertical-align: top;">Description</td><td style="padding: 4px 0;">${escapeHtml(descriptionLine)}</td></tr>`
+              : ''
+          }
+        </table>
+        <div style="padding: 12px 16px; background: #f7f7f7; border-radius: 6px; margin-bottom: 16px;">
+          <div style="color: #555; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px;">Assessment</div>
+          <div>${escapeHtml(assessmentBlock)}</div>
+        </div>
+        ${
+          photoUrl
+            ? `<div style="margin: 16px 0;"><a href="${escapeHtml(photoUrl)}"><img src="${escapeHtml(photoUrl)}" alt="Photo from homeowner" style="max-width: 100%; border-radius: 6px; border: 1px solid #ddd;"/></a></div>`
+            : ''
+        }
+        <div style="margin-top: 24px;">
+          <a href="${escapeHtml(dashboardLink)}" style="display: inline-block; padding: 10px 18px; background: #111; color: #fff; text-decoration: none; border-radius: 6px;">Open in dashboard</a>
+        </div>
+      </div>
+      <div style="padding: 12px 16px; background: #f5f5f5; text-align: center; color: #777; font-size: 12px;">
+        OpenHouse AI aftercare notifications
+      </div>
+    </div>
+  `.trim();
+
+  try {
+    const { client, fromEmail } = await getResendClient();
+    const result = await client.emails.send({
+      from: fromEmail,
+      to: aftercareEmail,
+      subject,
+      html,
+      text,
+    } as Parameters<typeof client.emails.send>[0]);
+    console.info(
+      '[homeowner-issue-notify] dispatched tenant=%s issue=%s to=%s id=%s',
+      tenantId,
+      issueReportId,
+      aftercareEmail,
+      (result as { id?: string })?.id ?? null,
+    );
+  } catch (err) {
+    console.error(
+      '[homeowner-issue-notify] dispatch_failed tenant=%s issue=%s reason=%s',
+      tenantId,
+      issueReportId,
+      err instanceof Error ? err.message : String(err),
+    );
+    return NextResponse.json({ error: 'Could not send notification' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    issue_report_id: issueReportId,
+    delivered_to: aftercareEmail,
+  });
+}

--- a/apps/unified-portal/app/api/settings/notifications/route.ts
+++ b/apps/unified-portal/app/api/settings/notifications/route.ts
@@ -1,0 +1,159 @@
+/**
+ * GET and POST /api/settings/notifications
+ *
+ * Assistant V2 Sprint 3.5a. Tenant-level notification preferences.
+ * Currently surfaces a single field: the aftercare email address that
+ * receives notifications when a new homeowner-raised issue arrives.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.7.
+ *
+ * GET:
+ *   - admin or site_team may read the tenant_settings row.
+ *   - If no row exists yet, returns { tenant_id, aftercare_email: null }
+ *     so the settings page can render the empty state.
+ *
+ * POST:
+ *   - admin only. site_team can read but not modify.
+ *   - Accepts { aftercare_email: string | null }.
+ *   - When non-null, validated as a basic email shape.
+ *   - Upserts the tenant_settings row keyed by tenant_id.
+ *
+ * tenant_settings has RLS with a service_role_bypass policy, so this
+ * route uses the service-role client. tenant_id is always derived from
+ * the verified site_team_members membership, never trusted from the
+ * client.
+ *
+ * Gated on FEATURE_HOMEOWNER_ISSUES. With the flag off the route is
+ * 404 before any auth or DB work, matching the rest of the Sprint 3.5a
+ * surface area.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LEN = 320;
+
+interface PostBody {
+  aftercare_email?: unknown;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data: row, error } = await supabase
+    .from('tenant_settings')
+    .select('tenant_id, aftercare_email, updated_at, updated_by')
+    .eq('tenant_id', auth.tenantId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[settings-notifications] read_failed reason=%s', error.message);
+    return NextResponse.json({ error: 'Could not load settings' }, { status: 500 });
+  }
+
+  if (!row) {
+    return NextResponse.json({
+      tenant_id: auth.tenantId,
+      aftercare_email: null,
+      updated_at: null,
+      updated_by: null,
+    });
+  }
+
+  return NextResponse.json(row);
+}
+
+export async function POST(request: NextRequest) {
+  if (!isHomeownerIssuesEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let payload: PostBody;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  let aftercareEmail: string | null = null;
+  if (payload.aftercare_email === null) {
+    aftercareEmail = null;
+  } else if (typeof payload.aftercare_email === 'string') {
+    const trimmed = payload.aftercare_email.trim();
+    if (trimmed.length === 0) {
+      aftercareEmail = null;
+    } else {
+      if (trimmed.length > MAX_EMAIL_LEN) {
+        return NextResponse.json({ error: 'aftercare_email is too long' }, { status: 400 });
+      }
+      if (!EMAIL_RE.test(trimmed)) {
+        return NextResponse.json({ error: 'aftercare_email is not a valid email' }, { status: 400 });
+      }
+      aftercareEmail = trimmed;
+    }
+  } else {
+    return NextResponse.json(
+      { error: 'aftercare_email must be a string or null' },
+      { status: 400 },
+    );
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+  if (auth.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const nowIso = new Date().toISOString();
+  const { data: row, error } = await supabase
+    .from('tenant_settings')
+    .upsert(
+      {
+        tenant_id: auth.tenantId,
+        aftercare_email: aftercareEmail,
+        updated_at: nowIso,
+        updated_by: auth.userId,
+      },
+      { onConflict: 'tenant_id' },
+    )
+    .select('tenant_id, aftercare_email, updated_at, updated_by')
+    .single();
+
+  if (error || !row) {
+    console.error('[settings-notifications] upsert_failed reason=%s', error?.message ?? 'no row');
+    return NextResponse.json({ error: 'Could not save settings' }, { status: 500 });
+  }
+
+  return NextResponse.json(row);
+}

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -82,6 +82,38 @@ export function isDeveloperDashboardEnabled(): boolean {
   );
 }
 
+/**
+ * Assistant V2 homeowner issues surface (Sprint 3.5a).
+ *
+ * Default off. When false:
+ *   - the /developer/homeowners Reported Issues card does not render
+ *   - the sidebar Homeowners notification badge does not render
+ *   - the homeowner list page card pending indicator does not render
+ *   - the /developer/settings/notifications page returns 404
+ *   - all new /api/homeowners/* routes added by Sprint 3.5a return 404
+ *     before any auth or DB work
+ *   - the /api/settings/notifications routes return 404 before any auth
+ *     or DB work
+ *   - the aftercare email notification on new homeowner-raised issues
+ *     does not fire
+ *
+ * The Recent Conversations card removal is a privacy fix that ships
+ * regardless of this flag.
+ *
+ * Server reads FEATURE_HOMEOWNER_ISSUES. Client reads
+ * NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES (must be set separately for the
+ * bundler to inline the value at build time).
+ */
+export function isHomeownerIssuesEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES === 'true';
+  }
+  return (
+    process.env.FEATURE_HOMEOWNER_ISSUES === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES === 'true'
+  );
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
@@ -90,5 +122,6 @@ export function getFeatureFlags() {
     assistantImageUpload: isAssistantImageUploadEnabled(),
     builderSnagApp: isBuilderSnagAppEnabled(),
     developerDashboard: isDeveloperDashboardEnabled(),
+    homeownerIssues: isHomeownerIssuesEnabled(),
   };
 }

--- a/docs/specs/assistant-v2-sprint-3-5a.md
+++ b/docs/specs/assistant-v2-sprint-3-5a.md
@@ -356,7 +356,7 @@ The sprint is done when all of the following pass on Vercel preview:
 1. Sprints 1, 2, 3, and 3.1 flows are unchanged. No regression on the homeowner chat, snagger /snag form, snagger /snag/[id] view, the issues dashboard, or the unit grouped view.
 2. The Recent Conversations card no longer renders on the homeowner detail page. This is true regardless of feature flag state.
 3. With FEATURE_HOMEOWNER_ISSUES=true, the Reported Issues card renders on the homeowner detail page below or alongside the redesigned Homeowner Activity card.
-4. A homeowner uploading a photo via the assistant chat creates an issue_reports row with status = 'homeowner_new' and source = 'homeowner_assistant'.
+4. When mediaAnalysisService returns action='create_issue_report', the multimodal route creates an issue_reports row with status = 'homeowner_new' and source = 'homeowner_assistant'. Until Sprint 1b replaces the placeholder analysis, this gate does not fire under normal homeowner uploads; testing the homeowner-side workflow requires manually inserting a test issue via Supabase.
 5. The sidebar badge next to Homeowners shows the correct count of homeowner_new items across the tenant, and refreshes within 60 seconds.
 6. The list view card shows a "N issues awaiting review" line beneath the address for any homeowner with at least one homeowner_new issue.
 7. Tapping Reply and resolve captures the reply text as an issue_notes row and moves the issue to status = 'resolved', resolution_type = 'direct_reply'.


### PR DESCRIPTION
## Summary

Implements section 5 of `docs/specs/assistant-v2-sprint-3-5a.md`. Server side only. No UI work in this PR.

## New routes

Seven new server routes:

| Route | Spec | Auth |
| --- | --- | --- |
| `GET  /api/homeowners/issues-count` | 5.2 | admin, site_team |
| `GET  /api/homeowners/[id]/issues` | 5.3 | admin, site_team |
| `POST /api/homeowners/issues/[issue_id]/resolve` | 5.4 | admin, site_team |
| `POST /api/homeowners/issues/[issue_id]/escalate` | 5.5 | admin, site_team |
| `POST /api/homeowners/issues/[issue_id]/warranty` | 5.6 | admin, site_team |
| `GET  /api/settings/notifications` | 5.7 | admin, site_team |
| `POST /api/settings/notifications` | 5.7 | admin only |

Plus one internal route:

| Route | Spec | Auth |
| --- | --- | --- |
| `POST /api/notifications/homeowner-issue` | 5.8 | internal key (timingSafeEqual against `INTERNAL_ENRICHMENT_KEY`) |

## Multimodal route change

One change to `/api/assistant/chat/multimodal`: when `mediaAnalysisService.analyse` returns `action='create_issue_report'`, the route now inserts an `issue_reports` row with `status='homeowner_new'` and `source='homeowner_assistant'`, links the analysis, records a `homeowner_issue_created` event, and fires a non-blocking `waitUntil` fetch to the new internal notifications route. The placeholder mediaAnalysisService still returns `answer_only` for every upload, so this branch is dormant until Sprint 1b replaces the placeholder with real multimodal reasoning. Spec acceptance criterion #4 was updated in the same commit to reflect that the gate is on `action='create_issue_report'` rather than every upload, per the conversation that resolved this ambiguity at the start of the session.

No other existing Sprint 1, 2, 3, or 3.1 routes were modified.

## Feature flag

`FEATURE_HOMEOWNER_ISSUES=false` added to both env example files and `isHomeownerIssuesEnabled()` exported from `lib/feature-flags.ts`. The flag follows the same server-plus-`NEXT_PUBLIC` pattern as `isBuilderSnagAppEnabled` and `isDeveloperDashboardEnabled`. With the flag off, all seven new routes return 404 before any auth or DB work, and the aftercare email hook in the multimodal route does not fire even if an issue is created.

## Email infrastructure

Existing email infrastructure was found and reused.

`lib/resend.ts` already exposes `getResendClient()` and is used by:
- `/api/onboarding/submit`
- `/api/notify/new-signup`
- `/api/agent/intelligence/send-draft`

The helper transparently falls back to a logging stub when `RESEND_API_KEY` is unset, so this route is exercisable in dev and preview without sending real mail. The new internal route reuses this helper. No new email provider was introduced.

## Internal key reuse

The new internal notifications route reuses the existing `INTERNAL_ENRICHMENT_KEY` env var (the same secret already used for `/api/snag/enrich`) rather than introducing a second internal-only secret. Header verification uses `crypto.timingSafeEqual`. The env-example docs were updated to reflect the dual purpose.

## Spec change

One small spec edit was included in the same commit: acceptance criterion #4 in `docs/specs/assistant-v2-sprint-3-5a.md` was rewritten to describe the action-gated issue creation path rather than implying every homeowner upload becomes an issue. This was discussed at the start of the session and is intentional rather than an unrelated change.

## What was NOT touched

- No other Sprint 1, 2, 3, or 3.1 routes
- No UI components (Session 3 of the spec)
- No new tables (schema is from PR #170 at 67921be8)
- No new email provider or new internal credential

## Test plan

- [ ] Confirm Vercel build is green
- [ ] With `FEATURE_HOMEOWNER_ISSUES=false`, hit each new route and verify 404 returned before auth or DB work
- [ ] With `FEATURE_HOMEOWNER_ISSUES=true`, a snagger_external session hitting any homeowner route returns 403
- [ ] Manually insert a `homeowner_new` issue and confirm `GET /api/homeowners/issues-count` returns the right number
- [ ] Manually insert a purchaser_agreement and a homeowner_new issue against the same unit; `GET /api/homeowners/[id]/issues` returns the issue with a signed thumbnail URL
- [ ] Reply-and-resolve, escalate, and warranty actions move the issue through the expected status/source transitions and emit the expected `issue_events` rows
- [ ] Settings notifications GET returns `{ tenant_id, aftercare_email: null }` for a tenant with no row, persists a value via POST, then GET returns it
- [ ] With an aftercare email set, a homeowner upload that hits the create_issue_report branch dispatches an email (or logs a stub send if RESEND_API_KEY is unset)

https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag)_