### PR TITLE
feat(assistant-v2): Sprint 4 schema and server routes for schedule

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -142,6 +142,15 @@ NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
 FEATURE_HOMEOWNER_ISSUES=false
 NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES=false
 
+# Assistant V2 schedule and calendar surface (Sprint 4). Default off in
+# production. Enable per tenant during testing. When false, the
+# /developer/schedule page is hidden, the sidebar Schedule item does not
+# render, all /api/schedule/* routes return 404 before any auth or DB
+# work, and the daily digest cron at /api/cron/schedule-digest is a
+# no-op.
+FEATURE_SCHEDULE=false
+NEXT_PUBLIC_FEATURE_SCHEDULE=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
 # from /api/snag/create to /api/snag/enrich/[issue_report_id] and the
 # aftercare email fetch from /api/assistant/chat/multimodal to

--- a/apps/unified-portal/.env.example
+++ b/apps/unified-portal/.env.example
@@ -105,6 +105,15 @@ NEXT_PUBLIC_FEATURE_DEVELOPER_DASHBOARD=false
 FEATURE_HOMEOWNER_ISSUES=false
 NEXT_PUBLIC_FEATURE_HOMEOWNER_ISSUES=false
 
+# Assistant V2 schedule and calendar surface (Sprint 4). Default off in
+# production. Enable per tenant during testing. When false, the
+# /developer/schedule page is hidden, the sidebar Schedule item does not
+# render, all /api/schedule/* routes return 404 before any auth or DB
+# work, and the daily digest cron at /api/cron/schedule-digest is a
+# no-op.
+FEATURE_SCHEDULE=false
+NEXT_PUBLIC_FEATURE_SCHEDULE=false
+
 # Internal key used to authorise the fire-and-forget enrichment fetch
 # from /api/snag/create to /api/snag/enrich/[issue_report_id] and the
 # aftercare email fetch from /api/assistant/chat/multimodal to

--- a/apps/unified-portal/app/api/cron/schedule-digest/route.ts
+++ b/apps/unified-portal/app/api/cron/schedule-digest/route.ts
@@ -1,0 +1,446 @@
+/**
+ * POST /api/cron/schedule-digest
+ *
+ * Assistant V2 Sprint 4. Daily digest of today's scheduled events,
+ * delivered to each tenant's aftercare_email. Triggered nominally by
+ * Vercel Cron (vercel.json) at 07:00 UTC and also exercisable via curl
+ * for testing.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md section 5.7.
+ *
+ * Auth. Reuses the INTERNAL_ENRICHMENT_KEY env var (same secret used
+ * by /api/snag/enrich and /api/notifications/homeowner-issue) to avoid
+ * introducing a second internal-only credential. The header check uses
+ * crypto.timingSafeEqual. As a secondary acceptable proof, an
+ * Authorization: Bearer with the Supabase service-role key is also
+ * accepted, mirroring the other internal routes. Vercel Cron's own
+ * Bearer CRON_SECRET is intentionally not accepted in V1; the cron
+ * entry is there so the Vercel project tracks the schedule, but the
+ * acceptance criterion is satisfied by manual curl invocation.
+ *
+ * Iteration. The spec's "tenants with FEATURE_SCHEDULE enabled" gate
+ * is global today (env var, not per-tenant). For V1 we iterate every
+ * tenant that has tenant_settings.aftercare_email set and let the
+ * global flag gate the route at the entry point.
+ *
+ * Timezone. Today's window is computed in Europe/Dublin. Vercel Cron
+ * runs in UTC; the 1-hour winter drift is accepted per the spec.
+ *
+ * Cancelled events are excluded from the digest.
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import { snagFeatureDisabledResponse } from '@/lib/assistant/snag-auth';
+import { getResendClient } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const EVENT_TYPE_LABELS: Record<string, string> = {
+  handover: 'Handovers',
+  snag_visit: 'Snag visits',
+  contractor_visit: 'Contractor visits',
+  homeowner_appointment: 'Homeowner appointments',
+  inspection: 'Inspections',
+  custom: 'Other',
+};
+
+const EVENT_TYPE_ORDER = [
+  'handover',
+  'snag_visit',
+  'contractor_visit',
+  'homeowner_appointment',
+  'inspection',
+  'custom',
+];
+
+interface DigestEventRow {
+  id: string;
+  tenant_id: string;
+  development_id: string | null;
+  unit_id: string | null;
+  event_type: string;
+  title: string;
+  starts_at: string;
+  ends_at: string | null;
+  all_day: boolean;
+  location: string | null;
+  status: string;
+}
+
+interface AttendeeRow {
+  event_id: string;
+  user_id: string | null;
+  external_name: string | null;
+  external_email: string | null;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+function isInternalCaller(request: NextRequest): boolean {
+  const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
+  const headerKey = request.headers.get('x-internal-key');
+  if (internalKey && headerKey && safeEqual(headerKey, internalKey)) {
+    return true;
+  }
+  const auth = request.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    const token = auth.slice(7);
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (serviceKey && safeEqual(token, serviceKey)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function dublinTodayUtcBounds(): { fromUtc: string; toUtc: string; dateLabel: string } {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = fmt.formatToParts(new Date());
+  const y = parts.find((p) => p.type === 'year')!.value;
+  const m = parts.find((p) => p.type === 'month')!.value;
+  const d = parts.find((p) => p.type === 'day')!.value;
+
+  const probe = new Date(`${y}-${m}-${d}T12:00:00Z`);
+  const dublinView = new Date(probe.toLocaleString('en-US', { timeZone: 'Europe/Dublin' }));
+  const utcView = new Date(probe.toLocaleString('en-US', { timeZone: 'UTC' }));
+  const offsetMs = dublinView.getTime() - utcView.getTime();
+
+  const fromUtcMs = new Date(`${y}-${m}-${d}T00:00:00Z`).getTime() - offsetMs;
+  const toUtcMs = new Date(`${y}-${m}-${d}T23:59:59.999Z`).getTime() - offsetMs;
+  return {
+    fromUtc: new Date(fromUtcMs).toISOString(),
+    toUtc: new Date(toUtcMs).toISOString(),
+    dateLabel: `${y}-${m}-${d}`,
+  };
+}
+
+function formatDublinTime(iso: string): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(iso));
+}
+
+function deriveUnitLabel(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+export async function POST(request: NextRequest) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  if (!isInternalCaller(request)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: settingsRows, error: settingsErr } = await supabase
+    .from('tenant_settings')
+    .select('tenant_id, aftercare_email')
+    .not('aftercare_email', 'is', null);
+  if (settingsErr) {
+    console.error('[schedule-digest] settings_lookup_failed reason=%s', settingsErr.message);
+    return NextResponse.json({ error: 'Could not load tenant settings' }, { status: 500 });
+  }
+
+  const candidates = (settingsRows ?? [])
+    .map((r) => ({
+      tenant_id: r.tenant_id as string,
+      aftercare_email: ((r.aftercare_email as string | null) ?? '').trim(),
+    }))
+    .filter((r) => r.aftercare_email.length > 0);
+
+  if (candidates.length === 0) {
+    console.info('[schedule-digest] no_tenants_with_aftercare_email');
+    return NextResponse.json({ ok: true, processed: 0, sent: 0 });
+  }
+
+  const { fromUtc, toUtc, dateLabel } = dublinTodayUtcBounds();
+  const tenantIds = candidates.map((c) => c.tenant_id);
+
+  const { data: eventsData, error: eventsErr } = await supabase
+    .from('schedule_events')
+    .select(
+      'id, tenant_id, development_id, unit_id, event_type, title, starts_at, ends_at, all_day, location, status',
+    )
+    .in('tenant_id', tenantIds)
+    .gte('starts_at', fromUtc)
+    .lte('starts_at', toUtc)
+    .neq('status', 'cancelled')
+    .order('starts_at', { ascending: true });
+  if (eventsErr) {
+    console.error('[schedule-digest] events_lookup_failed reason=%s', eventsErr.message);
+    return NextResponse.json({ error: 'Could not load events' }, { status: 500 });
+  }
+
+  const eventsByTenant = new Map<string, DigestEventRow[]>();
+  for (const e of (eventsData ?? []) as DigestEventRow[]) {
+    const arr = eventsByTenant.get(e.tenant_id) ?? [];
+    arr.push(e);
+    eventsByTenant.set(e.tenant_id, arr);
+  }
+
+  const allEventIds = (eventsData ?? []).map((e) => (e as DigestEventRow).id);
+  const allUnitIds = Array.from(
+    new Set(
+      (eventsData ?? [])
+        .map((e) => (e as DigestEventRow).unit_id)
+        .filter((v): v is string => !!v),
+    ),
+  );
+  const allDevIds = Array.from(
+    new Set(
+      (eventsData ?? [])
+        .map((e) => (e as DigestEventRow).development_id)
+        .filter((v): v is string => !!v),
+    ),
+  );
+
+  const attendeesByEvent = new Map<string, AttendeeRow[]>();
+  if (allEventIds.length > 0) {
+    const { data: attRows, error: attErr } = await supabase
+      .from('schedule_event_attendees')
+      .select('event_id, user_id, external_name, external_email')
+      .in('event_id', allEventIds);
+    if (attErr) {
+      console.error('[schedule-digest] attendees_lookup_failed reason=%s', attErr.message);
+    } else {
+      for (const a of (attRows ?? []) as AttendeeRow[]) {
+        const arr = attendeesByEvent.get(a.event_id) ?? [];
+        arr.push(a);
+        attendeesByEvent.set(a.event_id, arr);
+      }
+    }
+  }
+
+  const userIdSet = new Set<string>();
+  for (const list of attendeesByEvent.values()) {
+    for (const a of list) {
+      if (a.user_id) userIdSet.add(a.user_id);
+    }
+  }
+  const userNames = new Map<string, string>();
+  if (userIdSet.size > 0) {
+    const { data: memberRows, error: memberErr } = await supabase
+      .from('site_team_members')
+      .select('user_id, invited_email')
+      .in('user_id', Array.from(userIdSet));
+    if (memberErr) {
+      console.error('[schedule-digest] member_lookup_failed reason=%s', memberErr.message);
+    } else {
+      for (const m of (memberRows ?? []) as Array<{ user_id: string; invited_email: string | null }>) {
+        if (!userNames.has(m.user_id)) {
+          userNames.set(m.user_id, m.invited_email ?? '');
+        }
+      }
+    }
+  }
+
+  const units = new Map<string, string>();
+  if (allUnitIds.length > 0) {
+    const { data: unitRows, error: unitErr } = await supabase
+      .from('units')
+      .select('id, unit_code, unit_number, address_line_1')
+      .in('id', allUnitIds);
+    if (unitErr) {
+      console.error('[schedule-digest] units_lookup_failed reason=%s', unitErr.message);
+    } else {
+      for (const u of (unitRows ?? []) as Array<{
+        id: string;
+        unit_code: string | null;
+        unit_number: string | null;
+        address_line_1: string | null;
+      }>) {
+        units.set(u.id, deriveUnitLabel(u));
+      }
+    }
+  }
+
+  const developments = new Map<string, string>();
+  const tenantNames = new Map<string, string>();
+  if (allDevIds.length > 0) {
+    const { data: devRows, error: devErr } = await supabase
+      .from('developments')
+      .select('id, name')
+      .in('id', allDevIds);
+    if (devErr) {
+      console.error('[schedule-digest] developments_lookup_failed reason=%s', devErr.message);
+    } else {
+      for (const d of (devRows ?? []) as Array<{ id: string; name: string | null }>) {
+        developments.set(d.id, d.name ?? 'Development');
+      }
+    }
+  }
+  {
+    const { data: tenantRows, error: tenantErr } = await supabase
+      .from('tenants')
+      .select('id, name')
+      .in('id', tenantIds);
+    if (tenantErr) {
+      console.error('[schedule-digest] tenants_lookup_failed reason=%s', tenantErr.message);
+    } else {
+      for (const t of (tenantRows ?? []) as Array<{ id: string; name: string | null }>) {
+        tenantNames.set(t.id, t.name ?? 'your tenant');
+      }
+    }
+  }
+
+  let sent = 0;
+  let processed = 0;
+  let skippedEmpty = 0;
+  const sendErrors: string[] = [];
+
+  for (const candidate of candidates) {
+    processed += 1;
+    const tenantEvents = eventsByTenant.get(candidate.tenant_id) ?? [];
+    if (tenantEvents.length === 0) {
+      skippedEmpty += 1;
+      continue;
+    }
+
+    const grouped = new Map<string, DigestEventRow[]>();
+    for (const e of tenantEvents) {
+      const arr = grouped.get(e.event_type) ?? [];
+      arr.push(e);
+      grouped.set(e.event_type, arr);
+    }
+
+    const tenantName = tenantNames.get(candidate.tenant_id) ?? 'your tenant';
+    const subject = `Today's schedule - ${tenantEvents.length} events at ${tenantName}`;
+
+    const textParts: string[] = [
+      `Today's schedule for ${tenantName} (${dateLabel}, Europe/Dublin):`,
+      '',
+    ];
+    const htmlSections: string[] = [];
+
+    for (const key of EVENT_TYPE_ORDER) {
+      const group = grouped.get(key);
+      if (!group || group.length === 0) continue;
+      const label = EVENT_TYPE_LABELS[key] ?? key;
+      textParts.push(`${label}:`);
+      const htmlItems: string[] = [];
+      for (const e of group) {
+        const timePart = e.all_day
+          ? 'All day'
+          : e.ends_at
+          ? `${formatDublinTime(e.starts_at)} - ${formatDublinTime(e.ends_at)}`
+          : formatDublinTime(e.starts_at);
+        const venueBits: string[] = [];
+        if (e.unit_id && units.get(e.unit_id)) venueBits.push(units.get(e.unit_id) as string);
+        if (e.development_id && developments.get(e.development_id))
+          venueBits.push(developments.get(e.development_id) as string);
+        if (e.location) venueBits.push(e.location);
+        const venue = venueBits.join(' | ');
+
+        const attendeesList = (attendeesByEvent.get(e.id) ?? [])
+          .map((a) => a.external_name ?? userNames.get(a.user_id ?? '') ?? a.external_email ?? null)
+          .filter((v): v is string => !!v && v.length > 0);
+
+        const line = `  - ${timePart} ${e.title}${venue ? ` (${venue})` : ''}${
+          attendeesList.length > 0 ? ` - ${attendeesList.join(', ')}` : ''
+        }`;
+        textParts.push(line);
+        htmlItems.push(
+          `<li><strong>${escapeHtml(timePart)}</strong> ${escapeHtml(e.title)}${
+            venue ? ` <span style="color:#666">(${escapeHtml(venue)})</span>` : ''
+          }${
+            attendeesList.length > 0
+              ? `<br/><span style="color:#555;font-size:12px">${escapeHtml(attendeesList.join(', '))}</span>`
+              : ''
+          }</li>`,
+        );
+      }
+      textParts.push('');
+      htmlSections.push(
+        `<h3 style="margin:16px 0 4px 0;color:#111;font-size:14px;">${escapeHtml(label)}</h3><ul style="padding-left:18px;margin:4px 0 8px 0;">${htmlItems.join('')}</ul>`,
+      );
+    }
+
+    const text = textParts.join('\n');
+    const html = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background:#111;padding:20px;">
+          <h1 style="color:#fff;margin:0;font-size:18px;">Today's schedule</h1>
+          <p style="color:#bbb;margin:6px 0 0 0;font-size:12px;">${escapeHtml(dateLabel)} - ${escapeHtml(tenantName)}</p>
+        </div>
+        <div style="padding:20px;background:#fff;color:#111;">
+          ${htmlSections.join('')}
+        </div>
+        <div style="padding:12px 16px;background:#f5f5f5;text-align:center;color:#777;font-size:12px;">
+          OpenHouse AI schedule digest
+        </div>
+      </div>
+    `.trim();
+
+    try {
+      const { client, fromEmail } = await getResendClient();
+      const result = await client.emails.send({
+        from: fromEmail,
+        to: candidate.aftercare_email,
+        subject,
+        html,
+        text,
+      } as Parameters<typeof client.emails.send>[0]);
+      console.info(
+        '[schedule-digest] dispatched tenant=%s to=%s events=%s id=%s',
+        candidate.tenant_id,
+        candidate.aftercare_email,
+        tenantEvents.length,
+        (result as { id?: string })?.id ?? null,
+      );
+      sent += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        '[schedule-digest] dispatch_failed tenant=%s reason=%s',
+        candidate.tenant_id,
+        msg,
+      );
+      sendErrors.push(`${candidate.tenant_id}: ${msg}`);
+    }
+  }
+
+  return NextResponse.json({
+    ok: sendErrors.length === 0,
+    processed,
+    sent,
+    skipped_empty: skippedEmpty,
+    errors: sendErrors,
+    date_label: dateLabel,
+  });
+}

--- a/apps/unified-portal/app/api/schedule/events/[id]/cancel/route.ts
+++ b/apps/unified-portal/app/api/schedule/events/[id]/cancel/route.ts
@@ -1,0 +1,96 @@
+/**
+ * POST /api/schedule/events/[id]/cancel
+ *
+ * Assistant V2 Sprint 4. Cancels a scheduled event by setting its
+ * status to 'cancelled'. The row is preserved (no delete) so the audit
+ * trail of historical schedule changes stays intact and the daily
+ * digest can exclude cancelled events without losing them.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md section 5.5.
+ *
+ * admin and site_team only. snagger_external is rejected with 403.
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const eventId = params.id;
+  if (!UUID_RE.test(eventId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: existing, error: lookupErr } = await supabase
+    .from('schedule_events')
+    .select('id, tenant_id, status')
+    .eq('id', eventId)
+    .maybeSingle();
+  if (lookupErr) {
+    console.error('[schedule-event-cancel] lookup_failed reason=%s', lookupErr.message);
+    return NextResponse.json({ error: 'Could not load event' }, { status: 500 });
+  }
+  if (!existing) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+  }
+  if (existing.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  if (existing.status === 'cancelled') {
+    return NextResponse.json({ id: eventId, status: 'cancelled', already_cancelled: true });
+  }
+
+  const { data: updated, error: updateErr } = await supabase
+    .from('schedule_events')
+    .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+    .eq('id', eventId)
+    .select('id, status, updated_at')
+    .single();
+  if (updateErr || !updated) {
+    console.error('[schedule-event-cancel] update_failed reason=%s', updateErr?.message ?? 'unknown');
+    return NextResponse.json({ error: 'Could not cancel event' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    id: updated.id,
+    status: updated.status,
+    updated_at: updated.updated_at,
+  });
+}

--- a/apps/unified-portal/app/api/schedule/events/[id]/route.ts
+++ b/apps/unified-portal/app/api/schedule/events/[id]/route.ts
@@ -1,0 +1,579 @@
+/**
+ * /api/schedule/events/[id]
+ *
+ * Assistant V2 Sprint 4. Single-event detail and update endpoints.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md sections 5.2 and 5.4.
+ *
+ * GET: return the event with its full attendee list and joined
+ * unit/development labels. admin and site_team can see any event in
+ * their tenant; snagger_external is 403 unless they are an attendee or
+ * the event is on a unit/development they can access.
+ *
+ * PATCH: update an event. admin and site_team only. tenant_id and
+ * created_by are immutable. If attendees is provided, the existing
+ * attendee list is replaced (delete + re-insert; service-role bypasses
+ * RLS so the two-step is safe as long as we tolerate a brief window
+ * between calls).
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_TITLE = 200;
+const MAX_DESCRIPTION = 2000;
+const MAX_LOCATION = 200;
+
+const EVENT_TYPES = new Set([
+  'handover',
+  'snag_visit',
+  'contractor_visit',
+  'homeowner_appointment',
+  'inspection',
+  'custom',
+]);
+
+const ATTENDEE_ROLES = new Set([
+  'organiser',
+  'site_team',
+  'snagger',
+  'contractor',
+  'homeowner',
+  'other',
+]);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface RouteParams {
+  params: { id: string };
+}
+
+interface AttendeeInput {
+  user_id?: string | null;
+  external_email?: string | null;
+  external_name?: string | null;
+  role?: string | null;
+}
+
+interface AttendeeRow {
+  id: string;
+  event_id: string;
+  user_id: string | null;
+  external_email: string | null;
+  external_name: string | null;
+  role: string | null;
+  rsvp_status: string;
+  created_at: string;
+}
+
+interface EventRow {
+  id: string;
+  tenant_id: string;
+  development_id: string | null;
+  unit_id: string | null;
+  event_type: string;
+  title: string;
+  description: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  all_day: boolean;
+  location: string | null;
+  status: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function parseAttendees(input: unknown): { value: AttendeeInput[]; error?: string } {
+  if (input === undefined || input === null) return { value: [] };
+  if (!Array.isArray(input)) return { value: [], error: 'attendees must be an array' };
+  const out: AttendeeInput[] = [];
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') {
+      return { value: [], error: 'each attendee must be an object' };
+    }
+    const a = raw as Record<string, unknown>;
+    const userId = typeof a.user_id === 'string' ? a.user_id : null;
+    const externalEmail = typeof a.external_email === 'string' ? a.external_email : null;
+    const externalName = typeof a.external_name === 'string' ? a.external_name : null;
+    const role = typeof a.role === 'string' ? a.role : null;
+
+    const hasUser = !!userId;
+    const hasEmail = !!externalEmail;
+    if (hasUser === hasEmail) {
+      return {
+        value: [],
+        error: 'each attendee must have exactly one of user_id or external_email',
+      };
+    }
+    if (userId && !UUID_RE.test(userId)) {
+      return { value: [], error: 'attendee user_id must be a uuid' };
+    }
+    if (externalEmail && !EMAIL_RE.test(externalEmail)) {
+      return { value: [], error: 'attendee external_email must be a valid email' };
+    }
+    if (role && !ATTENDEE_ROLES.has(role)) {
+      return { value: [], error: 'attendee role is not one of the allowed values' };
+    }
+    out.push({
+      user_id: userId,
+      external_email: externalEmail,
+      external_name: externalName,
+      role,
+    });
+  }
+  return { value: out };
+}
+
+function deriveUnitLabel(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+async function loadEventBundle(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  event: EventRow,
+): Promise<{
+  attendees: AttendeeRow[];
+  unitLabel: string | null;
+  developmentLabel: string | null;
+}> {
+  const [attRes, unitRes, devRes] = await Promise.all([
+    supabase
+      .from('schedule_event_attendees')
+      .select('id, event_id, user_id, external_email, external_name, role, rsvp_status, created_at')
+      .eq('event_id', event.id),
+    event.unit_id
+      ? supabase
+          .from('units')
+          .select('id, unit_code, unit_number, address_line_1')
+          .eq('id', event.unit_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    event.development_id
+      ? supabase
+          .from('developments')
+          .select('id, name')
+          .eq('id', event.development_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  if (attRes.error) {
+    console.error('[schedule-event-detail] attendees_failed reason=%s', attRes.error.message);
+  }
+  if (unitRes.error) {
+    console.error('[schedule-event-detail] unit_failed reason=%s', unitRes.error.message);
+  }
+  if (devRes.error) {
+    console.error('[schedule-event-detail] dev_failed reason=%s', devRes.error.message);
+  }
+
+  const unitData = unitRes.data as
+    | { unit_code: string | null; unit_number: string | null; address_line_1: string | null }
+    | null;
+  const devData = devRes.data as { name: string | null } | null;
+
+  return {
+    attendees: (attRes.data ?? []) as AttendeeRow[],
+    unitLabel: unitData ? deriveUnitLabel(unitData) : null,
+    developmentLabel: devData ? devData.name ?? 'Development' : null,
+  };
+}
+
+function shapeEventResponse(
+  event: EventRow,
+  attendees: AttendeeRow[],
+  unitLabel: string | null,
+  developmentLabel: string | null,
+) {
+  return {
+    id: event.id,
+    tenant_id: event.tenant_id,
+    development_id: event.development_id,
+    unit_id: event.unit_id,
+    event_type: event.event_type,
+    title: event.title,
+    description: event.description,
+    starts_at: event.starts_at,
+    ends_at: event.ends_at,
+    all_day: event.all_day,
+    location: event.location,
+    status: event.status,
+    created_by: event.created_by,
+    created_at: event.created_at,
+    updated_at: event.updated_at,
+    unit_label: unitLabel,
+    development_label: developmentLabel,
+    attendees: attendees.map((a) => ({
+      id: a.id,
+      user_id: a.user_id,
+      external_email: a.external_email,
+      external_name: a.external_name,
+      role: a.role,
+      rsvp_status: a.rsvp_status,
+    })),
+  };
+}
+
+async function loadEventForCaller(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  auth: SnagAuthContext,
+  eventId: string,
+): Promise<
+  | { kind: 'ok'; event: EventRow; attendees: AttendeeRow[] }
+  | { kind: 'not_found' }
+  | { kind: 'forbidden' }
+  | { kind: 'error'; message: string }
+> {
+  const { data: eventData, error: eventErr } = await supabase
+    .from('schedule_events')
+    .select(
+      'id, tenant_id, development_id, unit_id, event_type, title, description, starts_at, ends_at, all_day, location, status, created_by, created_at, updated_at',
+    )
+    .eq('id', eventId)
+    .maybeSingle();
+  if (eventErr) {
+    return { kind: 'error', message: eventErr.message };
+  }
+  if (!eventData) {
+    return { kind: 'not_found' };
+  }
+  const event = eventData as EventRow;
+  if (event.tenant_id !== auth.tenantId) {
+    return { kind: 'forbidden' };
+  }
+
+  const { data: attData, error: attErr } = await supabase
+    .from('schedule_event_attendees')
+    .select('id, event_id, user_id, external_email, external_name, role, rsvp_status, created_at')
+    .eq('event_id', eventId);
+  if (attErr) {
+    return { kind: 'error', message: attErr.message };
+  }
+  const attendees = (attData ?? []) as AttendeeRow[];
+
+  if (auth.role === 'snagger_external') {
+    const allowedDevs = Array.isArray(auth.developmentIds) ? auth.developmentIds : [];
+    const isAttendee = attendees.some((a) => a.user_id === auth.userId);
+    const devOk = event.development_id ? allowedDevs.includes(event.development_id) : false;
+    if (!isAttendee && !devOk) {
+      return { kind: 'forbidden' };
+    }
+  }
+
+  return { kind: 'ok', event, attendees };
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const eventId = params.id;
+  if (!UUID_RE.test(eventId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const supabase = getSupabaseAdmin();
+  const result = await loadEventForCaller(supabase, auth, eventId);
+  if (result.kind === 'error') {
+    console.error('[schedule-event-detail] lookup_failed reason=%s', result.message);
+    return NextResponse.json({ error: 'Could not load event' }, { status: 500 });
+  }
+  if (result.kind === 'not_found') {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+  }
+  if (result.kind === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const bundle = await loadEventBundle(supabase, result.event);
+  return NextResponse.json(
+    shapeEventResponse(result.event, bundle.attendees, bundle.unitLabel, bundle.developmentLabel),
+  );
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const eventId = params.id;
+  if (!UUID_RE.test(eventId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: existingData, error: existingErr } = await supabase
+    .from('schedule_events')
+    .select('id, tenant_id, starts_at, ends_at, development_id, unit_id')
+    .eq('id', eventId)
+    .maybeSingle();
+  if (existingErr) {
+    console.error('[schedule-event-update] lookup_failed reason=%s', existingErr.message);
+    return NextResponse.json({ error: 'Could not load event' }, { status: 500 });
+  }
+  if (!existingData) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+  }
+  if (existingData.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const update: Record<string, unknown> = {};
+
+  if (payload.event_type !== undefined) {
+    if (typeof payload.event_type !== 'string' || !EVENT_TYPES.has(payload.event_type)) {
+      return NextResponse.json({ error: 'event_type must be one of the allowed values' }, { status: 400 });
+    }
+    update.event_type = payload.event_type;
+  }
+  if (payload.title !== undefined) {
+    const t = typeof payload.title === 'string' ? payload.title.trim() : '';
+    if (t.length === 0) {
+      return NextResponse.json({ error: 'title cannot be empty' }, { status: 400 });
+    }
+    if (t.length > MAX_TITLE) {
+      return NextResponse.json({ error: `title must be at most ${MAX_TITLE} characters` }, { status: 400 });
+    }
+    update.title = t;
+  }
+  if (payload.description !== undefined) {
+    if (payload.description !== null && typeof payload.description !== 'string') {
+      return NextResponse.json({ error: 'description must be a string or null' }, { status: 400 });
+    }
+    if (typeof payload.description === 'string' && payload.description.length > MAX_DESCRIPTION) {
+      return NextResponse.json(
+        { error: `description must be at most ${MAX_DESCRIPTION} characters` },
+        { status: 400 },
+      );
+    }
+    update.description = payload.description;
+  }
+  if (payload.location !== undefined) {
+    if (payload.location !== null && typeof payload.location !== 'string') {
+      return NextResponse.json({ error: 'location must be a string or null' }, { status: 400 });
+    }
+    if (typeof payload.location === 'string' && payload.location.length > MAX_LOCATION) {
+      return NextResponse.json(
+        { error: `location must be at most ${MAX_LOCATION} characters` },
+        { status: 400 },
+      );
+    }
+    update.location = payload.location;
+  }
+  if (payload.all_day !== undefined) {
+    if (typeof payload.all_day !== 'boolean') {
+      return NextResponse.json({ error: 'all_day must be a boolean' }, { status: 400 });
+    }
+    update.all_day = payload.all_day;
+  }
+
+  let nextStartsIso: string | null = null;
+  let nextEndsIso: string | null = null;
+  let endsCleared = false;
+  if (payload.starts_at !== undefined) {
+    if (typeof payload.starts_at !== 'string') {
+      return NextResponse.json({ error: 'starts_at must be an ISO timestamp' }, { status: 400 });
+    }
+    const d = new Date(payload.starts_at);
+    if (isNaN(d.getTime())) {
+      return NextResponse.json({ error: 'starts_at must be a valid ISO timestamp' }, { status: 400 });
+    }
+    nextStartsIso = d.toISOString();
+    update.starts_at = nextStartsIso;
+  }
+  if (payload.ends_at !== undefined) {
+    if (payload.ends_at === null) {
+      update.ends_at = null;
+      endsCleared = true;
+    } else if (typeof payload.ends_at !== 'string') {
+      return NextResponse.json({ error: 'ends_at must be an ISO timestamp or null' }, { status: 400 });
+    } else {
+      const d = new Date(payload.ends_at);
+      if (isNaN(d.getTime())) {
+        return NextResponse.json({ error: 'ends_at must be a valid ISO timestamp' }, { status: 400 });
+      }
+      nextEndsIso = d.toISOString();
+      update.ends_at = nextEndsIso;
+    }
+  }
+  if (!endsCleared) {
+    const effectiveStartsIso = nextStartsIso ?? (existingData.starts_at as string);
+    const effectiveEndsIso = nextEndsIso ?? (existingData.ends_at as string | null);
+    if (effectiveEndsIso && new Date(effectiveEndsIso).getTime() < new Date(effectiveStartsIso).getTime()) {
+      return NextResponse.json({ error: 'ends_at must be on or after starts_at' }, { status: 400 });
+    }
+  }
+
+  let nextDevelopmentId: string | null | undefined;
+  let nextUnitId: string | null | undefined;
+  if (payload.development_id !== undefined) {
+    if (payload.development_id === null) {
+      nextDevelopmentId = null;
+    } else if (typeof payload.development_id !== 'string' || !UUID_RE.test(payload.development_id)) {
+      return NextResponse.json({ error: 'development_id must be a uuid or null' }, { status: 400 });
+    } else {
+      nextDevelopmentId = payload.development_id;
+    }
+    update.development_id = nextDevelopmentId;
+  }
+  if (payload.unit_id !== undefined) {
+    if (payload.unit_id === null) {
+      nextUnitId = null;
+    } else if (typeof payload.unit_id !== 'string' || !UUID_RE.test(payload.unit_id)) {
+      return NextResponse.json({ error: 'unit_id must be a uuid or null' }, { status: 400 });
+    } else {
+      nextUnitId = payload.unit_id;
+    }
+    update.unit_id = nextUnitId;
+  }
+
+  if (nextDevelopmentId) {
+    const { data: dev, error: devErr } = await supabase
+      .from('developments')
+      .select('id, tenant_id')
+      .eq('id', nextDevelopmentId)
+      .maybeSingle();
+    if (devErr) {
+      console.error('[schedule-event-update] dev_lookup_failed reason=%s', devErr.message);
+      return NextResponse.json({ error: 'Could not validate development' }, { status: 500 });
+    }
+    if (!dev || dev.tenant_id !== auth.tenantId) {
+      return NextResponse.json(
+        { error: 'development_id is not in your tenant' },
+        { status: 403 },
+      );
+    }
+  }
+  if (nextUnitId) {
+    const { data: unit, error: unitErr } = await supabase
+      .from('units')
+      .select('id, tenant_id, development_id')
+      .eq('id', nextUnitId)
+      .maybeSingle();
+    if (unitErr) {
+      console.error('[schedule-event-update] unit_lookup_failed reason=%s', unitErr.message);
+      return NextResponse.json({ error: 'Could not validate unit' }, { status: 500 });
+    }
+    if (!unit || unit.tenant_id !== auth.tenantId) {
+      return NextResponse.json({ error: 'unit_id is not in your tenant' }, { status: 403 });
+    }
+    if (nextDevelopmentId && unit.development_id !== nextDevelopmentId) {
+      return NextResponse.json(
+        { error: 'unit_id does not belong to the supplied development_id' },
+        { status: 400 },
+      );
+    }
+  }
+
+  const attendeesProvided = payload.attendees !== undefined;
+  const attendeesParsed = attendeesProvided
+    ? parseAttendees(payload.attendees)
+    : { value: [] as AttendeeInput[], error: undefined as string | undefined };
+  if (attendeesParsed.error) {
+    return NextResponse.json({ error: attendeesParsed.error }, { status: 400 });
+  }
+
+  update.updated_at = new Date().toISOString();
+
+  const { data: updatedRow, error: updateErr } = await supabase
+    .from('schedule_events')
+    .update(update)
+    .eq('id', eventId)
+    .select(
+      'id, tenant_id, development_id, unit_id, event_type, title, description, starts_at, ends_at, all_day, location, status, created_by, created_at, updated_at',
+    )
+    .single();
+  if (updateErr || !updatedRow) {
+    console.error('[schedule-event-update] update_failed reason=%s', updateErr?.message ?? 'unknown');
+    return NextResponse.json({ error: 'Could not update event' }, { status: 500 });
+  }
+
+  if (attendeesProvided) {
+    const { error: delErr } = await supabase
+      .from('schedule_event_attendees')
+      .delete()
+      .eq('event_id', eventId);
+    if (delErr) {
+      console.error('[schedule-event-update] attendees_clear_failed reason=%s', delErr.message);
+      return NextResponse.json(
+        { error: 'Event updated but attendee replacement failed; please retry' },
+        { status: 500 },
+      );
+    }
+    if (attendeesParsed.value.length > 0) {
+      const rows = attendeesParsed.value.map((a) => ({
+        event_id: eventId,
+        user_id: a.user_id,
+        external_email: a.external_email,
+        external_name: a.external_name,
+        role: a.role,
+      }));
+      const { error: insErr } = await supabase.from('schedule_event_attendees').insert(rows);
+      if (insErr) {
+        console.error('[schedule-event-update] attendees_insert_failed reason=%s', insErr.message);
+        return NextResponse.json(
+          { error: 'Event updated but new attendees failed; please retry' },
+          { status: 500 },
+        );
+      }
+    }
+  }
+
+  const bundle = await loadEventBundle(supabase, updatedRow as EventRow);
+  return NextResponse.json(
+    shapeEventResponse(
+      updatedRow as EventRow,
+      bundle.attendees,
+      bundle.unitLabel,
+      bundle.developmentLabel,
+    ),
+  );
+}

--- a/apps/unified-portal/app/api/schedule/events/[id]/rsvp/route.ts
+++ b/apps/unified-portal/app/api/schedule/events/[id]/rsvp/route.ts
@@ -1,0 +1,122 @@
+/**
+ * POST /api/schedule/events/[id]/rsvp
+ *
+ * Assistant V2 Sprint 4. Lets an attendee update their own RSVP status
+ * on a scheduled event. Any caller with an attendee row on the event
+ * may update only their own row.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md section 5.6.
+ *
+ * Accepts { rsvp_status: 'confirmed' | 'declined' | 'tentative' }.
+ * 'invited' is the initial state and not a valid target value (callers
+ * cannot rewind their own RSVP back to invited).
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VALID_RSVP = new Set(['confirmed', 'declined', 'tentative']);
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  const eventId = params.id;
+  if (!UUID_RE.test(eventId)) {
+    return NextResponse.json({ error: 'id must be a uuid' }, { status: 400 });
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const rsvpStatus = typeof payload.rsvp_status === 'string' ? payload.rsvp_status : '';
+  if (!VALID_RSVP.has(rsvpStatus)) {
+    return NextResponse.json(
+      { error: "rsvp_status must be one of 'confirmed', 'declined', 'tentative'" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: eventRow, error: eventErr } = await supabase
+    .from('schedule_events')
+    .select('id, tenant_id')
+    .eq('id', eventId)
+    .maybeSingle();
+  if (eventErr) {
+    console.error('[schedule-event-rsvp] event_lookup_failed reason=%s', eventErr.message);
+    return NextResponse.json({ error: 'Could not load event' }, { status: 500 });
+  }
+  if (!eventRow) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+  }
+  if (eventRow.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: attendeeRow, error: attErr } = await supabase
+    .from('schedule_event_attendees')
+    .select('id, event_id, user_id, rsvp_status')
+    .eq('event_id', eventId)
+    .eq('user_id', auth.userId)
+    .maybeSingle();
+  if (attErr) {
+    console.error('[schedule-event-rsvp] attendee_lookup_failed reason=%s', attErr.message);
+    return NextResponse.json({ error: 'Could not load attendee record' }, { status: 500 });
+  }
+  if (!attendeeRow) {
+    return NextResponse.json(
+      { error: 'You are not an attendee on this event' },
+      { status: 403 },
+    );
+  }
+
+  const { data: updated, error: updateErr } = await supabase
+    .from('schedule_event_attendees')
+    .update({ rsvp_status: rsvpStatus })
+    .eq('id', attendeeRow.id)
+    .select('id, event_id, user_id, rsvp_status')
+    .single();
+  if (updateErr || !updated) {
+    console.error('[schedule-event-rsvp] update_failed reason=%s', updateErr?.message ?? 'unknown');
+    return NextResponse.json({ error: 'Could not update RSVP' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    id: updated.id,
+    event_id: updated.event_id,
+    user_id: updated.user_id,
+    rsvp_status: updated.rsvp_status,
+  });
+}

--- a/apps/unified-portal/app/api/schedule/events/route.ts
+++ b/apps/unified-portal/app/api/schedule/events/route.ts
@@ -1,0 +1,593 @@
+/**
+ * /api/schedule/events
+ *
+ * Assistant V2 Sprint 4. Schedule and calendar list + create endpoints.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md sections 5.1 and 5.3.
+ *
+ * GET: list events for the caller's tenant in a window, with optional
+ * filters. admin and site_team see all tenant events; snagger_external
+ * is scoped to events on units in their accessible developments, plus
+ * events where they appear as an attendee.
+ *
+ * POST: create an event. admin and site_team only. snagger_external is
+ * rejected with 403. tenant_id and created_by are derived from the
+ * verified site_team_members row; the client cannot supply them.
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_WINDOW_DAYS = 90;
+const MAX_TITLE = 200;
+const MAX_DESCRIPTION = 2000;
+const MAX_LOCATION = 200;
+
+const EVENT_TYPES = new Set([
+  'handover',
+  'snag_visit',
+  'contractor_visit',
+  'homeowner_appointment',
+  'inspection',
+  'custom',
+]);
+
+const ATTENDEE_ROLES = new Set([
+  'organiser',
+  'site_team',
+  'snagger',
+  'contractor',
+  'homeowner',
+  'other',
+]);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface AttendeeInput {
+  user_id?: string | null;
+  external_email?: string | null;
+  external_name?: string | null;
+  role?: string | null;
+}
+
+interface AttendeeRow {
+  id: string;
+  event_id: string;
+  user_id: string | null;
+  external_email: string | null;
+  external_name: string | null;
+  role: string | null;
+  rsvp_status: string;
+  created_at: string;
+}
+
+interface EventRow {
+  id: string;
+  tenant_id: string;
+  development_id: string | null;
+  unit_id: string | null;
+  event_type: string;
+  title: string;
+  description: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  all_day: boolean;
+  location: string | null;
+  status: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function parseAttendees(input: unknown): { value: AttendeeInput[]; error?: string } {
+  if (input === undefined || input === null) return { value: [] };
+  if (!Array.isArray(input)) return { value: [], error: 'attendees must be an array' };
+  const out: AttendeeInput[] = [];
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') {
+      return { value: [], error: 'each attendee must be an object' };
+    }
+    const a = raw as Record<string, unknown>;
+    const userId = typeof a.user_id === 'string' ? a.user_id : null;
+    const externalEmail = typeof a.external_email === 'string' ? a.external_email : null;
+    const externalName = typeof a.external_name === 'string' ? a.external_name : null;
+    const role = typeof a.role === 'string' ? a.role : null;
+
+    const hasUser = !!userId;
+    const hasEmail = !!externalEmail;
+    if (hasUser === hasEmail) {
+      return {
+        value: [],
+        error: 'each attendee must have exactly one of user_id or external_email',
+      };
+    }
+    if (userId && !UUID_RE.test(userId)) {
+      return { value: [], error: 'attendee user_id must be a uuid' };
+    }
+    if (externalEmail && !EMAIL_RE.test(externalEmail)) {
+      return { value: [], error: 'attendee external_email must be a valid email' };
+    }
+    if (role && !ATTENDEE_ROLES.has(role)) {
+      return { value: [], error: 'attendee role is not one of the allowed values' };
+    }
+    out.push({
+      user_id: userId,
+      external_email: externalEmail,
+      external_name: externalName,
+      role,
+    });
+  }
+  return { value: out };
+}
+
+function deriveUnitLabel(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+async function loadAttendeesForEvents(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  eventIds: string[],
+): Promise<Map<string, AttendeeRow[]>> {
+  const out = new Map<string, AttendeeRow[]>();
+  if (eventIds.length === 0) return out;
+  const { data, error } = await supabase
+    .from('schedule_event_attendees')
+    .select('id, event_id, user_id, external_email, external_name, role, rsvp_status, created_at')
+    .in('event_id', eventIds);
+  if (error) {
+    console.error('[schedule-events] attendees_lookup_failed reason=%s', error.message);
+    return out;
+  }
+  for (const row of (data ?? []) as AttendeeRow[]) {
+    const arr = out.get(row.event_id) ?? [];
+    arr.push(row);
+    out.set(row.event_id, arr);
+  }
+  return out;
+}
+
+async function loadLabelsForEvents(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  events: EventRow[],
+): Promise<{ units: Map<string, string>; developments: Map<string, string> }> {
+  const unitIds = Array.from(
+    new Set(events.map((e) => e.unit_id).filter((v): v is string => !!v)),
+  );
+  const devIds = Array.from(
+    new Set(events.map((e) => e.development_id).filter((v): v is string => !!v)),
+  );
+
+  const units = new Map<string, string>();
+  const developments = new Map<string, string>();
+
+  const [unitsRes, devRes] = await Promise.all([
+    unitIds.length > 0
+      ? supabase
+          .from('units')
+          .select('id, unit_code, unit_number, address_line_1')
+          .in('id', unitIds)
+      : Promise.resolve({ data: [], error: null }),
+    devIds.length > 0
+      ? supabase.from('developments').select('id, name').in('id', devIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  if (unitsRes.error) {
+    console.error('[schedule-events] units_lookup_failed reason=%s', unitsRes.error.message);
+  } else {
+    for (const u of (unitsRes.data ?? []) as Array<{
+      id: string;
+      unit_code: string | null;
+      unit_number: string | null;
+      address_line_1: string | null;
+    }>) {
+      units.set(u.id, deriveUnitLabel(u));
+    }
+  }
+  if (devRes.error) {
+    console.error(
+      '[schedule-events] developments_lookup_failed reason=%s',
+      devRes.error.message,
+    );
+  } else {
+    for (const d of (devRes.data ?? []) as Array<{ id: string; name: string | null }>) {
+      developments.set(d.id, d.name ?? 'Development');
+    }
+  }
+  return { units, developments };
+}
+
+function shapeEventResponse(
+  event: EventRow,
+  attendees: AttendeeRow[] | undefined,
+  unitLabel: string | null,
+  developmentLabel: string | null,
+) {
+  return {
+    id: event.id,
+    tenant_id: event.tenant_id,
+    development_id: event.development_id,
+    unit_id: event.unit_id,
+    event_type: event.event_type,
+    title: event.title,
+    description: event.description,
+    starts_at: event.starts_at,
+    ends_at: event.ends_at,
+    all_day: event.all_day,
+    location: event.location,
+    status: event.status,
+    created_by: event.created_by,
+    created_at: event.created_at,
+    updated_at: event.updated_at,
+    unit_label: unitLabel,
+    development_label: developmentLabel,
+    attendees: (attendees ?? []).map((a) => ({
+      id: a.id,
+      user_id: a.user_id,
+      external_email: a.external_email,
+      external_name: a.external_name,
+      role: a.role,
+      rsvp_status: a.rsvp_status,
+    })),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  const url = new URL(request.url);
+  const fromParam = url.searchParams.get('from');
+  const toParam = url.searchParams.get('to');
+
+  if (!fromParam || !toParam) {
+    return NextResponse.json(
+      { error: 'from and to query params are required (ISO timestamps)' },
+      { status: 400 },
+    );
+  }
+
+  const fromDate = new Date(fromParam);
+  const toDate = new Date(toParam);
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    return NextResponse.json(
+      { error: 'from and to must be valid ISO timestamps' },
+      { status: 400 },
+    );
+  }
+  if (toDate.getTime() < fromDate.getTime()) {
+    return NextResponse.json({ error: 'to must be on or after from' }, { status: 400 });
+  }
+  const spanDays = (toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24);
+  if (spanDays > MAX_WINDOW_DAYS) {
+    return NextResponse.json(
+      { error: `window must be at most ${MAX_WINDOW_DAYS} days` },
+      { status: 400 },
+    );
+  }
+
+  const developmentIdParam = url.searchParams.get('development_id');
+  const unitIdParam = url.searchParams.get('unit_id');
+  const attendeeUserIdParam = url.searchParams.get('attendee_user_id');
+  const eventTypeParams = url.searchParams.getAll('event_type');
+
+  if (developmentIdParam && !UUID_RE.test(developmentIdParam)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  if (unitIdParam && !UUID_RE.test(unitIdParam)) {
+    return NextResponse.json({ error: 'unit_id must be a uuid' }, { status: 400 });
+  }
+  if (attendeeUserIdParam && !UUID_RE.test(attendeeUserIdParam)) {
+    return NextResponse.json({ error: 'attendee_user_id must be a uuid' }, { status: 400 });
+  }
+  for (const t of eventTypeParams) {
+    if (!EVENT_TYPES.has(t)) {
+      return NextResponse.json({ error: `event_type '${t}' is not valid` }, { status: 400 });
+    }
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  let baseQuery = supabase
+    .from('schedule_events')
+    .select(
+      'id, tenant_id, development_id, unit_id, event_type, title, description, starts_at, ends_at, all_day, location, status, created_by, created_at, updated_at',
+    )
+    .eq('tenant_id', auth.tenantId)
+    .gte('starts_at', fromDate.toISOString())
+    .lte('starts_at', toDate.toISOString());
+
+  if (developmentIdParam) baseQuery = baseQuery.eq('development_id', developmentIdParam);
+  if (unitIdParam) baseQuery = baseQuery.eq('unit_id', unitIdParam);
+  if (eventTypeParams.length > 0) baseQuery = baseQuery.in('event_type', eventTypeParams);
+
+  let events: EventRow[] = [];
+
+  if (auth.role === 'snagger_external') {
+    const allowed = Array.isArray(auth.developmentIds) ? auth.developmentIds : [];
+
+    const { data: attendeeEventIdRows, error: attErr } = await supabase
+      .from('schedule_event_attendees')
+      .select('event_id')
+      .eq('user_id', auth.userId);
+    if (attErr) {
+      console.error('[schedule-events] external_attendee_lookup_failed reason=%s', attErr.message);
+      return NextResponse.json({ error: 'Could not load events' }, { status: 500 });
+    }
+    const attendeeEventIds = Array.from(
+      new Set((attendeeEventIdRows ?? []).map((r) => r.event_id as string)),
+    );
+
+    if (allowed.length === 0 && attendeeEventIds.length === 0) {
+      return NextResponse.json({ events: [] });
+    }
+
+    let scoped = baseQuery;
+    const clauses: string[] = [];
+    if (allowed.length > 0) {
+      clauses.push(`development_id.in.(${allowed.join(',')})`);
+    }
+    if (attendeeEventIds.length > 0) {
+      clauses.push(`id.in.(${attendeeEventIds.join(',')})`);
+    }
+    scoped = scoped.or(clauses.join(','));
+
+    const { data, error } = await scoped.order('starts_at', { ascending: true });
+    if (error) {
+      console.error('[schedule-events] external_list_failed reason=%s', error.message);
+      return NextResponse.json({ error: 'Could not load events' }, { status: 500 });
+    }
+    events = (data ?? []) as EventRow[];
+  } else {
+    let q = baseQuery;
+    if (attendeeUserIdParam) {
+      const { data: attRows, error: attErr } = await supabase
+        .from('schedule_event_attendees')
+        .select('event_id')
+        .eq('user_id', attendeeUserIdParam);
+      if (attErr) {
+        console.error('[schedule-events] attendee_filter_failed reason=%s', attErr.message);
+        return NextResponse.json({ error: 'Could not load events' }, { status: 500 });
+      }
+      const ids = Array.from(new Set((attRows ?? []).map((r) => r.event_id as string)));
+      if (ids.length === 0) {
+        return NextResponse.json({ events: [] });
+      }
+      q = q.in('id', ids);
+    }
+
+    const { data, error } = await q.order('starts_at', { ascending: true });
+    if (error) {
+      console.error('[schedule-events] list_failed reason=%s', error.message);
+      return NextResponse.json({ error: 'Could not load events' }, { status: 500 });
+    }
+    events = (data ?? []) as EventRow[];
+  }
+
+  const eventIds = events.map((e) => e.id);
+  const [attendeesByEvent, labels] = await Promise.all([
+    loadAttendeesForEvents(supabase, eventIds),
+    loadLabelsForEvents(supabase, events),
+  ]);
+
+  return NextResponse.json({
+    events: events.map((e) =>
+      shapeEventResponse(
+        e,
+        attendeesByEvent.get(e.id),
+        e.unit_id ? labels.units.get(e.unit_id) ?? null : null,
+        e.development_id ? labels.developments.get(e.development_id) ?? null : null,
+      ),
+    ),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const eventType = typeof payload.event_type === 'string' ? payload.event_type : '';
+  const title = typeof payload.title === 'string' ? payload.title.trim() : '';
+  const description = typeof payload.description === 'string' ? payload.description : null;
+  const startsAt = typeof payload.starts_at === 'string' ? payload.starts_at : '';
+  const endsAt = typeof payload.ends_at === 'string' ? payload.ends_at : null;
+  const allDay = payload.all_day === true;
+  const location = typeof payload.location === 'string' ? payload.location : null;
+  const developmentId =
+    typeof payload.development_id === 'string' ? payload.development_id : null;
+  const unitId = typeof payload.unit_id === 'string' ? payload.unit_id : null;
+
+  if (!EVENT_TYPES.has(eventType)) {
+    return NextResponse.json({ error: 'event_type is required and must be valid' }, { status: 400 });
+  }
+  if (title.length === 0) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+  if (title.length > MAX_TITLE) {
+    return NextResponse.json(
+      { error: `title must be at most ${MAX_TITLE} characters` },
+      { status: 400 },
+    );
+  }
+  if (description !== null && description.length > MAX_DESCRIPTION) {
+    return NextResponse.json(
+      { error: `description must be at most ${MAX_DESCRIPTION} characters` },
+      { status: 400 },
+    );
+  }
+  if (location !== null && location.length > MAX_LOCATION) {
+    return NextResponse.json(
+      { error: `location must be at most ${MAX_LOCATION} characters` },
+      { status: 400 },
+    );
+  }
+  const startsDate = new Date(startsAt);
+  if (isNaN(startsDate.getTime())) {
+    return NextResponse.json({ error: 'starts_at must be a valid ISO timestamp' }, { status: 400 });
+  }
+  let endsDate: Date | null = null;
+  if (endsAt) {
+    endsDate = new Date(endsAt);
+    if (isNaN(endsDate.getTime())) {
+      return NextResponse.json({ error: 'ends_at must be a valid ISO timestamp' }, { status: 400 });
+    }
+    if (endsDate.getTime() < startsDate.getTime()) {
+      return NextResponse.json({ error: 'ends_at must be on or after starts_at' }, { status: 400 });
+    }
+  }
+
+  if (developmentId && !UUID_RE.test(developmentId)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+  if (unitId && !UUID_RE.test(unitId)) {
+    return NextResponse.json({ error: 'unit_id must be a uuid' }, { status: 400 });
+  }
+
+  const attendeesParsed = parseAttendees(payload.attendees);
+  if (attendeesParsed.error) {
+    return NextResponse.json({ error: attendeesParsed.error }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  if (developmentId) {
+    const { data: dev, error: devErr } = await supabase
+      .from('developments')
+      .select('id, tenant_id')
+      .eq('id', developmentId)
+      .maybeSingle();
+    if (devErr) {
+      console.error('[schedule-create] dev_lookup_failed reason=%s', devErr.message);
+      return NextResponse.json({ error: 'Could not validate development' }, { status: 500 });
+    }
+    if (!dev || dev.tenant_id !== auth.tenantId) {
+      return NextResponse.json(
+        { error: 'development_id is not in your tenant' },
+        { status: 403 },
+      );
+    }
+  }
+  if (unitId) {
+    const { data: unit, error: unitErr } = await supabase
+      .from('units')
+      .select('id, tenant_id, development_id')
+      .eq('id', unitId)
+      .maybeSingle();
+    if (unitErr) {
+      console.error('[schedule-create] unit_lookup_failed reason=%s', unitErr.message);
+      return NextResponse.json({ error: 'Could not validate unit' }, { status: 500 });
+    }
+    if (!unit || unit.tenant_id !== auth.tenantId) {
+      return NextResponse.json({ error: 'unit_id is not in your tenant' }, { status: 403 });
+    }
+    if (developmentId && unit.development_id !== developmentId) {
+      return NextResponse.json(
+        { error: 'unit_id does not belong to the supplied development_id' },
+        { status: 400 },
+      );
+    }
+  }
+
+  const insertPayload = {
+    tenant_id: auth.tenantId,
+    development_id: developmentId,
+    unit_id: unitId,
+    event_type: eventType,
+    title,
+    description,
+    starts_at: startsDate.toISOString(),
+    ends_at: endsDate ? endsDate.toISOString() : null,
+    all_day: allDay,
+    location,
+    status: 'scheduled',
+    created_by: auth.userId,
+  };
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from('schedule_events')
+    .insert(insertPayload)
+    .select(
+      'id, tenant_id, development_id, unit_id, event_type, title, description, starts_at, ends_at, all_day, location, status, created_by, created_at, updated_at',
+    )
+    .single();
+
+  if (insertErr || !inserted) {
+    console.error('[schedule-create] insert_failed reason=%s', insertErr?.message ?? 'unknown');
+    return NextResponse.json({ error: 'Could not create event' }, { status: 500 });
+  }
+
+  let attendees: AttendeeRow[] = [];
+  if (attendeesParsed.value.length > 0) {
+    const rows = attendeesParsed.value.map((a) => ({
+      event_id: inserted.id,
+      user_id: a.user_id,
+      external_email: a.external_email,
+      external_name: a.external_name,
+      role: a.role,
+    }));
+    const { data: attRows, error: attErr } = await supabase
+      .from('schedule_event_attendees')
+      .insert(rows)
+      .select('id, event_id, user_id, external_email, external_name, role, rsvp_status, created_at');
+    if (attErr) {
+      console.error('[schedule-create] attendees_insert_failed reason=%s', attErr.message);
+      return NextResponse.json(
+        { error: 'Event created but attendees failed; please retry' },
+        { status: 500 },
+      );
+    }
+    attendees = (attRows ?? []) as AttendeeRow[];
+  }
+
+  return NextResponse.json(
+    shapeEventResponse(inserted as EventRow, attendees, null, null),
+    { status: 201 },
+  );
+}

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -114,6 +114,30 @@ export function isHomeownerIssuesEnabled(): boolean {
   );
 }
 
+/**
+ * Assistant V2 schedule and calendar surface (Sprint 4).
+ *
+ * Default off. When false:
+ *   - the Schedule sidebar item does not render
+ *   - the /developer/schedule page is hidden
+ *   - all /api/schedule/* server routes return 404 before any auth
+ *     or DB work
+ *   - the daily digest cron at /api/cron/schedule-digest is a no-op
+ *
+ * Server reads FEATURE_SCHEDULE. Client reads
+ * NEXT_PUBLIC_FEATURE_SCHEDULE (must be set separately for the
+ * bundler to inline the value at build time).
+ */
+export function isScheduleEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_SCHEDULE === 'true';
+  }
+  return (
+    process.env.FEATURE_SCHEDULE === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_SCHEDULE === 'true'
+  );
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
@@ -123,5 +147,6 @@ export function getFeatureFlags() {
     builderSnagApp: isBuilderSnagAppEnabled(),
     developerDashboard: isDeveloperDashboardEnabled(),
     homeownerIssues: isHomeownerIssuesEnabled(),
+    schedule: isScheduleEnabled(),
   };
 }

--- a/docs/specs/assistant-v2-sprint-4.md
+++ b/docs/specs/assistant-v2-sprint-4.md
@@ -19,12 +19,13 @@ Out of scope deliberately: external calendar sync (Google/Outlook), recurring ev
 
 ## 2. Who uses this
 
-- **Site managers and developer admins:** see the full schedule for their tenant. Add, edit, cancel events. Receive the daily digest email.
-- **Snaggers (site_team_snag):** see only events that include them as an attendee. No add/edit. Can mark themselves as confirmed/declined on events that include them.
-- **External snaggers (snagger_external):** same as site_team_snag but only see events tied to units they have access to (single-unit access remains scoped).
+**Correction (V1).** An earlier draft of this section described a `site_team_snag` user role. That label is not a role in the codebase; it is the `issue_reports.source` value used to mark snags submitted via the builder-side snag app. The actual user roles on `site_team_members` are `admin`, `site_team`, and `snagger_external`. V1 drops the attendee-only scoping for internal snaggers (there is no role to scope on) and only scopes external snaggers. A sub-role for "internal snagger" can be added in a later sprint if the distinction becomes valuable.
+
+- **Site managers and developer admins (`admin`, `site_team`):** see the full schedule for their tenant. Add, edit, cancel events. Receive the daily digest email.
+- **External snaggers (`snagger_external`):** read-only. See only events in developments they have access to (per the existing `developmentIds` scoping on `site_team_members`) or events where they are listed as an attendee. Can update their own RSVP on events they attend; cannot add/edit/cancel any events.
 - **Homeowners:** no visibility. The schedule is a developer-side tool. Future sprint can expose homeowner-specific events (handover dates, scheduled snag visits) on their portal.
 
-Role enforcement happens server-side via the existing `resolveSnagAuth` helper.
+Role enforcement happens server-side via the existing `resolveSnagAuth` helper. Write permission to create/update/cancel events is gated to `admin` and `site_team`.
 
 ---
 
@@ -160,13 +161,15 @@ Query params:
 - `attendee_user_id` (optional): events that include this user as attendee
 
 Behaviour:
-1. Verify caller via `resolveSnagAuth`. snagger_external is allowed but their results are further filtered server-side to events tied to units they have access to (or events with them as attendee).
-2. site_team_snag (internal) sees events with them as attendee only.
-3. Admin and site_team see all tenant events in the window.
+1. Verify caller via `resolveSnagAuth`.
+2. `admin` and `site_team` see all events in their tenant in the window (subject to optional filters).
+3. `snagger_external` sees the union of: events whose `development_id` is in their `developmentIds`, plus events where they appear in the attendees list. Other tenant events are not returned.
 4. Return events ordered by `starts_at asc`. Each event includes:
    - Standard event fields
    - `attendees: [{user_id?, external_name?, role, rsvp_status}]`
    - `unit_label`, `development_label` (joined for display)
+
+Note: an earlier draft referenced a `site_team_snag` role for attendee-only scoping. That label is an issue source, not a user role. V1 implements scoping only for `snagger_external` as described above. See section 2 for the full correction.
 
 ### 5.2 GET /api/schedule/events/[id]
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/send-scheduled-broadcasts",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/schedule-digest",
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
Implements sections 4 (schema) and 5 (server routes) of docs/specs/assistant-v2-sprint-4.md. No UI in this session.

## Schema (applied via Supabase MCP, project mddxbilpjukwskeefakz)

Three separate apply_migration calls per the established pattern; each verified via execute_sql before moving on.

| Migration | Verification |
|---|---|
| `sprint_4_schedule_events` (table + 3 indexes) | 15 columns, 2 check constraints (event_type, status), 4 indexes (PK + tenant/starts, unit/starts partial, dev/starts partial) |
| `sprint_4_schedule_event_attendees` (table + 2 indexes) | 8 columns, 2 check constraints (role, rsvp_status), 1 FK (event_id -> schedule_events on delete cascade), 3 indexes (PK + event, user partial) |
| `sprint_4_schedule_rls` (RLS + policies) | RLS enabled on both tables; `service_role_bypass` policy present on each |

## Feature flag

- `FEATURE_SCHEDULE=false` and `NEXT_PUBLIC_FEATURE_SCHEDULE=false` added to `apps/unified-portal/.env.example` and `.env.production.example`.
- `isScheduleEnabled()` exported from `apps/unified-portal/lib/feature-flags.ts`, mirroring `isHomeownerIssuesEnabled` exactly. Default off in production. Added to `getFeatureFlags()`.

## API routes

All gated on `FEATURE_SCHEDULE`; return 404 before any auth or DB work when the flag is off. All use `resolveSnagAuth` for identity, `getSupabaseAdmin()` for writes (RLS is `service_role_bypass`), and derive `tenant_id` / `created_by` from the verified `site_team_members` row.

| Route | Purpose | Auth |
|---|---|---|
| `GET /api/schedule/events` | List events in a window (max 90 days) with optional filters. admin/site_team see all tenant events; snagger_external is scoped to events on accessible developments OR events where they are an attendee. Returns attendees + unit/development labels joined. | session |
| `GET /api/schedule/events/[id]` | Single-event detail with full attendee list. snagger_external rejected with 403 unless attendee or on accessible development. | session |
| `POST /api/schedule/events` | Create event. admin/site_team only. Validates development_id/unit_id belong to caller's tenant; enforces exactly one of user_id or external_email per attendee row (app-level, no DB constraint); validates ends_at >= starts_at. | session |
| `PATCH /api/schedule/events/[id]` | Partial update. admin/site_team only. Same validation as POST for any provided fields. tenant_id/created_by immutable. Replaces attendee list when provided (delete + insert via service-role). | session |
| `POST /api/schedule/events/[id]/cancel` | Sets status='cancelled' (row preserved for audit). admin/site_team only. | session |
| `POST /api/schedule/events/[id]/rsvp` | Caller updates their own attendee row only. Accepts confirmed/declined/tentative. | session |
| `POST /api/cron/schedule-digest` | Daily digest of today's events grouped by event_type. Iterates tenants with `tenant_settings.aftercare_email` set. Today is computed in Europe/Dublin (1-hour winter drift accepted per spec). Cancelled events excluded. Skips silently when zero events. Sends via `getResendClient()`. | `INTERNAL_ENRICHMENT_KEY` via `x-internal-key` header (timingSafeEqual), or `Bearer <SUPABASE_SERVICE_ROLE_KEY>` (mirrors the homeowner-issue notification route from Sprint 3.5a) |

## vercel.json

Appended `/api/cron/schedule-digest` at `0 7 * * *` alongside the existing `refresh-tokens` and `send-scheduled-broadcasts` entries. No conflicting cron paths.

## Spec correction (in same PR)

`docs/specs/assistant-v2-sprint-4.md` sections 2 (Who uses this) and 5.1 (GET /events) updated to remove references to a `site_team_snag` user role. That label is the `issue_reports.source` value, not a `site_team_members.role` value (the actual roles are admin, site_team, snagger_external). V1 scopes only snagger_external for read; admin and site_team both see all tenant events. The original spec text was a drafting error; one-paragraph corrections inline in both sections.

## Build

`npm --workspace=@openhouse/unified-portal run build` is green locally; all 6 routes plus the cron registered in the route table. Will confirm Vercel preview READY before squash-merging.

## Out of scope (covered by Session 2)

Schedule sidebar item, /developer/schedule page, Add event modal, event detail drawer. No UI work in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)