### PR TITLE
fix(assistant-v2): homeowners issues route uses unit_id to match codebase convention

### DIFF
--- a/apps/unified-portal/app/api/homeowners/[id]/issues/route.ts
+++ b/apps/unified-portal/app/api/homeowners/[id]/issues/route.ts
@@ -8,11 +8,14 @@
  *
  * Spec: docs/specs/assistant-v2-sprint-3-5a.md section 5.3.
  *
- * The [id] path parameter is a purchaser_agreement.id, NOT an
- * issue_report.id. We look up the purchaser_agreement, derive the
- * unit_id, look up the unit to confirm it belongs to the caller's
- * tenant via assertCanAccessTenant, and then query issue_reports
- * scoped to that unit and tenant.
+ * The [id] path parameter is the unit's UUID. This matches the
+ * established convention used by every other /api/homeowners/[id]/*
+ * route in the codebase (the /developer/homeowners/[id] URL surfaces
+ * the unit id, not the purchaser_agreement id). The original spec
+ * called for purchaser_agreement.id; that was inconsistent and the
+ * route was updated to follow the codebase convention. The data model
+ * supports this cleanly because issue_reports.unit_id is the natural
+ * join key.
  *
  * Result ordering: status priority first (homeowner_new, then open,
  * then reopened, then resolved), then created_at desc within each
@@ -60,8 +63,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     return snagFeatureDisabledResponse();
   }
 
-  const purchaserAgreementId = params.id;
-  if (!UUID_RE.test(purchaserAgreementId)) {
+  const unitId = params.id;
+  if (!UUID_RE.test(unitId)) {
     return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
   }
 
@@ -77,24 +80,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const supabase = getSupabaseAdmin();
-
-  const { data: agreement, error: agreementErr } = await supabase
-    .from('purchaser_agreements')
-    .select('id, unit_id, development_id')
-    .eq('id', purchaserAgreementId)
-    .maybeSingle();
-  if (agreementErr) {
-    console.error('[homeowners-issues] agreement_lookup_failed reason=%s', agreementErr.message);
-    return NextResponse.json({ error: 'Could not load homeowner' }, { status: 500 });
-  }
-  if (!agreement) {
-    return NextResponse.json({ error: 'Homeowner not found' }, { status: 404 });
-  }
-
-  const unitId = agreement.unit_id as string | null;
-  if (!unitId) {
-    return NextResponse.json({ error: 'Homeowner is not linked to a unit' }, { status: 400 });
-  }
 
   const { data: unit, error: unitErr } = await supabase
     .from('units')
@@ -279,7 +264,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   );
 
   return NextResponse.json({
-    purchaser_agreement_id: purchaserAgreementId,
     unit_id: unitId,
     issues,
   });

--- a/docs/specs/assistant-v2-sprint-3-5a.md
+++ b/docs/specs/assistant-v2-sprint-3-5a.md
@@ -115,12 +115,12 @@ Behaviour:
 3. Return { count: number }.
 Lightweight, called on every dashboard page load.
 5.3 GET /api/homeowners/[id]/issues
-Returns all issues for a given homeowner (purchaser_agreement record).
+Returns all issues for a given unit (the [id] is the unit's UUID, matching the established convention used by every other /api/homeowners/[id]/* route). The original draft of this spec said purchaser_agreement.id; that was inconsistent with the codebase and was corrected during implementation. issue_reports.unit_id is the natural join key, so no purchaser_agreement lookup is needed.
 Behaviour:
 
 1. Verify caller. Reject snagger_external with 403.
-2. Look up the purchaser_agreement by id. Verify caller can access the unit's tenant via assertCanAccessTenant.
-3. Return issues where unit_id matches the purchaser_agreement's unit_id, ordered by status priority (homeowner_new first, then open, then reopened, then resolved) and then created_at desc.
+2. Look up the unit by id (units table). Verify caller can access the unit's tenant via assertCanAccessTenant.
+3. Return issues where unit_id matches the supplied id and tenant_id matches the caller's tenant, ordered by status priority (homeowner_new first, then open, then reopened, then resolved) and then created_at desc.
 4. Each issue includes the standard list row shape, plus the AI assessment if present, and a small media preview (first photo signed URL with one-hour expiry).
 This is the data feed for the Reported Issues card on the homeowner detail page.
 5.4 POST /api/homeowners/issues/[issue_id]/resolve


### PR DESCRIPTION
## Summary

PR #171 introduced `/api/homeowners/[id]/issues` with `[id]` interpreted as a `purchaser_agreement.id`, following the literal wording of the Sprint 3.5a spec section 5.3. That was inconsistent with every other `/api/homeowners/[id]/*` route in the codebase, all of which already treat `[id]` as the unit's UUID (matching the `/developer/homeowners/[id]` URL shape).

The mismatch surfaced during Session 3 UI setup: `detail-client.tsx` fetches `/api/homeowners/{homeownerId}/details` where `homeownerId` is the unit id, so any Reported Issues card on that page would also pass the unit id. With the route expecting a `purchaser_agreement` id, the lookup would return 404.

## Fix

- Treat `[id]` as a `unit_id`. Look up the unit, derive tenant from the unit row, verify tenant access via `assertCanAccessTenant`.
- Drop the `purchaser_agreements` lookup from the route entirely. `issue_reports.unit_id` is the natural join key.
- Drop the `purchaser_agreement_id` field from the response shape.
- Update spec section 5.3 to reflect the corrected behaviour.

The data model justifies this on its own: if a unit changes hands on resale, the issue history follows the unit, not the previous owner. That is the right semantics for a property platform.

No other Sprint 3.5a server routes were touched.

## Test plan

- [ ] Confirm Vercel build is green
- [ ] With `FEATURE_HOMEOWNER_ISSUES=true`, hit `GET /api/homeowners/{unit_id}/issues` and confirm 200 with the expected shape
- [ ] Hit the route with a unit_id from a different tenant and confirm 403
- [ ] Hit the route with an invalid UUID and confirm 400
- [ ] Hit the route as `snagger_external` and confirm 403

https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag)_