### PR TITLE
feat(assistant-v2): Sprint 3.5a.1 polish and restructure

### DIFF
--- a/apps/unified-portal/app/api/issues/list/route.ts
+++ b/apps/unified-portal/app/api/issues/list/route.ts
@@ -127,6 +127,7 @@ function buildResponseRow(
   developmentName: string | null,
   mediaCount: number,
   noteCount: number,
+  newlyEscalated: boolean,
 ) {
   return {
     id: r.id,
@@ -145,7 +146,35 @@ function buildResponseRow(
     created_at: r.created_at,
     resolved_at: r.resolved_at,
     logged_by_role: r.logged_by_role,
+    newly_escalated: newlyEscalated,
   };
+}
+
+// Sprint 3.5a.1: returns the set of issue IDs that had an
+// 'escalated_from_homeowner' event within the last 24 hours, so the
+// dashboard can surface a "From homeowner" marker on those rows.
+// Only queries issues whose source is currently 'homeowner_escalated',
+// which is the only set that can match.
+async function fetchNewlyEscalatedIds(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  rows: IssueRow[],
+): Promise<Set<string>> {
+  const candidateIds = rows
+    .filter((r) => r.source === 'homeowner_escalated')
+    .map((r) => r.id);
+  if (candidateIds.length === 0) return new Set();
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await supabase
+    .from('issue_events')
+    .select('issue_report_id')
+    .eq('event_type', 'escalated_from_homeowner')
+    .gte('created_at', cutoff)
+    .in('issue_report_id', candidateIds);
+  if (error) {
+    console.error('[issues-list] newly_escalated_lookup_failed reason=%s', error.message);
+    return new Set();
+  }
+  return new Set((data ?? []).map((r) => r.issue_report_id as string));
 }
 
 export async function GET(request: NextRequest) {
@@ -327,6 +356,7 @@ export async function GET(request: NextRequest) {
   }
 
   const { mediaCounts, noteCounts } = await fetchAuxCounts(supabase, issueIds);
+  const newlyEscalatedIds = await fetchNewlyEscalatedIds(supabase, reportRows);
 
   return NextResponse.json({
     rows: reportRows.map((r) => {
@@ -338,6 +368,7 @@ export async function GET(request: NextRequest) {
         dev?.name ?? null,
         mediaCounts.get(r.id) ?? 0,
         noteCounts.get(r.id) ?? 0,
+        newlyEscalatedIds.has(r.id),
       );
     }),
     total: count ?? reportRows.length,
@@ -579,6 +610,10 @@ async function handleGrouped(params: GroupedParams) {
   }
 
   const { mediaCounts, noteCounts } = await fetchAuxCounts(supabase, topIssueIds);
+  const allTopRows = paginated.flatMap(
+    (u) => topRowsByUnit.get(u.unit_id) ?? [],
+  );
+  const newlyEscalatedIds = await fetchNewlyEscalatedIds(supabase, allTopRows);
 
   const units = paginated.map((u) => {
     const topRows = topRowsByUnit.get(u.unit_id) ?? [];
@@ -597,6 +632,7 @@ async function handleGrouped(params: GroupedParams) {
           u.development_name,
           mediaCounts.get(r.id) ?? 0,
           noteCounts.get(r.id) ?? 0,
+          newlyEscalatedIds.has(r.id),
         ),
       ),
     };

--- a/apps/unified-portal/app/developer/homeowners/[id]/detail-client.tsx
+++ b/apps/unified-portal/app/developer/homeowners/[id]/detail-client.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation';
 import {
   ArrowLeft,
   User,
-  Home,
   Building2,
   MessageSquare,
   CheckCircle2,
@@ -17,7 +16,6 @@ import {
   ExternalLink,
   FileText,
   Activity,
-  Calendar,
   Shield,
   Globe,
   Monitor,
@@ -26,7 +24,8 @@ import {
   Save,
   X,
   Key,
-  CalendarCheck
+  CalendarCheck,
+  ChevronRight,
 } from 'lucide-react';
 import { isHomeownerIssuesEnabled } from '@/lib/feature-flags';
 import { HomeownerIssuesCard } from '@/components/homeowners/HomeownerIssuesCard';
@@ -109,6 +108,7 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
   const [deleting, setDeleting] = useState(false);
   const [copied, setCopied] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [docsOpen, setDocsOpen] = useState(false);
 
   useEffect(() => {
     fetchHomeownerDetails();
@@ -289,35 +289,37 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white">
-      {/* Header strip (Sprint 3.5a compact treatment) */}
-      <div className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <Link href="/developer/homeowners" className="text-gold-500 hover:text-gold-600 flex items-center gap-1 mb-2 text-sm">
-            <ArrowLeft className="w-4 h-4" />
+      {/* Sprint 3.5a.1 compact header strip. Back link sits above the
+          avatar row so the strip itself stays around 80px tall once the
+          page is scrolled. No bottom border; the cards below provide the
+          visual edge. */}
+      <div className="bg-white/80 backdrop-blur-sm sticky top-0 z-10">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-4 pb-3">
+          <Link href="/developer/homeowners" className="text-gold-500 hover:text-gold-600 inline-flex items-center gap-1 mb-2 text-xs">
+            <ArrowLeft className="w-3.5 h-3.5" />
             Back to Homeowners
           </Link>
           <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <div className="w-11 h-11 rounded-full bg-gradient-to-br from-gold-500 to-gold-600 text-white flex items-center justify-center font-semibold text-base shadow-sm">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-12 h-12 rounded-full bg-gradient-to-br from-gold-500 to-gold-600 text-white flex items-center justify-center font-semibold text-base shadow-sm flex-shrink-0">
                 {(homeowner.name || 'U').trim().charAt(0).toUpperCase()}
               </div>
-              <div>
-                <h1 className="text-xl font-bold text-gray-900 leading-tight">{homeowner.name}</h1>
-                <div className="flex items-center gap-1.5 mt-0.5 text-xs text-gray-500">
-                  <Building2 className="w-3.5 h-3.5" />
+              <div className="min-w-0">
+                <h1 className="text-lg font-bold text-gray-900 leading-tight truncate">{homeowner.name}</h1>
+                <p className="text-xs text-gray-500 truncate leading-tight mt-0.5">
                   {homeowner.development?.name || 'Unknown Development'}
-                </div>
+                </p>
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-shrink-0">
               {acknowledgement ? (
-                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-green-50 text-green-700 text-xs font-medium rounded-full">
-                  <CheckCircle2 className="w-3.5 h-3.5" />
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-green-50 text-green-700 text-xs font-medium rounded-full">
+                  <CheckCircle2 className="w-3 h-3" />
                   Documents Acknowledged
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full">
-                  <Clock className="w-3.5 h-3.5" />
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-amber-50 text-amber-700 text-xs font-medium rounded-full">
+                  <Clock className="w-3 h-3" />
                   Pending Acknowledgement
                 </span>
               )}
@@ -326,33 +328,36 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
         </div>
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left Column - Profile & QR */}
-          <div className="lg:col-span-1 space-y-6">
-            {/* Profile Card */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-12">
+        {/* Sprint 3.5a.1: explicit 4/8 split out of 12 so the Reported
+            Issues column on the right is the visual centre. Mobile stacks. */}
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          {/* Left column - 33% on desktop */}
+          <div className="lg:col-span-4 space-y-6">
+            {/* Profile Details - compact, no field icons. Edit becomes a
+                small inline link in the header. */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-gray-100 flex items-center justify-between">
-                <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <User className="w-5 h-5 text-gold-500" />
+              <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
+                <h2 className="text-heading-sm text-gray-900 flex items-center gap-2">
+                  <User className="w-4 h-4 text-gold-500" />
                   Profile Details
                 </h2>
                 {!isEditing ? (
                   <button
                     onClick={() => setIsEditing(true)}
-                    className="text-sm text-gold-600 hover:text-gold-700 flex items-center gap-1"
+                    className="text-xs text-gold-600 hover:text-gold-700 inline-flex items-center gap-1"
                   >
-                    <Edit3 className="w-4 h-4" />
+                    <Edit3 className="w-3.5 h-3.5" />
                     Edit
                   </button>
                 ) : (
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-3">
                     <button
                       onClick={handleSave}
                       disabled={saving}
-                      className="text-sm text-green-600 hover:text-green-700 flex items-center gap-1 disabled:opacity-50"
+                      className="text-xs text-green-600 hover:text-green-700 inline-flex items-center gap-1 disabled:opacity-50"
                     >
-                      <Save className="w-4 h-4" />
+                      <Save className="w-3.5 h-3.5" />
                       {saving ? 'Saving...' : 'Save'}
                     </button>
                     <button
@@ -365,192 +370,328 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
                           development_id: homeowner.development_id || '',
                         });
                       }}
-                      className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+                      className="text-xs text-gray-500 hover:text-gray-700 inline-flex items-center gap-1"
                     >
-                      <X className="w-4 h-4" />
+                      <X className="w-3.5 h-3.5" />
                       Cancel
                     </button>
                   </div>
                 )}
               </div>
-              <div className="p-5 space-y-4">
+              <div className="p-5">
                 {isEditing ? (
-                  <>
+                  <div className="space-y-3">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">Name</label>
                       <input
                         type="text"
                         value={editForm.name}
                         onChange={(e) => setEditForm(prev => ({ ...prev, name: e.target.value }))}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">House Type</label>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">House Type</label>
                       <input
                         type="text"
                         value={editForm.house_type}
                         onChange={(e) => setEditForm(prev => ({ ...prev, house_type: e.target.value }))}
                         placeholder="e.g., BS01, BD03"
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Address</label>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">Address</label>
                       <input
                         type="text"
                         value={editForm.address}
                         onChange={(e) => setEditForm(prev => ({ ...prev, address: e.target.value }))}
                         placeholder="Unit address"
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Development</label>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">Development</label>
                       <select
                         value={editForm.development_id}
                         onChange={(e) => setEditForm(prev => ({ ...prev, development_id: e.target.value }))}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500"
                       >
                         {developments.map(dev => (
                           <option key={dev.id} value={dev.id}>{dev.name}</option>
                         ))}
                       </select>
                     </div>
-                  </>
+                  </div>
                 ) : (
-                  <>
-                    <div className="flex items-start gap-3">
-                      <Home className="w-5 h-5 text-gray-400 mt-0.5" />
-                      <div>
-                        <p className="text-sm text-gray-500">House Type</p>
-                        <p className="font-medium text-gray-900">{homeowner.house_type || 'Not specified'}</p>
-                      </div>
+                  <dl className="space-y-3 text-sm">
+                    <div className="flex justify-between gap-3">
+                      <dt className="text-gray-500">House Type</dt>
+                      <dd className="font-medium text-gray-900 text-right">{homeowner.house_type || 'Not specified'}</dd>
                     </div>
-                    <div className="flex items-start gap-3">
-                      <Building2 className="w-5 h-5 text-gray-400 mt-0.5" />
-                      <div>
-                        <p className="text-sm text-gray-500">Address</p>
-                        <p className="font-medium text-gray-900">{homeowner.address || 'Not specified'}</p>
-                      </div>
+                    <div className="flex justify-between gap-3">
+                      <dt className="text-gray-500">Address</dt>
+                      <dd className="font-medium text-gray-900 text-right">{homeowner.address || 'Not specified'}</dd>
                     </div>
-                    <div className="flex items-start gap-3">
-                      <Calendar className="w-5 h-5 text-gray-400 mt-0.5" />
-                      <div>
-                        <p className="text-sm text-gray-500">Added</p>
-                        <p className="font-medium text-gray-900">
-                          {new Date(homeowner.created_at).toLocaleDateString('en-GB', {
-                            day: 'numeric',
-                            month: 'long',
-                            year: 'numeric'
-                          })}
-                        </p>
-                      </div>
+                    <div className="flex justify-between gap-3">
+                      <dt className="text-gray-500">Added</dt>
+                      <dd className="font-medium text-gray-900 text-right">
+                        {new Date(homeowner.created_at).toLocaleDateString('en-GB', {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric'
+                        })}
+                      </dd>
                     </div>
-                  </>
+                  </dl>
                 )}
               </div>
             </div>
 
-            {/* Access Code & Portal Card */}
+            {/* Access Code & Portal - compact treatment */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-gray-100">
-                <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <Key className="w-5 h-5 text-gold-500" />
+              <div className="px-5 py-4 border-b border-gray-100">
+                <h2 className="text-heading-sm text-gray-900 flex items-center gap-2">
+                  <Key className="w-4 h-4 text-gold-500" />
                   Access Code & Portal
                 </h2>
               </div>
-              <div className="p-5 space-y-4">
-                {/* Access Code */}
+              <div className="p-5 space-y-3">
                 {homeowner.access_code && (
-                  <div className="bg-gradient-to-r from-gold-50 to-amber-50 rounded-lg p-4 border border-gold-200">
-                    <p className="text-xs text-gold-700 font-medium mb-2">Access Code</p>
+                  <div className="bg-gold-50 rounded-lg p-3 border border-gold-200">
+                    <p className="text-xs text-gold-700 font-medium mb-1.5">Access Code</p>
                     <div className="flex items-center gap-2">
-                      <code className="text-lg font-bold bg-white px-3 py-1.5 rounded border border-gold-300 flex-1 text-center tracking-wider text-gold-800">
+                      <code className="text-sm font-semibold bg-white px-2.5 py-1 rounded border border-gold-300 flex-1 text-center tracking-wider text-gold-800">
                         {homeowner.access_code}
                       </code>
                       <button
                         onClick={() => copyToClipboard(homeowner.access_code || '')}
-                        className="p-2 hover:bg-gold-100 rounded-lg transition-colors"
+                        className="p-1.5 hover:bg-gold-100 rounded transition-colors"
                         title="Copy Access Code"
                       >
-                        {copied ? <CheckCircle2 className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4 text-gold-600" />}
+                        {copied ? <CheckCircle2 className="w-3.5 h-3.5 text-green-600" /> : <Copy className="w-3.5 h-3.5 text-gold-600" />}
                       </button>
                     </div>
                   </div>
                 )}
 
-                {/* Portal Type Status */}
-                <div className={`rounded-lg p-4 ${homeowner.is_handed_over ? 'bg-green-50 border border-green-200' : 'bg-blue-50 border border-blue-200'}`}>
-                  <div className="flex items-center gap-2 mb-2">
+                <div className={`rounded-lg p-3 ${homeowner.is_handed_over ? 'bg-green-50 border border-green-200' : 'bg-blue-50 border border-blue-200'}`}>
+                  <div className="flex items-center gap-1.5 mb-1">
                     {homeowner.is_handed_over ? (
                       <>
-                        <CheckCircle2 className="w-4 h-4 text-green-600" />
-                        <span className="text-sm font-medium text-green-700">Property Handed Over</span>
+                        <CheckCircle2 className="w-3.5 h-3.5 text-green-600" />
+                        <span className="text-xs font-medium text-green-700">Property Handed Over</span>
                       </>
                     ) : (
                       <>
-                        <Clock className="w-4 h-4 text-blue-600" />
-                        <span className="text-sm font-medium text-blue-700">Pre-Handover</span>
+                        <Clock className="w-3.5 h-3.5 text-blue-600" />
+                        <span className="text-xs font-medium text-blue-700">Pre-Handover</span>
                       </>
                     )}
                   </div>
                   <p className="text-xs text-gray-600">
-                    {homeowner.is_handed_over 
+                    {homeowner.is_handed_over
                       ? 'Access code grants Property Assistant portal access'
-                      : 'Access code grants Pre-Handover Portal access'
-                    }
+                      : 'Access code grants Pre-Handover Portal access'}
                   </p>
                   {homeowner.handover_date && (
-                    <div className="flex items-center gap-1.5 mt-2 text-xs text-gray-500">
-                      <CalendarCheck className="w-3.5 h-3.5" />
+                    <div className="flex items-center gap-1.5 mt-1.5 text-xs text-gray-500">
+                      <CalendarCheck className="w-3 h-3" />
                       Handover: {new Date(homeowner.handover_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
                     </div>
                   )}
                 </div>
 
-                {/* Portal URL */}
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <p className="text-xs text-gray-500 mb-2">Portal URL</p>
+                <div className="bg-gray-50 rounded-lg p-3">
+                  <p className="text-xs text-gray-500 mb-1.5">Portal URL</p>
                   <div className="flex items-center gap-2">
                     <code className="text-xs bg-white px-2 py-1 rounded border border-gray-200 flex-1 truncate">
                       {getQRPortalUrl()}
                     </code>
                     <button
                       onClick={() => copyToClipboard(getQRPortalUrl())}
-                      className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
+                      className="p-1.5 hover:bg-gray-200 rounded transition-colors"
                       title="Copy URL"
                     >
-                      {copied ? <CheckCircle2 className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4 text-gray-600" />}
+                      {copied ? <CheckCircle2 className="w-3.5 h-3.5 text-green-600" /> : <Copy className="w-3.5 h-3.5 text-gray-600" />}
                     </button>
                   </div>
                 </div>
                 <div className="flex gap-2">
                   <button
                     onClick={downloadQRCode}
-                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-gradient-to-r from-gold-500 to-gold-600 text-white rounded-lg hover:from-gold-600 hover:to-gold-700 transition-all text-sm font-medium"
+                    className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 bg-gold-500 text-white rounded-lg hover:bg-gold-600 transition text-xs font-medium"
                   >
-                    <Download className="w-4 h-4" />
+                    <Download className="w-3.5 h-3.5" />
                     Download QR
                   </button>
                   <a
                     href={getQRPortalUrl()}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-center gap-2 px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium text-gray-700"
+                    className="inline-flex items-center justify-center gap-1.5 px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-xs font-medium text-gray-700"
                   >
-                    <ExternalLink className="w-4 h-4" />
+                    <ExternalLink className="w-3.5 h-3.5" />
                     Open Portal
                   </a>
                 </div>
               </div>
             </div>
 
+            {/* Sprint 3.5a.1 Documents & Acceptance collapsible. Wraps the
+                two acknowledgement cards that used to live in the right
+                column. Closed by default; the header surfaces the overall
+                acknowledgement status. */}
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setDocsOpen((v) => !v)}
+                className="w-full flex items-center justify-between gap-2 px-5 py-4 hover:bg-gray-50 transition-colors"
+                aria-expanded={docsOpen}
+              >
+                <div className="flex items-center gap-2">
+                  <ChevronRight
+                    className={`w-4 h-4 text-gray-400 transition-transform duration-200 ease-out ${
+                      docsOpen ? 'rotate-90' : ''
+                    }`}
+                  />
+                  <span className="text-heading-sm text-gray-900">Documents & Acceptance</span>
+                </div>
+                {acknowledgement ? (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-50 text-green-700 text-xs font-medium rounded-full">
+                    <CheckCircle2 className="w-3 h-3" />
+                    Acknowledged
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-700 text-xs font-medium rounded-full">
+                    <Clock className="w-3 h-3" />
+                    Pending
+                  </span>
+                )}
+              </button>
+              {docsOpen && (
+                <div className="border-t border-gray-100 divide-y divide-gray-100">
+                  {/* Community Noticeboard Terms - nested, reduced chrome */}
+                  <div className="p-5">
+                    <div className="flex items-center gap-2 mb-3">
+                      <MessageSquare className="w-4 h-4 text-gold-500" />
+                      <h3 className="text-sm font-semibold text-gray-900">Community Noticeboard Terms</h3>
+                    </div>
+                    {noticeboard_terms ? (
+                      <div className="flex items-start gap-3 p-3 bg-green-50 rounded-lg border border-green-200">
+                        <CheckCircle2 className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-green-800">Guidelines Accepted</p>
+                          <p className="text-xs text-green-700">
+                            Agreed on {new Date(noticeboard_terms.accepted_at).toLocaleDateString('en-GB', {
+                              day: 'numeric',
+                              month: 'long',
+                              year: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit'
+                            })}
+                          </p>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
+                        <Clock className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5" />
+                        <div>
+                          <p className="text-sm font-medium text-gray-700">Not Yet Accepted</p>
+                          <p className="text-xs text-gray-500">
+                            They will be prompted to accept the community noticeboard guidelines before their first post.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Must-Read Document Acknowledgement - nested, reduced chrome */}
+                  <div className="p-5">
+                    <div className="flex items-center gap-2 mb-3">
+                      <Shield className="w-4 h-4 text-gold-500" />
+                      <h3 className="text-sm font-semibold text-gray-900">Must-Read Document Acknowledgement</h3>
+                    </div>
+                    {acknowledgement ? (
+                      <div className="space-y-3">
+                        <div className="flex items-start gap-3 p-3 bg-green-50 rounded-lg border border-green-200">
+                          <CheckCircle2 className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-green-800">Documents Acknowledged</p>
+                            <p className="text-xs text-green-700">
+                              Agreed on {new Date(acknowledgement.agreed_at).toLocaleDateString('en-GB', {
+                                day: 'numeric',
+                                month: 'long',
+                                year: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit'
+                              })}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="space-y-2">
+                          <div className="flex items-start gap-2 text-xs">
+                            <User className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 mt-0.5" />
+                            <div className="min-w-0">
+                              <span className="text-gray-500">Acknowledged by </span>
+                              <span className="text-gray-900 font-medium">{acknowledgement.purchaser_name || 'Unknown'}</span>
+                            </div>
+                          </div>
+                          <div className="flex items-start gap-2 text-xs">
+                            <Globe className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 mt-0.5" />
+                            <div className="min-w-0">
+                              <span className="text-gray-500">IP </span>
+                              <span className="text-gray-900 font-mono">{acknowledgement.ip_address || 'Not recorded'}</span>
+                            </div>
+                          </div>
+                          {acknowledgement.user_agent && (
+                            <div className="flex items-start gap-2 text-xs">
+                              <Monitor className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 mt-0.5" />
+                              <div className="min-w-0 flex-1">
+                                <p className="text-gray-500">Device</p>
+                                <p className="text-gray-700 truncate">{acknowledgement.user_agent}</p>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+
+                        {acknowledgement.documents_acknowledged.length > 0 && (
+                          <div>
+                            <p className="text-xs font-medium text-gray-700 mb-2">Documents ({acknowledgement.documents_acknowledged.length})</p>
+                            <ul className="space-y-1">
+                              {acknowledgement.documents_acknowledged.map((doc, index) => (
+                                <li key={doc.id || index} className="flex items-center gap-2 px-2.5 py-1.5 bg-gray-50 rounded text-xs">
+                                  <FileText className="w-3.5 h-3.5 text-gold-500 flex-shrink-0" />
+                                  <span className="text-gray-700 truncate">{doc.title}</span>
+                                  <CheckCircle2 className="w-3.5 h-3.5 text-green-500 flex-shrink-0 ml-auto" />
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="flex items-start gap-3 p-3 bg-amber-50 rounded-lg border border-amber-200">
+                        <AlertCircle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">No Acknowledgement Recorded</p>
+                          <p className="text-xs text-gray-600">
+                            This homeowner has not yet acknowledged the must-read documents. They will be prompted on first access.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
             {/* Danger Zone */}
             <div className="bg-white rounded-xl border border-red-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-red-100 bg-red-50">
-                <h2 className="font-semibold text-red-700 flex items-center gap-2">
-                  <Trash2 className="w-5 h-5" />
+              <div className="px-5 py-4 border-b border-red-100 bg-red-50">
+                <h2 className="text-sm font-semibold text-red-700 flex items-center gap-2">
+                  <Trash2 className="w-4 h-4" />
                   Danger Zone
                 </h2>
               </div>
@@ -558,7 +699,7 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
                 {!showDeleteConfirm ? (
                   <button
                     onClick={() => setShowDeleteConfirm(true)}
-                    className="w-full px-4 py-2.5 border border-red-300 text-red-600 rounded-lg hover:bg-red-50 transition-colors text-sm font-medium"
+                    className="w-full px-3 py-2 border border-red-300 text-red-600 rounded-lg hover:bg-red-50 transition-colors text-sm font-medium"
                   >
                     Delete Homeowner
                   </button>
@@ -571,13 +712,13 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
                       <button
                         onClick={handleDelete}
                         disabled={deleting}
-                        className="flex-1 px-4 py-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm font-medium disabled:opacity-50"
+                        className="flex-1 px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm font-medium disabled:opacity-50"
                       >
                         {deleting ? 'Deleting...' : 'Confirm Delete'}
                       </button>
                       <button
                         onClick={() => setShowDeleteConfirm(false)}
-                        className="flex-1 px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
+                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium"
                       >
                         Cancel
                       </button>
@@ -588,162 +729,55 @@ export function HomeownerDetailClient({ homeownerId }: { homeownerId: string }) 
             </div>
           </div>
 
-          {/* Right Column - Reported Issues + Activity + Acknowledgement */}
-          <div className="lg:col-span-2 space-y-6">
+          {/* Right column - 67% on desktop, anchored by the Reported Issues card. */}
+          <div className="lg:col-span-8 space-y-6">
             {homeownerIssuesOn && (
               <HomeownerIssuesCard homeownerId={homeownerId} homeownerName={homeowner.name} />
             )}
 
-            {/* Homeowner Activity (Sprint 3.5a, replaces Chat Activity & Engagement
-                and the Recent Conversations card. Aggregate stats only, no verbatim
-                chat text per the privacy fix in section 1 of the spec.) */}
+            {/* Homeowner Activity - Sprint 3.5a.1 icon-led stat blocks. */}
             <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-gray-100">
-                <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <Activity className="w-5 h-5 text-gold-500" />
+              <div className="px-5 py-4 border-b border-gray-100">
+                <h2 className="text-heading-sm text-gray-900 flex items-center gap-2">
+                  <Activity className="w-4 h-4 text-gold-500" />
                   Homeowner Activity
                 </h2>
               </div>
               <div className="p-5">
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-xs text-gray-500 mb-1">Total messages</p>
-                    <p className="text-2xl font-bold text-gray-900">{activity.total_messages}</p>
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-gold-50 flex items-center justify-center flex-shrink-0">
+                      <MessageSquare className="w-4 h-4 text-gold-700" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-2xl font-semibold text-gray-900 leading-tight">{activity.total_messages}</p>
+                      <p className="text-[13px] text-gray-600">Total messages</p>
+                    </div>
                   </div>
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-xs text-gray-500 mb-1">Engagement level</p>
-                    <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${engagement.className}`}>
-                      {engagement.label}
-                    </span>
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-gold-50 flex items-center justify-center flex-shrink-0">
+                      <Activity className="w-4 h-4 text-gold-700" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="leading-tight">
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${engagement.className}`}>
+                          {engagement.label}
+                        </span>
+                      </div>
+                      <p className="text-[13px] text-gray-600 mt-1">Engagement level</p>
+                    </div>
                   </div>
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-xs text-gray-500 mb-1">Last active</p>
-                    <p className="text-sm font-medium text-gray-900">{formatRelativeTime(activity.last_message)}</p>
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-gold-50 flex items-center justify-center flex-shrink-0">
+                      <Clock className="w-4 h-4 text-gold-700" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-base font-semibold text-gray-900 leading-tight truncate">{formatRelativeTime(activity.last_message)}</p>
+                      <p className="text-[13px] text-gray-600">Last active</p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-
-            {/* Community Noticeboard Terms */}
-            <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-gray-100">
-                <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <MessageSquare className="w-5 h-5 text-gold-500" />
-                  Community Noticeboard Terms
-                </h2>
-              </div>
-              {noticeboard_terms ? (
-                <div className="p-5">
-                  <div className="flex items-center gap-3 p-4 bg-green-50 rounded-lg border border-green-200">
-                    <CheckCircle2 className="w-6 h-6 text-green-600" />
-                    <div>
-                      <p className="font-medium text-green-800">Guidelines Accepted</p>
-                      <p className="text-sm text-green-600">
-                        Agreed on {new Date(noticeboard_terms.accepted_at).toLocaleDateString('en-GB', {
-                          day: 'numeric',
-                          month: 'long',
-                          year: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div className="p-5">
-                  <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
-                    <Clock className="w-6 h-6 text-gray-400" />
-                    <div>
-                      <p className="font-medium text-gray-700">Not Yet Accepted</p>
-                      <p className="text-sm text-gray-500">
-                        This homeowner has not yet accepted the community noticeboard guidelines.
-                        They will be prompted to do so before their first post.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Acknowledgement Details */}
-            <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-              <div className="p-5 border-b border-gray-100">
-                <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                  <Shield className="w-5 h-5 text-gold-500" />
-                  Must-Read Document Acknowledgement
-                </h2>
-              </div>
-              {acknowledgement ? (
-                <div className="p-5 space-y-6">
-                  <div className="flex items-center gap-3 p-4 bg-green-50 rounded-lg border border-green-200">
-                    <CheckCircle2 className="w-6 h-6 text-green-600" />
-                    <div>
-                      <p className="font-medium text-green-800">Documents Acknowledged</p>
-                      <p className="text-sm text-green-600">
-                        Agreed on {new Date(acknowledgement.agreed_at).toLocaleDateString('en-GB', {
-                          day: 'numeric',
-                          month: 'long',
-                          year: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Audit Info */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="bg-gray-50 rounded-lg p-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <User className="w-4 h-4 text-gray-400" />
-                        <span className="text-sm font-medium text-gray-700">Acknowledged By</span>
-                      </div>
-                      <p className="text-gray-900">{acknowledgement.purchaser_name || 'Unknown'}</p>
-                    </div>
-                    <div className="bg-gray-50 rounded-lg p-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <Globe className="w-4 h-4 text-gray-400" />
-                        <span className="text-sm font-medium text-gray-700">IP Address</span>
-                      </div>
-                      <p className="text-gray-900 font-mono text-sm">{acknowledgement.ip_address || 'Not recorded'}</p>
-                    </div>
-                    {acknowledgement.user_agent && (
-                      <div className="bg-gray-50 rounded-lg p-4 md:col-span-2">
-                        <div className="flex items-center gap-2 mb-2">
-                          <Monitor className="w-4 h-4 text-gray-400" />
-                          <span className="text-sm font-medium text-gray-700">Device</span>
-                        </div>
-                        <p className="text-gray-600 text-sm truncate">{acknowledgement.user_agent}</p>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Documents List */}
-                  {acknowledgement.documents_acknowledged.length > 0 && (
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-700 mb-3">Documents Acknowledged ({acknowledgement.documents_acknowledged.length})</h3>
-                      <div className="space-y-2">
-                        {acknowledgement.documents_acknowledged.map((doc, index) => (
-                          <div key={doc.id || index} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
-                            <FileText className="w-4 h-4 text-gold-500" />
-                            <span className="text-sm text-gray-700">{doc.title}</span>
-                            <CheckCircle2 className="w-4 h-4 text-green-500 ml-auto" />
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className="p-8 text-center">
-                  <AlertCircle className="w-12 h-12 text-amber-400 mx-auto mb-4" />
-                  <h3 className="font-medium text-gray-900 mb-2">No Acknowledgement Recorded</h3>
-                  <p className="text-sm text-gray-500 max-w-md mx-auto">
-                    This homeowner has not yet acknowledged the must-read documents. They will be prompted to do so when they access their portal.
-                  </p>
-                </div>
-              )}
             </div>
           </div>
         </div>

--- a/apps/unified-portal/components/homeowners/EscalateModal.tsx
+++ b/apps/unified-portal/components/homeowners/EscalateModal.tsx
@@ -10,8 +10,9 @@
  */
 
 import { useState } from 'react';
+import Link from 'next/link';
 import * as Dialog from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
+import { ArrowRight, CheckCircle2, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 
 const MAX_LEN = 2000;
@@ -44,7 +45,39 @@ export function EscalateModal({ open, onClose, issueId, onResolved }: EscalateMo
         const data = await res.json().catch(() => ({}));
         throw new Error(data?.error ?? 'Could not escalate issue');
       }
-      toast.success('Escalated to snag list.');
+      toast.custom(
+        (t) => (
+          <div
+            className={`bg-white rounded-xl border border-gray-200 shadow-lg p-4 flex items-start gap-3 min-w-[320px] max-w-[440px] ${
+              t.visible ? 'animate-in slide-in-from-right-full fade-in' : 'animate-out fade-out'
+            }`}
+          >
+            <CheckCircle2 className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900">
+                Escalated to snag list. Now visible in Issues dashboard.
+              </p>
+              <Link
+                href={`/developer/issues?issue=${issueId}`}
+                onClick={() => toast.dismiss(t.id)}
+                className="inline-flex items-center gap-1 text-xs font-medium text-gold-700 hover:text-gold-800 mt-2"
+              >
+                View in Issues dashboard
+                <ArrowRight className="w-3 h-3" />
+              </Link>
+            </div>
+            <button
+              type="button"
+              onClick={() => toast.dismiss(t.id)}
+              className="p-1 rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
+              aria-label="Dismiss"
+            >
+              <X className="w-4 h-4 text-gray-400" />
+            </button>
+          </div>
+        ),
+        { duration: 8000 },
+      );
       setNote('');
       onResolved();
       onClose();

--- a/apps/unified-portal/components/homeowners/HomeownerIssueRow.tsx
+++ b/apps/unified-portal/components/homeowners/HomeownerIssueRow.tsx
@@ -60,19 +60,26 @@ export function HomeownerIssueRow({ issue, homeownerName, onRefetch }: Homeowner
   return (
     <>
       <div
-        className={`rounded-lg border transition-colors ${
+        className={`relative rounded-lg border overflow-hidden transition-colors ${
           isHomeownerNew
             ? 'border-amber-200 bg-amber-50/40'
             : isResolved
               ? 'border-gray-200 bg-white'
               : 'border-blue-200 bg-white'
         }`}
-        style={isHomeownerNew ? { borderLeft: '3px solid #d97706' } : undefined}
       >
+        {isHomeownerNew && (
+          <span
+            aria-hidden
+            className="absolute left-0 top-0 bottom-0 w-1 bg-amber-500 rounded-l-lg"
+          />
+        )}
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}
-          className="w-full text-left p-3 flex items-start gap-3 hover:bg-black/[0.02] rounded-lg transition-colors"
+          className={`w-full text-left flex items-start gap-3 hover:bg-black/[0.02] transition-colors ${
+            isHomeownerNew ? 'pl-4 pr-3 py-5' : 'p-3 py-5'
+          }`}
           aria-expanded={expanded}
         >
           <div className="flex-shrink-0">
@@ -84,7 +91,7 @@ export function HomeownerIssueRow({ issue, homeownerName, onRefetch }: Homeowner
                 aria-label="Issue photo"
               />
             ) : (
-              <div className="w-12 h-12 rounded-md bg-gray-100 border border-gray-200 flex items-center justify-center">
+              <div className="w-12 h-12 rounded-md bg-neutral-100 border border-gray-200 flex items-center justify-center">
                 <ImageIcon className="w-5 h-5 text-gray-400" />
               </div>
             )}
@@ -93,10 +100,10 @@ export function HomeownerIssueRow({ issue, homeownerName, onRefetch }: Homeowner
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
-                <p className={`text-sm font-medium truncate ${isResolved ? 'text-gray-600' : 'text-gray-900'}`}>
+                <p className={`text-sm font-semibold truncate ${isResolved ? 'text-gray-600' : 'text-gray-900'}`}>
                   {issue.title}
                 </p>
-                <div className="flex items-center gap-2 mt-0.5 text-xs text-gray-500">
+                <div className="flex items-center gap-2 mt-0.5 text-xs text-neutral-500">
                   {issue.room && (
                     <>
                       <span className="truncate">{issue.room}</span>
@@ -126,96 +133,106 @@ export function HomeownerIssueRow({ issue, homeownerName, onRefetch }: Homeowner
         </button>
 
         {expanded && (
-          <div className="px-3 pb-3 border-t border-gray-100">
-            {fullImage && (
-              <button
-                type="button"
-                onClick={() => setShowLightbox(true)}
-                className="block mt-3 w-full rounded-md overflow-hidden border border-gray-200 bg-gray-50 hover:opacity-95 transition-opacity"
-                aria-label="View full photo"
-              >
-                <img
-                  src={fullImage}
-                  alt={issue.title}
-                  className="w-full max-h-72 object-contain bg-black/5"
-                />
-              </button>
-            )}
-
-            {issue.description && (
-              <div className="mt-3 text-sm text-gray-700 whitespace-pre-wrap">
-                {issue.description}
-              </div>
-            )}
-
-            <div className="mt-3 rounded-md border border-gray-200 bg-white">
-              <div className="px-3 py-2 border-b border-gray-100 flex items-center justify-between">
-                <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
-                  AI assessment
-                </span>
-                {placeholderAnalysis && (
-                  <span className="text-[10px] text-gray-400">Assessment pending</span>
+          <div
+            className={`border-t border-gray-100 divide-y divide-gray-100 ${
+              isHomeownerNew ? 'pl-4 pr-3' : 'px-3'
+            }`}
+          >
+            {(fullImage || issue.description) && (
+              <div className="py-4 space-y-3">
+                {fullImage && (
+                  <button
+                    type="button"
+                    onClick={() => setShowLightbox(true)}
+                    className="block w-full rounded-md overflow-hidden border border-gray-200 bg-gray-50 hover:opacity-95 transition-opacity"
+                    aria-label="View full photo"
+                  >
+                    <img
+                      src={fullImage}
+                      alt={issue.title}
+                      className="w-full max-h-72 object-contain bg-black/5"
+                    />
+                  </button>
                 )}
-              </div>
-              <div className="p-3 text-sm text-gray-700">
-                {placeholderAnalysis ? (
-                  <p className="text-gray-500">
-                    Full analysis is not enabled yet. A member of the team can review this manually.
-                  </p>
-                ) : (
-                  <div className="space-y-2">
-                    {issue.analysis?.developer_summary && (
-                      <p>{issue.analysis.developer_summary}</p>
-                    )}
-                    {(issue.analysis?.severity_label ||
-                      issue.analysis?.likely_trade ||
-                      issue.analysis?.likely_system) && (
-                      <div className="flex flex-wrap gap-3 pt-1 text-xs text-gray-500">
-                        {issue.analysis?.severity_label && (
-                          <span className="inline-flex items-center gap-1">
-                            <AlertTriangle className="w-3 h-3" />
-                            Severity: {issue.analysis.severity_label}
-                          </span>
-                        )}
-                        {issue.analysis?.likely_trade && (
-                          <span className="inline-flex items-center gap-1">
-                            <Hammer className="w-3 h-3" />
-                            {issue.analysis.likely_trade}
-                          </span>
-                        )}
-                        {issue.analysis?.safety_risk && (
-                          <span className="inline-flex items-center gap-1 text-red-600">
-                            <Shield className="w-3 h-3" />
-                            Safety risk
-                          </span>
-                        )}
-                      </div>
-                    )}
+
+                {issue.description && (
+                  <div className="text-sm text-gray-700 whitespace-pre-wrap">
+                    {issue.description}
                   </div>
                 )}
+              </div>
+            )}
+
+            <div className="py-4">
+              <div className="rounded-md border border-gray-200 bg-white">
+                <div className="px-3 py-2 border-b border-gray-100 flex items-center justify-between">
+                  <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                    AI assessment
+                  </span>
+                  {placeholderAnalysis && (
+                    <span className="text-[10px] text-gray-400">Assessment pending</span>
+                  )}
+                </div>
+                <div className="p-3 text-sm text-gray-700">
+                  {placeholderAnalysis ? (
+                    <p className="text-gray-500">
+                      Full analysis is not enabled yet. A member of the team can review this manually.
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {issue.analysis?.developer_summary && (
+                        <p>{issue.analysis.developer_summary}</p>
+                      )}
+                      {(issue.analysis?.severity_label ||
+                        issue.analysis?.likely_trade ||
+                        issue.analysis?.likely_system) && (
+                        <div className="flex flex-wrap gap-3 pt-1 text-xs text-gray-500">
+                          {issue.analysis?.severity_label && (
+                            <span className="inline-flex items-center gap-1">
+                              <AlertTriangle className="w-3 h-3" />
+                              Severity: {issue.analysis.severity_label}
+                            </span>
+                          )}
+                          {issue.analysis?.likely_trade && (
+                            <span className="inline-flex items-center gap-1">
+                              <Hammer className="w-3 h-3" />
+                              {issue.analysis.likely_trade}
+                            </span>
+                          )}
+                          {issue.analysis?.safety_risk && (
+                            <span className="inline-flex items-center gap-1 text-red-600">
+                              <Shield className="w-3 h-3" />
+                              Safety risk
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
 
             {showActions && (
-              <div className="mt-4 flex flex-wrap gap-2 justify-end">
+              <div className="py-4 flex flex-wrap gap-2 justify-end items-center">
                 <button
                   type="button"
                   onClick={() => setActiveModal('warranty')}
-                  className="px-3 py-2 text-sm font-medium text-gray-700 border border-gray-300 bg-white hover:bg-gray-50 rounded-lg transition"
+                  className="px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition"
                 >
                   Mark for warranty
                 </button>
                 <button
                   type="button"
                   onClick={() => setActiveModal('escalate')}
-                  className="px-3 py-2 text-sm font-medium text-gold-700 border border-gold-300 bg-gold-50 hover:bg-gold-100 rounded-lg transition"
+                  className="px-3 py-2 text-sm font-medium text-gold-700 border border-gold-400 bg-transparent hover:bg-gold-50 rounded-lg transition"
                 >
                   Escalate to snag list
                 </button>
                 <button
                   type="button"
                   onClick={() => setActiveModal('reply')}
-                  className="px-3 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition inline-flex items-center gap-1.5"
+                  className="px-3 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg transition inline-flex items-center gap-1.5 shadow-sm"
                 >
                   <CheckCircle2 className="w-4 h-4" />
                   Reply and resolve

--- a/apps/unified-portal/components/homeowners/HomeownerIssuesCard.tsx
+++ b/apps/unified-portal/components/homeowners/HomeownerIssuesCard.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, FileWarning } from 'lucide-react';
+import { AlertCircle, FileWarning, Inbox } from 'lucide-react';
 import { HomeownerIssueRow } from './HomeownerIssueRow';
 import { HomeownerIssue, HomeownerIssuesResponse, compareIssues } from './types';
 
@@ -64,20 +64,22 @@ export function HomeownerIssuesCard({ homeownerId, homeownerName }: HomeownerIss
   const resolvedIssues = issues?.filter((i) => i.status === 'resolved') ?? [];
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-      <div className="p-5 border-b border-gray-100 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <FileWarning className="w-5 h-5 text-gold-500" />
-          <h2 className="font-semibold text-gray-900">Reported Issues</h2>
+    <div className="bg-white rounded-xl border-[1.5px] border-gray-200 shadow-card overflow-hidden">
+      <div className="px-6 py-5 border-b border-gray-100 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <FileWarning className="w-4 h-4 text-gold-500" />
+            <h2 className="text-heading-sm text-gray-900">Reported Issues</h2>
+          </div>
           {awaitingReview > 0 && (
-            <span className="text-sm font-normal text-amber-700">
-              ({awaitingReview} awaiting review)
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+              {awaitingReview} awaiting review
             </span>
           )}
         </div>
       </div>
 
-      <div className="p-5">
+      <div className="p-6">
         {loading ? (
           <div className="space-y-2" aria-busy="true">
             {[0, 1].map((i) => (
@@ -93,8 +95,16 @@ export function HomeownerIssuesCard({ homeownerId, homeownerName }: HomeownerIss
             {error}
           </div>
         ) : (issues?.length ?? 0) === 0 ? (
-          <div className="text-center py-10 text-sm text-gray-600">
-            No issues raised by this homeowner yet.
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <div className="w-16 h-16 rounded-full bg-gold-50 flex items-center justify-center mb-4">
+              <Inbox className="w-8 h-8 text-gold-500" />
+            </div>
+            <p className="text-sm font-medium text-gray-900">
+              No issues raised by this homeowner yet.
+            </p>
+            <p className="text-xs text-gray-500 mt-1 max-w-xs">
+              Issues raised through the assistant chat or escalated by site team will appear here.
+            </p>
           </div>
         ) : (
           <div className="space-y-3">

--- a/apps/unified-portal/components/issues/IssueListRow.tsx
+++ b/apps/unified-portal/components/issues/IssueListRow.tsx
@@ -64,8 +64,14 @@ export function IssueListRow({ row, onOpen }: IssueListRowProps) {
               />
             ) : null}
           </div>
-          <div className="text-body-sm text-neutral-500 truncate mt-0.5">
-            {subtitle || 'No location'}
+          <div className="text-body-sm text-neutral-500 mt-0.5 flex items-center gap-2 min-w-0">
+            {row.newly_escalated ? (
+              <span className="inline-flex items-center gap-1 text-caption font-medium text-amber-700 flex-shrink-0">
+                <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                From homeowner
+              </span>
+            ) : null}
+            <span className="truncate">{subtitle || 'No location'}</span>
           </div>
         </div>
 

--- a/apps/unified-portal/components/issues/types.ts
+++ b/apps/unified-portal/components/issues/types.ts
@@ -29,6 +29,11 @@ export interface IssueListRow {
   created_at: string;
   resolved_at: string | null;
   logged_by_role: string | null;
+  // Sprint 3.5a.1: true when source is 'homeowner_escalated' and the
+  // most recent 'escalated_from_homeowner' event landed within 24h.
+  // Used to render a "From homeowner" marker on dashboard rows. Older
+  // server responses without this field fall through as undefined.
+  newly_escalated?: boolean;
 }
 
 export interface IssueListResponse {


### PR DESCRIPTION
Implements Sprint 3.5a.1 per `docs/specs/assistant-v2-sprint-3-5a-1.md`.

## Page restructure on /developer/homeowners/[id]

- Compact header strip (~80px) replaces the previous chunky header. No bottom border on the strip; the cards below provide the visual edge.
- Explicit 4/8 grid (33/67) using `grid-cols-12` so the Reported Issues card sits as the visual centre of the page.
- **Profile Details** slimmed: no field icons, dl-style rows, inline Edit link in the header (small lucide Edit3 icon at 14px) instead of a button.
- **Access Code & Portal** tightened: smaller access-code pill, smaller buttons, tighter sub-card padding.
- **Documents & Acceptance** (new collapsible) on the left wraps Community Noticeboard Terms and Must-Read Document Acknowledgement, collapsed by default. Chevron rotates 90 degrees with 200ms ease. Status pill in the header reflects the acknowledgement state (green Acknowledged or amber Pending).
- **Reported Issues** stays in the right column and is anchored there alongside the Homeowner Activity card.
- Danger Zone stays at the bottom of the left column.

## Polish details

- Standardised card border, padding, corner radius across the page.
- Standardised h2 treatment for card titles (text-heading-sm, 16px lucide icon).
- 24px gap between cards in each column (gap-6).
- 32px gap between header strip and the first cards row (pt-8).
- 48px bottom padding (pb-12).

### Reported Issues card

- Slightly heavier border (1.5px), `text-heading-sm` title.
- "N awaiting review" rendered as a separate amber-100 / amber-700 pill beside the title (not parentheses).
- Icon-led empty state: 32px Inbox icon in a 64px gold-50 background circle, primary + secondary lines underneath.
- Issue rows: row vertical padding bumped from ~12px to ~20px, 4px amber left edge accent on `homeowner_new` rows (full row height, rounded corners), 48px photo thumbnail with neutral-100 background and 20px Image icon when no media, semibold title.
- Expanded row: divider lines between resident message, description, AI assessment, and action buttons.

### Homeowner Activity card

- Three stat blocks each get a 32px gold-50 background circle with a 16px gold-700 icon to the left of the value: MessageSquare (Total messages), Activity (Engagement level), Clock (Last active). Values are 24px semibold, labels 13px neutral-600.

### Action button hierarchy in the expanded issue row

- **Mark for warranty**: ghost (no border, no fill, neutral-600 text, hover bg only).
- **Escalate to snag list**: outlined (gold-400 border, transparent bg, gold-700 text).
- **Reply and resolve**: filled primary (gold-500 bg, white text, subtle shadow).

## Escalation feedback (spec section 5)

### 5.1 Success toast with link

`EscalateModal` now fires `toast.custom` on successful escalation with:
- Text: "Escalated to snag list. Now visible in Issues dashboard."
- Inline link "View in Issues dashboard" pointing at `/developer/issues?issue=<issue_id>` (the issues dashboard drawer opens automatically via the existing `?issue=` param handling).
- Duration 8000ms (longer than the 3-4s default so the user has time to click the link).
- Dismiss button on the right.

### 5.2 Newly escalated marker on Issues dashboard rows

- `/api/issues/list` returns a new additive `newly_escalated: boolean` field on each row.
- **Computed server-side**. The route joins `issue_events` for `event_type = 'escalated_from_homeowner'` with a 24h cutoff. Only rows whose `source = 'homeowner_escalated'` are sent to the events query, so the extra DB hit stays small (typically empty for tenants with no recent escalations).
- Server-side keeps the dashboard from doing N+1 lookups for many rows.
- `IssueListRow` renders an amber dot followed by "From homeowner" in amber-700 (12px) on the row's secondary line when `newly_escalated` is true.
- After 24h the server stops returning the flag for that issue, so the marker disappears automatically with no client-side timer needed.
- Existing callers of the endpoint are unaffected (additive field).

## Touched files

- `apps/unified-portal/app/api/issues/list/route.ts` (extension: `fetchNewlyEscalatedIds` helper, `newly_escalated` field on each row)
- `apps/unified-portal/app/developer/homeowners/[id]/detail-client.tsx` (full restructure)
- `apps/unified-portal/components/homeowners/EscalateModal.tsx` (toast with link)
- `apps/unified-portal/components/homeowners/HomeownerIssueRow.tsx` (button hierarchy, separators, left edge, spacing)
- `apps/unified-portal/components/homeowners/HomeownerIssuesCard.tsx` (visual lift, h2 title, amber pill, icon empty state)
- `apps/unified-portal/components/issues/IssueListRow.tsx` (From homeowner marker)
- `apps/unified-portal/components/issues/types.ts` (optional `newly_escalated` field)

## Build

`npm run build:unified` passes locally. Vercel build status will be confirmed on the PR once the deploy completes.

## Preserved behaviour

- The Recent Conversations card stays removed (the Sprint 3.5a privacy fix is unconditional).
- All existing Sprint 3.5a functionality is preserved: sidebar badge polling, list-card "N issues awaiting review" indicator, the three resolution actions (Reply and resolve, Escalate, Mark for warranty), the settings page.
- All `FEATURE_HOMEOWNER_ISSUES` and `FEATURE_DEVELOPER_DASHBOARD` flag-gating is unchanged.

No schema changes, no new API routes, no new feature flags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNw2vrKnkJCRf9T8ojaYNu)_