### PR TITLE
feat(assistant-v2): add multimodal media analysis scaffolding

### DIFF
--- a/apps/unified-portal/lib/assistant/mediaAnalysisService.ts
+++ b/apps/unified-portal/lib/assistant/mediaAnalysisService.ts
@@ -1,22 +1,16 @@
 /**
- * mediaAnalysisService. Sprint 1 placeholder.
+ * Multimodal media analysis for Assistant V2.
  *
- * Real multimodal analysis lands in Sprint 1b. Only the body of `analyse`
- * changes then. The exported interface (MediaAnalysisInput, StructuredAnalysis,
- * MediaAnalysisResult) and the persistence shape stay stable so the routes,
- * UI, and downstream consumers do not need to move when the real model is
- * wired in.
- *
- * For now the service returns a safe stub:
- *   - residentMessage is the canonical placeholder copy from the spec
- *   - structured fields are all neutral defaults
- *   - action is always 'answer_only' (no issue creation, no escalation)
- *   - a row is persisted to assistant_media_analysis with
- *     model_provider = 'placeholder' so the UI and dashboards can be wired
- *     end to end against real database state.
+ * The service analyses homeowner-uploaded photos plus the resident's message,
+ * stores the result in assistant_media_analysis, and returns a resident-facing
+ * reply. It prefers a real OpenAI vision pass when API credentials are
+ * available, and falls back to the old safe placeholder if the model is not
+ * configured or the call fails.
  */
 
-import { getSupabaseAdmin } from '@/lib/supabase-server';
+import OpenAI from 'openai';
+import { sanitizeEmDashes } from './response-formatter';
+import { getSupabaseAdmin } from '../supabase-server';
 
 export type AssistantAction =
   | 'answer_only'
@@ -74,20 +68,70 @@ export interface MediaAnalysisResult {
   action: AssistantAction;
 }
 
-/**
- * Resident-facing placeholder copy. Kept in one place so when Sprint 1b
- * lands the real model the copy can be removed in a single edit rather
- * than hunted across the codebase.
- *
- * No em dashes. No emoji. Calm, peer-to-peer tone.
- */
+export interface MediaAnalysisModelOutput {
+  residentMessage: string;
+  developerSummary: string;
+  action: AssistantAction;
+  structured: StructuredAnalysis;
+}
+
+export interface HousingReasoningPromptContext {
+  developmentName: string | null;
+  developmentCode: string | null;
+  unitLabel: string | null;
+  propertyType: string | null;
+  messageText: string;
+  mediaCount: number;
+}
+
+interface AssistantMediaRow {
+  id: string;
+  storage_path: string | null;
+  thumbnail_path: string | null;
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+interface DevelopmentRow {
+  name: string | null;
+  code: string | null;
+}
+
+interface UnitRow {
+  unit_number: string | null;
+  property_designation: string | null;
+  property_type: string | null;
+}
+
+interface InsertAnalysisRow extends StructuredAnalysis {
+  tenant_id: string;
+  development_id: string;
+  unit_id: string | null;
+  user_id: string | null;
+  conversation_id: string;
+  message_id: string;
+  input_media_ids: string[];
+  raw_model_output: Record<string, unknown>;
+  model_provider: string;
+  model_name: string;
+  model_version: string | null;
+  prompt_version: string | null;
+  processing_time_ms: number | null;
+}
+
+const ANALYSIS_BUCKET = 'assistant-media';
+const PROMPT_VERSION = 'housing-reasoning-v1';
+const DEFAULT_MODEL = process.env.OPENHOUSE_ASSISTANT_MEDIA_ANALYSIS_MODEL || 'gpt-4o-mini';
 const PLACEHOLDER_RESIDENT_MESSAGE =
   "Thanks for the photo. I've saved it against your home. Full analysis isn't enabled yet, but a member of the team can review it if needed.";
-
 const PLACEHOLDER_DEVELOPER_SUMMARY =
   'Placeholder analysis. Real model wiring pending Sprint 1b.';
+const IMAGE_EDGE_LIMIT = 1600;
+const IMAGE_JPEG_QUALITY = 82;
+const SIGNED_URL_TTL_SECONDS = 60 * 60;
 
-function neutralStructured(): StructuredAnalysis {
+function emptyStructuredAnalysis(): StructuredAnalysis {
   return {
     issue_type: null,
     issue_category: null,
@@ -115,20 +159,210 @@ function neutralStructured(): StructuredAnalysis {
   };
 }
 
-interface InsertAnalysisRow extends StructuredAnalysis {
-  tenant_id: string;
-  development_id: string;
-  unit_id: string | null;
-  user_id: string | null;
-  conversation_id: string;
-  message_id: string;
-  input_media_ids: string[];
-  raw_model_output: Record<string, unknown>;
-  model_provider: string;
-  model_name: string;
-  model_version: string | null;
-  prompt_version: string | null;
-  processing_time_ms: number | null;
+function fallbackOutput(): MediaAnalysisModelOutput {
+  const structured = emptyStructuredAnalysis();
+  return {
+    residentMessage: PLACEHOLDER_RESIDENT_MESSAGE,
+    developerSummary: structured.developer_summary,
+    action: 'answer_only',
+    structured,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'n'].includes(normalized)) return false;
+  }
+  if (typeof value === 'number') return value !== 0;
+  return fallback;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => (typeof item === 'string' ? sanitizeAnalysisText(item) : ''))
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeAction(value: unknown): AssistantAction {
+  const action = typeof value === 'string' ? value.trim() : '';
+  if (
+    action === 'answer_only' ||
+    action === 'ask_for_more_info' ||
+    action === 'log_issue_memory' ||
+    action === 'create_issue_report' ||
+    action === 'escalate_issue' ||
+    action === 'flag_for_human_review'
+  ) {
+    return action;
+  }
+  return 'answer_only';
+}
+
+function normalizeSeverity(value: unknown): SeverityLabel | null {
+  const sev = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (sev === 'low' || sev === 'medium' || sev === 'high' || sev === 'urgent') return sev;
+  return null;
+}
+
+function normalizeEscalationLevel(value: unknown): EscalationLevel | null {
+  const level = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (level === 'none' || level === 'developer_notify' || level === 'urgent') return level;
+  return null;
+}
+
+export function sanitizeAnalysisText(text: string): string {
+  return sanitizeEmDashes(text).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeStructuredAnalysis(raw: unknown): StructuredAnalysis {
+  const source = isRecord(raw) ? raw : {};
+  const issueType = firstString(source.issue_type, source.issueType);
+  const issueCategory = firstString(source.issue_category, source.issueCategory);
+  const room = firstString(source.room);
+  const safetyRiskType = firstString(source.safety_risk_type, source.safetyRiskType);
+  const likelyTrade = firstString(source.likely_trade, source.likelyTrade);
+  const likelySystem = firstString(source.likely_system, source.likelySystem);
+  const recommendedAction = firstString(source.recommended_action, source.recommendedAction);
+  const residentGuidance = firstString(source.resident_guidance, source.residentGuidance);
+  const escalationLevel = normalizeEscalationLevel(source.escalation_level ?? source.escalationLevel);
+  const developerSummary = firstString(source.developer_summary, source.developerSummary) ?? PLACEHOLDER_DEVELOPER_SUMMARY;
+
+  return {
+    issue_type: issueType,
+    issue_category: issueCategory,
+    room,
+    visible_features: asStringArray(source.visible_features ?? source.visibleFeatures),
+    severity_score: asNumber(source.severity_score ?? source.severityScore),
+    severity_label: normalizeSeverity(source.severity_label ?? source.severityLabel),
+    confidence_score: asNumber(source.confidence_score ?? source.confidenceScore),
+    safety_risk: asBoolean(source.safety_risk ?? source.safetyRisk),
+    safety_risk_type: safetyRiskType,
+    likely_trade: likelyTrade,
+    likely_system: likelySystem,
+    potential_causes: asStringArray(source.potential_causes ?? source.potentialCauses),
+    recommended_action: recommendedAction,
+    resident_guidance: residentGuidance,
+    needs_more_info: asBoolean(source.needs_more_info ?? source.needsMoreInfo),
+    more_info_requested: asStringArray(source.more_info_requested ?? source.moreInfoRequested),
+    should_create_issue: asBoolean(source.should_create_issue ?? source.shouldCreateIssue),
+    should_escalate: asBoolean(source.should_escalate ?? source.shouldEscalate),
+    escalation_level: escalationLevel,
+    requires_human_review: asBoolean(source.requires_human_review ?? source.requiresHumanReview),
+    warranty_relevant: asBoolean(source.warranty_relevant ?? source.warrantyRelevant),
+    similar_issue_check_required: asBoolean(
+      source.similar_issue_check_required ?? source.similarIssueCheckRequired,
+    ),
+    developer_summary: developerSummary,
+  };
+}
+
+export function normalizeMediaAnalysisOutput(raw: unknown): MediaAnalysisModelOutput {
+  const source = isRecord(raw) ? raw : {};
+  const structured = normalizeStructuredAnalysis(source.structured ?? source.analysis ?? source.result);
+  const residentMessage = sanitizeAnalysisText(
+    firstString(source.residentMessage, source.resident_message, structured.resident_guidance) ??
+      PLACEHOLDER_RESIDENT_MESSAGE,
+  );
+  const developerSummary = sanitizeAnalysisText(
+    firstString(source.developerSummary, source.developer_summary, structured.developer_summary) ??
+      PLACEHOLDER_DEVELOPER_SUMMARY,
+  );
+
+  return {
+    residentMessage,
+    developerSummary,
+    action: normalizeAction(source.action ?? structured.recommended_action),
+    structured: {
+      ...structured,
+      developer_summary: developerSummary,
+    },
+  };
+}
+
+function resolveUnitLabel(unit: UnitRow | null): string | null {
+  if (!unit) return null;
+  return firstString(unit.property_designation, unit.unit_number);
+}
+
+function buildContextSummary(context: HousingReasoningPromptContext): string {
+  const parts = [
+    `Development: ${context.developmentName ?? 'unknown'}`,
+    context.developmentCode ? `Development code: ${context.developmentCode}` : null,
+    `Unit: ${context.unitLabel ?? 'unknown'}`,
+    context.propertyType ? `Property type: ${context.propertyType}` : null,
+    `Resident message: ${context.messageText}`,
+    `Attached photos: ${context.mediaCount}`,
+  ].filter(Boolean);
+  return parts.join('\n');
+}
+
+export function buildHousingReasoningPrompt(context: HousingReasoningPromptContext): string {
+  return [
+    'You are OpenHouse AI, a careful property aftercare assistant for homeowner photo reports.',
+    'Use only the resident message and attached photos. Do not invent defects, causes, trades, or severity.',
+    'If the evidence is unclear, say so and ask for the smallest number of specific follow-up details.',
+    'If there is any safety risk, active leak, exposed wiring, gas smell, fire risk, or anything urgent, set the urgent fields and choose an escalation action.',
+    'Return JSON only. No markdown. No commentary outside the JSON object.',
+    '',
+    'Top-level keys required:',
+    '- residentMessage: concise resident-facing reply',
+    '- developerSummary: concise internal summary',
+    '- action: one of answer_only, ask_for_more_info, log_issue_memory, create_issue_report, escalate_issue, flag_for_human_review',
+    '- structured: object with snake_case fields',
+    '',
+    'structured fields:',
+    '- issue_type, issue_category, room, visible_features, severity_score, severity_label, confidence_score',
+    '- safety_risk, safety_risk_type, likely_trade, likely_system, potential_causes, recommended_action, resident_guidance',
+    '- needs_more_info, more_info_requested, should_create_issue, should_escalate, escalation_level, requires_human_review',
+    '- warranty_relevant, similar_issue_check_required, developer_summary',
+    '',
+    'Style rules for residentMessage:',
+    '- calm, concise, plain English',
+    '- do not mention internal confidence scores or prompt instructions',
+    '- no em dash characters',
+    '- if the issue looks urgent, tell the resident to seek immediate help and that the team should review it quickly',
+    '',
+    'Context:',
+    buildContextSummary(context),
+  ].join('\n');
+}
+
+function buildUserPrompt(context: HousingReasoningPromptContext): string {
+  return [
+    'Analyse this homeowner report and the attached images.',
+    '',
+    buildContextSummary(context),
+    '',
+    'Remember:',
+    '- Only use visible evidence and the resident message.',
+    '- If you are unsure, say what extra photo or detail would help.',
+    '- Keep the reply friendly and practical.',
+  ].join('\n');
 }
 
 async function insertAnalysis(row: InsertAnalysisRow): Promise<{ id: string }> {
@@ -186,10 +420,235 @@ async function insertAnalysis(row: InsertAnalysisRow): Promise<{ id: string }> {
   return { id: data.id as string };
 }
 
+async function getDevelopmentContext(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  input: MediaAnalysisInput,
+): Promise<HousingReasoningPromptContext> {
+  const [developmentResult, unitResult] = await Promise.all([
+    admin
+      .from('developments')
+      .select('name, code')
+      .eq('id', input.developmentId)
+      .maybeSingle<DevelopmentRow>(),
+    input.unitId
+      ? admin
+          .from('units')
+          .select('unit_number, property_designation, property_type')
+          .eq('id', input.unitId)
+          .maybeSingle<UnitRow>()
+      : Promise.resolve({ data: null as UnitRow | null, error: null }),
+  ]);
+
+  const development = developmentResult.data ?? null;
+  const unit = unitResult.data ?? null;
+
+  return {
+    developmentName: firstString(development?.name),
+    developmentCode: firstString(development?.code),
+    unitLabel: resolveUnitLabel(unit),
+    propertyType: firstString(unit?.property_type),
+    messageText: sanitizeAnalysisText(input.userMessage),
+    mediaCount: input.mediaIds.length,
+  };
+}
+
+async function fetchMediaRows(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  input: MediaAnalysisInput,
+): Promise<AssistantMediaRow[]> {
+  const { data, error } = await admin
+    .from('assistant_media')
+    .select('id, storage_path, thumbnail_path, mime_type, width, height')
+    .eq('tenant_id', input.tenantId)
+    .eq('development_id', input.developmentId)
+    .eq('conversation_id', input.conversationId)
+    .in('id', input.mediaIds);
+
+  if (error) {
+    throw new Error(`[mediaAnalysisService] failed to load media rows: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as AssistantMediaRow[];
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const ordered = input.mediaIds.map((id) => byId.get(id)).filter(Boolean) as AssistantMediaRow[];
+
+  if (ordered.length === 0) {
+    throw new Error('[mediaAnalysisService] no media rows found for analysis');
+  }
+
+  return ordered;
+}
+
+async function storageObjectToDataUrl(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  storagePath: string,
+  mimeType: string | null,
+): Promise<string> {
+  const { data, error } = await admin.storage.from(ANALYSIS_BUCKET).download(storagePath);
+  if (error || !data) {
+    throw new Error(error?.message ?? 'download failed');
+  }
+
+  const raw = Buffer.from(await data.arrayBuffer());
+  const sharp = (await import('sharp')) as any;
+  const image = await sharp(raw)
+    .rotate()
+    .resize({
+      width: IMAGE_EDGE_LIMIT,
+      height: IMAGE_EDGE_LIMIT,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: IMAGE_JPEG_QUALITY })
+    .toBuffer();
+
+  return `data:image/jpeg;base64,${image.toString('base64')}`;
+}
+
+async function prepareImageReference(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  row: AssistantMediaRow,
+): Promise<string> {
+  if (row.thumbnail_path) {
+    const { data, error } = await admin.storage
+      .from(ANALYSIS_BUCKET)
+      .createSignedUrl(row.thumbnail_path, SIGNED_URL_TTL_SECONDS);
+    if (!error && data?.signedUrl) return data.signedUrl;
+  }
+
+  if (row.storage_path) {
+    try {
+      return await storageObjectToDataUrl(admin, row.storage_path, row.mime_type);
+    } catch {
+      const { data, error } = await admin.storage
+        .from(ANALYSIS_BUCKET)
+        .createSignedUrl(row.storage_path, SIGNED_URL_TTL_SECONDS);
+      if (!error && data?.signedUrl) return data.signedUrl;
+    }
+  }
+
+  throw new Error(`[mediaAnalysisService] could not prepare image reference for media ${row.id}`);
+}
+
+async function buildModelPayload(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  input: MediaAnalysisInput,
+): Promise<{
+  context: HousingReasoningPromptContext;
+  messages: Array<{ role: 'system' | 'user'; content: unknown }>;
+  mediaRows: AssistantMediaRow[];
+}> {
+  const [context, mediaRows] = await Promise.all([
+    getDevelopmentContext(admin, input),
+    fetchMediaRows(admin, input),
+  ]);
+
+  const imageParts = await Promise.all(
+    mediaRows.map(async (row) => ({
+      type: 'image_url' as const,
+      image_url: { url: await prepareImageReference(admin, row) },
+    })),
+  );
+
+  return {
+    context,
+    mediaRows,
+    messages: [
+      { role: 'system', content: buildHousingReasoningPrompt(context) },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: buildUserPrompt(context) }, ...imageParts],
+      },
+    ],
+  };
+}
+
+function extractJsonText(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return match ? match[1].trim() : trimmed;
+}
+
+function safeParseJson(text: string): unknown {
+  try {
+    return JSON.parse(extractJsonText(text));
+  } catch {
+    return null;
+  }
+}
+
+async function runVisionAnalysis(
+  admin: ReturnType<typeof getSupabaseAdmin>,
+  input: MediaAnalysisInput,
+): Promise<{
+  payload: MediaAnalysisModelOutput;
+  rawModelOutput: Record<string, unknown>;
+  modelProvider: string;
+  modelName: string;
+  modelVersion: string | null;
+}> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return {
+      payload: fallbackOutput(),
+      rawModelOutput: { placeholder: true, reason: 'missing_openai_api_key' },
+      modelProvider: 'placeholder',
+      modelName: 'placeholder-v1',
+      modelVersion: null,
+    };
+  }
+
+  const { messages } = await buildModelPayload(admin, input);
+  const client = new OpenAI({ apiKey });
+
+  try {
+    const response = await client.chat.completions.create({
+      model: DEFAULT_MODEL,
+      temperature: 0.2,
+      max_tokens: 1200,
+      response_format: { type: 'json_object' },
+      messages: messages as any,
+    });
+
+    const content = response.choices[0]?.message?.content ?? '{}';
+    const parsed = safeParseJson(content) ?? {};
+    const payload = normalizeMediaAnalysisOutput(parsed);
+
+    return {
+      payload,
+      rawModelOutput: isRecord(parsed) ? parsed : { raw_content: content },
+      modelProvider: 'openai',
+      modelName: DEFAULT_MODEL,
+      modelVersion: response.id ?? null,
+    };
+  } catch (error) {
+    console.warn(
+      '[mediaAnalysisService] vision analysis failed; falling back to placeholder: %s',
+      error instanceof Error ? error.message : String(error),
+    );
+    return {
+      payload: fallbackOutput(),
+      rawModelOutput: {
+        placeholder: true,
+        reason: 'vision_analysis_failed',
+        error: error instanceof Error ? error.message : String(error),
+      },
+      modelProvider: 'placeholder',
+      modelName: 'placeholder-v1',
+      modelVersion: null,
+    };
+  }
+}
+
 export async function analyse(input: MediaAnalysisInput): Promise<MediaAnalysisResult> {
   const startedAt = Date.now();
-  const structured = neutralStructured();
+  const admin = getSupabaseAdmin();
+  const { payload, rawModelOutput, modelProvider, modelName, modelVersion } = await runVisionAnalysis(
+    admin,
+    input,
+  );
 
+  const structured = payload.structured;
   const analysisRow = await insertAnalysis({
     tenant_id: input.tenantId,
     development_id: input.developmentId,
@@ -198,20 +657,20 @@ export async function analyse(input: MediaAnalysisInput): Promise<MediaAnalysisR
     conversation_id: input.conversationId,
     message_id: input.messageId,
     input_media_ids: input.mediaIds,
-    raw_model_output: { placeholder: true },
-    model_provider: 'placeholder',
-    model_name: 'placeholder-v1',
-    model_version: null,
-    prompt_version: 'placeholder-v1',
+    raw_model_output: rawModelOutput,
+    model_provider: modelProvider,
+    model_name: modelName,
+    model_version: modelVersion,
+    prompt_version: PROMPT_VERSION,
     processing_time_ms: Date.now() - startedAt,
     ...structured,
   });
 
   return {
     analysisId: analysisRow.id,
-    residentMessage: PLACEHOLDER_RESIDENT_MESSAGE,
-    developerSummary: structured.developer_summary,
+    residentMessage: payload.residentMessage,
+    developerSummary: payload.developerSummary,
     structured,
-    action: 'answer_only',
+    action: payload.action,
   };
 }

--- a/apps/unified-portal/tests/assistant/media-analysis-service.test.ts
+++ b/apps/unified-portal/tests/assistant/media-analysis-service.test.ts
@@ -1,0 +1,63 @@
+import { strict as assert } from 'node:assert';
+import {
+  buildHousingReasoningPrompt,
+  normalizeMediaAnalysisOutput,
+  sanitizeAnalysisText,
+} from '../../lib/assistant/mediaAnalysisService';
+
+const prompt = buildHousingReasoningPrompt({
+  developmentName: 'Longview Park',
+  developmentCode: 'LVP',
+  unitLabel: '12A',
+  propertyType: 'house',
+  messageText: 'There is a damp patch on the ceiling near the stairwell.',
+  mediaCount: 2,
+});
+
+assert.match(prompt, /JSON only/i, 'prompt should force JSON-only output');
+assert.match(prompt, /do not invent/i, 'prompt should forbid invention');
+assert.match(prompt, /residentMessage/i, 'prompt should mention residentMessage');
+assert.match(prompt, /developerSummary/i, 'prompt should mention developerSummary');
+assert.match(prompt, /urgent/i, 'prompt should mention urgent escalation handling');
+
+assert.equal(
+  sanitizeAnalysisText('Ceiling leak — urgent — above the window.'),
+  'Ceiling leak - urgent - above the window.',
+);
+
+const normalized = normalizeMediaAnalysisOutput({
+  residentMessage: 'We should have a plumber look at it — soon.',
+  developerSummary: 'Possible plumbing leak in the first-floor ceiling.',
+  action: 'escalate_issue',
+  structured: {
+    issue_type: 'plumbing',
+    issue_category: 'plumbing',
+    room: 'stairs',
+    visible_features: ['Water staining on ceiling'],
+    severity_score: 0.87,
+    severity_label: 'high',
+    confidence_score: 0.87,
+    safety_risk: true,
+    safety_risk_type: 'water near electrics',
+    likely_trade: 'plumber',
+    likely_system: 'pipe run',
+    potential_causes: ['Active leak in an upstairs pipe run.'],
+    recommended_action: 'Arrange a plumber to inspect the ceiling leak.',
+    resident_guidance: 'Keep the area clear and avoid using the room if the leak worsens.',
+    needs_more_info: false,
+    more_info_requested: [],
+    should_create_issue: true,
+    should_escalate: true,
+    escalation_level: 'urgent',
+    requires_human_review: true,
+    warranty_relevant: true,
+    similar_issue_check_required: false,
+    developer_summary: 'Possible plumbing leak in the first-floor ceiling.',
+  },
+});
+
+assert.equal(normalized.residentMessage, 'We should have a plumber look at it - soon.');
+assert.equal(normalized.action, 'escalate_issue');
+assert.equal(normalized.structured.issue_type, 'plumbing');
+assert.equal(normalized.structured.safety_risk, true);
+assert.equal(normalized.structured.severity_label, 'high');


### PR DESCRIPTION
## Summary\n- add multimodal media analysis service helpers\n- keep placeholder fallback and persistence shape stable\n- add focused unit coverage for prompt building and normalization\n\n## Verification\n- npx tsx apps/unified-portal/tests/assistant/media-analysis-service.test.ts