### PR TITLE
feat(assistant-v2): Sprint 3.5a homeowner pages redesign with reported issues

### DIFF
--- a/apps/unified-portal/app/developer/homeowners/[id]/detail-client.tsx
+++ b/apps/unified-portal/app/developer/homeowners/[id]/detail-client.tsx
@@ -12,7 +12,6 @@ import {
   CheckCircle2,
   AlertCircle,
   Clock,
-  QrCode,
   Download,
   Copy,
   ExternalLink,
@@ -26,12 +25,11 @@ import {
   Edit3,
   Save,
   X,
-  TrendingUp,
-  TrendingDown,
-  Minus,
   Key,
   CalendarCheck
 } from 'lucide-react';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import { HomeownerIssuesCard } from '@/components/homeowners/HomeownerIssuesCard';
 
 interface HomeownerDetails {
   homeowner: {
@@ -227,22 +225,37 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
     }
   }
 
-  function getEngagementIcon(level: string) {
+  function getEngagementPill(level: string): { label: string; className: string } {
     switch (level) {
-      case 'high': return <TrendingUp className="w-4 h-4 text-green-600" />;
-      case 'medium': return <Minus className="w-4 h-4 text-amber-600" />;
-      case 'low': return <TrendingDown className="w-4 h-4 text-red-600" />;
-      default: return <Minus className="w-4 h-4 text-gray-400" />;
+      case 'high':
+        return { label: 'High', className: 'bg-emerald-100 text-emerald-700' };
+      case 'medium':
+        return { label: 'Medium', className: 'bg-gray-100 text-gray-700' };
+      case 'low':
+        return { label: 'Low', className: 'bg-gray-100 text-gray-700' };
+      default:
+        return { label: 'None', className: 'bg-gray-100 text-gray-500' };
     }
   }
 
-  function getEngagementLabel(level: string) {
-    switch (level) {
-      case 'high': return { text: 'High Engagement', color: 'text-green-600 bg-green-50' };
-      case 'medium': return { text: 'Medium Engagement', color: 'text-amber-600 bg-amber-50' };
-      case 'low': return { text: 'Low Engagement', color: 'text-red-600 bg-red-50' };
-      default: return { text: 'No Activity', color: 'text-gray-500 bg-gray-50' };
-    }
+  function formatRelativeTime(iso: string | null): string {
+    if (!iso) return 'Never';
+    const now = Date.now();
+    const then = new Date(iso).getTime();
+    const diff = Math.max(0, now - then);
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+    const week = 7 * day;
+    if (diff < minute) return 'Just now';
+    if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
+    if (diff < day) return `${Math.floor(diff / hour)}h ago`;
+    if (diff < week) return `${Math.floor(diff / day)}d ago`;
+    return new Date(iso).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
   }
 
   if (loading) {
@@ -271,39 +284,40 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
   }
 
   const { homeowner, activity, acknowledgement, noticeboard_terms } = data;
-  const engagement = getEngagementLabel(activity.engagement_level);
+  const engagement = getEngagementPill(activity.engagement_level);
+  const homeownerIssuesOn = isHomeownerIssuesEnabled();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white">
-      {/* Header */}
+      {/* Header strip (Sprint 3.5a compact treatment) */}
       <div className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <Link href="/developer/homeowners" className="text-gold-500 hover:text-gold-600 flex items-center gap-1 mb-3 text-sm">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <Link href="/developer/homeowners" className="text-gold-500 hover:text-gold-600 flex items-center gap-1 mb-2 text-sm">
             <ArrowLeft className="w-4 h-4" />
             Back to Homeowners
           </Link>
           <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <div className="p-3 bg-gradient-to-br from-gold-100 to-gold-50 rounded-xl">
-                <User className="w-8 h-8 text-gold-600" />
+            <div className="flex items-center gap-3">
+              <div className="w-11 h-11 rounded-full bg-gradient-to-br from-gold-500 to-gold-600 text-white flex items-center justify-center font-semibold text-base shadow-sm">
+                {(homeowner.name || 'U').trim().charAt(0).toUpperCase()}
               </div>
               <div>
-                <h1 className="text-2xl font-bold text-gray-900">{homeowner.name}</h1>
-                <div className="flex items-center gap-2 mt-1 text-sm text-gray-500">
-                  <Building2 className="w-4 h-4" />
+                <h1 className="text-xl font-bold text-gray-900 leading-tight">{homeowner.name}</h1>
+                <div className="flex items-center gap-1.5 mt-0.5 text-xs text-gray-500">
+                  <Building2 className="w-3.5 h-3.5" />
                   {homeowner.development?.name || 'Unknown Development'}
                 </div>
               </div>
             </div>
             <div className="flex items-center gap-2">
               {acknowledgement ? (
-                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-green-50 text-green-700 text-sm font-medium rounded-full">
-                  <CheckCircle2 className="w-4 h-4" />
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-green-50 text-green-700 text-xs font-medium rounded-full">
+                  <CheckCircle2 className="w-3.5 h-3.5" />
                   Documents Acknowledged
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-50 text-amber-700 text-sm font-medium rounded-full">
-                  <Clock className="w-4 h-4" />
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full">
+                  <Clock className="w-3.5 h-3.5" />
                   Pending Acknowledgement
                 </span>
               )}
@@ -574,104 +588,41 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
             </div>
           </div>
 
-          {/* Right Column - Activity & Acknowledgement */}
+          {/* Right Column - Reported Issues + Activity + Acknowledgement */}
           <div className="lg:col-span-2 space-y-6">
-            {/* Activity Stats */}
+            {homeownerIssuesOn && (
+              <HomeownerIssuesCard homeownerId={homeownerId} homeownerName={homeowner.name} />
+            )}
+
+            {/* Homeowner Activity (Sprint 3.5a, replaces Chat Activity & Engagement
+                and the Recent Conversations card. Aggregate stats only, no verbatim
+                chat text per the privacy fix in section 1 of the spec.) */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
               <div className="p-5 border-b border-gray-100">
                 <h2 className="font-semibold text-gray-900 flex items-center gap-2">
                   <Activity className="w-5 h-5 text-gold-500" />
-                  Chat Activity & Engagement
+                  Homeowner Activity
                 </h2>
               </div>
               <div className="p-5">
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-                  <div className="bg-gray-50 rounded-lg p-4 text-center">
-                    <p className="text-3xl font-bold text-gray-900">{activity.total_messages}</p>
-                    <p className="text-xs text-gray-500 mt-1">Total Messages</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-500 mb-1">Total messages</p>
+                    <p className="text-2xl font-bold text-gray-900">{activity.total_messages}</p>
                   </div>
-                  <div className="bg-blue-50 rounded-lg p-4 text-center">
-                    <p className="text-3xl font-bold text-blue-600">{activity.user_messages}</p>
-                    <p className="text-xs text-gray-500 mt-1">User Questions</p>
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-500 mb-1">Engagement level</p>
+                    <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${engagement.className}`}>
+                      {engagement.label}
+                    </span>
                   </div>
-                  <div className="bg-purple-50 rounded-lg p-4 text-center">
-                    <p className="text-3xl font-bold text-purple-600">{activity.assistant_messages}</p>
-                    <p className="text-xs text-gray-500 mt-1">AI Responses</p>
-                  </div>
-                  <div className={`rounded-lg p-4 text-center ${engagement.color}`}>
-                    <div className="flex items-center justify-center gap-2">
-                      {getEngagementIcon(activity.engagement_level)}
-                      <p className="text-lg font-bold">{engagement.text.split(' ')[0]}</p>
-                    </div>
-                    <p className="text-xs mt-1">Engagement Level</p>
+                  <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-500 mb-1">Last active</p>
+                    <p className="text-sm font-medium text-gray-900">{formatRelativeTime(activity.last_message)}</p>
                   </div>
                 </div>
-
-                {activity.first_message && (
-                  <div className="flex items-center gap-6 text-sm text-gray-600 border-t border-gray-100 pt-4">
-                    <div className="flex items-center gap-2">
-                      <Calendar className="w-4 h-4 text-gray-400" />
-                      <span>First message: {new Date(activity.first_message).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
-                    </div>
-                    {activity.last_message && (
-                      <div className="flex items-center gap-2">
-                        <Clock className="w-4 h-4 text-gray-400" />
-                        <span>Last active: {new Date(activity.last_message).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
-                      </div>
-                    )}
-                    {activity.is_active_this_week && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs font-medium">
-                        <span className="w-1.5 h-1.5 bg-green-500 rounded-full animate-pulse"></span>
-                        Active This Week
-                      </span>
-                    )}
-                  </div>
-                )}
               </div>
             </div>
-
-            {/* Recent Messages */}
-            {activity.recent_messages.length > 0 && (
-              <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-                <div className="p-5 border-b border-gray-100">
-                  <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                    <MessageSquare className="w-5 h-5 text-gold-500" />
-                    Recent Conversations
-                  </h2>
-                </div>
-                <div className="divide-y divide-gray-100">
-                  {activity.recent_messages.map((message) => (
-                    <div key={message.id} className="p-4 hover:bg-gray-50 transition-colors">
-                      <div className="flex items-start gap-3">
-                        <div className={`p-2 rounded-lg ${message.role === 'user' ? 'bg-blue-100' : 'bg-purple-100'}`}>
-                          {message.role === 'user' ? (
-                            <User className="w-4 h-4 text-blue-600" />
-                          ) : (
-                            <MessageSquare className="w-4 h-4 text-purple-600" />
-                          )}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
-                            <span className="text-sm font-medium text-gray-900">
-                              {message.role === 'user' ? 'Homeowner' : 'AI Assistant'}
-                            </span>
-                            <span className="text-xs text-gray-400">
-                              {new Date(message.created_at).toLocaleDateString('en-GB', { 
-                                day: 'numeric', 
-                                month: 'short',
-                                hour: '2-digit',
-                                minute: '2-digit'
-                              })}
-                            </span>
-                          </div>
-                          <p className="text-sm text-gray-600">{message.content}</p>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
 
             {/* Community Noticeboard Terms */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">

--- a/apps/unified-portal/app/developer/homeowners/list.tsx
+++ b/apps/unified-portal/app/developer/homeowners/list.tsx
@@ -604,6 +604,16 @@ export function HomeownersList({
                             {unit.address && (
                               <p className="text-xs text-grey-500 truncate">{unit.address}</p>
                             )}
+                            {/* Sprint 3.5a pending indicator. Renders only when at least one
+                                homeowner_new issue exists for this unit. */}
+                            {(unit.homeowner_new_issue_count ?? 0) > 0 && (
+                              <p className="flex items-center gap-1.5 text-xs font-medium text-amber-700">
+                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-500" aria-hidden />
+                                {unit.homeowner_new_issue_count === 1
+                                  ? '1 issue awaiting review'
+                                  : `${unit.homeowner_new_issue_count} issues awaiting review`}
+                              </p>
+                            )}
                           </div>
                         </div>
 

--- a/apps/unified-portal/app/developer/homeowners/page.tsx
+++ b/apps/unified-portal/app/developer/homeowners/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
 import { db } from '@openhouse/db/client';
 import { sql } from 'drizzle-orm';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,7 +24,7 @@ async function getAcknowledgedUnits(): Promise<Map<string, number>> {
     // Get the latest docs_version for each unit from purchaser_agreements
     const result = await db.execute(sql`
       SELECT DISTINCT ON (unit_id) unit_id, docs_version
-      FROM purchaser_agreements 
+      FROM purchaser_agreements
       WHERE unit_id IS NOT NULL
       ORDER BY unit_id, agreed_at DESC
     `);
@@ -33,6 +34,48 @@ async function getAcknowledgedUnits(): Promise<Map<string, number>> {
     }
     return map;
   } catch (error) {
+    return new Map();
+  }
+}
+
+/**
+ * Per-unit count of homeowner_new issues. Used by the list-card
+ * pending indicator (Sprint 3.5a section 6.2). Returns an empty map
+ * if FEATURE_HOMEOWNER_ISSUES is off so the indicator never renders.
+ *
+ * The query uses the partial index issue_reports_homeowner_new_idx
+ * and a single tenant_id equality filter, then group-by unit_id, so
+ * the cost stays cheap as the tenant grows.
+ */
+async function getHomeownerNewCounts(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  tenantId: string,
+): Promise<Map<string, number>> {
+  if (!isHomeownerIssuesEnabled()) {
+    return new Map();
+  }
+  try {
+    const { data, error } = await supabase
+      .from('issue_reports')
+      .select('unit_id')
+      .eq('tenant_id', tenantId)
+      .eq('status', 'homeowner_new');
+    if (error) {
+      console.error('[homeowners-page] homeowner_new_counts_failed reason=%s', error.message);
+      return new Map();
+    }
+    const counts = new Map<string, number>();
+    for (const row of data ?? []) {
+      const id = row.unit_id as string | null;
+      if (!id) continue;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  } catch (err) {
+    console.error(
+      '[homeowners-page] homeowner_new_counts_threw reason=%s',
+      err instanceof Error ? err.message : String(err),
+    );
     return new Map();
   }
 }
@@ -121,19 +164,24 @@ export default async function HomeownersPage({
     
     // Fetch acknowledged unit data from purchaser_agreements table
     const acknowledgedUnits = await getAcknowledgedUnits();
-    
+
+    // Sprint 3.5a: per-unit count of homeowner_new issues for the
+    // list-card pending indicator. Returns empty map when the flag is
+    // off so the indicator never renders.
+    const homeownerNewCounts = await getHomeownerNewCounts(supabaseAdmin, tenantId);
+
     // Enrich units with development info, acknowledgement status, and purchaser name from pipeline
     unitsData = unitsData.map((u: any) => {
       // Get purchaser name from unit_sales_pipeline if available
-      const pipelineData = Array.isArray(u.unit_sales_pipeline) 
-        ? u.unit_sales_pipeline[0] 
+      const pipelineData = Array.isArray(u.unit_sales_pipeline)
+        ? u.unit_sales_pipeline[0]
         : u.unit_sales_pipeline;
-      
+
       const pipelinePurchaserName = pipelineData?.purchaser_name || null;
-      const isSocialHousing = pipelineData?.sale_type === 'social' || 
-        (pipelinePurchaserName?.toLowerCase().includes('clúid') || 
+      const isSocialHousing = pipelineData?.sale_type === 'social' ||
+        (pipelinePurchaserName?.toLowerCase().includes('clúid') ||
          pipelinePurchaserName?.toLowerCase().includes('cluid'));
-      
+
       return {
         ...u,
         development: projectsMap.get(u.development_id) || projectsMap.get(u.project_id) || null,
@@ -146,6 +194,7 @@ export default async function HomeownersPage({
         handover_date: pipelineData?.handover_date || u.handover_date,
         // Set acknowledged status from purchaser_agreements table with actual docs_version
         important_docs_agreed_version: acknowledgedUnits.get(u.id) || u.important_docs_agreed_version || 0,
+        homeowner_new_issue_count: homeownerNewCounts.get(u.id) ?? 0,
       };
     });
     

--- a/apps/unified-portal/app/developer/layout-sidebar.tsx
+++ b/apps/unified-portal/app/developer/layout-sidebar.tsx
@@ -12,10 +12,12 @@ import {
   CalendarCheck, Building2, Wrench, Dumbbell, BookOpen as Welcome,
   Plug, Megaphone, HardDrive, LogOut, UserPlus, ClipboardList
 } from 'lucide-react';
-import { isDeveloperDashboardEnabled, isBuilderSnagAppEnabled } from '@/lib/feature-flags';
+import { isDeveloperDashboardEnabled, isBuilderSnagAppEnabled, isHomeownerIssuesEnabled } from '@/lib/feature-flags';
 import { ScopeSwitcher } from '@/components/developer/ScopeSwitcher';
 import { CommandPalette } from '@/components/ui/CommandPalette';
+import { HomeownersBadge } from '@/components/developer/HomeownersBadge';
 import { useCurrentContext } from '@/contexts/CurrentContext';
+import { useSafeAuth } from '@/contexts/AuthContext';
 
 interface SidebarMenuProps {
   children: React.ReactNode;
@@ -27,12 +29,14 @@ interface NavSection {
     label: string;
     href: string;
     icon: any;
+    rightAccessory?: 'homeowners_badge';
   }>;
 }
 
-function buildBtsNavSections(): NavSection[] {
+function buildBtsNavSections(opts: { isAdmin: boolean }): NavSection[] {
   const dashboardOn = isDeveloperDashboardEnabled();
   const snagAppOn = isBuilderSnagAppEnabled();
+  const homeownerIssuesOn = isHomeownerIssuesEnabled();
 
   const snaggingItems: NavSection['items'] = [];
   if (dashboardOn) {
@@ -40,6 +44,15 @@ function buildBtsNavSections(): NavSection[] {
   }
   if (snagAppOn) {
     snaggingItems.push({ label: 'Team', href: '/developer/snaggers', icon: UserPlus });
+  }
+
+  const homeownersItem: NavSection['items'][number] = {
+    label: 'Homeowners',
+    href: '/developer/homeowners',
+    icon: Users,
+  };
+  if (homeownerIssuesOn) {
+    homeownersItem.rightAccessory = 'homeowners_badge';
   }
 
   const sections: NavSection[] = [
@@ -57,6 +70,17 @@ function buildBtsNavSections(): NavSection[] {
     sections.push({ title: 'Snagging', items: snaggingItems });
   }
 
+  const settingsItems: NavSection['items'] = [
+    { label: 'Integrations', href: '/developer/integrations', icon: Plug },
+  ];
+  if (homeownerIssuesOn && opts.isAdmin) {
+    settingsItems.push({
+      label: 'Notifications',
+      href: '/developer/settings/notifications',
+      icon: Mail,
+    });
+  }
+
   sections.push(
     {
       title: 'Developer Tools',
@@ -70,7 +94,7 @@ function buildBtsNavSections(): NavSection[] {
     {
       title: 'Management',
       items: [
-        { label: 'Homeowners', href: '/developer/homeowners', icon: Users },
+        homeownersItem,
         { label: 'Smart Archive', href: '/developer/archive', icon: FolderArchive },
         { label: 'Data Hub', href: '/developer/data-hub', icon: HardDrive },
         { label: 'Room Dimensions', href: '/developer/room-dimensions', icon: Ruler },
@@ -94,9 +118,7 @@ function buildBtsNavSections(): NavSection[] {
     },
     {
       title: 'Settings',
-      items: [
-        { label: 'Integrations', href: '/developer/integrations', icon: Plug },
-      ],
+      items: settingsItems,
     },
   );
 
@@ -128,6 +150,8 @@ export function DeveloperLayoutWithSidebar({ children }: SidebarMenuProps) {
   const [signingOut, setSigningOut] = useState(false);
   const { developmentId, projectType: contextProjectType } = useCurrentContext();
   const [fetchedProjectType, setFetchedProjectType] = useState<string | null>(null);
+  const { userRole } = useSafeAuth();
+  const isAdmin = userRole === 'admin' || userRole === 'super_admin';
 
   useEffect(() => {
     if (!developmentId) {
@@ -160,12 +184,12 @@ export function DeveloperLayoutWithSidebar({ children }: SidebarMenuProps) {
   const effectiveProjectType = contextProjectType || fetchedProjectType || 'bts';
 
   const navSections = useMemo(() => {
-    const sections = buildBtsNavSections();
+    const sections = buildBtsNavSections({ isAdmin });
     if (developmentId && (effectiveProjectType === 'btr' || effectiveProjectType === 'mixed')) {
       sections.push(...getBtrNavSections(developmentId));
     }
     return sections;
-  }, [developmentId, effectiveProjectType]);
+  }, [developmentId, effectiveProjectType, isAdmin]);
 
   const isActive = (href: string) => {
     if (href === '/developer') {
@@ -218,6 +242,7 @@ export function DeveloperLayoutWithSidebar({ children }: SidebarMenuProps) {
                     >
                       <Icon className="w-4 h-4 flex-shrink-0" />
                       <span>{item.label}</span>
+                      {item.rightAccessory === 'homeowners_badge' && <HomeownersBadge />}
                     </Link>
                   );
                 })}
@@ -302,6 +327,7 @@ export function DeveloperLayoutWithSidebar({ children }: SidebarMenuProps) {
                       >
                         <Icon className="w-4 h-4 flex-shrink-0" />
                         <span>{item.label}</span>
+                        {item.rightAccessory === 'homeowners_badge' && <HomeownersBadge />}
                       </Link>
                     );
                   })}

--- a/apps/unified-portal/app/developer/settings/notifications/notifications-client.tsx
+++ b/apps/unified-portal/app/developer/settings/notifications/notifications-client.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+/**
+ * Sprint 3.5a notifications settings client. Single field for the
+ * aftercare email address. Save persists via POST /api/settings/notifications
+ * and shows a 2-second inline confirmation.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Mail, Loader2, CheckCircle2 } from 'lucide-react';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function NotificationsSettingsClient() {
+  const [email, setEmail] = useState('');
+  const [originalEmail, setOriginalEmail] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch('/api/settings/notifications', { cache: 'no-store' });
+        if (!res.ok) {
+          if (!cancelled) setError('Could not load settings.');
+          return;
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        const value = (data?.aftercare_email as string | null) ?? '';
+        setEmail(value);
+        setOriginalEmail(value);
+      } catch {
+        if (!cancelled) setError('Could not load settings.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (savedAt === null) return;
+    const timer = setTimeout(() => setSavedAt(null), 2000);
+    return () => clearTimeout(timer);
+  }, [savedAt]);
+
+  const trimmed = email.trim();
+  const isEmpty = trimmed.length === 0;
+  const isValid = isEmpty || EMAIL_RE.test(trimmed);
+  const dirty = trimmed !== originalEmail.trim();
+  const canSave = isValid && dirty && !saving && !loading;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/settings/notifications', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ aftercare_email: isEmpty ? null : trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'Could not save settings');
+      }
+      const data = await res.json();
+      const saved = (data?.aftercare_email as string | null) ?? '';
+      setEmail(saved);
+      setOriginalEmail(saved);
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save settings');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-full bg-gradient-to-br from-white via-grey-50 to-white">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <Link
+          href="/developer"
+          className="text-gold-500 hover:text-gold-600 flex items-center gap-1 mb-3 text-sm"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Dashboard
+        </Link>
+        <h1 className="text-3xl font-bold text-gray-900 mb-1">Notifications</h1>
+        <p className="text-gray-600 mb-8">
+          Where should new homeowner-raised issues be sent?
+        </p>
+
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <div className="p-5 border-b border-gray-100 flex items-center gap-2">
+            <Mail className="w-5 h-5 text-gold-500" />
+            <h2 className="font-semibold text-gray-900">Aftercare email</h2>
+          </div>
+          <div className="p-5 space-y-4">
+            <div>
+              <label
+                htmlFor="aftercare_email"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Aftercare email address
+              </label>
+              <input
+                id="aftercare_email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="e.g. aftercare@example.com"
+                disabled={loading || saving}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm disabled:bg-gray-50"
+              />
+              <p className="text-xs text-gray-500 mt-2">
+                When a homeowner uploads a photo or raises an issue through the assistant, we will send an email to this address with the photo, the homeowner&apos;s details, and a link to the dashboard. Leave blank to disable email notifications.
+              </p>
+              {!isValid && !isEmpty && (
+                <p className="text-xs text-red-600 mt-2">Enter a valid email address.</p>
+              )}
+              {error && <p className="text-xs text-red-600 mt-2">{error}</p>}
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave}
+                className="px-4 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition disabled:bg-gold-300 disabled:cursor-not-allowed inline-flex items-center gap-2"
+              >
+                {saving && <Loader2 className="w-4 h-4 animate-spin" />}
+                Save
+              </button>
+              {savedAt !== null && (
+                <span className="inline-flex items-center gap-1.5 text-sm text-green-700">
+                  <CheckCircle2 className="w-4 h-4" />
+                  Saved.
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/developer/settings/notifications/page.tsx
+++ b/apps/unified-portal/app/developer/settings/notifications/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * /developer/settings/notifications
+ *
+ * Sprint 3.5a tenant settings page for the aftercare email address.
+ * Gated on FEATURE_HOMEOWNER_ISSUES (returns 404 when off) and on the
+ * caller being an admin (returns 404 if not admin). The 404 path
+ * matches the spec section 6.4 wording: snagger_external and other
+ * non-admin roles should not even know this surface exists.
+ */
+
+import { notFound } from 'next/navigation';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import { resolveSnagAuth, SnagAuthError } from '@/lib/assistant/snag-auth';
+import { NotificationsSettingsClient } from './notifications-client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NotificationsSettingsPage() {
+  if (!isHomeownerIssuesEnabled()) {
+    notFound();
+  }
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      notFound();
+    }
+    throw err;
+  }
+  if (auth.role !== 'admin') {
+    notFound();
+  }
+
+  return <NotificationsSettingsClient />;
+}

--- a/apps/unified-portal/components/developer/HomeownersBadge.tsx
+++ b/apps/unified-portal/components/developer/HomeownersBadge.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * Sprint 3.5a sidebar badge. Renders next to the Homeowners nav link
+ * with a count of homeowner_new issues for the caller's tenant.
+ *
+ * Visual: small amber-500 pill with white text, 1-9 shown literally,
+ * higher counts shown as "9+". Hidden when count is zero or when
+ * FEATURE_HOMEOWNER_ISSUES is off.
+ *
+ * Polls every 60 seconds. No realtime push - the page would have
+ * already been opened by the time realtime would matter.
+ */
+
+import { useEffect, useState } from 'react';
+import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+export function HomeownersBadge() {
+  const enabled = isHomeownerIssuesEnabled();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+
+    async function fetchCount() {
+      try {
+        const res = await fetch('/api/homeowners/issues-count', { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && typeof data.count === 'number') {
+          setCount(data.count);
+        }
+      } catch {
+        // Network failure here is non-fatal. The badge stays at its
+        // last-known value until the next interval.
+      }
+    }
+
+    fetchCount();
+    const id = setInterval(fetchCount, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [enabled]);
+
+  if (!enabled || count <= 0) return null;
+
+  const display = count > 9 ? '9+' : String(count);
+
+  return (
+    <span
+      className="ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-amber-500 text-white text-[11px] font-semibold leading-none"
+      aria-label={`${count} homeowner ${count === 1 ? 'issue' : 'issues'} awaiting review`}
+    >
+      {display}
+    </span>
+  );
+}

--- a/apps/unified-portal/components/homeowners/EscalateModal.tsx
+++ b/apps/unified-portal/components/homeowners/EscalateModal.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Sprint 3.5a escalate-to-snag-list modal. Confirms the escalation
+ * and accepts an optional note. The issue moves to source =
+ * 'homeowner_escalated' and status = 'open', which makes it appear in
+ * the regular /developer/issues dashboard and unit grouped view.
+ *
+ * Calls POST /api/homeowners/issues/[issue_id]/escalate on submit.
+ */
+
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+
+const MAX_LEN = 2000;
+
+interface EscalateModalProps {
+  open: boolean;
+  onClose: () => void;
+  issueId: string;
+  onResolved: () => void;
+}
+
+export function EscalateModal({ open, onClose, issueId, onResolved }: EscalateModalProps) {
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const trimmed = note.trim();
+  const tooLong = trimmed.length > MAX_LEN;
+
+  const handleSubmit = async () => {
+    if (submitting || tooLong) return;
+    setSubmitting(true);
+    try {
+      const payload: { note?: string } = {};
+      if (trimmed) payload.note = trimmed;
+      const res = await fetch(`/api/homeowners/issues/${issueId}/escalate`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'Could not escalate issue');
+      }
+      toast.success('Escalated to snag list.');
+      setNote('');
+      onResolved();
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not escalate issue');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting) {
+      setNote('');
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 animate-in fade-in duration-150" />
+        <Dialog.Content
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[95vw] max-w-lg bg-white rounded-xl shadow-xl focus:outline-none animate-in fade-in zoom-in-95 duration-150"
+        >
+          <div className="flex items-start justify-between p-5 border-b border-gray-100">
+            <div>
+              <Dialog.Title className="text-lg font-semibold text-gray-900">
+                Escalate to snag list?
+              </Dialog.Title>
+              <Dialog.Description className="text-sm text-gray-500 mt-1">
+                This issue will move into the operational snag workflow. The homeowner will still be linked. A site team member can resolve it from there.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                aria-label="Close"
+                disabled={submitting}
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="p-5 space-y-3">
+            <label className="block text-sm font-medium text-gray-700">Note (optional)</label>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={4}
+              maxLength={MAX_LEN}
+              placeholder="Add any context for the site team..."
+              disabled={submitting}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm resize-y disabled:bg-gray-50"
+            />
+            <div className="flex justify-end text-xs text-gray-400">
+              {note.length} / {MAX_LEN}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 p-5 border-t border-gray-100 bg-gray-50 rounded-b-xl">
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || tooLong}
+              className="px-4 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition disabled:bg-gold-300 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Escalating...' : 'Escalate'}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/unified-portal/components/homeowners/HomeownerIssueRow.tsx
+++ b/apps/unified-portal/components/homeowners/HomeownerIssueRow.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+/**
+ * Sprint 3.5a single-row component inside the Reported Issues card.
+ * Tap to expand inline. Renders the thumbnail, title, room, status
+ * pill, and (when expanded) the AI assessment and the three action
+ * buttons.
+ *
+ * The expanded view does not navigate or open a drawer; it stays
+ * inline so the site team can triage one issue without losing scroll
+ * position on the rest.
+ */
+
+import { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Image as ImageIcon,
+  AlertTriangle,
+  CheckCircle2,
+  Hammer,
+  Shield,
+} from 'lucide-react';
+import { IssueLightbox } from '@/components/issues/IssueLightbox';
+import { ReplyResolveModal } from './ReplyResolveModal';
+import { EscalateModal } from './EscalateModal';
+import { WarrantyModal } from './WarrantyModal';
+import {
+  HomeownerIssue,
+  formatDate,
+  relativeTime,
+  statusPillClass,
+  statusPillLabel,
+} from './types';
+
+interface HomeownerIssueRowProps {
+  issue: HomeownerIssue;
+  homeownerName: string;
+  onRefetch: () => void;
+}
+
+export function HomeownerIssueRow({ issue, homeownerName, onRefetch }: HomeownerIssueRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [showLightbox, setShowLightbox] = useState(false);
+  const [activeModal, setActiveModal] = useState<'reply' | 'escalate' | 'warranty' | null>(null);
+
+  const isHomeownerNew = issue.status === 'homeowner_new';
+  const isResolved = issue.status === 'resolved';
+  const showActions = isHomeownerNew && expanded;
+
+  const thumb = issue.first_media?.thumbnail_url ?? issue.first_media?.signed_url ?? null;
+  const fullImage = issue.first_media?.signed_url ?? null;
+
+  const placeholderAnalysis =
+    !issue.analysis ||
+    !issue.analysis.developer_summary ||
+    issue.analysis.model_provider === 'placeholder' ||
+    /^placeholder/i.test(issue.analysis.developer_summary);
+
+  return (
+    <>
+      <div
+        className={`rounded-lg border transition-colors ${
+          isHomeownerNew
+            ? 'border-amber-200 bg-amber-50/40'
+            : isResolved
+              ? 'border-gray-200 bg-white'
+              : 'border-blue-200 bg-white'
+        }`}
+        style={isHomeownerNew ? { borderLeft: '3px solid #d97706' } : undefined}
+      >
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full text-left p-3 flex items-start gap-3 hover:bg-black/[0.02] rounded-lg transition-colors"
+          aria-expanded={expanded}
+        >
+          <div className="flex-shrink-0">
+            {thumb ? (
+              <div
+                className="w-12 h-12 rounded-md bg-gray-100 bg-cover bg-center border border-gray-200"
+                style={{ backgroundImage: `url(${thumb})` }}
+                role="img"
+                aria-label="Issue photo"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-md bg-gray-100 border border-gray-200 flex items-center justify-center">
+                <ImageIcon className="w-5 h-5 text-gray-400" />
+              </div>
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className={`text-sm font-medium truncate ${isResolved ? 'text-gray-600' : 'text-gray-900'}`}>
+                  {issue.title}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
+                  {issue.room && (
+                    <>
+                      <span className="truncate">{issue.room}</span>
+                      <span aria-hidden>&middot;</span>
+                    </>
+                  )}
+                  <span>{relativeTime(issue.created_at)}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${statusPillClass(issue.status)}`}>
+                  {statusPillLabel(issue.status, issue.resolution_type)}
+                </span>
+                {expanded ? (
+                  <ChevronUp className="w-4 h-4 text-gray-400" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-gray-400" />
+                )}
+              </div>
+            </div>
+            {isResolved && issue.resolved_at && (
+              <p className="text-xs text-gray-400 mt-0.5">
+                Resolved {formatDate(issue.resolved_at)}
+              </p>
+            )}
+          </div>
+        </button>
+
+        {expanded && (
+          <div className="px-3 pb-3 border-t border-gray-100">
+            {fullImage && (
+              <button
+                type="button"
+                onClick={() => setShowLightbox(true)}
+                className="block mt-3 w-full rounded-md overflow-hidden border border-gray-200 bg-gray-50 hover:opacity-95 transition-opacity"
+                aria-label="View full photo"
+              >
+                <img
+                  src={fullImage}
+                  alt={issue.title}
+                  className="w-full max-h-72 object-contain bg-black/5"
+                />
+              </button>
+            )}
+
+            {issue.description && (
+              <div className="mt-3 text-sm text-gray-700 whitespace-pre-wrap">
+                {issue.description}
+              </div>
+            )}
+
+            <div className="mt-3 rounded-md border border-gray-200 bg-white">
+              <div className="px-3 py-2 border-b border-gray-100 flex items-center justify-between">
+                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                  AI assessment
+                </span>
+                {placeholderAnalysis && (
+                  <span className="text-[10px] text-gray-400">Assessment pending</span>
+                )}
+              </div>
+              <div className="p-3 text-sm text-gray-700">
+                {placeholderAnalysis ? (
+                  <p className="text-gray-500">
+                    Full analysis is not enabled yet. A member of the team can review this manually.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {issue.analysis?.developer_summary && (
+                      <p>{issue.analysis.developer_summary}</p>
+                    )}
+                    {(issue.analysis?.severity_label ||
+                      issue.analysis?.likely_trade ||
+                      issue.analysis?.likely_system) && (
+                      <div className="flex flex-wrap gap-3 pt-1 text-xs text-gray-500">
+                        {issue.analysis?.severity_label && (
+                          <span className="inline-flex items-center gap-1">
+                            <AlertTriangle className="w-3 h-3" />
+                            Severity: {issue.analysis.severity_label}
+                          </span>
+                        )}
+                        {issue.analysis?.likely_trade && (
+                          <span className="inline-flex items-center gap-1">
+                            <Hammer className="w-3 h-3" />
+                            {issue.analysis.likely_trade}
+                          </span>
+                        )}
+                        {issue.analysis?.safety_risk && (
+                          <span className="inline-flex items-center gap-1 text-red-600">
+                            <Shield className="w-3 h-3" />
+                            Safety risk
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {showActions && (
+              <div className="mt-4 flex flex-wrap gap-2 justify-end">
+                <button
+                  type="button"
+                  onClick={() => setActiveModal('warranty')}
+                  className="px-3 py-2 text-sm font-medium text-gray-700 border border-gray-300 bg-white hover:bg-gray-50 rounded-lg transition"
+                >
+                  Mark for warranty
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveModal('escalate')}
+                  className="px-3 py-2 text-sm font-medium text-gold-700 border border-gold-300 bg-gold-50 hover:bg-gold-100 rounded-lg transition"
+                >
+                  Escalate to snag list
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveModal('reply')}
+                  className="px-3 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition inline-flex items-center gap-1.5"
+                >
+                  <CheckCircle2 className="w-4 h-4" />
+                  Reply and resolve
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {showLightbox && (
+        <IssueLightbox src={fullImage} alt={issue.title} onClose={() => setShowLightbox(false)} />
+      )}
+
+      <ReplyResolveModal
+        open={activeModal === 'reply'}
+        onClose={() => setActiveModal(null)}
+        issueId={issue.id}
+        homeownerName={homeownerName}
+        onResolved={onRefetch}
+      />
+      <EscalateModal
+        open={activeModal === 'escalate'}
+        onClose={() => setActiveModal(null)}
+        issueId={issue.id}
+        onResolved={onRefetch}
+      />
+      <WarrantyModal
+        open={activeModal === 'warranty'}
+        onClose={() => setActiveModal(null)}
+        issueId={issue.id}
+        onResolved={onRefetch}
+      />
+    </>
+  );
+}

--- a/apps/unified-portal/components/homeowners/HomeownerIssuesCard.tsx
+++ b/apps/unified-portal/components/homeowners/HomeownerIssuesCard.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+/**
+ * Sprint 3.5a Reported Issues card. The main attention surface on
+ * /developer/homeowners/[id] when the feature flag is on. Lists
+ * homeowner_new items first with an amber accent, then open and
+ * reopened, then resolved at the bottom in a more compact treatment.
+ *
+ * Data source: GET /api/homeowners/[id]/issues where [id] is the
+ * unit's UUID (matches the codebase convention for this route family).
+ *
+ * The site team triages from here:
+ *   - Tap a row to expand inline and see the photo and AI assessment
+ *   - Use one of the three action buttons (Reply and resolve, Escalate
+ *     to snag list, Mark for warranty) to move the item to its next
+ *     state
+ *   - Resolved items stay visible for context but become read-only
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle, FileWarning } from 'lucide-react';
+import { HomeownerIssueRow } from './HomeownerIssueRow';
+import { HomeownerIssue, HomeownerIssuesResponse, compareIssues } from './types';
+
+interface HomeownerIssuesCardProps {
+  homeownerId: string;
+  homeownerName: string;
+}
+
+export function HomeownerIssuesCard({ homeownerId, homeownerName }: HomeownerIssuesCardProps) {
+  const [issues, setIssues] = useState<HomeownerIssue[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchIssues = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/homeowners/${homeownerId}/issues`, {
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        setError('Could not load issues for this homeowner.');
+        setIssues([]);
+        return;
+      }
+      const data = (await res.json()) as HomeownerIssuesResponse;
+      const sorted = [...(data.issues ?? [])].sort(compareIssues);
+      setIssues(sorted);
+      setError(null);
+    } catch {
+      setError('Could not load issues for this homeowner.');
+      setIssues([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [homeownerId]);
+
+  useEffect(() => {
+    fetchIssues();
+  }, [fetchIssues]);
+
+  const awaitingReview =
+    issues?.filter((i) => i.status === 'homeowner_new').length ?? 0;
+  const activeIssues = issues?.filter((i) => i.status !== 'resolved') ?? [];
+  const resolvedIssues = issues?.filter((i) => i.status === 'resolved') ?? [];
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+      <div className="p-5 border-b border-gray-100 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FileWarning className="w-5 h-5 text-gold-500" />
+          <h2 className="font-semibold text-gray-900">Reported Issues</h2>
+          {awaitingReview > 0 && (
+            <span className="text-sm font-normal text-amber-700">
+              ({awaitingReview} awaiting review)
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="p-5">
+        {loading ? (
+          <div className="space-y-2" aria-busy="true">
+            {[0, 1].map((i) => (
+              <div
+                key={i}
+                className="h-16 rounded-lg bg-gray-100 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="text-center py-6 text-sm text-red-600 flex flex-col items-center gap-2">
+            <AlertCircle className="w-5 h-5" />
+            {error}
+          </div>
+        ) : (issues?.length ?? 0) === 0 ? (
+          <div className="text-center py-10 text-sm text-gray-600">
+            No issues raised by this homeowner yet.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {activeIssues.length > 0 && (
+              <div className="space-y-2">
+                {activeIssues.map((issue) => (
+                  <HomeownerIssueRow
+                    key={issue.id}
+                    issue={issue}
+                    homeownerName={homeownerName}
+                    onRefetch={fetchIssues}
+                  />
+                ))}
+              </div>
+            )}
+
+            {resolvedIssues.length > 0 && (
+              <div className="space-y-2">
+                {activeIssues.length > 0 && (
+                  <div className="pt-1">
+                    <p className="text-xs font-medium uppercase tracking-wide text-gray-400 pb-1">
+                      Resolved
+                    </p>
+                  </div>
+                )}
+                {resolvedIssues.map((issue) => (
+                  <HomeownerIssueRow
+                    key={issue.id}
+                    issue={issue}
+                    homeownerName={homeownerName}
+                    onRefetch={fetchIssues}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/components/homeowners/ReplyResolveModal.tsx
+++ b/apps/unified-portal/components/homeowners/ReplyResolveModal.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+/**
+ * Sprint 3.5a reply-and-resolve modal. The site team writes a reply
+ * which is captured as an issue_notes row and moves the issue to
+ * resolved with resolution_type='direct_reply'. The homeowner is not
+ * yet notified of the reply (Sprint 1b adds the messaging loop); the
+ * helper copy sets expectations accordingly.
+ *
+ * Calls POST /api/homeowners/issues/[issue_id]/resolve on submit.
+ */
+
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+
+const MAX_LEN = 2000;
+
+interface ReplyResolveModalProps {
+  open: boolean;
+  onClose: () => void;
+  issueId: string;
+  homeownerName: string;
+  onResolved: () => void;
+}
+
+export function ReplyResolveModal({
+  open,
+  onClose,
+  issueId,
+  homeownerName,
+  onResolved,
+}: ReplyResolveModalProps) {
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const trimmed = body.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_LEN && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/homeowners/issues/${issueId}/resolve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reply_body: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'Could not resolve issue');
+      }
+      toast.success('Reply captured. Issue resolved.');
+      setBody('');
+      onResolved();
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not resolve issue');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting) {
+      setBody('');
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 animate-in fade-in duration-150" />
+        <Dialog.Content
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[95vw] max-w-lg bg-white rounded-xl shadow-xl focus:outline-none animate-in fade-in zoom-in-95 duration-150"
+        >
+          <div className="flex items-start justify-between p-5 border-b border-gray-100">
+            <div>
+              <Dialog.Title className="text-lg font-semibold text-gray-900">
+                Reply to {homeownerName}
+              </Dialog.Title>
+              <Dialog.Description className="text-sm text-gray-500 mt-1">
+                Your reply will be captured as the resolution note. The homeowner will be notified separately.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                aria-label="Close"
+                disabled={submitting}
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="p-5 space-y-3">
+            <label className="block text-sm font-medium text-gray-700">Reply</label>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={4}
+              maxLength={MAX_LEN}
+              placeholder="Write your reply..."
+              disabled={submitting}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm resize-y disabled:bg-gray-50"
+            />
+            <div className="flex justify-end text-xs text-gray-400">
+              {body.length} / {MAX_LEN}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 p-5 border-t border-gray-100 bg-gray-50 rounded-b-xl">
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-4 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition disabled:bg-gold-300 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Sending...' : 'Send and resolve'}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/unified-portal/components/homeowners/WarrantyModal.tsx
+++ b/apps/unified-portal/components/homeowners/WarrantyModal.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * Sprint 3.5a mark-for-warranty modal. A required documentation note
+ * is captured as an issue_notes row and the issue moves to resolved
+ * with resolution_type='warranty_referral'. Unlike the escalate modal
+ * the note is required because warranty referrals need documentation.
+ *
+ * Calls POST /api/homeowners/issues/[issue_id]/warranty on submit.
+ */
+
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+
+const MAX_LEN = 2000;
+
+interface WarrantyModalProps {
+  open: boolean;
+  onClose: () => void;
+  issueId: string;
+  onResolved: () => void;
+}
+
+export function WarrantyModal({ open, onClose, issueId, onResolved }: WarrantyModalProps) {
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const trimmed = note.trim();
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_LEN && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/homeowners/issues/${issueId}/warranty`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ note: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.error ?? 'Could not mark for warranty');
+      }
+      toast.success('Marked for warranty.');
+      setNote('');
+      onResolved();
+      onClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not mark for warranty');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && !submitting) {
+      setNote('');
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 animate-in fade-in duration-150" />
+        <Dialog.Content
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[95vw] max-w-lg bg-white rounded-xl shadow-xl focus:outline-none animate-in fade-in zoom-in-95 duration-150"
+        >
+          <div className="flex items-start justify-between p-5 border-b border-gray-100">
+            <div>
+              <Dialog.Title className="text-lg font-semibold text-gray-900">
+                Mark for warranty
+              </Dialog.Title>
+              <Dialog.Description className="text-sm text-gray-500 mt-1">
+                Record a note about how this should be handled by warranty. The issue will close on the dashboard but remain searchable.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                aria-label="Close"
+                disabled={submitting}
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="p-5 space-y-3">
+            <label className="block text-sm font-medium text-gray-700">Warranty note</label>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={4}
+              maxLength={MAX_LEN}
+              placeholder="How should this be handled by warranty?"
+              disabled={submitting}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm resize-y disabled:bg-gray-50"
+            />
+            <div className="flex justify-end text-xs text-gray-400">
+              {note.length} / {MAX_LEN}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 p-5 border-t border-gray-100 bg-gray-50 rounded-b-xl">
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg transition disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-4 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition disabled:bg-gold-300 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Marking...' : 'Mark for warranty'}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/unified-portal/components/homeowners/types.ts
+++ b/apps/unified-portal/components/homeowners/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Sprint 3.5a homeowner-issue types. Shared by the Reported Issues
+ * card and the three resolution-action modals. Mirrors the response
+ * shape of GET /api/homeowners/[id]/issues.
+ */
+
+export type HomeownerIssueStatus = 'homeowner_new' | 'open' | 'reopened' | 'resolved';
+
+export type HomeownerIssueSource =
+  | 'homeowner_assistant'
+  | 'site_team_snag'
+  | 'snagger_external'
+  | 'homeowner_escalated';
+
+export type HomeownerIssueResolutionType = 'direct_reply' | 'warranty_referral' | null;
+
+export interface HomeownerIssueMedia {
+  id: string;
+  signed_url: string;
+  thumbnail_url: string;
+  mime_type: string;
+  width: number | null;
+  height: number | null;
+  expires_at: string;
+}
+
+export interface HomeownerIssueAnalysis {
+  id?: string;
+  model_provider?: string | null;
+  model_name?: string | null;
+  developer_summary?: string | null;
+  severity_label?: string | null;
+  severity_score?: number | null;
+  safety_risk?: boolean | null;
+  likely_trade?: string | null;
+  likely_system?: string | null;
+  recommended_action?: string | null;
+  created_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface HomeownerIssue {
+  id: string;
+  title: string;
+  description: string | null;
+  room: string | null;
+  source: HomeownerIssueSource;
+  status: HomeownerIssueStatus;
+  priority: string | null;
+  severity_label: string | null;
+  severity_score: number | null;
+  safety_risk: boolean | null;
+  likely_trade: string | null;
+  likely_system: string | null;
+  resolution_type: HomeownerIssueResolutionType;
+  logged_by_role: string | null;
+  created_at: string;
+  updated_at: string | null;
+  resolved_at: string | null;
+  analysis: HomeownerIssueAnalysis | null;
+  first_media: HomeownerIssueMedia | null;
+}
+
+export interface HomeownerIssuesResponse {
+  unit_id: string;
+  issues: HomeownerIssue[];
+}
+
+const STATUS_ORDER: Record<HomeownerIssueStatus, number> = {
+  homeowner_new: 0,
+  open: 1,
+  reopened: 2,
+  resolved: 3,
+};
+
+export function compareIssues(a: HomeownerIssue, b: HomeownerIssue): number {
+  const orderA = STATUS_ORDER[a.status] ?? 99;
+  const orderB = STATUS_ORDER[b.status] ?? 99;
+  if (orderA !== orderB) return orderA - orderB;
+  return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+}
+
+export function statusPillClass(status: HomeownerIssueStatus): string {
+  switch (status) {
+    case 'homeowner_new':
+      return 'bg-amber-100 text-amber-800';
+    case 'open':
+      return 'bg-blue-100 text-blue-800';
+    case 'reopened':
+      return 'bg-amber-100 text-amber-800';
+    case 'resolved':
+      return 'bg-green-100 text-green-700';
+    default:
+      return 'bg-gray-100 text-gray-700';
+  }
+}
+
+export function statusPillLabel(
+  status: HomeownerIssueStatus,
+  resolutionType: HomeownerIssueResolutionType,
+): string {
+  switch (status) {
+    case 'homeowner_new':
+      return 'Awaiting review';
+    case 'open':
+      return 'Open';
+    case 'reopened':
+      return 'Reopened';
+    case 'resolved':
+      if (resolutionType === 'direct_reply') return 'Resolved by reply';
+      if (resolutionType === 'warranty_referral') return 'Warranty referral';
+      return 'Resolved';
+    default:
+      return status;
+  }
+}
+
+export function relativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diff = Math.max(0, now - then);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+  if (diff < minute) return 'just now';
+  if (diff < hour) {
+    const m = Math.floor(diff / minute);
+    return `${m}m ago`;
+  }
+  if (diff < day) {
+    const h = Math.floor(diff / hour);
+    return `${h}h ago`;
+  }
+  if (diff < week) {
+    const d = Math.floor(diff / day);
+    return `${d}d ago`;
+  }
+  return new Date(iso).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}


### PR DESCRIPTION
## Summary

Implements section 6 of `docs/specs/assistant-v2-sprint-3-5a.md`. Four UI surfaces change and one card is removed unconditionally as a privacy fix.

## What changed

### A. Homeowner detail page redesign

Path: `/developer/homeowners/[id]`

- Compact header strip with avatar circle (initial), name, development, and Documents Acknowledged pill on the right.
- New `Reported Issues` card on the right column as the main attention surface. Fetches `GET /api/homeowners/[id]/issues` on mount.
  - `homeowner_new` items first with an amber left-edge accent and a "N awaiting review" inline count.
  - Tap a row to expand inline. The expanded view shows the photo, the AI assessment (with an "Assessment pending" treatment while the placeholder analysis is active), and the three action buttons.
- Three action buttons inside the expanded row when `status === 'homeowner_new'`:
  - **Reply and resolve** (primary): POST `/api/homeowners/issues/[id]/resolve` with `reply_body`
  - **Escalate to snag list** (secondary): POST `/api/homeowners/issues/[id]/escalate` with optional `note`
  - **Mark for warranty** (tertiary): POST `/api/homeowners/issues/[id]/warranty` with required `note`
- New `Homeowner Activity` card replaces `Chat Activity & Engagement`. Three aggregate stat blocks: Total messages, Engagement level, Last active. No conversation text, no question previews, no AI response previews.

### B. Homeowner list card pending indicator

Path: `/developer/homeowners`

- Server-side count of `homeowner_new` issues per unit, computed once per page load using the partial index `issue_reports_homeowner_new_idx` and grouped by `unit_id`. Returns an empty map when the flag is off.
- Each card now renders `N issues awaiting review` with a small amber dot beneath the address line when the count is non-zero. Hides entirely when the count is zero.

### C. Sidebar notification badge

- New `HomeownersBadge` client component (`components/developer/`) fetches `GET /api/homeowners/issues-count` on mount, polls every 60 seconds, renders as a small amber-500 pill with white text. Shows 1-9 then `9+`. Hidden when count is zero or the flag is off.
- Mounted in the desktop sidebar and the mobile menu next to the `Homeowners` link.

### D. Sidebar Settings section + new settings page

- The existing Settings section gains a `Notifications` link, shown only when `FEATURE_HOMEOWNER_ISSUES` is on AND the caller is `admin` or `super_admin` (read via `AuthContext` from the developer `layout-provider`). The existing `Integrations` link continues to render for all developer-side roles as before.
- New route `/developer/settings/notifications`. Server component gates on `FEATURE_HOMEOWNER_ISSUES` (returns 404 when off) and on `resolveSnagAuth` role being `admin` (returns 404 if not admin). The 404 paths match the spec wording so non-admin roles cannot enumerate the surface.
- Client component shows a single field for the aftercare email with validation, helper copy verbatim from spec section 6.4, and an inline `Saved.` confirmation that fades after two seconds. On save, POSTs to `/api/settings/notifications`.

### E. Privacy fix: Recent Conversations card removed

**UNCONDITIONAL. Not gated on any feature flag.** The Recent Conversations card on the homeowner detail page is gone regardless of `FEATURE_HOMEOWNER_ISSUES` state. The underlying chat data stays in the database (needed for future AI training and the Sprint 3.5b anonymised aggregation); we just stop surfacing verbatim chat text on the admin dashboard. This is the privacy fix from section 1 of the spec.

## Components added

- `components/homeowners/types.ts` (shared shape, status pill helpers, relative-time helper)
- `components/homeowners/HomeownerIssuesCard.tsx`
- `components/homeowners/HomeownerIssueRow.tsx`
- `components/homeowners/ReplyResolveModal.tsx`
- `components/homeowners/EscalateModal.tsx`
- `components/homeowners/WarrantyModal.tsx`
- `components/developer/HomeownersBadge.tsx`
- `app/developer/settings/notifications/page.tsx`
- `app/developer/settings/notifications/notifications-client.tsx`

## What was NOT touched

- No new server routes
- No new tables
- No changes to any other existing Sprint 1, 2, 3, 3.1, or 3.5a routes
- No changes to the snagger-side surface (`/snag`, `/snag/[id]`)
- No changes to the issues dashboard (`/developer/issues`)

## Test plan

- [ ] Confirm Vercel build is green
- [ ] With `FEATURE_HOMEOWNER_ISSUES=false`: the Reported Issues card, sidebar badge, list card indicator, sidebar Notifications link, and settings page do not render. The Recent Conversations card is still gone.
- [ ] With `FEATURE_HOMEOWNER_ISSUES=true` and a `homeowner_new` issue inserted manually: the sidebar badge shows the count, the list card shows `1 issue awaiting review`, the Reported Issues card lists the row with the amber accent
- [ ] Tap a `homeowner_new` row, expand inline, tap Reply and resolve, submit a reply. Confirm the issue moves to the Resolved bucket and the badge count decrements on the next refresh.
- [ ] Tap Escalate to snag list, confirm with optional note. Confirm the issue source moves to `homeowner_escalated` and status to `open`, and that the row appears in `/developer/issues` as a regular open snag.
- [ ] Tap Mark for warranty, attempt to submit with empty note, confirm the button is disabled. Submit with a note, confirm the issue moves to Resolved with `resolution_type='warranty_referral'`.
- [ ] Sign in as a developer (non-admin) role. Confirm the `Notifications` link does not appear in the Settings section and visiting `/developer/settings/notifications` returns 404.
- [ ] Sign in as `admin`. Confirm the link appears, the settings page loads, saving persists the email and shows `Saved.` for 2 seconds.

https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1HBPwBsxmTy3xjeTtQ7Ag)_