### PR TITLE
Sprint 1b: Wire housing reasoning v0.1 into multimodal endpoint (flag-gated)

### DIFF
--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -35,14 +35,25 @@ import { NextRequest, NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
 import { waitUntil } from '@vercel/functions';
 import { getSupabaseAdmin } from '@/lib/supabase-server';
-import { isAssistantImageUploadEnabled, isHomeownerIssuesEnabled } from '@/lib/feature-flags';
+import {
+  isAssistantImageUploadEnabled,
+  isHomeownerIssuesEnabled,
+  isHousingReasoningV1Enabled,
+} from '@/lib/feature-flags';
 import {
   resolveMediaAuth,
   mediaAuthErrorToResponse,
   featureDisabledResponse,
   MediaAuthError,
 } from '@/lib/assistant/media-auth';
-import { analyse } from '@/lib/assistant/mediaAnalysisService';
+import {
+  analyse,
+  type AssistantAction,
+  type SeverityLabel,
+} from '@/lib/assistant/mediaAnalysisService';
+import { analyseMessage } from '@/lib/housing-reasoning/v1/service';
+import { HOUSING_REASONING_V1_PROMPT_VERSION } from '@/lib/housing-reasoning/v1/prompt';
+import type { HousingReasoningResult, IssueSeverity } from '@/lib/housing-reasoning/v1/types';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -51,6 +62,21 @@ export const maxDuration = 60;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_MEDIA_PER_MESSAGE = 6;
 const MAX_MESSAGE_LENGTH = 4000;
+
+// Housing Reasoning v0.1 (Sprint 1b). Storage + boundary-mapping constants for
+// the flag-gated OpenAI path. The placeholder path does not use these.
+const ASSISTANT_MEDIA_BUCKET = 'assistant-media';
+const SIGNED_URL_TTL_SECONDS = 600;
+
+// Boundary translation, not arbitrary: the v0.1 prompt scores severity on an
+// impact scale (minor/moderate/major); issue_reports stores the existing
+// low/medium/high/urgent labels. 'urgent' is reserved for ESCALATE_IMMEDIATELY
+// and applied separately.
+const SEVERITY_LABEL_BY_V1_SEVERITY: Record<IssueSeverity, SeverityLabel> = {
+  minor: 'low',
+  moderate: 'medium',
+  major: 'high',
+};
 
 interface MultimodalBody {
   conversation_id?: unknown;
@@ -201,7 +227,7 @@ export async function POST(request: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { data: mediaRows, error: mediaErr } = await supabase
     .from('assistant_media')
-    .select('id, tenant_id, unit_id, conversation_id, message_id')
+    .select('id, tenant_id, unit_id, conversation_id, message_id, storage_path')
     .in('id', mediaIds);
 
   if (mediaErr) {
@@ -248,115 +274,349 @@ export async function POST(request: NextRequest) {
     (mediaRows[0]?.message_id as string | null | undefined) ??
     randomUUID();
 
-  let result;
-  try {
-    result = await analyse({
-      tenantId: auth.tenantId,
-      developmentId: auth.developmentId,
-      unitId: auth.unitId,
-      conversationId,
-      messageId,
-      userId: auth.userId,
-      userMessage: messageText,
-      mediaIds,
-    });
-  } catch (err) {
-    console.error(
-      '[assistant-chat-multimodal] analyse_failed reason=%s',
-      err instanceof Error ? err.message : String(err),
-    );
-    return NextResponse.json(
-      { error: 'Could not analyse the photo. Try again.' },
-      { status: 500 },
-    );
-  }
-
-  // Sprint 3.5a section 5.1. When the AI determines the upload represents
-  // an actual issue (not a curiosity question, not "look at my kitchen"),
-  // create an issue_reports row in the homeowner_new state and fire the
-  // aftercare email notification. The placeholder mediaAnalysisService
-  // currently never returns 'create_issue_report', so this branch is
-  // dormant until Sprint 1b replaces the placeholder with real reasoning.
+  // Media analysis is feature-gated. With FEATURE_HOUSING_REASONING_V1 on, run
+  // the OpenAI gpt-4o housing-reasoning service (Sprint 1b). With it off, fall
+  // back to the unchanged Sprint 1 placeholder. The flag is read per-request,
+  // so rollback is a config change (set the env var false, redeploy) with no
+  // code revert. See lib/housing-reasoning/v1/service.ts.
+  let residentMessage: string;
+  let analysisId: string;
+  let responseAction: AssistantAction;
   let createdIssueReportId: string | null = null;
-  if (result.action === 'create_issue_report' && auth.unitId && auth.developmentId) {
-    const titleSource =
-      result.structured.developer_summary?.trim() ||
-      result.structured.issue_type?.trim() ||
-      'Photo from homeowner';
-    const title = titleSource.length > 200 ? `${titleSource.slice(0, 197)}...` : titleSource;
 
-    const { data: issueRow, error: issueErr } = await supabase
-      .from('issue_reports')
+  if (isHousingReasoningV1Enabled()) {
+    // ===================================================================
+    // Housing Reasoning v0.1 (Sprint 1b). BOUNDARY MAPPING LIVES HERE, by
+    // design — analyseMessage() returns the locked v0.1 shape verbatim
+    // (4 actions + minor/moderate/major) and this route translates it to the
+    // existing issue_reports columns. The service stays pure. This route is
+    // the homeowner-facing surface, so userType is always 'homeowner'.
+    // See docs/prompts/housing-reasoning-v1.md.
+    // ===================================================================
+
+    // Resolve each media row to a short-lived signed URL and hand them to
+    // OpenAI as image_url inputs. Same createSignedUrl + assistant-media bucket
+    // pattern as /api/issues/[id] and the upload route; same image_url shape as
+    // packages/api/src/extractors/vision.ts.
+    const imageUrls: string[] = [];
+    for (const m of mediaRows) {
+      const path = (m as { storage_path: string | null }).storage_path;
+      if (!path) continue;
+      const { data: signed, error: signErr } = await supabase.storage
+        .from(ASSISTANT_MEDIA_BUCKET)
+        .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+      if (signErr || !signed?.signedUrl) {
+        console.warn(
+          '[assistant-chat-multimodal] sign_failed media_id=%s reason=%s',
+          m.id,
+          signErr?.message ?? 'no url',
+        );
+        continue;
+      }
+      imageUrls.push(signed.signedUrl);
+    }
+
+    const startedAt = Date.now();
+    let reasoning: HousingReasoningResult;
+    try {
+      reasoning = await analyseMessage({
+        userType: 'homeowner',
+        text: messageText,
+        images: imageUrls,
+      });
+    } catch (err) {
+      console.error(
+        '[assistant-chat-multimodal] housing_reasoning_failed reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return NextResponse.json(
+        { error: 'Could not analyse the photo. Try again.' },
+        { status: 500 },
+      );
+    }
+
+    residentMessage = reasoning.message;
+
+    // --- Boundary mapping (action + severity) ---
+    // ANSWER_ONLY          -> no issue created, just return the answer text.
+    // CREATE_ISSUE_REPORT  -> issue created, severity mapped minor/moderate/
+    //                         major -> low/medium/high.
+    // ESCALATE_IMMEDIATELY -> issue created, severity forced to 'urgent'
+    //                         (overrides the model) and safety_risk = true.
+    // REFER_TO_WARRANTY    -> issue created and flagged for warranty. NOTE:
+    //                         issue_reports has no warranty or category column,
+    //                         so the warranty signal and the v0.1 category both
+    //                         live on the linked assistant_media_analysis row
+    //                         (warranty_relevant / issue_category). FLAGGED:
+    //                         a first-class warranty field on issue_reports
+    //                         would need a migration (out of scope this PR).
+    const action = reasoning.action;
+    const ir = reasoning.issue_report;
+    const createsIssue = action !== 'ANSWER_ONLY' && !!ir;
+    const isEscalation = action === 'ESCALATE_IMMEDIATELY';
+    const isWarranty = action === 'REFER_TO_WARRANTY';
+
+    const severityLabel: SeverityLabel | null = !ir
+      ? null
+      : isEscalation
+        ? 'urgent'
+        : SEVERITY_LABEL_BY_V1_SEVERITY[ir.severity];
+
+    // Response keeps the existing AssistantAction vocabulary so the client
+    // contract is unchanged. ESCALATE and WARRANTY both create an issue.
+    responseAction = isEscalation
+      ? 'escalate_issue'
+      : createsIssue
+        ? 'create_issue_report'
+        : 'answer_only';
+
+    // Persist the analysis row so analysis_id is returned and the developer
+    // dashboards (which read assistant_media_analysis) work for this path too.
+    // category and warranty_relevant live here (issue_reports has neither).
+    const { data: analysisRow, error: analysisErr } = await supabase
+      .from('assistant_media_analysis')
       .insert({
         tenant_id: auth.tenantId,
         development_id: auth.developmentId,
         unit_id: auth.unitId,
         user_id: auth.userId,
-        title,
-        description: messageText || result.structured.developer_summary || null,
-        room: result.structured.room ?? null,
-        status: 'homeowner_new',
-        priority: 'normal',
-        source: 'homeowner_assistant',
-        severity_label: result.structured.severity_label,
-        severity_score: result.structured.severity_score,
-        safety_risk: result.structured.safety_risk,
-        likely_trade: result.structured.likely_trade,
-        likely_system: result.structured.likely_system,
-        linked_analysis_id: result.analysisId,
-        logged_by_user_id: auth.userId,
-        logged_by_role: 'homeowner',
+        conversation_id: conversationId,
+        message_id: messageId,
+        analysis_scope: 'single_message',
+        input_media_ids: mediaIds,
+        issue_type: ir?.category ?? null,
+        issue_category: ir?.category ?? null,
+        room: ir?.area ?? null,
+        visible_features: [],
+        severity_score: null,
+        severity_label: severityLabel,
+        confidence_score: null,
+        safety_risk: isEscalation,
+        safety_risk_type: null,
+        likely_trade: null,
+        likely_system: null,
+        potential_causes: [],
+        recommended_action: action,
+        resident_guidance: null,
+        needs_more_info: false,
+        more_info_requested: [],
+        should_create_issue: createsIssue,
+        should_escalate: isEscalation,
+        escalation_level: isEscalation ? 'urgent' : 'none',
+        requires_human_review: isWarranty,
+        warranty_relevant: isWarranty,
+        similar_issue_check_required: false,
+        developer_summary: ir?.title ?? reasoning.message,
+        raw_model_output: reasoning as unknown as Record<string, unknown>,
+        model_provider: 'openai',
+        model_name: 'gpt-4o',
+        model_version: null,
+        prompt_version: HOUSING_REASONING_V1_PROMPT_VERSION,
+        processing_time_ms: Date.now() - startedAt,
       })
       .select('id')
       .single();
 
-    if (issueErr || !issueRow) {
+    if (analysisErr || !analysisRow) {
       console.error(
-        '[assistant-chat-multimodal] issue_insert_failed reason=%s',
-        issueErr?.message ?? 'no row',
+        '[assistant-chat-multimodal] analysis_insert_failed reason=%s',
+        analysisErr?.message ?? 'no row',
       );
-    } else {
-      createdIssueReportId = issueRow.id as string;
+      return NextResponse.json(
+        { error: 'Could not analyse the photo. Try again.' },
+        { status: 500 },
+      );
+    }
+    analysisId = analysisRow.id as string;
 
-      const mediaJoinRows = mediaIds.map((mediaId) => ({
-        tenant_id: auth.tenantId,
-        issue_report_id: createdIssueReportId,
-        media_id: mediaId,
-      }));
-      const { error: joinErr } = await supabase.from('issue_report_media').insert(mediaJoinRows);
-      if (joinErr) {
-        console.error(
-          '[assistant-chat-multimodal] issue_media_join_failed reason=%s',
-          joinErr.message,
-        );
-      }
+    // Create the issue (homeowner surface => status homeowner_new, source
+    // homeowner_assistant), mirroring the placeholder path's linkage.
+    if (createsIssue && ir && auth.unitId && auth.developmentId) {
+      const title = ir.title.length > 200 ? `${ir.title.slice(0, 197)}...` : ir.title;
 
-      const { error: eventErr } = await supabase.from('issue_events').insert({
-        tenant_id: auth.tenantId,
-        issue_report_id: createdIssueReportId,
-        event_type: 'homeowner_issue_created',
-        actor_type: 'homeowner',
-        actor_id: auth.userId,
-        metadata: {
+      const { data: issueRow, error: issueErr } = await supabase
+        .from('issue_reports')
+        .insert({
+          tenant_id: auth.tenantId,
+          development_id: auth.developmentId,
+          unit_id: auth.unitId,
+          user_id: auth.userId,
+          title,
+          description: ir.description || messageText || null,
+          room: ir.area ?? null,
+          status: 'homeowner_new',
+          priority: 'normal',
           source: 'homeowner_assistant',
-          analysis_id: result.analysisId,
-          media_count: mediaIds.length,
-        },
-      });
-      if (eventErr) {
-        console.error('[assistant-chat-multimodal] event_insert_failed reason=%s', eventErr.message);
-      }
+          severity_label: severityLabel,
+          severity_score: null,
+          safety_risk: isEscalation,
+          likely_trade: null,
+          likely_system: null,
+          linked_analysis_id: analysisId,
+          logged_by_user_id: auth.userId,
+          logged_by_role: 'homeowner',
+        })
+        .select('id')
+        .single();
 
-      if (isHomeownerIssuesEnabled()) {
-        triggerHomeownerIssueNotification(request, createdIssueReportId);
+      if (issueErr || !issueRow) {
+        console.error(
+          '[assistant-chat-multimodal] issue_insert_failed reason=%s',
+          issueErr?.message ?? 'no row',
+        );
+      } else {
+        createdIssueReportId = issueRow.id as string;
+
+        const mediaJoinRows = mediaIds.map((mediaId) => ({
+          tenant_id: auth.tenantId,
+          issue_report_id: createdIssueReportId,
+          media_id: mediaId,
+        }));
+        const { error: joinErr } = await supabase.from('issue_report_media').insert(mediaJoinRows);
+        if (joinErr) {
+          console.error(
+            '[assistant-chat-multimodal] issue_media_join_failed reason=%s',
+            joinErr.message,
+          );
+        }
+
+        const { error: eventErr } = await supabase.from('issue_events').insert({
+          tenant_id: auth.tenantId,
+          issue_report_id: createdIssueReportId,
+          event_type: 'homeowner_issue_created',
+          actor_type: 'homeowner',
+          actor_id: auth.userId,
+          metadata: {
+            source: 'homeowner_assistant',
+            analysis_id: analysisId,
+            media_count: mediaIds.length,
+            housing_reasoning_action: action,
+          },
+        });
+        if (eventErr) {
+          console.error('[assistant-chat-multimodal] event_insert_failed reason=%s', eventErr.message);
+        }
+
+        if (isHomeownerIssuesEnabled()) {
+          triggerHomeownerIssueNotification(request, createdIssueReportId);
+        }
+      }
+    }
+  } else {
+    // ===== Sprint 1 placeholder path. Unchanged. =====
+    let result;
+    try {
+      result = await analyse({
+        tenantId: auth.tenantId,
+        developmentId: auth.developmentId,
+        unitId: auth.unitId,
+        conversationId,
+        messageId,
+        userId: auth.userId,
+        userMessage: messageText,
+        mediaIds,
+      });
+    } catch (err) {
+      console.error(
+        '[assistant-chat-multimodal] analyse_failed reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return NextResponse.json(
+        { error: 'Could not analyse the photo. Try again.' },
+        { status: 500 },
+      );
+    }
+
+    residentMessage = result.residentMessage;
+    analysisId = result.analysisId;
+    responseAction = result.action;
+
+    // Sprint 3.5a section 5.1. When the AI determines the upload represents
+    // an actual issue (not a curiosity question, not "look at my kitchen"),
+    // create an issue_reports row in the homeowner_new state and fire the
+    // aftercare email notification. The placeholder mediaAnalysisService
+    // currently never returns 'create_issue_report', so this branch is
+    // dormant until the flag above is turned on.
+    if (result.action === 'create_issue_report' && auth.unitId && auth.developmentId) {
+      const titleSource =
+        result.structured.developer_summary?.trim() ||
+        result.structured.issue_type?.trim() ||
+        'Photo from homeowner';
+      const title = titleSource.length > 200 ? `${titleSource.slice(0, 197)}...` : titleSource;
+
+      const { data: issueRow, error: issueErr } = await supabase
+        .from('issue_reports')
+        .insert({
+          tenant_id: auth.tenantId,
+          development_id: auth.developmentId,
+          unit_id: auth.unitId,
+          user_id: auth.userId,
+          title,
+          description: messageText || result.structured.developer_summary || null,
+          room: result.structured.room ?? null,
+          status: 'homeowner_new',
+          priority: 'normal',
+          source: 'homeowner_assistant',
+          severity_label: result.structured.severity_label,
+          severity_score: result.structured.severity_score,
+          safety_risk: result.structured.safety_risk,
+          likely_trade: result.structured.likely_trade,
+          likely_system: result.structured.likely_system,
+          linked_analysis_id: result.analysisId,
+          logged_by_user_id: auth.userId,
+          logged_by_role: 'homeowner',
+        })
+        .select('id')
+        .single();
+
+      if (issueErr || !issueRow) {
+        console.error(
+          '[assistant-chat-multimodal] issue_insert_failed reason=%s',
+          issueErr?.message ?? 'no row',
+        );
+      } else {
+        createdIssueReportId = issueRow.id as string;
+
+        const mediaJoinRows = mediaIds.map((mediaId) => ({
+          tenant_id: auth.tenantId,
+          issue_report_id: createdIssueReportId,
+          media_id: mediaId,
+        }));
+        const { error: joinErr } = await supabase.from('issue_report_media').insert(mediaJoinRows);
+        if (joinErr) {
+          console.error(
+            '[assistant-chat-multimodal] issue_media_join_failed reason=%s',
+            joinErr.message,
+          );
+        }
+
+        const { error: eventErr } = await supabase.from('issue_events').insert({
+          tenant_id: auth.tenantId,
+          issue_report_id: createdIssueReportId,
+          event_type: 'homeowner_issue_created',
+          actor_type: 'homeowner',
+          actor_id: auth.userId,
+          metadata: {
+            source: 'homeowner_assistant',
+            analysis_id: result.analysisId,
+            media_count: mediaIds.length,
+          },
+        });
+        if (eventErr) {
+          console.error('[assistant-chat-multimodal] event_insert_failed reason=%s', eventErr.message);
+        }
+
+        if (isHomeownerIssuesEnabled()) {
+          triggerHomeownerIssueNotification(request, createdIssueReportId);
+        }
       }
     }
   }
 
   return NextResponse.json({
-    message: result.residentMessage,
-    analysis_id: result.analysisId,
-    action: result.action,
+    message: residentMessage,
+    analysis_id: analysisId,
+    action: responseAction,
     message_id: messageId,
     conversation_id: conversationId,
     issue_report_id: createdIssueReportId,

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -138,6 +138,21 @@ export function isScheduleEnabled(): boolean {
   );
 }
 
+/**
+ * Housing Reasoning v0.1 (Sprint 1b).
+ *
+ * Default off. When true, /api/assistant/chat/multimodal routes media analysis
+ * through the OpenAI gpt-4o housing-reasoning service instead of the
+ * placeholder mediaAnalysisService.
+ *
+ * Server-only: the gating happens entirely in the route handler, so there is
+ * no client-side check and no NEXT_PUBLIC_ variant. Reads
+ * FEATURE_HOUSING_REASONING_V1.
+ */
+export function isHousingReasoningV1Enabled(): boolean {
+  return process.env.FEATURE_HOUSING_REASONING_V1 === 'true';
+}
+
 export function getFeatureFlags() {
   return {
     videos: isVideosFeatureEnabled(),
@@ -148,5 +163,6 @@ export function getFeatureFlags() {
     developerDashboard: isDeveloperDashboardEnabled(),
     homeownerIssues: isHomeownerIssuesEnabled(),
     schedule: isScheduleEnabled(),
+    housingReasoningV1: isHousingReasoningV1Enabled(),
   };
 }

--- a/apps/unified-portal/lib/housing-reasoning/v1/prompt.ts
+++ b/apps/unified-portal/lib/housing-reasoning/v1/prompt.ts
@@ -1,0 +1,259 @@
+// Source of truth: docs/prompts/housing-reasoning-v1.md
+// Do not edit here without updating the docs file and vice versa.
+//
+// This is the v0.1 prompt body verbatim — the block between the triple
+// backticks under "## The prompt (v0.1)" in the docs file. It is the locked
+// behavioural contract for multimodal media analysis and is used as-is as the
+// OpenAI system prompt. The lock is the behaviour, not the model.
+
+export const HOUSING_REASONING_V1_PROMPT_VERSION = 'housing-reasoning-v1';
+
+export const HOUSING_REASONING_V1_PROMPT = `You are the OpenHouse property assistant. You help homeowners and
+site teams with questions about new-build homes in Ireland.
+
+You receive messages that may include photos, text, or both, from
+one of two types of user:
+
+1. HOMEOWNER. Someone living in or about to move into a home built
+   by the developer. They typically have no construction background.
+   They may be uncertain, worried, or just curious. Their messages
+   are often short ("is this normal?", "what is this?", a photo with
+   no text).
+
+2. SITE TEAM. A snagger, site manager, or developer staff member.
+   They typically use industry language ("touch up plaster at
+   reveal", "complete drainage channel"). Their messages are usually
+   instructions or observations, not questions. They may also upload
+   full snagging reports as PDFs.
+
+You will be told which type of user you are speaking to via a
+system tag. If you are not told, assume HOMEOWNER and use the more
+cautious behaviour described below.
+
+CORE PRINCIPLE: BE TRUTHFUL ABOUT WHAT YOU CAN AND CANNOT SEE
+
+You are looking at a photograph, not the actual house. You cannot
+measure anything, tell if a crack is structural or cosmetic, tell
+if something is wet or dry, tell what was there yesterday, tell if
+something is finished or mid-installation, diagnose plumbing,
+electrical, or heating problems.
+
+You can describe what is visible, recognise common new-build
+features (heat pump unit, MVHR vent, ESB meter cabinet, drainage
+gully, render finish, lead flashing), note when something looks
+unfinished, damaged, or unusual, and compare what's visible to
+what would be normal for a new-build at this stage.
+
+If you cannot tell, say so. The phrase "I can't tell from the
+photo, but" is preferable to a confident wrong answer.
+
+THE FOUR ACTIONS
+
+Every message routes to exactly one action.
+
+1. ANSWER_ONLY. The user asked a question and you can answer it
+   without raising anything with the site team. Use for "is this
+   normal?" where it clearly is, "what is this?" where you can
+   name it, general questions, settlement issues (hairline cracks,
+   nail pops, creaking floors), and when the photo shows something
+   working normally.
+
+2. CREATE_ISSUE_REPORT. Worth logging to the site team but not
+   urgent. Use for cosmetic defects, cleaning items, snagger-style
+   items, anything that would naturally end up on a paper snag
+   list, and any real issue from a homeowner that isn't urgent.
+   When in doubt between ANSWER_ONLY and CREATE_ISSUE_REPORT,
+   prefer CREATE_ISSUE_REPORT.
+
+3. ESCALATE_IMMEDIATELY. Safety, water, electrical, or active
+   damage. Visible leaks, exposed electrical, structural concerns
+   wider than a hairline crack, heating system fully down, blocked
+   drains, anything that looks like immediate property risk. Rare.
+   If unsure whether it's active damage vs settlement, route to
+   CREATE_ISSUE_REPORT.
+
+4. REFER_TO_WARRANTY. Post-handover structural item, appliance
+   warranty issue, anything where the homeowner needs to file a
+   claim rather than raise a snag. If you don't know whether the
+   home is post-handover, default to CREATE_ISSUE_REPORT.
+
+NORMAL THINGS THAT LOOK ALARMING
+
+Don't escalate or even create issues for these unless the user
+explicitly reports a problem. Hairline cracks in plaster (settlement,
+expected in first 12-18 months), nail pops, creaking floorboards,
+doors needing slight adjustment, small skirting/floor gaps,
+condensation on windows in winter, heat pump humming, MVHR vents,
+black drainage gullies and downpipes, outdoor brass tap, ESB
+meter cabinet with multiple wires.
+
+ISSUE REPORT FIELDS
+
+Every issue report needs:
+
+- title: short imperative in the style of a snag list ("Touch up
+  paint on landing wall", "Doorbell not operational"). Match the
+  tone of a professional snagger. No emoji, no AI flourish.
+
+- area: which room or area. If not obvious AND not stated, leave
+  null and ask one clarifying question. See SCOPE LEVELS below.
+
+- severity: "minor" | "moderate" | "major"
+  - minor: adjustments, touch-ups, cleaning, sealing, sticking
+    doors, rubbing doors, small missing parts (handle off a
+    cabinet, missing door stop). Most snags are minor.
+  - moderate: a whole component missing or non-functional
+    (cabinet door missing, fire seals missing, broken trickle
+    vent, door not closing at all, water pressure failing on
+    a fixture). Not a property emergency, but more than an
+    adjustment.
+  - major: a whole element missing or property damage (whole
+    kitchen cabinet missing, sink not installed, hole in a
+    wall, cracked window pane, exposed wiring across a floor,
+    heating fully down, active water ingress).
+
+- category: "cosmetic" | "cleaning" | "joinery" | "plumbing" |
+  "electrical" | "external" | "landscape" | "compliance" |
+  "appliance" | "other"
+
+- description: 1-2 sentences. What's visible. What the user said.
+  No invented detail.
+
+- status: "open" by default. Set to "closed" only when ingesting
+  a snagger document that explicitly marks the item Closed
+  (see STATUS AWARENESS below).
+
+MULTI-ITEM HANDLING
+
+If a single message lists multiple distinct items (numbered,
+bulleted, or separated by sentences each describing a different
+defect, location, or trade), create one issue report per item.
+But: do not split if multiple clauses describe the SAME fix on
+the same element ("cracking around window board, window frame
+and reveals" is one item, not three).
+
+COMPOUND PROSE. A single description with multiple verbs of
+action ("check X / provide Y / demonstrate Z") splits into
+separate items. Snaggers often write a paragraph in one cell to
+save typing; the site team needs them apart.
+
+SAME FIX, DIFFERENT LOCATION = SEPARATE ITEMS. "Water pressure
+is low" across three ensuites is three issue reports, not one.
+Each fixture needs addressing in its own location.
+
+SCOPE LEVELS
+
+Distinguish three scope levels and set the area field accordingly:
+- element-level: "both sides", "all four sides" → area is the
+  specific element (e.g. "front door")
+- room-level: "throughout the room", "both walls in the kitchen"
+  → area is the room (e.g. "whole kitchen")
+- property-level: "throughout the property", "throughout the
+  house", "all rooms" → area is "whole property"
+
+Do not flatten property-level scope to a single room.
+
+PAST-TENSE / COMPLETED ITEMS
+
+If a message describes something as already done ("replaced",
+"fixed", "sorted", "now installed"), do not create an issue
+report for that item. Acknowledge it briefly and move on.
+
+SCOPE HANDOFF ("BY OTHERS")
+
+If a line item says "by others", "purchaser's contractor", "owner
+to fit", or similar, do not create an issue report. This is a
+scope-of-work note, not a snag. Flag as informational only.
+
+STATUS AWARENESS
+
+When ingesting a snagging document or message with an explicit
+status column or marker (Open, Closed, Resolved, Signed off, Done):
+- Items marked Open: create issue reports normally, status "open".
+- Items marked Closed: still create the issue report, but with
+  status "closed". This preserves audit trail (the work was done
+  and verified) and lets the dashboard show what has been
+  resolved as well as what is outstanding.
+
+If status is missing or ambiguous, default to "open".
+
+If a document carries a header indicating its phase ("Practical
+Completion", "End of Defects", "De Snagging", "Revisit"), use
+this as context. A revisit document is expected to contain mostly
+Closed items; if it contains mostly Open items, flag this in your
+response rather than ingesting silently.
+
+PRESERVE TERMINOLOGY
+
+When the message comes from a snagger or site team member, preserve
+their technical vocabulary. Do not paraphrase "architrave" to "door
+trim", "lead flashing" to "metal strip", or "ACO drain" to "drain
+channel". Do not convert "cills" to "sills". The snag list should
+read like a snagger wrote it. Translation only happens when a
+homeowner asks what a term means.
+
+ABBREVIATION HANDLING
+
+Snaggers use heavy abbreviations (Tu, Mg, Rwp, Wb, Ls, Trv, Aj,
+B1 FL, B2 FR, B3 RL, B4 RR). Preserve them in the title verbatim.
+In the description, expand once for clarity ONLY when you can
+infer the meaning with certainty from a legend or context (e.g.
+"Tu" → "Touch up" if the legend defines it). If you cannot infer,
+preserve the abbreviation and do not invent.
+
+OCR AND SPEECH-TO-TEXT ARTIFACTS
+
+Snagging documents sometimes contain transcription errors from
+voice dictation or OCR ("may cry" for "make right", "x-ray meets
+wall" for "architrave meets wall", "rice finish" for "right
+finish"). Do not try to "fix" these. Preserve the description
+verbatim and let the site team interpret. Inventing a correction
+risks changing meaning.
+
+RED ANNOTATIONS
+
+Snaggers commonly draw red circles, ovals, or arrows on photos to
+indicate the area of concern. Use these as focus cues. Real
+homeowners will rarely annotate; they'll just send the photo and
+say "look at this."
+
+TONE
+
+Irish understated, peer-to-peer. Knowledgeable colleague, not
+customer service bot.
+
+Good:
+"That's the MVHR vent, the mechanical ventilation system. Meant
+to be there. Runs continuously at a low rate to keep the air
+fresh."
+
+"Paint scuff at the base of the front door. I'll log it to the
+site team to touch up. Anything else you noticed on the door?"
+
+"Hairline crack above the door frame. Normal settlement in a
+new-build during the first year. Shouldn't get bigger. If it
+does, send another photo and we'll get someone to look at it."
+
+Bad:
+"Great photo!"
+"I'm so sorry you're experiencing this issue!"
+"As an AI assistant, I cannot diagnose..."
+
+Never use em dashes, emoji, exclamation marks for emphasis, AI
+disclaimers, "I understand" as a preamble, or repeated user
+questions.
+
+WHEN INFORMATION IS MISSING
+
+If a photo arrives with no text and you genuinely cannot tell
+what the user wants you to look at, ask ONE specific question.
+Not a list.
+
+Good: "What's caught your eye in this photo?"
+Bad: "Can you tell me 1) when this happened 2) what room..."
+
+FINAL RULE
+
+When in genuine doubt, route to CREATE_ISSUE_REPORT and let a
+human decide. Triage well enough that the site team's day is
+shorter, not longer.`;

--- a/apps/unified-portal/lib/housing-reasoning/v1/service.ts
+++ b/apps/unified-portal/lib/housing-reasoning/v1/service.ts
@@ -1,0 +1,132 @@
+/**
+ * Housing Reasoning v0.1 — multimodal media analysis service (Sprint 1b).
+ *
+ * Source of truth for the prompt and behavioural contract:
+ *   docs/prompts/housing-reasoning-v1.md
+ *
+ * Calls OpenAI gpt-4o with the locked v0.1 prompt and a strict json_schema
+ * response_format. This matches the existing OpenAI vision pattern in
+ * packages/api/src/extractors/vision.ts and the structured-output pattern in
+ * packages/api/src/train/floorplan-vision.ts. Single provider, no Anthropic.
+ *
+ * This module is PURE. It does not touch the database, storage, or the HTTP
+ * request. Image loading (signed URLs from assistant_media) and the mapping to
+ * the existing issue_reports shape both live at the route boundary
+ * (app/api/assistant/chat/multimodal/route.ts), not here.
+ *
+ * Gated behind FEATURE_HOUSING_REASONING_V1 (isHousingReasoningV1Enabled() in
+ * lib/feature-flags.ts). The flag is read per-request in the route handler.
+ *
+ * SMOKE TEST (mocked OpenAI client — no network, no API key):
+ *   npx tsx apps/unified-portal/scripts/smoke/housing-reasoning-v1.smoke.ts
+ *   Exit 0 = all pass, exit 1 = a case failed.
+ *
+ * ROLLBACK PLAN:
+ *   Set FEATURE_HOUSING_REASONING_V1=false in Vercel and redeploy. Because the
+ *   flag is read per-request, the next request falls back to the unchanged
+ *   placeholder mediaAnalysisService. No code revert is required.
+ */
+
+import OpenAI from 'openai';
+import { HOUSING_REASONING_V1_PROMPT } from './prompt';
+import type { AnalyseMessageInput, HousingReasoningResult } from './types';
+
+const MODEL = 'gpt-4o';
+
+// Strict JSON schema. Mirrors the types in types.ts so the model output is
+// shaped correctly without free-form parsing. issue_report is nullable for
+// ANSWER_ONLY (and any case where no issue is logged).
+const RESULT_JSON_SCHEMA = {
+  type: 'object',
+  properties: {
+    action: {
+      type: 'string',
+      enum: ['ANSWER_ONLY', 'CREATE_ISSUE_REPORT', 'ESCALATE_IMMEDIATELY', 'REFER_TO_WARRANTY'],
+    },
+    message: { type: 'string' },
+    issue_report: {
+      type: ['object', 'null'],
+      properties: {
+        title: { type: 'string' },
+        area: { type: ['string', 'null'] },
+        severity: { type: 'string', enum: ['minor', 'moderate', 'major'] },
+        category: {
+          type: 'string',
+          enum: [
+            'cosmetic',
+            'cleaning',
+            'joinery',
+            'plumbing',
+            'electrical',
+            'external',
+            'landscape',
+            'compliance',
+            'appliance',
+            'other',
+          ],
+        },
+        description: { type: 'string' },
+        status: { type: 'string', enum: ['open', 'closed'] },
+      },
+      required: ['title', 'area', 'severity', 'category', 'description', 'status'],
+      additionalProperties: false,
+    },
+  },
+  required: ['action', 'message', 'issue_report'],
+  additionalProperties: false,
+};
+
+export interface AnalyseMessageOptions {
+  /** Inject a client for tests. Defaults to a real OpenAI client. */
+  client?: OpenAI;
+}
+
+export async function analyseMessage(
+  input: AnalyseMessageInput,
+  options: AnalyseMessageOptions = {},
+): Promise<HousingReasoningResult> {
+  const client = options.client ?? new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  // The v0.1 prompt references a "system tag" telling it which user type it is
+  // speaking to. We supply it as a second system message rather than editing
+  // the locked prompt body.
+  const userTypeTag = input.userType === 'site_team' ? 'SITE TEAM' : 'HOMEOWNER';
+
+  const imageBlocks: OpenAI.Chat.Completions.ChatCompletionContentPart[] = input.images.map(
+    (url) => ({
+      type: 'image_url',
+      image_url: { url, detail: 'high' },
+    }),
+  );
+
+  const userContent: OpenAI.Chat.Completions.ChatCompletionContentPart[] = [
+    ...imageBlocks,
+    { type: 'text', text: input.text?.trim() || '(no text provided)' },
+  ];
+
+  const response = await client.chat.completions.create({
+    model: MODEL,
+    messages: [
+      { role: 'system', content: HOUSING_REASONING_V1_PROMPT },
+      { role: 'system', content: `USER TYPE: ${userTypeTag}` },
+      { role: 'user', content: userContent },
+    ],
+    max_tokens: 1500,
+    temperature: 0.2,
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'housing_reasoning_v1',
+        strict: true,
+        schema: RESULT_JSON_SCHEMA,
+      },
+    },
+  });
+
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error('[housing-reasoning-v1] OpenAI returned no content');
+  }
+
+  return JSON.parse(content) as HousingReasoningResult;
+}

--- a/apps/unified-portal/lib/housing-reasoning/v1/types.ts
+++ b/apps/unified-portal/lib/housing-reasoning/v1/types.ts
@@ -1,0 +1,55 @@
+// Housing Reasoning v0.1 types.
+//
+// These mirror the locked behavioural contract in
+// docs/prompts/housing-reasoning-v1.md: the four actions and the issue-report
+// fields. They define the JSON the model is constrained to return (see
+// service.ts) and are mapped to the existing issue_reports shape at the route
+// boundary, not here.
+
+export type HousingUserType = 'homeowner' | 'site_team';
+
+export type HousingReasoningAction =
+  | 'ANSWER_ONLY'
+  | 'CREATE_ISSUE_REPORT'
+  | 'ESCALATE_IMMEDIATELY'
+  | 'REFER_TO_WARRANTY';
+
+export type IssueSeverity = 'minor' | 'moderate' | 'major';
+
+export type IssueCategory =
+  | 'cosmetic'
+  | 'cleaning'
+  | 'joinery'
+  | 'plumbing'
+  | 'electrical'
+  | 'external'
+  | 'landscape'
+  | 'compliance'
+  | 'appliance'
+  | 'other';
+
+export type IssueStatus = 'open' | 'closed';
+
+export interface HousingIssueReport {
+  title: string;
+  area: string | null;
+  severity: IssueSeverity;
+  category: IssueCategory;
+  description: string;
+  status: IssueStatus;
+}
+
+export interface HousingReasoningResult {
+  action: HousingReasoningAction;
+  /** Resident/site-team-facing reply text. For ANSWER_ONLY this is the answer. */
+  message: string;
+  /** Present when the action logs an issue; null for ANSWER_ONLY. */
+  issue_report: HousingIssueReport | null;
+}
+
+export interface AnalyseMessageInput {
+  userType: HousingUserType;
+  text: string;
+  /** Image inputs passed straight to OpenAI as image_url (signed URLs or data URLs). */
+  images: string[];
+}

--- a/apps/unified-portal/scripts/smoke/housing-reasoning-v1.smoke.ts
+++ b/apps/unified-portal/scripts/smoke/housing-reasoning-v1.smoke.ts
@@ -1,0 +1,180 @@
+/**
+ * Housing Reasoning v0.1 — smoke test (Sprint 1b).
+ *
+ * Plain TypeScript, no test runner. Mocks the OpenAI client (no network, no API
+ * key) and exercises analyseMessage() against three calibration cases, asserting
+ * the structured response and the request wiring (model, json_schema, the v0.1
+ * system prompt, the USER TYPE tag, and image inputs).
+ *
+ * Run:
+ *   npx tsx apps/unified-portal/scripts/smoke/housing-reasoning-v1.smoke.ts
+ *
+ * Exit 0 = all cases pass. Exit 1 = a case failed.
+ *
+ * Real-photo smoke testing (live OpenAI) is a separate ticket; this file never
+ * calls the real API.
+ */
+
+import type OpenAI from 'openai';
+import { analyseMessage } from '../../lib/housing-reasoning/v1/service';
+import type { HousingReasoningResult } from '../../lib/housing-reasoning/v1/types';
+
+let failures = 0;
+
+function check(name: string, condition: boolean, detail?: string): void {
+  if (condition) {
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+// A mock OpenAI client that returns canned JSON and records the request it was
+// given, so we can assert both the parsed result and the wiring.
+function mockClient(canned: HousingReasoningResult): {
+  client: OpenAI;
+  calls: Array<Record<string, any>>;
+} {
+  const calls: Array<Record<string, any>> = [];
+  const client = {
+    chat: {
+      completions: {
+        create: async (args: Record<string, any>) => {
+          calls.push(args);
+          return { choices: [{ message: { content: JSON.stringify(canned) } }] };
+        },
+      },
+    },
+  } as unknown as OpenAI;
+  return { client, calls };
+}
+
+function assertWiring(
+  calls: Array<Record<string, any>>,
+  expectedUserTag: string,
+  expectImages: boolean,
+): void {
+  const req = calls[0];
+  check('one OpenAI call made', calls.length === 1, `got ${calls.length}`);
+  check('model is gpt-4o', req?.model === 'gpt-4o', String(req?.model));
+  check(
+    'response_format is json_schema',
+    req?.response_format?.type === 'json_schema',
+    String(req?.response_format?.type),
+  );
+  const messages = req?.messages ?? [];
+  const systemPrompt = messages[0]?.content ?? '';
+  check(
+    'v0.1 system prompt is sent verbatim',
+    typeof systemPrompt === 'string' &&
+      systemPrompt.startsWith('You are the OpenHouse property assistant.'),
+  );
+  check(
+    `USER TYPE tag is "${expectedUserTag}"`,
+    messages[1]?.content === `USER TYPE: ${expectedUserTag}`,
+    String(messages[1]?.content),
+  );
+  const userParts = Array.isArray(messages[2]?.content) ? messages[2].content : [];
+  const hasImage = userParts.some((p: any) => p?.type === 'image_url');
+  check(
+    expectImages ? 'user message includes an image_url block' : 'user message has no image block',
+    hasImage === expectImages,
+  );
+}
+
+async function run(): Promise<void> {
+  // --- Case 1: homeowner asks "is this normal?" about a hairline crack ---
+  // Expect ANSWER_ONLY, no issue report.
+  {
+    console.log('Case 1: homeowner — "is this normal?" (hairline crack)');
+    const canned: HousingReasoningResult = {
+      action: 'ANSWER_ONLY',
+      message:
+        "Hairline crack above the door frame. Normal settlement in a new-build during the first year.",
+      issue_report: null,
+    };
+    const { client, calls } = mockClient(canned);
+    const result = await analyseMessage(
+      { userType: 'homeowner', text: 'is this normal?', images: ['https://signed.example/crack.jpg'] },
+      { client },
+    );
+    check('action is ANSWER_ONLY', result.action === 'ANSWER_ONLY', result.action);
+    check('no issue_report', result.issue_report === null);
+    assertWiring(calls, 'HOMEOWNER', true);
+  }
+
+  // --- Case 2: snagger "touch up paint at hall reveal" ---
+  // Expect CREATE_ISSUE_REPORT, category cosmetic, severity minor.
+  {
+    console.log('Case 2: site team — "touch up paint at hall reveal"');
+    const canned: HousingReasoningResult = {
+      action: 'CREATE_ISSUE_REPORT',
+      message: 'Logged a touch-up for the site team.',
+      issue_report: {
+        title: 'Touch up paint at hall reveal',
+        area: 'hall',
+        severity: 'minor',
+        category: 'cosmetic',
+        description: 'Paint touch-up required at the hall reveal.',
+        status: 'open',
+      },
+    };
+    const { client, calls } = mockClient(canned);
+    const result = await analyseMessage(
+      { userType: 'site_team', text: 'touch up paint at hall reveal', images: [] },
+      { client },
+    );
+    check('action is CREATE_ISSUE_REPORT', result.action === 'CREATE_ISSUE_REPORT', result.action);
+    check(
+      'category is cosmetic',
+      result.issue_report?.category === 'cosmetic',
+      result.issue_report?.category,
+    );
+    check('severity is minor', result.issue_report?.severity === 'minor', result.issue_report?.severity);
+    assertWiring(calls, 'SITE TEAM', false);
+  }
+
+  // --- Case 3: snagger "exposed wiring across utility floor, make safe" ---
+  // Expect CREATE_ISSUE_REPORT, severity major.
+  {
+    console.log('Case 3: site team — "exposed wiring across utility floor, make safe"');
+    const canned: HousingReasoningResult = {
+      action: 'CREATE_ISSUE_REPORT',
+      message: 'Logged for the site team to make safe.',
+      issue_report: {
+        title: 'Make safe exposed wiring in utility',
+        area: 'utility',
+        severity: 'major',
+        category: 'electrical',
+        description: 'Exposed wiring across the utility floor. Make safe.',
+        status: 'open',
+      },
+    };
+    const { client, calls } = mockClient(canned);
+    const result = await analyseMessage(
+      {
+        userType: 'site_team',
+        text: 'exposed wiring across utility floor, make safe',
+        images: ['https://signed.example/utility.jpg'],
+      },
+      { client },
+    );
+    check('action is CREATE_ISSUE_REPORT', result.action === 'CREATE_ISSUE_REPORT', result.action);
+    check('severity is major', result.issue_report?.severity === 'major', result.issue_report?.severity);
+    assertWiring(calls, 'SITE TEAM', true);
+  }
+
+  console.log('');
+  if (failures > 0) {
+    console.log(`SMOKE FAILED — ${failures} assertion(s) failed.`);
+    process.exit(1);
+  }
+  console.log('SMOKE PASSED — all cases green.');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error('SMOKE ERRORED:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds flag-gated OpenAI gpt-4o path for `/api/assistant/chat/multimodal`, preserving the existing placeholder unchanged when the flag is off.

- New module: `apps/unified-portal/lib/housing-reasoning/v1/` (prompt.ts verbatim from `docs/prompts/housing-reasoning-v1.md`, types.ts, service.ts with injectable OpenAI client)
- Feature flag: `FEATURE_HOUSING_REASONING_V1` (server-only, default off)
- Boundary mapping in route handler: minor->low, moderate->medium, major->high; `ESCALATE_IMMEDIATELY` forces urgent
- Warranty/category routed to `assistant_media_analysis` (no `issue_reports` column exists; migration deferred)
- Mocked smoke test: `scripts/smoke/housing-reasoning-v1.smoke.ts`

Rollback: set `FEATURE_HOUSING_REASONING_V1=false` and redeploy.

Not yet covered by this endpoint (intentional):
- Multi-item splitting (homeowner endpoint is 1:1; bulk snagger doc ingestion is a separate future route)
- Snagger status open/closed (same reason)

## Testing
- Mocked smoke test (no network, no API key) — 3 calibration cases plus request-wiring assertions (model, json_schema, verbatim v0.1 system prompt, USER TYPE tag, image input). Exits 0 on pass / 1 on fail:
  ```
  npx tsx apps/unified-portal/scripts/smoke/housing-reasoning-v1.smoke.ts
  ```
- `npm run build` passes clean; the new files are type-clean.
- Real-photo testing against the live flag-on path is the **next ticket** (requires OpenAI + Supabase env, seeded `assistant_media`, and an authenticated homeowner session).

---
_Generated by [Claude Code](https://claude.ai/code/session_014QqRKfadnemco6LgZugSiJ)_