### PR TITLE
feat(assistant-v2): Sprint 4 schedule calendar UI

### DIFF
--- a/apps/unified-portal/app/api/cron/schedule-digest/route.ts
+++ b/apps/unified-portal/app/api/cron/schedule-digest/route.ts
@@ -8,15 +8,15 @@
  *
  * Spec: docs/specs/assistant-v2-sprint-4.md section 5.7.
  *
- * Auth. Reuses the INTERNAL_ENRICHMENT_KEY env var (same secret used
- * by /api/snag/enrich and /api/notifications/homeowner-issue) to avoid
- * introducing a second internal-only credential. The header check uses
- * crypto.timingSafeEqual. As a secondary acceptable proof, an
- * Authorization: Bearer with the Supabase service-role key is also
- * accepted, mirroring the other internal routes. Vercel Cron's own
- * Bearer CRON_SECRET is intentionally not accepted in V1; the cron
- * entry is there so the Vercel project tracks the schedule, but the
- * acceptance criterion is satisfied by manual curl invocation.
+ * Auth. Two acceptable paths:
+ *   1. Authorization: Bearer <CRON_SECRET> - what Vercel Cron sends
+ *      automatically when triggering scheduled invocations. Same env
+ *      var used by /api/cron/refresh-tokens and
+ *      /api/cron/send-scheduled-broadcasts.
+ *   2. x-internal-key: <INTERNAL_ENRICHMENT_KEY> - for manual curl
+ *      testing, matching the homeowner-issue notification route.
+ * Both comparisons use crypto.timingSafeEqual so the route is not
+ * vulnerable to timing oracles. Any other request returns 401.
  *
  * Iteration. The spec's "tenants with FEATURE_SCHEDULE enabled" gate
  * is global today (env var, not per-tenant). For V1 we iterate every
@@ -88,19 +88,19 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(ba, bb);
 }
 
-function isInternalCaller(request: NextRequest): boolean {
+function isAuthorisedCaller(request: NextRequest): boolean {
+  const auth = request.headers.get('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    const token = auth.slice(7);
+    const cronSecret = process.env.CRON_SECRET;
+    if (cronSecret && safeEqual(token, cronSecret)) {
+      return true;
+    }
+  }
   const internalKey = process.env.INTERNAL_ENRICHMENT_KEY;
   const headerKey = request.headers.get('x-internal-key');
   if (internalKey && headerKey && safeEqual(headerKey, internalKey)) {
     return true;
-  }
-  const auth = request.headers.get('authorization');
-  if (auth?.startsWith('Bearer ')) {
-    const token = auth.slice(7);
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (serviceKey && safeEqual(token, serviceKey)) {
-      return true;
-    }
   }
   return false;
 }
@@ -162,8 +162,8 @@ export async function POST(request: NextRequest) {
     return snagFeatureDisabledResponse();
   }
 
-  if (!isInternalCaller(request)) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  if (!isAuthorisedCaller(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const supabase = getSupabaseAdmin();

--- a/apps/unified-portal/app/api/schedule/lookups/route.ts
+++ b/apps/unified-portal/app/api/schedule/lookups/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /api/schedule/lookups
+ *
+ * Assistant V2 Sprint 4. Returns the tenant's developments and active
+ * site_team_members for use in the Add/Edit event modal's pickers.
+ * admin and site_team only; snagger_external cannot create or edit
+ * events so they have no reason to fetch this data.
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const [devRes, memberRes] = await Promise.all([
+    supabase
+      .from('developments')
+      .select('id, name')
+      .eq('tenant_id', auth.tenantId)
+      .order('name', { ascending: true }),
+    supabase
+      .from('site_team_members')
+      .select('user_id, role, invited_email')
+      .eq('tenant_id', auth.tenantId)
+      .eq('active', true)
+      .order('invited_at', { ascending: true }),
+  ]);
+
+  if (devRes.error) {
+    console.error('[schedule-lookups] dev_lookup_failed reason=%s', devRes.error.message);
+    return NextResponse.json({ error: 'Could not load developments' }, { status: 500 });
+  }
+  if (memberRes.error) {
+    console.error('[schedule-lookups] member_lookup_failed reason=%s', memberRes.error.message);
+    return NextResponse.json({ error: 'Could not load team members' }, { status: 500 });
+  }
+
+  const developments = (devRes.data ?? []).map((d) => ({
+    id: d.id as string,
+    name: (d.name as string | null) ?? 'Development',
+  }));
+
+  const members = (memberRes.data ?? [])
+    .filter((m) => !!m.user_id)
+    .map((m) => ({
+      user_id: m.user_id as string,
+      role: (m.role as string | null) ?? null,
+      email: (m.invited_email as string | null) ?? null,
+    }));
+
+  return NextResponse.json({ developments, members });
+}

--- a/apps/unified-portal/app/api/schedule/lookups/units/route.ts
+++ b/apps/unified-portal/app/api/schedule/lookups/units/route.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /api/schedule/lookups/units?development_id=...
+ *
+ * Assistant V2 Sprint 4. Returns the units in a given development for
+ * use in the Add/Edit event modal's unit picker. admin and site_team
+ * only; matches the rest of the schedule write surface.
+ *
+ * Gated on FEATURE_SCHEDULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase-server';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import {
+  resolveSnagAuth,
+  snagAuthErrorToResponse,
+  snagFeatureDisabledResponse,
+  SnagAuthError,
+  type SnagAuthContext,
+} from '@/lib/assistant/snag-auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function deriveUnitLabel(u: {
+  unit_code: string | null;
+  unit_number: string | null;
+  address_line_1: string | null;
+}): string {
+  return u.unit_code ?? u.unit_number ?? u.address_line_1 ?? 'Unit';
+}
+
+export async function GET(request: NextRequest) {
+  if (!isScheduleEnabled()) {
+    return snagFeatureDisabledResponse();
+  }
+
+  let auth: SnagAuthContext;
+  try {
+    auth = await resolveSnagAuth(request);
+  } catch (err) {
+    if (err instanceof SnagAuthError) return snagAuthErrorToResponse(err);
+    throw err;
+  }
+
+  if (auth.role !== 'admin' && auth.role !== 'site_team') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const developmentId = url.searchParams.get('development_id') ?? '';
+  if (!UUID_RE.test(developmentId)) {
+    return NextResponse.json({ error: 'development_id must be a uuid' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: dev, error: devErr } = await supabase
+    .from('developments')
+    .select('id, tenant_id')
+    .eq('id', developmentId)
+    .maybeSingle();
+  if (devErr) {
+    console.error('[schedule-lookups-units] dev_lookup_failed reason=%s', devErr.message);
+    return NextResponse.json({ error: 'Could not validate development' }, { status: 500 });
+  }
+  if (!dev || dev.tenant_id !== auth.tenantId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: unitRows, error: unitErr } = await supabase
+    .from('units')
+    .select('id, unit_code, unit_number, address_line_1')
+    .eq('development_id', developmentId)
+    .order('unit_code', { ascending: true });
+  if (unitErr) {
+    console.error('[schedule-lookups-units] units_failed reason=%s', unitErr.message);
+    return NextResponse.json({ error: 'Could not load units' }, { status: 500 });
+  }
+
+  const units = (unitRows ?? []).map((u) => ({
+    id: u.id as string,
+    label: deriveUnitLabel({
+      unit_code: (u.unit_code as string | null) ?? null,
+      unit_number: (u.unit_number as string | null) ?? null,
+      address_line_1: (u.address_line_1 as string | null) ?? null,
+    }),
+  }));
+
+  return NextResponse.json({ units });
+}

--- a/apps/unified-portal/app/developer/layout-sidebar.tsx
+++ b/apps/unified-portal/app/developer/layout-sidebar.tsx
@@ -10,9 +10,9 @@ import {
   FolderArchive, MessageSquare, Shield, Sparkles,
   Layers, ShieldCheck, GitBranch, Mail, Command,
   CalendarCheck, Building2, Wrench, Dumbbell, BookOpen as Welcome,
-  Plug, Megaphone, HardDrive, LogOut, UserPlus, ClipboardList
+  Plug, Megaphone, HardDrive, LogOut, UserPlus, ClipboardList, Calendar
 } from 'lucide-react';
-import { isDeveloperDashboardEnabled, isBuilderSnagAppEnabled, isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import { isDeveloperDashboardEnabled, isBuilderSnagAppEnabled, isHomeownerIssuesEnabled, isScheduleEnabled } from '@/lib/feature-flags';
 import { ScopeSwitcher } from '@/components/developer/ScopeSwitcher';
 import { CommandPalette } from '@/components/ui/CommandPalette';
 import { HomeownersBadge } from '@/components/developer/HomeownersBadge';
@@ -37,6 +37,7 @@ function buildBtsNavSections(opts: { isAdmin: boolean }): NavSection[] {
   const dashboardOn = isDeveloperDashboardEnabled();
   const snagAppOn = isBuilderSnagAppEnabled();
   const homeownerIssuesOn = isHomeownerIssuesEnabled();
+  const scheduleOn = isScheduleEnabled();
 
   const snaggingItems: NavSection['items'] = [];
   if (dashboardOn) {
@@ -95,6 +96,9 @@ function buildBtsNavSections(opts: { isAdmin: boolean }): NavSection[] {
       title: 'Management',
       items: [
         homeownersItem,
+        ...(scheduleOn
+          ? [{ label: 'Schedule', href: '/developer/schedule', icon: Calendar }]
+          : []),
         { label: 'Smart Archive', href: '/developer/archive', icon: FolderArchive },
         { label: 'Data Hub', href: '/developer/data-hub', icon: HardDrive },
         { label: 'Room Dimensions', href: '/developer/room-dimensions', icon: Ruler },

--- a/apps/unified-portal/app/developer/schedule/EventDrawer.tsx
+++ b/apps/unified-portal/app/developer/schedule/EventDrawer.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Calendar, MapPin, X } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import {
+  AttendeeRole,
+  ATTENDEE_ROLE_LABELS,
+  eventTypeColour,
+  eventTypeLabel,
+  formatDublinDate,
+  formatDublinTime,
+  RsvpStatus,
+  ScheduleEvent,
+} from './eventTypes';
+
+interface EventDrawerProps {
+  eventId: string | null;
+  currentUserId: string;
+  canWrite: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+  onEdit: (event: ScheduleEvent) => void;
+}
+
+const RSVP_BADGE_STYLES: Record<RsvpStatus, string> = {
+  confirmed: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+  declined: 'bg-red-100 text-red-700 border-red-200',
+  tentative: 'bg-amber-100 text-amber-700 border-amber-200',
+  invited: 'bg-neutral-100 text-neutral-600 border-neutral-200',
+};
+
+const RSVP_BADGE_LABELS: Record<RsvpStatus, string> = {
+  confirmed: 'Confirmed',
+  declined: 'Declined',
+  tentative: 'Tentative',
+  invited: 'Invited',
+};
+
+const STATUS_BADGE_STYLES: Record<ScheduleEvent['status'], string> = {
+  scheduled: 'bg-blue-50 text-blue-700 border-blue-200',
+  in_progress: 'bg-amber-50 text-amber-700 border-amber-200',
+  completed: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  cancelled: 'bg-neutral-100 text-neutral-600 border-neutral-200',
+};
+
+const STATUS_BADGE_LABELS: Record<ScheduleEvent['status'], string> = {
+  scheduled: 'Scheduled',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+function formatTimeRange(event: ScheduleEvent): string {
+  if (event.all_day) {
+    return `${formatDublinDate(event.starts_at)}, all day`;
+  }
+  const dateLabel = formatDublinDate(event.starts_at);
+  if (event.ends_at) {
+    return `${dateLabel}, ${formatDublinTime(event.starts_at)} - ${formatDublinTime(event.ends_at)}`;
+  }
+  return `${dateLabel}, ${formatDublinTime(event.starts_at)}`;
+}
+
+export function EventDrawer({
+  eventId,
+  currentUserId,
+  canWrite,
+  onClose,
+  onChanged,
+  onEdit,
+}: EventDrawerProps) {
+  const [data, setData] = useState<ScheduleEvent | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rsvpBusy, setRsvpBusy] = useState(false);
+  const [cancelBusy, setCancelBusy] = useState(false);
+  const [confirmCancelOpen, setConfirmCancelOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!eventId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/schedule/events/${eventId}`, { cache: 'no-store' });
+      if (!res.ok) {
+        setError(res.status === 404 ? 'Event not found.' : "Couldn't load this event.");
+        setData(null);
+        return;
+      }
+      const json = (await res.json()) as ScheduleEvent;
+      setData(json);
+    } catch {
+      setError("Couldn't load this event.");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    if (!eventId) {
+      setData(null);
+      setError(null);
+      setConfirmCancelOpen(false);
+      return;
+    }
+    void load();
+  }, [eventId, load]);
+
+  useEffect(() => {
+    if (!eventId) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      document.body.style.overflow = prev;
+    };
+  }, [eventId, onClose]);
+
+  const myAttendee = data?.attendees.find((a) => a.user_id === currentUserId);
+
+  const sendRsvp = async (next: 'confirmed' | 'declined' | 'tentative') => {
+    if (!eventId || rsvpBusy) return;
+    setRsvpBusy(true);
+    try {
+      const res = await fetch(`/api/schedule/events/${eventId}/rsvp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ rsvp_status: next }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json?.error ?? "Couldn't update RSVP");
+        return;
+      }
+      toast.success(`RSVP set to ${next}.`);
+      await load();
+      onChanged();
+    } finally {
+      setRsvpBusy(false);
+    }
+  };
+
+  const confirmCancel = async () => {
+    if (!eventId || cancelBusy) return;
+    setCancelBusy(true);
+    try {
+      const res = await fetch(`/api/schedule/events/${eventId}/cancel`, { method: 'POST' });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json?.error ?? "Couldn't cancel event");
+        return;
+      }
+      toast.success('Event cancelled.');
+      setConfirmCancelOpen(false);
+      await load();
+      onChanged();
+    } finally {
+      setCancelBusy(false);
+    }
+  };
+
+  if (!eventId) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-modal flex justify-end" role="dialog" aria-modal="true" aria-label="Event detail">
+        <button
+          type="button"
+          aria-label="Close event detail"
+          onClick={onClose}
+          className="absolute inset-0 bg-neutral-900/40"
+        />
+        <div className="relative bg-white w-full sm:w-[560px] sm:max-w-[560px] h-full shadow-2xl flex flex-col overflow-hidden">
+          <header className="flex items-center gap-1 px-4 py-3 border-b border-neutral-200 bg-white">
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="w-10 h-10 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            <div className="flex-1 min-w-0">
+              {data ? (
+                <div className="flex items-center gap-2 min-w-0">
+                  <h2 className="text-sm font-semibold text-neutral-900 truncate">{data.title}</h2>
+                  <span
+                    className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${STATUS_BADGE_STYLES[data.status]}`}
+                  >
+                    {STATUS_BADGE_LABELS[data.status]}
+                  </span>
+                </div>
+              ) : (
+                <h2 className="text-sm font-semibold text-neutral-500">Event</h2>
+              )}
+            </div>
+          </header>
+
+          <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+            {loading && !data ? (
+              <p className="text-sm text-neutral-500">Loading event...</p>
+            ) : error ? (
+              <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            ) : data ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium text-white"
+                    style={{ backgroundColor: eventTypeColour(data.event_type) }}
+                  >
+                    {eventTypeLabel(data.event_type)}
+                  </span>
+                </div>
+                <div className="flex items-start gap-2 text-sm text-neutral-700">
+                  <Calendar className="w-4 h-4 text-neutral-400 mt-0.5 flex-shrink-0" />
+                  <span>{formatTimeRange(data)}</span>
+                </div>
+                {data.location ? (
+                  <div className="flex items-start gap-2 text-sm text-neutral-700">
+                    <MapPin className="w-4 h-4 text-neutral-400 mt-0.5 flex-shrink-0" />
+                    <span>{data.location}</span>
+                  </div>
+                ) : null}
+                {data.unit_label || data.development_label ? (
+                  <div className="text-sm text-neutral-700 space-y-1">
+                    {data.unit_label ? (
+                      <div>
+                        Unit:{' '}
+                        {data.unit_id ? (
+                          <a
+                            href={`/developer/homeowners`}
+                            className="text-gold-700 hover:text-gold-800"
+                          >
+                            {data.unit_label}
+                          </a>
+                        ) : (
+                          <span>{data.unit_label}</span>
+                        )}
+                      </div>
+                    ) : null}
+                    {data.development_label ? (
+                      <div>
+                        Development: <span>{data.development_label}</span>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+                {data.description ? (
+                  <div className="text-sm text-neutral-800 whitespace-pre-wrap leading-relaxed">
+                    {data.description}
+                  </div>
+                ) : null}
+
+                <div>
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-neutral-500 mb-2">
+                    Attendees ({data.attendees.length})
+                  </h3>
+                  {data.attendees.length === 0 ? (
+                    <p className="text-sm text-neutral-500">No attendees on this event.</p>
+                  ) : (
+                    <ul className="space-y-1.5">
+                      {data.attendees.map((a) => (
+                        <li
+                          key={a.id}
+                          className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-neutral-200"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-neutral-900 truncate">
+                              {a.external_name ?? a.external_email ?? 'Team member'}
+                            </div>
+                            <div className="flex items-center gap-1.5 text-xs text-neutral-500 mt-0.5">
+                              {a.role ? (
+                                <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600">
+                                  {ATTENDEE_ROLE_LABELS[a.role as AttendeeRole] ?? a.role}
+                                </span>
+                              ) : null}
+                              {a.external_email && a.external_name ? (
+                                <span className="truncate">{a.external_email}</span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <span
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${RSVP_BADGE_STYLES[a.rsvp_status]}`}
+                          >
+                            {RSVP_BADGE_LABELS[a.rsvp_status]}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {myAttendee && data.status !== 'cancelled' ? (
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      <span className="text-xs text-neutral-500">Your RSVP:</span>
+                      <button
+                        type="button"
+                        disabled={rsvpBusy}
+                        onClick={() => void sendRsvp('confirmed')}
+                        className="px-3 py-1.5 rounded-lg border border-emerald-200 bg-emerald-50 hover:bg-emerald-100 text-emerald-700 text-xs font-medium disabled:opacity-50"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        type="button"
+                        disabled={rsvpBusy}
+                        onClick={() => void sendRsvp('tentative')}
+                        className="px-3 py-1.5 rounded-lg border border-amber-200 bg-amber-50 hover:bg-amber-100 text-amber-700 text-xs font-medium disabled:opacity-50"
+                      >
+                        Tentative
+                      </button>
+                      <button
+                        type="button"
+                        disabled={rsvpBusy}
+                        onClick={() => void sendRsvp('declined')}
+                        className="px-3 py-1.5 rounded-lg border border-red-200 bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium disabled:opacity-50"
+                      >
+                        Decline
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </>
+            ) : null}
+          </div>
+
+          {canWrite && data && data.status !== 'cancelled' ? (
+            <div className="px-4 py-3 border-t border-neutral-200 bg-neutral-50 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmCancelOpen(true)}
+                className="px-3 py-2 rounded-lg text-sm font-medium text-neutral-700 hover:bg-neutral-100"
+              >
+                Cancel event
+              </button>
+              <button
+                type="button"
+                onClick={() => onEdit(data)}
+                className="px-3 py-2 rounded-lg text-sm font-medium text-white bg-gold-500 hover:bg-gold-600"
+              >
+                Edit
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <Dialog.Root open={confirmCancelOpen} onOpenChange={(o) => !cancelBusy && setConfirmCancelOpen(o)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[95vw] max-w-sm bg-white rounded-xl shadow-xl focus:outline-none">
+            <div className="p-5 border-b border-gray-100">
+              <Dialog.Title className="text-lg font-semibold text-gray-900">Cancel this event?</Dialog.Title>
+              <Dialog.Description className="text-sm text-gray-500 mt-1">
+                Attendees will not be notified automatically.
+              </Dialog.Description>
+            </div>
+            <div className="flex items-center justify-end gap-2 p-5 bg-gray-50 rounded-b-xl">
+              <button
+                type="button"
+                onClick={() => setConfirmCancelOpen(false)}
+                disabled={cancelBusy}
+                className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg disabled:opacity-50"
+              >
+                Keep
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmCancel()}
+                disabled={cancelBusy}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg disabled:bg-red-300"
+              >
+                {cancelBusy ? 'Cancelling...' : 'Cancel event'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/apps/unified-portal/app/developer/schedule/EventModal.tsx
+++ b/apps/unified-portal/app/developer/schedule/EventModal.tsx
@@ -1,0 +1,625 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Plus, Search, Trash2, X } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import {
+  AttendeeRole,
+  ATTENDEE_ROLES,
+  ATTENDEE_ROLE_LABELS,
+  EVENT_TYPES,
+  EVENT_TYPE_LABELS,
+  ScheduleEvent,
+  ScheduleEventType,
+} from './eventTypes';
+
+interface EventModalProps {
+  editingEvent: ScheduleEvent | null;
+  tenantId: string;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+interface DevelopmentOption {
+  id: string;
+  name: string;
+}
+
+interface MemberOption {
+  user_id: string;
+  email: string | null;
+  role: string | null;
+}
+
+interface UnitOption {
+  id: string;
+  label: string;
+}
+
+interface AttendeeDraft {
+  key: string;
+  user_id: string | null;
+  external_email: string | null;
+  external_name: string | null;
+  display_name: string;
+  role: AttendeeRole;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isoDateLocal(iso: string): string {
+  const d = new Date(iso);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+function isoTimeLocal(iso: string): string {
+  const d = new Date(iso);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+function combineLocalToIso(date: string, time: string): string {
+  return new Date(`${date}T${time || '00:00'}`).toISOString();
+}
+
+export function EventModal({ editingEvent, tenantId, onClose, onSaved }: EventModalProps) {
+  const isEdit = !!editingEvent;
+
+  const [lookupLoading, setLookupLoading] = useState(true);
+  const [developments, setDevelopments] = useState<DevelopmentOption[]>([]);
+  const [members, setMembers] = useState<MemberOption[]>([]);
+
+  const [title, setTitle] = useState(editingEvent?.title ?? '');
+  const [eventType, setEventType] = useState<ScheduleEventType>(
+    (editingEvent?.event_type as ScheduleEventType) ?? 'custom',
+  );
+  const [startDate, setStartDate] = useState(
+    editingEvent ? isoDateLocal(editingEvent.starts_at) : '',
+  );
+  const [startTime, setStartTime] = useState(
+    editingEvent && !editingEvent.all_day ? isoTimeLocal(editingEvent.starts_at) : '09:00',
+  );
+  const [endDate, setEndDate] = useState(
+    editingEvent?.ends_at ? isoDateLocal(editingEvent.ends_at) : '',
+  );
+  const [endTime, setEndTime] = useState(
+    editingEvent?.ends_at && !editingEvent.all_day ? isoTimeLocal(editingEvent.ends_at) : '10:00',
+  );
+  const [allDay, setAllDay] = useState(editingEvent?.all_day ?? false);
+  const [location, setLocation] = useState(editingEvent?.location ?? '');
+  const [developmentId, setDevelopmentId] = useState<string>(editingEvent?.development_id ?? '');
+  const [unitId, setUnitId] = useState<string>(editingEvent?.unit_id ?? '');
+  const [description, setDescription] = useState(editingEvent?.description ?? '');
+  const [attendees, setAttendees] = useState<AttendeeDraft[]>(() =>
+    (editingEvent?.attendees ?? []).map((a, idx) => ({
+      key: `existing-${idx}-${a.id}`,
+      user_id: a.user_id,
+      external_email: a.external_email,
+      external_name: a.external_name,
+      display_name: a.external_name ?? a.external_email ?? 'Team member',
+      role: ((a.role as AttendeeRole) && ATTENDEE_ROLES.includes(a.role as AttendeeRole)
+        ? (a.role as AttendeeRole)
+        : 'other') as AttendeeRole,
+    })),
+  );
+  const [units, setUnits] = useState<UnitOption[]>([]);
+  const [unitsLoading, setUnitsLoading] = useState(false);
+  const [memberPickerOpen, setMemberPickerOpen] = useState(false);
+  const [memberQuery, setMemberQuery] = useState('');
+  const [externalDraft, setExternalDraft] = useState<{ name: string; email: string } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    (async () => {
+      setLookupLoading(true);
+      try {
+        const res = await fetch('/api/schedule/lookups', { cache: 'no-store', signal: ac.signal });
+        if (!res.ok) return;
+        const json = (await res.json()) as { developments: DevelopmentOption[]; members: MemberOption[] };
+        setDevelopments(json.developments ?? []);
+        setMembers(json.members ?? []);
+      } catch {
+        // swallow; user can still type fields without lookups
+      } finally {
+        setLookupLoading(false);
+      }
+    })();
+    return () => ac.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!developmentId) {
+      setUnits([]);
+      return;
+    }
+    const ac = new AbortController();
+    (async () => {
+      setUnitsLoading(true);
+      try {
+        const res = await fetch(`/api/schedule/lookups/units?development_id=${developmentId}`, {
+          cache: 'no-store',
+          signal: ac.signal,
+        });
+        if (!res.ok) {
+          setUnits([]);
+          return;
+        }
+        const json = (await res.json()) as { units: UnitOption[] };
+        setUnits(json.units ?? []);
+      } catch {
+        setUnits([]);
+      } finally {
+        setUnitsLoading(false);
+      }
+    })();
+    return () => ac.abort();
+  }, [developmentId]);
+
+  const filteredMembers = useMemo(() => {
+    const q = memberQuery.trim().toLowerCase();
+    const picked = new Set(attendees.filter((a) => a.user_id).map((a) => a.user_id as string));
+    return members.filter((m) => {
+      if (picked.has(m.user_id)) return false;
+      if (!q) return true;
+      return (m.email ?? '').toLowerCase().includes(q);
+    });
+  }, [members, memberQuery, attendees]);
+
+  const addMemberAttendee = (member: MemberOption) => {
+    setAttendees((prev) => [
+      ...prev,
+      {
+        key: `member-${member.user_id}-${Date.now()}`,
+        user_id: member.user_id,
+        external_email: null,
+        external_name: null,
+        display_name: member.email ?? 'Team member',
+        role: 'site_team',
+      },
+    ]);
+    setMemberPickerOpen(false);
+    setMemberQuery('');
+  };
+
+  const addExternalAttendee = () => {
+    if (!externalDraft) return;
+    const name = externalDraft.name.trim();
+    const email = externalDraft.email.trim();
+    if (!name) {
+      toast.error('External attendee needs a name.');
+      return;
+    }
+    if (!EMAIL_RE.test(email)) {
+      toast.error('External attendee needs a valid email.');
+      return;
+    }
+    setAttendees((prev) => [
+      ...prev,
+      {
+        key: `external-${email}-${Date.now()}`,
+        user_id: null,
+        external_email: email,
+        external_name: name,
+        display_name: name,
+        role: 'contractor',
+      },
+    ]);
+    setExternalDraft(null);
+  };
+
+  const removeAttendee = (key: string) => {
+    setAttendees((prev) => prev.filter((a) => a.key !== key));
+  };
+
+  const setAttendeeRole = (key: string, role: AttendeeRole) => {
+    setAttendees((prev) => prev.map((a) => (a.key === key ? { ...a, role } : a)));
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      toast.error('Title is required.');
+      return;
+    }
+    if (!startDate) {
+      toast.error('Start date is required.');
+      return;
+    }
+    const startsIso = combineLocalToIso(startDate, allDay ? '00:00' : startTime);
+    const endsIso =
+      endDate && !allDay
+        ? combineLocalToIso(endDate, endTime)
+        : endDate && allDay
+        ? combineLocalToIso(endDate, '23:59')
+        : null;
+    if (endsIso && new Date(endsIso).getTime() < new Date(startsIso).getTime()) {
+      toast.error('End must be on or after start.');
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      title: trimmedTitle,
+      event_type: eventType,
+      starts_at: startsIso,
+      ends_at: endsIso,
+      all_day: allDay,
+      location: location.trim() || null,
+      description: description.trim() || null,
+      development_id: developmentId || null,
+      unit_id: unitId || null,
+      attendees: attendees.map((a) => ({
+        user_id: a.user_id,
+        external_email: a.external_email,
+        external_name: a.external_name,
+        role: a.role,
+      })),
+    };
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        isEdit && editingEvent ? `/api/schedule/events/${editingEvent.id}` : '/api/schedule/events',
+        {
+          method: isEdit ? 'PATCH' : 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+      );
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({}));
+        toast.error(json?.error ?? "Couldn't save event");
+        return;
+      }
+      onSaved();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open onOpenChange={(o) => !submitting && !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[95vw] max-w-2xl bg-white rounded-xl shadow-xl focus:outline-none max-h-[92vh] flex flex-col">
+          <div className="flex items-start justify-between p-5 border-b border-gray-100">
+            <div>
+              <Dialog.Title className="text-lg font-semibold text-gray-900">
+                {isEdit ? 'Edit event' : 'Add event'}
+              </Dialog.Title>
+              <Dialog.Description className="text-sm text-gray-500 mt-1">
+                {isEdit ? 'Update the event details.' : 'Schedule a new event for your tenant.'}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                className="p-2 rounded-lg hover:bg-gray-100"
+                aria-label="Close"
+                disabled={submitting}
+              >
+                <X className="w-5 h-5 text-gray-400" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-5 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                maxLength={200}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm"
+                placeholder="What's the event?"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Event type</label>
+                <select
+                  value={eventType}
+                  onChange={(e) => setEventType(e.target.value as ScheduleEventType)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400"
+                >
+                  {EVENT_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {EVENT_TYPE_LABELS[t]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-end pb-2">
+                <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={allDay}
+                    onChange={(e) => setAllDay(e.target.checked)}
+                    className="rounded text-gold-500 focus:ring-gold-400"
+                  />
+                  All day
+                </label>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Start date</label>
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400"
+                />
+              </div>
+              {!allDay ? (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Start time</label>
+                  <input
+                    type="time"
+                    value={startTime}
+                    onChange={(e) => setStartTime(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400"
+                  />
+                </div>
+              ) : (
+                <div />
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">End date (optional)</label>
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400"
+                />
+              </div>
+              {!allDay ? (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">End time</label>
+                  <input
+                    type="time"
+                    value={endTime}
+                    onChange={(e) => setEndTime(e.target.value)}
+                    disabled={!endDate}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 disabled:bg-gray-50"
+                  />
+                </div>
+              ) : (
+                <div />
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Location (optional)</label>
+              <input
+                type="text"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                maxLength={200}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm"
+                placeholder="Site office, Block A meeting room, etc."
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Development (optional)</label>
+                <select
+                  value={developmentId}
+                  onChange={(e) => {
+                    setDevelopmentId(e.target.value);
+                    setUnitId('');
+                  }}
+                  disabled={lookupLoading}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 disabled:bg-gray-50"
+                >
+                  <option value="">No development</option>
+                  {developments.map((d) => (
+                    <option key={d.id} value={d.id}>
+                      {d.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Unit (optional)</label>
+                <select
+                  value={unitId}
+                  onChange={(e) => setUnitId(e.target.value)}
+                  disabled={!developmentId || unitsLoading}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 disabled:bg-gray-50"
+                >
+                  <option value="">{developmentId ? 'No unit' : 'Pick a development first'}</option>
+                  {units.map((u) => (
+                    <option key={u.id} value={u.id}>
+                      {u.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Description (optional)</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                maxLength={2000}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gold-500/40 focus:border-gold-400 text-sm resize-y"
+                placeholder="Add any context..."
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label className="block text-sm font-medium text-gray-700">Attendees</label>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setMemberPickerOpen(true)}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-gold-700 hover:text-gold-800"
+                  >
+                    <Plus className="w-3 h-3" />
+                    Add team member
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setExternalDraft({ name: '', email: '' })}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-gold-700 hover:text-gold-800"
+                  >
+                    <Plus className="w-3 h-3" />
+                    Add external
+                  </button>
+                </div>
+              </div>
+              {attendees.length === 0 ? (
+                <p className="text-xs text-gray-500">No attendees added yet.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {attendees.map((a) => (
+                    <li
+                      key={a.key}
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-gray-900 truncate">{a.display_name}</div>
+                        {a.external_email ? (
+                          <div className="text-xs text-gray-500 truncate">{a.external_email}</div>
+                        ) : null}
+                      </div>
+                      <select
+                        value={a.role}
+                        onChange={(e) => setAttendeeRole(a.key, e.target.value as AttendeeRole)}
+                        className="text-xs px-2 py-1 border border-gray-200 rounded focus:outline-none focus:ring-2 focus:ring-gold-500/40"
+                      >
+                        {ATTENDEE_ROLES.map((r) => (
+                          <option key={r} value={r}>
+                            {ATTENDEE_ROLE_LABELS[r]}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => removeAttendee(a.key)}
+                        className="p-1 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                        aria-label="Remove attendee"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {memberPickerOpen ? (
+                <div className="mt-2 rounded-lg border border-gray-200 bg-white p-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Search className="w-4 h-4 text-gray-400" />
+                    <input
+                      type="text"
+                      placeholder="Search by email..."
+                      value={memberQuery}
+                      onChange={(e) => setMemberQuery(e.target.value)}
+                      className="flex-1 text-sm bg-transparent focus:outline-none"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setMemberPickerOpen(false)}
+                      className="text-xs text-gray-500 hover:text-gray-700"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <div className="max-h-40 overflow-y-auto divide-y divide-gray-100">
+                    {filteredMembers.length === 0 ? (
+                      <p className="text-xs text-gray-400 py-2">No members match.</p>
+                    ) : (
+                      filteredMembers.map((m) => (
+                        <button
+                          key={m.user_id}
+                          type="button"
+                          onClick={() => addMemberAttendee(m)}
+                          className="w-full text-left px-2 py-1.5 text-sm text-gray-800 hover:bg-gray-50 rounded"
+                        >
+                          {m.email ?? 'Team member'}
+                          {m.role ? (
+                            <span className="ml-2 text-xs text-gray-400">({m.role})</span>
+                          ) : null}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              ) : null}
+              {externalDraft ? (
+                <div className="mt-2 rounded-lg border border-gray-200 bg-white p-3 space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <input
+                      type="text"
+                      placeholder="Name"
+                      value={externalDraft.name}
+                      onChange={(e) => setExternalDraft((d) => (d ? { ...d, name: e.target.value } : null))}
+                      className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40"
+                    />
+                    <input
+                      type="email"
+                      placeholder="email@example.com"
+                      value={externalDraft.email}
+                      onChange={(e) => setExternalDraft((d) => (d ? { ...d, email: e.target.value } : null))}
+                      className="px-2 py-1.5 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gold-500/40"
+                    />
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setExternalDraft(null)}
+                      className="text-xs text-gray-500 hover:text-gray-700"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={addExternalAttendee}
+                      className="text-xs font-medium px-3 py-1.5 rounded bg-gold-500 hover:bg-gold-600 text-white"
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 p-5 border-t border-gray-100 bg-gray-50 rounded-b-xl">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleSubmit()}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-white bg-gold-500 hover:bg-gold-600 rounded-lg disabled:bg-gold-300"
+            >
+              {submitting ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/unified-portal/app/developer/schedule/MonthView.tsx
+++ b/apps/unified-portal/app/developer/schedule/MonthView.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  addDays,
+  dublinDateKey,
+  eventTypeColour,
+  formatDublinDate,
+  formatDublinTime,
+  ScheduleEvent,
+} from './eventTypes';
+
+interface MonthViewProps {
+  start: Date;
+  monthAnchor: Date;
+  events: ScheduleEvent[];
+  loading: boolean;
+  onEventClick: (id: string) => void;
+}
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function monthOf(d: Date): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+    month: '2-digit',
+  }).formatToParts(d);
+  return `${parts.find((p) => p.type === 'year')!.value}-${parts.find((p) => p.type === 'month')!.value}`;
+}
+
+function dayLabel(d: Date): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    day: 'numeric',
+  }).format(d);
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+export function MonthView({ start, monthAnchor, events, loading, onEventClick }: MonthViewProps) {
+  const [dayDrawerKey, setDayDrawerKey] = useState<string | null>(null);
+
+  const todayKey = dublinDateKey(new Date());
+  const monthKey = monthOf(monthAnchor);
+
+  const cells: Date[] = [];
+  for (let i = 0; i < 42; i += 1) {
+    cells.push(addDays(start, i));
+  }
+
+  const eventsByDay = new Map<string, ScheduleEvent[]>();
+  for (const e of events) {
+    const key = dublinDateKey(new Date(e.starts_at));
+    const list = eventsByDay.get(key) ?? [];
+    list.push(e);
+    eventsByDay.set(key, list);
+  }
+  for (const list of eventsByDay.values()) {
+    list.sort((a, b) => a.starts_at.localeCompare(b.starts_at));
+  }
+
+  const dayDrawerEvents = dayDrawerKey ? eventsByDay.get(dayDrawerKey) ?? [] : [];
+  const dayDrawerDate = dayDrawerKey
+    ? new Date(
+        Date.UTC(
+          parseInt(dayDrawerKey.slice(0, 4), 10),
+          parseInt(dayDrawerKey.slice(5, 7), 10) - 1,
+          parseInt(dayDrawerKey.slice(8, 10), 10),
+          12,
+          0,
+          0,
+        ),
+      )
+    : null;
+
+  return (
+    <div className="border border-neutral-200 rounded-lg overflow-hidden bg-white">
+      <div className="grid grid-cols-7 border-b border-neutral-200 bg-neutral-50">
+        {DAY_NAMES.map((name) => (
+          <div
+            key={name}
+            className="px-3 py-2 text-center text-xs uppercase tracking-wider text-neutral-500 font-semibold border-l first:border-l-0 border-neutral-200"
+          >
+            {name}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7">
+        {cells.map((d) => {
+          const key = dublinDateKey(d);
+          const isToday = key === todayKey;
+          const isCurrentMonth = monthOf(d) === monthKey;
+          const dayEvents = eventsByDay.get(key) ?? [];
+          const overflow = dayEvents.length > 3 ? dayEvents.length - 3 : 0;
+          const visible = dayEvents.slice(0, 3);
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => {
+                if (dayEvents.length > 0) setDayDrawerKey(key);
+              }}
+              className={`relative min-h-[96px] text-left p-1.5 border-l first:border-l-0 border-t border-neutral-200 first:border-t-0 align-top ${
+                isCurrentMonth ? 'bg-white' : 'bg-neutral-50/60'
+              } ${isToday ? 'ring-2 ring-gold-500 ring-inset' : ''} ${
+                dayEvents.length === 0 ? 'cursor-default' : 'hover:bg-neutral-50'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span
+                  className={`text-xs font-semibold ${
+                    isCurrentMonth ? (isToday ? 'text-gold-700' : 'text-neutral-700') : 'text-neutral-400'
+                  }`}
+                >
+                  {dayLabel(d)}
+                </span>
+              </div>
+              <div className="space-y-1">
+                {visible.map((e) => {
+                  const cancelled = e.status === 'cancelled';
+                  const colour = eventTypeColour(e.event_type);
+                  return (
+                    <div
+                      key={e.id}
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        onEventClick(e.id);
+                      }}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault();
+                          ev.stopPropagation();
+                          onEventClick(e.id);
+                        }
+                      }}
+                      title={e.title}
+                      className={`block text-[11px] px-1.5 py-0.5 rounded text-white font-medium truncate cursor-pointer ${
+                        cancelled ? 'opacity-50 line-through' : ''
+                      }`}
+                      style={{ backgroundColor: colour }}
+                    >
+                      {truncate(e.title, 18)}
+                    </div>
+                  );
+                })}
+                {overflow > 0 ? (
+                  <div className="text-[11px] text-neutral-500 font-medium pl-1">+{overflow} more</div>
+                ) : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {loading ? (
+        <div className="px-4 py-2 text-xs text-neutral-400 border-t border-neutral-200">Loading...</div>
+      ) : null}
+
+      {dayDrawerKey && dayDrawerDate ? (
+        <DayDetailDrawer
+          dateLabel={formatDublinDate(dayDrawerDate.toISOString())}
+          events={dayDrawerEvents}
+          onClose={() => setDayDrawerKey(null)}
+          onEventClick={onEventClick}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface DayDetailDrawerProps {
+  dateLabel: string;
+  events: ScheduleEvent[];
+  onClose: () => void;
+  onEventClick: (id: string) => void;
+}
+
+function DayDetailDrawer({ dateLabel, events, onClose, onEventClick }: DayDetailDrawerProps) {
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end" role="dialog" aria-modal="true" aria-label="Day detail">
+      <button type="button" aria-label="Close day detail" onClick={onClose} className="absolute inset-0 bg-neutral-900/40" />
+      <div className="relative bg-white w-full sm:w-[420px] sm:max-w-[420px] h-full shadow-2xl flex flex-col overflow-hidden">
+        <header className="flex items-center gap-1 px-4 py-3 border-b border-neutral-200 bg-white">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="w-10 h-10 -ml-2 flex items-center justify-center rounded-lg text-neutral-700 hover:bg-neutral-100"
+          >
+            <X className="w-5 h-5" />
+          </button>
+          <h2 className="text-sm font-semibold text-neutral-900">{dateLabel}</h2>
+        </header>
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-2">
+          {events.length === 0 ? (
+            <p className="text-sm text-neutral-500">No events on this day.</p>
+          ) : (
+            events.map((e) => {
+              const colour = eventTypeColour(e.event_type);
+              const cancelled = e.status === 'cancelled';
+              const time = e.all_day
+                ? 'All day'
+                : e.ends_at
+                ? `${formatDublinTime(e.starts_at)} - ${formatDublinTime(e.ends_at)}`
+                : formatDublinTime(e.starts_at);
+              return (
+                <button
+                  key={e.id}
+                  type="button"
+                  onClick={() => {
+                    onEventClick(e.id);
+                    onClose();
+                  }}
+                  className={`w-full text-left bg-white border border-neutral-200 rounded-md p-3 hover:shadow-sm transition-shadow ${
+                    cancelled ? 'opacity-60' : ''
+                  }`}
+                  style={{ borderLeft: `3px solid ${colour}` }}
+                >
+                  <div className={`text-sm font-medium text-neutral-900 ${cancelled ? 'line-through' : ''}`}>
+                    {e.title}
+                  </div>
+                  <div className="text-xs text-neutral-500">{time}</div>
+                  {e.unit_label || e.development_label ? (
+                    <div className="text-xs text-neutral-400 truncate">
+                      {[e.unit_label, e.development_label].filter(Boolean).join(' | ')}
+                    </div>
+                  ) : null}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/unified-portal/app/developer/schedule/ScheduleClient.tsx
+++ b/apps/unified-portal/app/developer/schedule/ScheduleClient.tsx
@@ -1,0 +1,455 @@
+'use client';
+
+/**
+ * Top-level client for /developer/schedule.
+ *
+ * Owns the view state (week vs month), the anchor date, the loaded
+ * events for the active window, and the open/close state for the
+ * detail drawer and Add/Edit modal. Renders the toolbar plus either
+ * WeekView or MonthView, with EventDrawer and EventModal mounted at
+ * the root and controlled by id.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, Filter, Plus } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import {
+  addDays,
+  dublinDateKey,
+  EVENT_TYPES,
+  EVENT_TYPE_LABELS,
+  formatMonthLabel,
+  formatRangeLabel,
+  ScheduleEvent,
+  startOfDublinWeek,
+} from './eventTypes';
+import { WeekView } from './WeekView';
+import { MonthView } from './MonthView';
+import { EventDrawer } from './EventDrawer';
+import { EventModal } from './EventModal';
+
+type CalendarView = 'week' | 'month';
+
+interface ScheduleClientProps {
+  role: 'admin' | 'site_team' | 'snagger_external';
+  userId: string;
+  tenantId: string;
+}
+
+interface Filters {
+  developmentIds: string[];
+  eventTypes: string[];
+}
+
+const EMPTY_FILTERS: Filters = { developmentIds: [], eventTypes: [] };
+
+function startOfDublinMonth(d: Date): Date {
+  const key = dublinDateKey(d);
+  const [y, m] = key.split('-').map((s) => parseInt(s, 10));
+  return new Date(Date.UTC(y, m - 1, 1, 12, 0, 0));
+}
+
+function endOfDublinMonth(d: Date): Date {
+  const key = dublinDateKey(d);
+  const [y, m] = key.split('-').map((s) => parseInt(s, 10));
+  return new Date(Date.UTC(y, m, 0, 12, 0, 0));
+}
+
+function gridStartForMonth(d: Date): Date {
+  const monthStart = startOfDublinMonth(d);
+  return startOfDublinWeek(monthStart);
+}
+
+function gridEndForMonth(d: Date): Date {
+  const monthEnd = endOfDublinMonth(d);
+  const weekStart = startOfDublinWeek(monthEnd);
+  return addDays(weekStart, 6);
+}
+
+export function ScheduleClient({ role, userId, tenantId }: ScheduleClientProps) {
+  const [view, setView] = useState<CalendarView>('week');
+  const [anchor, setAnchor] = useState<Date>(() => new Date());
+  const [events, setEvents] = useState<ScheduleEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<ScheduleEvent | null>(null);
+
+  const canWrite = role === 'admin' || role === 'site_team';
+
+  const { windowStart, windowEnd } = useMemo(() => {
+    if (view === 'week') {
+      const start = startOfDublinWeek(anchor);
+      return { windowStart: start, windowEnd: addDays(start, 6) };
+    }
+    return { windowStart: gridStartForMonth(anchor), windowEnd: gridEndForMonth(anchor) };
+  }, [anchor, view]);
+
+  const fetchEvents = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      params.set('from', windowStart.toISOString());
+      const toEnd = new Date(windowEnd.getTime());
+      toEnd.setUTCHours(23, 59, 59, 999);
+      params.set('to', toEnd.toISOString());
+      for (const id of filters.developmentIds) params.append('development_id', id);
+      for (const t of filters.eventTypes) params.append('event_type', t);
+      const res = await fetch(`/api/schedule/events?${params.toString()}`, { cache: 'no-store' });
+      if (!res.ok) {
+        setError("Couldn't load the schedule.");
+        setEvents([]);
+        return;
+      }
+      const json = (await res.json()) as { events: ScheduleEvent[] };
+      setEvents(json.events ?? []);
+    } catch {
+      setError("Couldn't load the schedule.");
+      setEvents([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [windowStart, windowEnd, filters]);
+
+  useEffect(() => {
+    void fetchEvents();
+  }, [fetchEvents]);
+
+  const goPrevious = () => {
+    if (view === 'week') {
+      setAnchor(addDays(anchor, -7));
+    } else {
+      const key = dublinDateKey(anchor);
+      const [y, m, d] = key.split('-').map((s) => parseInt(s, 10));
+      setAnchor(new Date(Date.UTC(y, m - 2, d, 12, 0, 0)));
+    }
+  };
+  const goNext = () => {
+    if (view === 'week') {
+      setAnchor(addDays(anchor, 7));
+    } else {
+      const key = dublinDateKey(anchor);
+      const [y, m, d] = key.split('-').map((s) => parseInt(s, 10));
+      setAnchor(new Date(Date.UTC(y, m, d, 12, 0, 0)));
+    }
+  };
+  const goToday = () => setAnchor(new Date());
+
+  const periodLabel =
+    view === 'week'
+      ? formatRangeLabel(windowStart, addDays(windowStart, 6))
+      : formatMonthLabel(anchor);
+
+  const subhead = useMemo(() => {
+    if (events.length === 0) return '';
+    const periodWord = view === 'week' ? 'this week' : 'this month';
+    return `${events.length} event${events.length === 1 ? '' : 's'} scheduled across all developments ${periodWord}`;
+  }, [events.length, view]);
+
+  const developmentOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const e of events) {
+      if (e.development_id && e.development_label) {
+        map.set(e.development_id, e.development_label);
+      }
+    }
+    return Array.from(map.entries())
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [events]);
+
+  const handleEventClick = (id: string) => setSelectedEventId(id);
+  const handleAddClick = () => {
+    setEditingEvent(null);
+    setModalOpen(true);
+  };
+  const handleEditClick = (event: ScheduleEvent) => {
+    setEditingEvent(event);
+    setModalOpen(true);
+    setSelectedEventId(null);
+  };
+
+  const handleModalSaved = () => {
+    setModalOpen(false);
+    setEditingEvent(null);
+    toast.success('Event saved.');
+    void fetchEvents();
+  };
+
+  const handleEventChanged = () => {
+    void fetchEvents();
+  };
+
+  return (
+    <div className="px-6 py-6 max-w-screen-2xl mx-auto">
+      <div className="mb-4">
+        <h1 className="text-2xl font-semibold text-neutral-900">Schedule</h1>
+        {subhead ? (
+          <p className="text-sm text-neutral-500 mt-1">{subhead}</p>
+        ) : (
+          <p className="text-sm text-neutral-400 mt-1">
+            No events scheduled. {canWrite ? 'Add an event using the button above or check a different week.' : 'Check a different week.'}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <div
+          role="tablist"
+          aria-label="Schedule view"
+          className="inline-flex items-center gap-1 p-1 bg-neutral-100 rounded-full"
+        >
+          {(['week', 'month'] as CalendarView[]).map((opt) => {
+            const isActive = opt === view;
+            return (
+              <button
+                key={opt}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setView(opt)}
+                className={`inline-flex items-center gap-1.5 h-9 px-4 rounded-full text-sm font-medium transition-colors min-h-[36px] ${
+                  isActive
+                    ? 'bg-gold-500 text-white shadow-sm'
+                    : 'text-neutral-700 hover:text-neutral-900'
+                }`}
+              >
+                {opt === 'week' ? 'Week' : 'Month'}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="inline-flex items-center gap-1 ml-1">
+          <button
+            type="button"
+            aria-label="Previous"
+            onClick={goPrevious}
+            className="w-9 h-9 inline-flex items-center justify-center rounded-lg border border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={goToday}
+            className="h-9 px-3 inline-flex items-center text-sm font-medium rounded-lg border border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700"
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            aria-label="Next"
+            onClick={goNext}
+            className="w-9 h-9 inline-flex items-center justify-center rounded-lg border border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="text-sm text-neutral-600 font-medium">{periodLabel}</div>
+
+        <div className="ml-auto inline-flex items-center gap-2">
+          <FiltersDropdown
+            open={filtersOpen}
+            onToggle={() => setFiltersOpen((v) => !v)}
+            onClose={() => setFiltersOpen(false)}
+            developments={developmentOptions}
+            filters={filters}
+            onChange={setFilters}
+          />
+          {canWrite ? (
+            <button
+              type="button"
+              onClick={handleAddClick}
+              className="inline-flex items-center gap-2 h-9 px-4 rounded-lg bg-gold-500 hover:bg-gold-600 text-white text-sm font-medium shadow-sm"
+            >
+              <Plus className="w-4 h-4" />
+              Add event
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {view === 'week' ? (
+        <WeekView
+          start={windowStart}
+          events={events}
+          loading={loading}
+          onEventClick={handleEventClick}
+        />
+      ) : (
+        <MonthView
+          start={windowStart}
+          monthAnchor={anchor}
+          events={events}
+          loading={loading}
+          onEventClick={handleEventClick}
+        />
+      )}
+
+      <EventDrawer
+        eventId={selectedEventId}
+        currentUserId={userId}
+        canWrite={canWrite}
+        onClose={() => setSelectedEventId(null)}
+        onChanged={handleEventChanged}
+        onEdit={(event) => handleEditClick(event)}
+      />
+
+      {modalOpen ? (
+        <EventModal
+          editingEvent={editingEvent}
+          tenantId={tenantId}
+          onClose={() => {
+            setModalOpen(false);
+            setEditingEvent(null);
+          }}
+          onSaved={handleModalSaved}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface FiltersDropdownProps {
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  developments: Array<{ id: string; name: string }>;
+  filters: Filters;
+  onChange: (next: Filters) => void;
+}
+
+function FiltersDropdown({
+  open,
+  onToggle,
+  onClose,
+  developments,
+  filters,
+  onChange,
+}: FiltersDropdownProps) {
+  const active = filters.developmentIds.length + filters.eventTypes.length;
+
+  const toggleDevelopment = (id: string) => {
+    if (filters.developmentIds.includes(id)) {
+      onChange({ ...filters, developmentIds: filters.developmentIds.filter((x) => x !== id) });
+    } else {
+      onChange({ ...filters, developmentIds: [...filters.developmentIds, id] });
+    }
+  };
+
+  const toggleEventType = (type: string) => {
+    if (filters.eventTypes.includes(type)) {
+      onChange({ ...filters, eventTypes: filters.eventTypes.filter((x) => x !== type) });
+    } else {
+      onChange({ ...filters, eventTypes: [...filters.eventTypes, type] });
+    }
+  };
+
+  const clearAll = () => onChange({ developmentIds: [], eventTypes: [] });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`inline-flex items-center gap-2 h-9 px-3 rounded-lg border text-sm font-medium ${
+          active > 0
+            ? 'border-gold-300 bg-gold-50 text-gold-700'
+            : 'border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700'
+        }`}
+      >
+        <Filter className="w-4 h-4" />
+        Filters
+        {active > 0 ? (
+          <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 text-xs font-semibold bg-gold-500 text-white rounded-full">
+            {active}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <>
+          <button
+            type="button"
+            aria-hidden
+            tabIndex={-1}
+            onClick={onClose}
+            className="fixed inset-0 z-10 bg-transparent cursor-default"
+          />
+          <div className="absolute right-0 top-full mt-1 z-20 w-72 rounded-lg border border-neutral-200 bg-white shadow-lg p-3 space-y-3">
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500">Event type</p>
+                {active > 0 ? (
+                  <button
+                    type="button"
+                    onClick={clearAll}
+                    className="text-xs font-medium text-gold-700 hover:text-gold-800"
+                  >
+                    Clear all
+                  </button>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {EVENT_TYPES.map((t) => {
+                  const isActive = filters.eventTypes.includes(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => toggleEventType(t)}
+                      className={`px-2.5 py-1 rounded-full text-xs font-medium border ${
+                        isActive
+                          ? 'border-gold-400 bg-gold-50 text-gold-800'
+                          : 'border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50'
+                      }`}
+                    >
+                      {EVENT_TYPE_LABELS[t]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            {developments.length > 0 ? (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-neutral-500 mb-2">
+                  Development
+                </p>
+                <div className="space-y-1 max-h-40 overflow-y-auto">
+                  {developments.map((d) => {
+                    const isActive = filters.developmentIds.includes(d.id);
+                    return (
+                      <label
+                        key={d.id}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-neutral-50 cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isActive}
+                          onChange={() => toggleDevelopment(d.id)}
+                          className="rounded text-gold-500 focus:ring-gold-400"
+                        />
+                        <span className="text-sm text-neutral-800 truncate">{d.name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/unified-portal/app/developer/schedule/WeekView.tsx
+++ b/apps/unified-portal/app/developer/schedule/WeekView.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {
+  addDays,
+  dublinDateKey,
+  eventTypeColour,
+  formatDublinTime,
+  ScheduleEvent,
+} from './eventTypes';
+
+interface WeekViewProps {
+  start: Date;
+  events: ScheduleEvent[];
+  loading: boolean;
+  onEventClick: (id: string) => void;
+}
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function dayLabel(d: Date): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    day: 'numeric',
+  }).format(d);
+}
+
+function dublinEventDateKey(iso: string): string {
+  return dublinDateKey(new Date(iso));
+}
+
+export function WeekView({ start, events, loading, onEventClick }: WeekViewProps) {
+  const days: Date[] = [];
+  for (let i = 0; i < 7; i += 1) {
+    days.push(addDays(start, i));
+  }
+
+  const todayKey = dublinDateKey(new Date());
+  const eventsByDay = new Map<string, ScheduleEvent[]>();
+  for (const e of events) {
+    const key = dublinEventDateKey(e.starts_at);
+    const list = eventsByDay.get(key) ?? [];
+    list.push(e);
+    eventsByDay.set(key, list);
+  }
+
+  return (
+    <div className="border border-neutral-200 rounded-lg overflow-hidden bg-white">
+      <div className="grid grid-cols-7 border-b border-neutral-200 bg-neutral-50">
+        {days.map((d, i) => {
+          const key = dublinDateKey(d);
+          const isToday = key === todayKey;
+          return (
+            <div
+              key={key}
+              className={`px-3 py-2 text-center border-l first:border-l-0 border-neutral-200 ${
+                isToday ? 'bg-gold-50' : ''
+              }`}
+            >
+              <div className="text-xs uppercase tracking-wider text-neutral-500 font-semibold">
+                {DAY_NAMES[i]}
+              </div>
+              <div
+                className={`mt-0.5 text-base font-semibold ${
+                  isToday ? 'text-gold-700' : 'text-neutral-800'
+                }`}
+              >
+                {dayLabel(d)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="grid grid-cols-7 min-h-[480px]">
+        {days.map((d) => {
+          const key = dublinDateKey(d);
+          const isToday = key === todayKey;
+          const dayEvents = eventsByDay.get(key) ?? [];
+          dayEvents.sort((a, b) => a.starts_at.localeCompare(b.starts_at));
+          return (
+            <div
+              key={key}
+              className={`px-2 py-2 border-l first:border-l-0 border-neutral-200 space-y-2 ${
+                isToday ? 'bg-gold-50/40' : ''
+              }`}
+            >
+              {loading ? (
+                <div className="text-xs text-neutral-400">Loading...</div>
+              ) : dayEvents.length === 0 ? (
+                <div className="text-xs text-neutral-400">No events</div>
+              ) : (
+                dayEvents.map((e) => <EventCard key={e.id} event={e} onClick={() => onEventClick(e.id)} />)
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function EventCard({ event, onClick }: { event: ScheduleEvent; onClick: () => void }) {
+  const cancelled = event.status === 'cancelled';
+  const venue = event.unit_label || event.development_label || '';
+  const attendeeCount = event.attendees.length;
+  const timeText = event.all_day
+    ? 'All day'
+    : event.ends_at
+    ? `${formatDublinTime(event.starts_at)} - ${formatDublinTime(event.ends_at)}`
+    : formatDublinTime(event.starts_at);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={event.title}
+      className={`w-full text-left bg-white border border-neutral-200 rounded-md p-3 hover:shadow-sm transition-shadow flex flex-col gap-1 ${
+        cancelled ? 'opacity-60' : ''
+      }`}
+      style={{ borderLeft: `3px solid ${eventTypeColour(event.event_type)}` }}
+    >
+      <div
+        className={`text-sm font-medium text-neutral-900 truncate ${
+          cancelled ? 'line-through' : ''
+        }`}
+      >
+        {event.title}
+      </div>
+      <div className="text-xs text-neutral-500">{timeText}</div>
+      {venue ? (
+        <div className="text-xs text-neutral-400 truncate">{venue}</div>
+      ) : null}
+      {attendeeCount > 0 ? (
+        <span className="inline-flex items-center self-start mt-0.5 px-1.5 py-0.5 rounded-full bg-neutral-100 text-neutral-600 text-[10px] font-medium">
+          {attendeeCount} attendee{attendeeCount === 1 ? '' : 's'}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/unified-portal/app/developer/schedule/eventTypes.ts
+++ b/apps/unified-portal/app/developer/schedule/eventTypes.ts
@@ -1,0 +1,158 @@
+export const EVENT_TYPES = [
+  'handover',
+  'snag_visit',
+  'contractor_visit',
+  'homeowner_appointment',
+  'inspection',
+  'custom',
+] as const;
+
+export type ScheduleEventType = (typeof EVENT_TYPES)[number];
+
+export const EVENT_TYPE_COLOURS: Record<ScheduleEventType, string> = {
+  handover: '#D4AF37',
+  snag_visit: '#3b82f6',
+  contractor_visit: '#f97316',
+  homeowner_appointment: '#10b981',
+  inspection: '#8b5cf6',
+  custom: '#6b7280',
+};
+
+export const EVENT_TYPE_LABELS: Record<ScheduleEventType, string> = {
+  handover: 'Handover',
+  snag_visit: 'Snag visit',
+  contractor_visit: 'Contractor visit',
+  homeowner_appointment: 'Homeowner appointment',
+  inspection: 'Inspection',
+  custom: 'Other',
+};
+
+export const ATTENDEE_ROLES = [
+  'organiser',
+  'site_team',
+  'snagger',
+  'contractor',
+  'homeowner',
+  'other',
+] as const;
+
+export type AttendeeRole = (typeof ATTENDEE_ROLES)[number];
+
+export const ATTENDEE_ROLE_LABELS: Record<AttendeeRole, string> = {
+  organiser: 'Organiser',
+  site_team: 'Site team',
+  snagger: 'Snagger',
+  contractor: 'Contractor',
+  homeowner: 'Homeowner',
+  other: 'Other',
+};
+
+export type RsvpStatus = 'invited' | 'confirmed' | 'declined' | 'tentative';
+
+export interface ScheduleAttendee {
+  id: string;
+  user_id: string | null;
+  external_email: string | null;
+  external_name: string | null;
+  role: string | null;
+  rsvp_status: RsvpStatus;
+}
+
+export interface ScheduleEvent {
+  id: string;
+  tenant_id: string;
+  development_id: string | null;
+  unit_id: string | null;
+  event_type: string;
+  title: string;
+  description: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  all_day: boolean;
+  location: string | null;
+  status: 'scheduled' | 'in_progress' | 'completed' | 'cancelled';
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  unit_label: string | null;
+  development_label: string | null;
+  attendees: ScheduleAttendee[];
+}
+
+export function eventTypeColour(type: string): string {
+  return (EVENT_TYPE_COLOURS as Record<string, string>)[type] ?? EVENT_TYPE_COLOURS.custom;
+}
+
+export function eventTypeLabel(type: string): string {
+  return (EVENT_TYPE_LABELS as Record<string, string>)[type] ?? type;
+}
+
+export function formatDublinTime(iso: string): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(iso));
+}
+
+export function formatDublinDate(iso: string): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(iso));
+}
+
+export function dublinDateKey(d: Date): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(d);
+  const y = parts.find((p) => p.type === 'year')!.value;
+  const m = parts.find((p) => p.type === 'month')!.value;
+  const day = parts.find((p) => p.type === 'day')!.value;
+  return `${y}-${m}-${day}`;
+}
+
+export function startOfDublinWeek(d: Date): Date {
+  const key = dublinDateKey(d);
+  const [y, m, day] = key.split('-').map((s) => parseInt(s, 10));
+  const dt = new Date(Date.UTC(y, m - 1, day, 12, 0, 0));
+  const dow = new Date(dt.toLocaleString('en-US', { timeZone: 'Europe/Dublin' })).getDay();
+  const mondayOffset = dow === 0 ? -6 : 1 - dow;
+  dt.setUTCDate(dt.getUTCDate() + mondayOffset);
+  return dt;
+}
+
+export function addDays(d: Date, n: number): Date {
+  const next = new Date(d.getTime());
+  next.setUTCDate(next.getUTCDate() + n);
+  return next;
+}
+
+export function formatRangeLabel(from: Date, to: Date): string {
+  const fmt = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  });
+  const yearFmt = new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    year: 'numeric',
+  });
+  return `${fmt.format(from)} to ${fmt.format(to)} ${yearFmt.format(to)}`;
+}
+
+export function formatMonthLabel(d: Date): string {
+  return new Intl.DateTimeFormat('en-IE', {
+    timeZone: 'Europe/Dublin',
+    month: 'long',
+    year: 'numeric',
+  }).format(d);
+}

--- a/apps/unified-portal/app/developer/schedule/page.tsx
+++ b/apps/unified-portal/app/developer/schedule/page.tsx
@@ -1,0 +1,43 @@
+/**
+ * /developer/schedule
+ *
+ * Assistant V2 Sprint 4. Schedule and calendar surface for site
+ * managers and snaggers. Server component that gates the route on
+ * FEATURE_SCHEDULE and verifies the caller has a site_team_members
+ * row in some tenant. Handoff to ScheduleClient for the calendar.
+ *
+ * Spec: docs/specs/assistant-v2-sprint-4.md section 6.
+ */
+
+import { notFound } from 'next/navigation';
+import { isScheduleEnabled } from '@/lib/feature-flags';
+import { resolveSnagAuth, SnagAuthError } from '@/lib/assistant/snag-auth';
+import { SnagNoAccess } from '../../snag/SnagNoAccess';
+import { ScheduleClient } from './ScheduleClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function DeveloperSchedulePage() {
+  if (!isScheduleEnabled()) notFound();
+
+  let auth;
+  try {
+    auth = await resolveSnagAuth();
+  } catch (err) {
+    if (err instanceof SnagAuthError) {
+      if (err.code === 'unauthenticated') {
+        return <SnagNoAccess code="unauthenticated" />;
+      }
+      return <SnagNoAccess code={err.code} />;
+    }
+    throw err;
+  }
+
+  return (
+    <ScheduleClient
+      role={auth.role}
+      userId={auth.userId}
+      tenantId={auth.tenantId}
+    />
+  );
+}


### PR DESCRIPTION
Implements section 6 of docs/specs/assistant-v2-sprint-4.md (the UI surfaces) plus a small follow-up fix to the Session 1 cron auth path.

## Session 1 follow-up: cron auth

The `/api/cron/schedule-digest` route previously only accepted `x-internal-key` (matching the homeowner-issue notification pattern). Vercel Cron sends `Authorization: Bearer <CRON_SECRET>` instead, so the nightly auto-trigger was returning 403.

Now accepts both:
- `Authorization: Bearer <CRON_SECRET>` (Vercel Cron, matches `refresh-tokens` and `send-scheduled-broadcasts`)
- `x-internal-key: <INTERNAL_ENRICHMENT_KEY>` (manual curl testing)

Both compared via `crypto.timingSafeEqual`. Any other request returns 401.

## UI surfaces (all gated on FEATURE_SCHEDULE)

| Surface | Notes |
|---|---|
| Sidebar item | "Schedule" inserted in Management section between Homeowners and Smart Archive. lucide `Calendar` icon. Hidden when flag is off. No badge in V1. |
| `/developer/schedule` page | Server component (`page.tsx`) gates on `isScheduleEnabled()`, returns 404 when off, resolves auth, hands off to `ScheduleClient`. snagger_external is allowed (read-only); admin/site_team get the Add event button. |
| Toolbar | Week / Month toggle (gold-active pill mirroring `IssueViewToggle`), Previous / Today / Next nav with range label, Filters dropdown (multi-select for development + event type), Add event button. |
| Week view (default) | 7-column Mon-Sun grid; today's column tinted `gold-50`; event cards with 3px coloured left border per `event_type` (handover gold, snag_visit blue, contractor_visit orange, homeowner_appointment emerald, inspection purple, custom neutral); title, time range, location, attendee count badge. |
| Month view | Standard 42-cell grid; up to 3 colour pills per day with title truncation; `+N more` link beneath; today gets a 2px gold ring; clicking a day cell opens a right-side day-detail drawer listing all events. |
| Event drawer | 560px right-side. Title + status pill + type chip in header. Time range (Calendar icon), location (MapPin icon), unit/development labels, description. Attendees list with role pill and colour-coded RSVP badge (confirmed=emerald, declined=red, tentative=amber, invited=neutral). RSVP buttons render for the caller if they're an attendee. Edit + Cancel buttons render for admin/site_team; Cancel opens a Radix confirmation dialog with the exact spec copy ("Cancel this event? Attendees will not be notified automatically."). |
| Add/Edit modal | Radix Dialog (matches the EscalateModal/ReplyResolveModal/WarrantyModal pattern). Native HTML `<input type=date>` and `<input type=time>` (no new picker dep, per spec). Event type select, all-day toggle, location, development + unit selects (units load on demand from `/api/schedule/lookups/units`), description, attendees with two add modes: team-member picker (searches by email) and Add external sub-form (name + email). Each attendee chip has a role dropdown. Save calls `POST /api/schedule/events` (or `PATCH .../[id]` in edit mode); on success the modal closes, a toast confirms, and the calendar refetches. |

## Helper endpoints (FEATURE_SCHEDULE-gated, admin/site_team only)

- `GET /api/schedule/lookups` returns the tenant's developments and active `site_team_members` for the Add/Edit modal pickers.
- `GET /api/schedule/lookups/units?development_id=...` returns the units in a given development (validated against the caller's tenant).

## Reuse

Radix Dialog, `react-hot-toast`, gold/neutral Tailwind tokens, `lucide-react` icons. No new dependencies, no new design tokens.

## Flag-off behaviour

- Sidebar item: hidden
- `/developer/schedule`: 404 via `notFound()` (server-side)
- `/api/schedule/*` and `/api/schedule/lookups/*`: 404 before any auth or DB work
- `/api/cron/schedule-digest`: 404 before auth or DB work

## Build

`npm --workspace=@openhouse/unified-portal run build` is green locally. New route `/developer/schedule` (26.5 kB) plus the helper endpoints register cleanly. Will confirm Vercel preview READY before squash-merging.

## Out of scope (intentionally deferred)

- External calendar sync, recurring events, email-on-create invitations, drag-to-reschedule, conflict detection (all listed as out-of-scope in spec section 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)