### PR TITLE
fix(assistant): populate issue_category on new path

### DIFF
--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -444,6 +444,7 @@ export async function POST(request: NextRequest) {
           title,
           description: ir.description || messageText || null,
           room: ir.area ?? null,
+          issue_category: ir.category,
           status: 'homeowner_new',
           priority: 'normal',
           source: 'homeowner_assistant',


### PR DESCRIPTION
PR #184 merged the housing-reasoning v0.1 wiring but with a small gap: the new (flag-on) path didn't populate the existing `issue_reports.issue_category` column, so it was left null on issues created via that path. This one-line fix adds `issue_category: ir.category` to the new-path `issue_reports` insert. The mocked smoke test passes (3 cases plus request-wiring assertions) and the route is type-clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_014QqRKfadnemco6LgZugSiJ)_