### PR TITLE
Sprint 2: Anonymous assistant analytics logging

### DIFF
--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -61,6 +61,8 @@ import type {
   OpenhouseAgentResult,
   OpenhouseAgentHouseContext,
 } from '@/lib/openhouse-agent/v1/types';
+import { logTurn } from '@/lib/assistant-analytics/logger';
+import type { AttachedMediaItem, LogInput } from '@/lib/assistant-analytics/types';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -84,6 +86,24 @@ const SEVERITY_LABEL_BY_V1_SEVERITY: Record<IssueSeverity, SeverityLabel> = {
   moderate: 'medium',
   major: 'high',
 };
+
+// ── Anonymous per-turn analytics ──────────────────────────────────────────
+// Flag-path labels stored in assistant_analytics_anonymous.flag_path.
+const ANALYTICS_FLAG_OPENHOUSE_AGENT = 'openhouse_agent_v1';
+const ANALYTICS_FLAG_HOUSING_REASONING = 'housing_reasoning_v1';
+const ANALYTICS_FLAG_PLACEHOLDER = 'placeholder';
+
+// gpt-4o pricing in USD per 1M tokens, hardcoded (NOT a live feed — update by
+// hand if pricing changes). Cost is stored in micro-USD (millionths of a
+// dollar), so one input token costs GPT4O_USD_PER_1M_INPUT micro-USD and the
+// total is simply in*rate_in + out*rate_out.
+const GPT4O_USD_PER_1M_INPUT = 2.5;
+const GPT4O_USD_PER_1M_OUTPUT = 10.0;
+
+function computeCostUsdMicro(tokensIn: number | null, tokensOut: number | null): number | null {
+  if (tokensIn == null && tokensOut == null) return null;
+  return Math.round((tokensIn ?? 0) * GPT4O_USD_PER_1M_INPUT + (tokensOut ?? 0) * GPT4O_USD_PER_1M_OUTPUT);
+}
 
 interface MultimodalBody {
   conversation_id?: unknown;
@@ -295,6 +315,47 @@ export async function POST(request: NextRequest) {
   let responseAction: AssistantAction;
   let createdIssueReportId: string | null = null;
 
+  // ── Anonymous analytics setup (fire-and-forget) ───────────────────────────
+  // userRole is coarse and non-identifying. userName (admin display name only;
+  // homeowners on the QR path have none) is for redaction only. developmentId
+  // is for development_type derivation only. Neither userName nor developmentId
+  // is stored. Attachments on this route are images; we only know the count, so
+  // we pass count-accurate placeholders to classifyImage (real mime/dimensions
+  // are not fetched yet — a follow-up for when classification is wired).
+  const analyticsUserRole: string | null = auth.adminSession?.role ?? auth.callerType;
+  const analyticsUserName: string | null = auth.adminSession?.displayName ?? null;
+  const analyticsAttachedMedia: AttachedMediaItem[] = mediaRows.map(() => ({
+    mime: 'image/unknown',
+    size: 0,
+  }));
+
+  // Path-level analytics fields, set inside the matched branch and read by the
+  // success log just before the response is returned.
+  let logFlagPath = ANALYTICS_FLAG_PLACEHOLDER;
+  let logPromptVersion: string | null = null;
+  let logModelUsed: string | null = null;
+  let logTokensIn: number | null = null;
+  let logTokensOut: number | null = null;
+  let logLatencyMs: number | null = null;
+  let logSeverityReturned: string | null = null;
+  let logCategoryReturned: string | null = null;
+
+  // Fire one anonymous analytics row WITHOUT blocking or delaying the response.
+  // waitUntil keeps the lambda alive until the insert completes (same pattern
+  // as triggerHomeownerIssueNotification); logTurn itself never throws.
+  const fireAnalytics = (fields: Partial<LogInput> & { flagPath: string }): void => {
+    const input: LogInput = {
+      userRole: analyticsUserRole,
+      userName: analyticsUserName,
+      developmentId: auth.developmentId,
+      messageText,
+      attachedMedia: analyticsAttachedMedia,
+      audioTranscript: null,
+      ...fields,
+    };
+    waitUntil(logTurn(input).catch(() => {}));
+  };
+
   if (isOpenhouseAgentV1Enabled()) {
     // ===================================================================
     // OpenHouse Assistant v1 (Sprint 2). General home agent, highest
@@ -350,10 +411,19 @@ export async function POST(request: NextRequest) {
         houseContext,
       });
     } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
       console.error(
         '[assistant-chat-multimodal] openhouse_agent_failed reason=%s',
-        err instanceof Error ? err.message : String(err),
+        reason,
       );
+      fireAnalytics({
+        flagPath: ANALYTICS_FLAG_OPENHOUSE_AGENT,
+        promptVersion: OPENHOUSE_AGENT_V1_PROMPT_VERSION,
+        modelUsed: 'gpt-4o',
+        latencyMs: Date.now() - startedAt,
+        errored: true,
+        errorType: `model_call_failed: ${reason}`,
+      });
       return NextResponse.json(
         { error: 'Could not analyse the photo. Try again.' },
         { status: 500 },
@@ -361,6 +431,12 @@ export async function POST(request: NextRequest) {
     }
 
     residentMessage = agentResult.message;
+    logFlagPath = ANALYTICS_FLAG_OPENHOUSE_AGENT;
+    logPromptVersion = OPENHOUSE_AGENT_V1_PROMPT_VERSION;
+    logModelUsed = 'gpt-4o';
+    logTokensIn = agentResult.usage?.input_tokens ?? null;
+    logTokensOut = agentResult.usage?.output_tokens ?? null;
+    logLatencyMs = Date.now() - startedAt;
     const ir = agentResult.issue_report ?? null;
 
     if (!ir) {
@@ -376,6 +452,8 @@ export async function POST(request: NextRequest) {
       // and severity maps minor/moderate/major -> low/medium/high.
       responseAction = 'create_issue_report';
       const severityLabel: SeverityLabel = SEVERITY_LABEL_BY_V1_SEVERITY[ir.severity];
+      logSeverityReturned = severityLabel;
+      logCategoryReturned = ir.category;
 
       const { data: analysisRow, error: analysisErr } = await supabase
         .from('assistant_media_analysis')
@@ -426,6 +504,20 @@ export async function POST(request: NextRequest) {
           '[assistant-chat-multimodal] analysis_insert_failed reason=%s',
           analysisErr?.message ?? 'no row',
         );
+        fireAnalytics({
+          flagPath: logFlagPath,
+          promptVersion: logPromptVersion,
+          modelUsed: logModelUsed,
+          tokensIn: logTokensIn,
+          tokensOut: logTokensOut,
+          costUsdMicro: computeCostUsdMicro(logTokensIn, logTokensOut),
+          latencyMs: logLatencyMs,
+          responseText: residentMessage,
+          severityReturned: logSeverityReturned,
+          categoryReturned: logCategoryReturned,
+          errored: true,
+          errorType: `analysis_insert_failed: ${analysisErr?.message ?? 'no row'}`,
+        });
         return NextResponse.json(
           { error: 'Could not analyse the photo. Try again.' },
           { status: 500 },
@@ -547,10 +639,19 @@ export async function POST(request: NextRequest) {
         images: imageUrls,
       });
     } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
       console.error(
         '[assistant-chat-multimodal] housing_reasoning_failed reason=%s',
-        err instanceof Error ? err.message : String(err),
+        reason,
       );
+      fireAnalytics({
+        flagPath: ANALYTICS_FLAG_HOUSING_REASONING,
+        promptVersion: HOUSING_REASONING_V1_PROMPT_VERSION,
+        modelUsed: 'gpt-4o',
+        latencyMs: Date.now() - startedAt,
+        errored: true,
+        errorType: `model_call_failed: ${reason}`,
+      });
       return NextResponse.json(
         { error: 'Could not analyse the photo. Try again.' },
         { status: 500 },
@@ -558,6 +659,12 @@ export async function POST(request: NextRequest) {
     }
 
     residentMessage = reasoning.message;
+    logFlagPath = ANALYTICS_FLAG_HOUSING_REASONING;
+    logPromptVersion = HOUSING_REASONING_V1_PROMPT_VERSION;
+    logModelUsed = 'gpt-4o';
+    logTokensIn = reasoning.usage?.input_tokens ?? null;
+    logTokensOut = reasoning.usage?.output_tokens ?? null;
+    logLatencyMs = Date.now() - startedAt;
 
     // --- Boundary mapping (action + severity) ---
     // ANSWER_ONLY          -> no issue created, just return the answer text.
@@ -583,6 +690,8 @@ export async function POST(request: NextRequest) {
       : isEscalation
         ? 'urgent'
         : SEVERITY_LABEL_BY_V1_SEVERITY[ir.severity];
+    logSeverityReturned = severityLabel;
+    logCategoryReturned = ir?.category ?? null;
 
     // Response keeps the existing AssistantAction vocabulary so the client
     // contract is unchanged. ESCALATE and WARRANTY both create an issue.
@@ -644,6 +753,20 @@ export async function POST(request: NextRequest) {
         '[assistant-chat-multimodal] analysis_insert_failed reason=%s',
         analysisErr?.message ?? 'no row',
       );
+      fireAnalytics({
+        flagPath: logFlagPath,
+        promptVersion: logPromptVersion,
+        modelUsed: logModelUsed,
+        tokensIn: logTokensIn,
+        tokensOut: logTokensOut,
+        costUsdMicro: computeCostUsdMicro(logTokensIn, logTokensOut),
+        latencyMs: logLatencyMs,
+        responseText: residentMessage,
+        severityReturned: logSeverityReturned,
+        categoryReturned: logCategoryReturned,
+        errored: true,
+        errorType: `analysis_insert_failed: ${analysisErr?.message ?? 'no row'}`,
+      });
       return NextResponse.json(
         { error: 'Could not analyse the photo. Try again.' },
         { status: 500 },
@@ -726,7 +849,8 @@ export async function POST(request: NextRequest) {
       }
     }
   } else {
-    // ===== Sprint 1 placeholder path. Unchanged. =====
+    // ===== Sprint 1 placeholder path. Unchanged (analytics aside). =====
+    const placeholderStartedAt = Date.now();
     let result;
     try {
       result = await analyse({
@@ -740,10 +864,18 @@ export async function POST(request: NextRequest) {
         mediaIds,
       });
     } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
       console.error(
         '[assistant-chat-multimodal] analyse_failed reason=%s',
-        err instanceof Error ? err.message : String(err),
+        reason,
       );
+      fireAnalytics({
+        flagPath: ANALYTICS_FLAG_PLACEHOLDER,
+        modelUsed: 'placeholder',
+        latencyMs: Date.now() - placeholderStartedAt,
+        errored: true,
+        errorType: `analyse_failed: ${reason}`,
+      });
       return NextResponse.json(
         { error: 'Could not analyse the photo. Try again.' },
         { status: 500 },
@@ -753,6 +885,11 @@ export async function POST(request: NextRequest) {
     residentMessage = result.residentMessage;
     analysisId = result.analysisId;
     responseAction = result.action;
+    logFlagPath = ANALYTICS_FLAG_PLACEHOLDER;
+    logModelUsed = 'placeholder';
+    logLatencyMs = Date.now() - placeholderStartedAt;
+    logSeverityReturned = result.structured?.severity_label ?? null;
+    logCategoryReturned = result.structured?.issue_type ?? null;
 
     // Sprint 3.5a section 5.1. When the AI determines the upload represents
     // an actual issue (not a curiosity question, not "look at my kitchen"),
@@ -835,6 +972,25 @@ export async function POST(request: NextRequest) {
       }
     }
   }
+
+  // Anonymous analytics for the successful turn. Fired after the response is
+  // built and never awaited (waitUntil inside fireAnalytics), so it cannot add
+  // latency to the user's reply.
+  fireAnalytics({
+    flagPath: logFlagPath,
+    promptVersion: logPromptVersion,
+    modelUsed: logModelUsed,
+    tokensIn: logTokensIn,
+    tokensOut: logTokensOut,
+    costUsdMicro: computeCostUsdMicro(logTokensIn, logTokensOut),
+    latencyMs: logLatencyMs,
+    responseText: residentMessage,
+    actionReturned: responseAction,
+    issueCreated: !!createdIssueReportId,
+    severityReturned: logSeverityReturned,
+    categoryReturned: logCategoryReturned,
+    errored: false,
+  });
 
   return NextResponse.json({
     message: residentMessage,

--- a/apps/unified-portal/lib/assistant-analytics/classify-image.ts
+++ b/apps/unified-portal/lib/assistant-analytics/classify-image.ts
@@ -1,0 +1,17 @@
+import type { AttachedMediaItem } from './types';
+
+/**
+ * Coarse image category for analytics (image_classification column).
+ *
+ * Placeholder: returns 'image' for every attachment. The point of this function
+ * existing now is to give the route a stable hook so the column is populated
+ * non-null and the wiring is in place.
+ *
+ * TODO: Wire real image classification via a separate GPT-4o call or cached
+ * vision-model output. For now returns 'image' to populate the column non-null.
+ */
+export function classifyImage(_imageRef: { mime: string; size: number; width?: number; height?: number }): string {
+  return 'image';
+}
+
+export type { AttachedMediaItem };

--- a/apps/unified-portal/lib/assistant-analytics/dev-type.ts
+++ b/apps/unified-portal/lib/assistant-analytics/dev-type.ts
@@ -1,0 +1,16 @@
+/**
+ * Coarse development_type bucket for analytics.
+ *
+ * Takes a developmentId so the mapping can be done here without the caller ever
+ * storing the id itself (the id is NOT persisted — only the derived bucket is).
+ *
+ * Placeholder: returns 'unknown' for every input.
+ *
+ * TODO: Map developmentId to a coarse, non-identifying bucket (e.g.
+ * 'houses-snagging-phase', 'apartments-occupied', 'mixed-handover') once we
+ * decide the bucket taxonomy. The buckets must stay coarse enough that they
+ * cannot single out one development.
+ */
+export function deriveDevelopmentType(_developmentId: string | null): string {
+  return 'unknown';
+}

--- a/apps/unified-portal/lib/assistant-analytics/logger.ts
+++ b/apps/unified-portal/lib/assistant-analytics/logger.ts
@@ -1,0 +1,120 @@
+/**
+ * Anonymous per-turn analytics logger for the multimodal assistant route.
+ *
+ * ── What this is ──────────────────────────────────────────────────────────
+ * One row per assistant turn (all three flag paths: openhouse agent,
+ * housing-reasoning-v1, placeholder), written to assistant_analytics_anonymous
+ * (migration 064). Used for service-quality and cost monitoring.
+ *
+ * ── Legal basis ───────────────────────────────────────────────────────────
+ * GDPR Article 6(1)(f) — legitimate interest: improving the assistant and
+ * monitoring model cost/latency. The balancing test is satisfied because the
+ * data stored is anonymous (see below) and the processing is disclosed.
+ *
+ * Authorised by the live privacy policy section titled
+ *   "OpenHouse Assistant Conversations".
+ * That section must remain published for this logging to stay lawful. If the
+ * disclosure is removed, disable the logging (it is a fire-and-forget call at
+ * the route boundary and can be commented out, or roll back the table).
+ *
+ * ── What is and is NOT stored ─────────────────────────────────────────────
+ * NO direct identifiers are stored: no user_id, conversation_id, unit_id,
+ * development_id, message_id, IP, or device info. No image bytes, hashes, or
+ * filenames. Free-text message/response are PII-redacted (best-effort, see
+ * redact.ts) before insert. developmentId and userName reach this function but
+ * are used only to DERIVE non-identifying fields (development_type) and to
+ * REDACT (the user's own name) — they are never written to a column.
+ *
+ * ── Failure policy ────────────────────────────────────────────────────────
+ * Best-effort. logTurn catches everything, logs "[analytics] log_failed:
+ * <reason>" to the console, and never throws. A logging failure must never
+ * break or delay a user's chat — the route fires this without awaiting (via
+ * waitUntil) so it cannot add latency either.
+ *
+ * ── Rollback ──────────────────────────────────────────────────────────────
+ * Drop the table: `drop table assistant_analytics_anonymous;`. No other code
+ * path reads it, so the only impact is loss of analytics. Inserts will then
+ * start failing, but logTurn swallows the error, so the user's chat is
+ * unaffected.
+ */
+
+import { redactPII } from './redact';
+import { classifyImage } from './classify-image';
+import { deriveDevelopmentType } from './dev-type';
+import type { AnalyticsInsertClient, AnalyticsRow, AttachedMediaItem, LogInput } from './types';
+
+const ANALYTICS_TABLE = 'assistant_analytics_anonymous';
+
+export interface LogTurnOptions {
+  /**
+   * Insert client. Defaults to the service-role Supabase client. Injected by
+   * the smoke test so it can assert the captured insert without touching the
+   * real DB. Resolved lazily (only when no client is passed) so importing this
+   * module never pulls in the service-role client's env/DB requirements.
+   */
+  client?: AnalyticsInsertClient;
+}
+
+function imageItems(media: AttachedMediaItem[] | null | undefined): AttachedMediaItem[] {
+  if (!media || media.length === 0) return [];
+  // This route's attachments are images; guard anyway so a future audio/other
+  // attachment cannot be miscounted as an image.
+  return media.filter((m) => typeof m.mime === 'string' && m.mime.startsWith('image/'));
+}
+
+function buildRow(input: LogInput): AnalyticsRow {
+  const images = imageItems(input.attachedMedia);
+  const classifications = Array.from(new Set(images.map((m) => classifyImage(m))));
+  const hasAudioAttachment = (input.attachedMedia ?? []).some(
+    (m) => typeof m.mime === 'string' && m.mime.startsWith('audio/'),
+  );
+
+  return {
+    flag_path: input.flagPath,
+    prompt_version: input.promptVersion ?? null,
+    user_role: input.userRole ?? null,
+    message_text_redacted: input.messageText ? redactPII(input.messageText, input.userName) : null,
+    message_had_image: images.length > 0,
+    image_count: images.length,
+    image_classification: classifications.length > 0 ? classifications.join(',') : null,
+    message_had_audio: !!input.audioTranscript || hasAudioAttachment,
+    model_used: input.modelUsed ?? null,
+    tokens_input: input.tokensIn ?? null,
+    tokens_output: input.tokensOut ?? null,
+    cost_usd_micro: input.costUsdMicro ?? null,
+    latency_ms: input.latencyMs ?? null,
+    response_text_redacted: input.responseText ? redactPII(input.responseText, input.userName) : null,
+    action_returned: input.actionReturned ?? null,
+    issue_created: !!input.issueCreated,
+    severity_returned: input.severityReturned ?? null,
+    category_returned: input.categoryReturned ?? null,
+    development_type: deriveDevelopmentType(input.developmentId ?? null),
+    errored: !!input.errored,
+    error_type: input.errorType ?? null,
+  };
+}
+
+/**
+ * Write one anonymous analytics row. Never throws. Safe to fire-and-forget.
+ */
+export async function logTurn(input: LogInput, options: LogTurnOptions = {}): Promise<void> {
+  try {
+    const row = buildRow(input);
+
+    let client = options.client;
+    if (!client) {
+      // Lazy, relative import: keeps this module free of a top-level dependency
+      // on the service-role client so the smoke test (which injects a client)
+      // never loads it.
+      const mod = await import('../supabase-server');
+      client = mod.getSupabaseAdmin() as unknown as AnalyticsInsertClient;
+    }
+
+    const { error } = await client.from(ANALYTICS_TABLE).insert(row);
+    if (error) {
+      console.error(`[analytics] log_failed: ${error.message}`);
+    }
+  } catch (err) {
+    console.error(`[analytics] log_failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/apps/unified-portal/lib/assistant-analytics/redact.ts
+++ b/apps/unified-portal/lib/assistant-analytics/redact.ts
@@ -1,0 +1,67 @@
+/**
+ * Best-effort PII redaction for the free-text columns of the anonymous
+ * assistant analytics table.
+ *
+ * LIMITATIONS — read before relying on this:
+ *   - This is a REGEX pass, not a guarantee. It catches common, well-formed
+ *     emails, Irish phone numbers and Eircodes, plus the user's own name when
+ *     that name is known. It will MISS: obfuscated contact details
+ *     ("sam at evolv dot ie"), foreign phone formats, addresses, names of
+ *     OTHER people, dates of birth, free-text descriptions that happen to
+ *     identify someone, and anything the model echoes back in an unusual form.
+ *   - It can also OVER-redact: the Eircode pattern (letter + 2 digits + 4
+ *     alphanumerics) is loose and may clip unrelated tokens. That is the safe
+ *     direction for a privacy pass.
+ *   - It does not normalise unicode or homoglyphs.
+ *
+ * The analytics table is internal and the source text is already low-risk
+ * (home/DIY questions), so this is a defence-in-depth measure on top of the
+ * "store no identifiers" design, not the only safeguard. Do not treat redacted
+ * text as fully anonymised for onward sharing without a human review.
+ */
+
+const REDACTED = '[redacted]';
+
+// Standard email shape. Intentionally simple; covers the common case.
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+// Irish international format: +353 then 8-10 digits, spaces/dashes allowed
+// between digits (e.g. "+353 87 123 4567"). Run BEFORE the 08x pattern so the
+// leading +353 is consumed first.
+const PHONE_INTL_RE = /\+353[\s-]?(?:\d[\s-]?){8,10}/g;
+
+// Irish mobile prefixes 083/085/086/087/089 then 7 digits, spaces/dashes
+// allowed (e.g. "087 123 4567", "086-1234567").
+const PHONE_MOBILE_RE = /\b0(?:83|85|86|87|89)[\s-]?(?:\d[\s-]?){7}\b/g;
+
+// Eircode: one letter, two digits, optional space, four alphanumerics
+// (e.g. "T12 ABCD", "D02X285"). Loose by design.
+const EIRCODE_RE = /\b[A-Za-z]\d{2}\s?[A-Za-z0-9]{4}\b/g;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Strip likely PII from `text`. If `userName` is supplied, exact (whole-string,
+ * case-insensitive) matches of it are also removed. Returns the text with each
+ * match replaced by "[redacted]". Returns '' for nullish input.
+ */
+export function redactPII(text: string | null | undefined, userName?: string | null): string {
+  if (!text) return '';
+
+  let out = text
+    .replace(EMAIL_RE, REDACTED)
+    .replace(PHONE_INTL_RE, REDACTED)
+    .replace(PHONE_MOBILE_RE, REDACTED)
+    .replace(EIRCODE_RE, REDACTED);
+
+  const name = userName?.trim();
+  if (name) {
+    // Escape regex metacharacters so a name like "O'Brien (Jr.)" can't break or
+    // widen the pattern. Case-insensitive, global.
+    out = out.replace(new RegExp(escapeRegExp(name), 'gi'), REDACTED);
+  }
+
+  return out;
+}

--- a/apps/unified-portal/lib/assistant-analytics/types.ts
+++ b/apps/unified-portal/lib/assistant-analytics/types.ts
@@ -1,0 +1,95 @@
+/**
+ * Types for anonymous per-turn assistant analytics.
+ *
+ * LogInput is what the route hands to logTurn() for one turn. AnalyticsRow is
+ * the exact shape inserted into the assistant_analytics_anonymous table
+ * (migration 064). The two differ deliberately:
+ *
+ *   - developmentId and userName are present on LogInput but NEVER stored.
+ *     developmentId is used only to derive a coarse development_type bucket;
+ *     userName is used only to redact the user's own name out of free text.
+ *   - message/response free text is redacted before it becomes
+ *     message_text_redacted / response_text_redacted.
+ *   - id and occurred_on are omitted: the database fills them (gen_random_uuid
+ *     and current_date defaults).
+ */
+
+/** One attached media item, as much as the route knows about it. */
+export interface AttachedMediaItem {
+  mime: string;
+  size: number;
+  width?: number;
+  height?: number;
+}
+
+export interface LogInput {
+  /** 'openhouse_agent_v1' | 'housing_reasoning_v1' | 'placeholder'. */
+  flagPath: string;
+  promptVersion?: string | null;
+  /** Coarse role (homeowner / admin role / snag). Not an identifier. */
+  userRole?: string | null;
+
+  /** Raw user message text. Redacted before storage. */
+  messageText?: string | null;
+  /** Attached media (images). Count + dimensions only; no bytes/filenames. */
+  attachedMedia?: AttachedMediaItem[] | null;
+  /** Transcript of a voice note, if one was provided. Redacted before storage. */
+  audioTranscript?: string | null;
+
+  modelUsed?: string | null;
+  tokensIn?: number | null;
+  tokensOut?: number | null;
+  costUsdMicro?: number | null;
+  latencyMs?: number | null;
+
+  /** Assistant reply text. Redacted before storage. */
+  responseText?: string | null;
+  actionReturned?: string | null;
+  issueCreated?: boolean;
+  severityReturned?: string | null;
+  categoryReturned?: string | null;
+
+  /** Used ONLY to derive development_type. NOT stored. */
+  developmentId?: string | null;
+  /** Used ONLY to redact the user's own name from free text. NOT stored. */
+  userName?: string | null;
+
+  errored?: boolean;
+  errorType?: string | null;
+}
+
+/** Exact column shape inserted into assistant_analytics_anonymous. */
+export interface AnalyticsRow {
+  flag_path: string;
+  prompt_version: string | null;
+  user_role: string | null;
+  message_text_redacted: string | null;
+  message_had_image: boolean;
+  image_count: number;
+  image_classification: string | null;
+  message_had_audio: boolean;
+  model_used: string | null;
+  tokens_input: number | null;
+  tokens_output: number | null;
+  cost_usd_micro: number | null;
+  latency_ms: number | null;
+  response_text_redacted: string | null;
+  action_returned: string | null;
+  issue_created: boolean;
+  severity_returned: string | null;
+  category_returned: string | null;
+  development_type: string;
+  errored: boolean;
+  error_type: string | null;
+}
+
+/**
+ * Minimal structural type for the Supabase insert surface logTurn needs. Lets
+ * the smoke test inject a mock that records the insert call without pulling in
+ * the real service-role client (and its env/DB requirements).
+ */
+export interface AnalyticsInsertClient {
+  from(table: string): {
+    insert(row: AnalyticsRow): Promise<{ error: { message: string } | null }>;
+  };
+}

--- a/apps/unified-portal/lib/housing-reasoning/v1/service.ts
+++ b/apps/unified-portal/lib/housing-reasoning/v1/service.ts
@@ -128,5 +128,12 @@ export async function analyseMessage(
     throw new Error('[housing-reasoning-v1] OpenAI returned no content');
   }
 
-  return JSON.parse(content) as HousingReasoningResult;
+  const parsed = JSON.parse(content) as HousingReasoningResult;
+  // Attach token usage for analytics. Not part of the model JSON; comes from
+  // response.usage (absent when the client is mocked, hence the ?? null).
+  parsed.usage = {
+    input_tokens: response.usage?.prompt_tokens ?? null,
+    output_tokens: response.usage?.completion_tokens ?? null,
+  };
+  return parsed;
 }

--- a/apps/unified-portal/lib/housing-reasoning/v1/types.ts
+++ b/apps/unified-portal/lib/housing-reasoning/v1/types.ts
@@ -39,12 +39,29 @@ export interface HousingIssueReport {
   status: IssueStatus;
 }
 
+/**
+ * OpenAI token usage for one call. Surfaced by the service so the route can log
+ * cost/usage analytics. Not part of the model's JSON output — the service
+ * attaches it from response.usage after parsing. Fields are null when the
+ * provider does not report usage (e.g. the mocked client in the smoke test).
+ */
+export interface TokenUsage {
+  input_tokens: number | null;
+  output_tokens: number | null;
+}
+
 export interface HousingReasoningResult {
   action: HousingReasoningAction;
   /** Resident/site-team-facing reply text. For ANSWER_ONLY this is the answer. */
   message: string;
   /** Present when the action logs an issue; null for ANSWER_ONLY. */
   issue_report: HousingIssueReport | null;
+  /**
+   * Token usage for this call. Attached by the service after parsing the model
+   * output; never produced by the model itself. Optional so callers (and the
+   * smoke test's canned results) need not supply it.
+   */
+  usage?: TokenUsage;
 }
 
 export interface AnalyseMessageInput {

--- a/apps/unified-portal/lib/openhouse-agent/v1/service.ts
+++ b/apps/unified-portal/lib/openhouse-agent/v1/service.ts
@@ -153,5 +153,12 @@ export async function callAgent(
     throw new Error('[openhouse-agent-v1] OpenAI returned no content');
   }
 
-  return JSON.parse(content) as OpenhouseAgentResult;
+  const parsed = JSON.parse(content) as OpenhouseAgentResult;
+  // Attach token usage for analytics. Not part of the model JSON; comes from
+  // response.usage (absent when the client is mocked, hence the ?? null).
+  parsed.usage = {
+    input_tokens: response.usage?.prompt_tokens ?? null,
+    output_tokens: response.usage?.completion_tokens ?? null,
+  };
+  return parsed;
 }

--- a/apps/unified-portal/lib/openhouse-agent/v1/types.ts
+++ b/apps/unified-portal/lib/openhouse-agent/v1/types.ts
@@ -34,6 +34,17 @@ export interface OpenhouseAgentIssueReport {
   status: IssueStatus;
 }
 
+/**
+ * OpenAI token usage for one call. Surfaced by the service so the route can log
+ * cost/usage analytics. Not part of the model's JSON output — the service
+ * attaches it from response.usage after parsing. Fields are null when the
+ * provider does not report usage (e.g. the mocked client in the smoke test).
+ */
+export interface TokenUsage {
+  input_tokens: number | null;
+  output_tokens: number | null;
+}
+
 export interface OpenhouseAgentResult {
   /** Conversational, homeowner-facing reply. Always present. */
   message: string;
@@ -42,6 +53,12 @@ export interface OpenhouseAgentResult {
    * logged for the site team. Null for an ordinary chat turn.
    */
   issue_report?: OpenhouseAgentIssueReport | null;
+  /**
+   * Token usage for this call. Attached by the service after parsing the
+   * model output; never produced by the model itself. Optional so callers
+   * (and the smoke test's canned results) need not supply it.
+   */
+  usage?: TokenUsage;
 }
 
 /**

--- a/apps/unified-portal/migrations/064_assistant_analytics_anonymous.sql
+++ b/apps/unified-portal/migrations/064_assistant_analytics_anonymous.sql
@@ -1,0 +1,59 @@
+-- 064_assistant_analytics_anonymous.sql
+--
+-- Anonymous, per-turn analytics for the multimodal assistant route
+-- (app/api/assistant/chat/multimodal). One row per turn across all three
+-- flag paths (openhouse agent, housing-reasoning-v1, placeholder).
+--
+-- GDPR basis: legitimate interest (service improvement + cost monitoring).
+-- Disclosed in the live privacy policy section "OpenHouse Assistant
+-- Conversations". NO direct identifiers are stored (no user_id,
+-- conversation_id, unit_id, development_id, message_id), no image bytes/
+-- hashes/filenames, no IP or device info. Free-text message/response columns
+-- are PII-redacted (best-effort) before insert by lib/assistant-analytics.
+--
+-- RUN MANUALLY against production Supabase (SQL Editor) BEFORE the code that
+-- writes to this table deploys. This file is NOT auto-applied.
+--
+-- Rollback: drop table assistant_analytics_anonymous. No other code path reads
+-- it, so the only impact is loss of analytics.
+
+create table if not exists assistant_analytics_anonymous (
+  id uuid primary key default gen_random_uuid(),
+  occurred_on date not null default current_date,
+  flag_path text not null,
+  prompt_version text,
+  user_role text,
+  message_text_redacted text,
+  message_had_image boolean not null default false,
+  image_count integer default 0,
+  image_classification text,
+  message_had_audio boolean not null default false,
+  model_used text,
+  tokens_input integer,
+  tokens_output integer,
+  cost_usd_micro integer,
+  latency_ms integer,
+  response_text_redacted text,
+  action_returned text,
+  issue_created boolean not null default false,
+  severity_returned text,
+  category_returned text,
+  development_type text default 'unknown',
+  errored boolean not null default false,
+  error_type text
+);
+
+create index if not exists idx_analytics_occurred_on
+  on assistant_analytics_anonymous(occurred_on);
+create index if not exists idx_analytics_flag_path
+  on assistant_analytics_anonymous(flag_path);
+create index if not exists idx_analytics_action
+  on assistant_analytics_anonymous(action_returned);
+create index if not exists idx_analytics_errored
+  on assistant_analytics_anonymous(errored) where errored = true;
+
+-- RLS: nobody reads this except service role
+alter table assistant_analytics_anonymous enable row level security;
+
+-- No policies means no access except via service role
+-- (intentional — this table is internal analytics only)

--- a/apps/unified-portal/scripts/smoke/assistant-analytics.smoke.ts
+++ b/apps/unified-portal/scripts/smoke/assistant-analytics.smoke.ts
@@ -1,0 +1,216 @@
+/**
+ * Assistant analytics — smoke test.
+ *
+ * Plain TypeScript, no test runner. Exercises redactPII() and logTurn() with a
+ * MOCKED Supabase insert client (no network, no DB, no env). Covers PII
+ * redaction (email / Irish phone / Eircode / user name) and that logTurn builds
+ * and inserts a row of the expected shape — including the privacy guarantee
+ * that no direct identifiers are written.
+ *
+ * Run:
+ *   npx tsx apps/unified-portal/scripts/smoke/assistant-analytics.smoke.ts
+ *
+ * Exit 0 = all cases pass. Exit 1 = a case failed.
+ */
+
+import { redactPII } from '../../lib/assistant-analytics/redact';
+import { logTurn } from '../../lib/assistant-analytics/logger';
+import type {
+  AnalyticsInsertClient,
+  AnalyticsRow,
+  LogInput,
+} from '../../lib/assistant-analytics/types';
+
+let failures = 0;
+
+function check(name: string, condition: boolean, detail?: string): void {
+  if (condition) {
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+// Mock insert client that records the table + row it was asked to insert, so we
+// can assert against the captured call without touching a real database.
+function mockClient(): { client: AnalyticsInsertClient; captured: { table?: string; row?: AnalyticsRow } } {
+  const captured: { table?: string; row?: AnalyticsRow } = {};
+  const client: AnalyticsInsertClient = {
+    from(table: string) {
+      captured.table = table;
+      return {
+        insert(row: AnalyticsRow) {
+          captured.row = row;
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  };
+  return { client, captured };
+}
+
+async function run(): Promise<void> {
+  // --- Case 1: redactPII strips an email ---
+  {
+    console.log('Case 1: redactPII strips an email');
+    const out = redactPII('reach me at sam@evolvai.ie anytime');
+    check('email removed', !out.includes('sam@evolvai.ie'), out);
+    check('replaced with [redacted]', out.includes('[redacted]'), out);
+  }
+
+  // --- Case 2: redactPII strips Irish phones (+353 and 08x forms) ---
+  {
+    console.log('Case 2: redactPII strips Irish phone numbers');
+    const intl = redactPII('call +353 87 1234567 now');
+    check('+353 form removed', !intl.includes('1234567') && !intl.includes('+353'), intl);
+    check('+353 replaced', intl.includes('[redacted]'), intl);
+
+    const mobile = redactPII('or 087 1234567 instead');
+    check('087 form removed', !mobile.includes('087 1234567') && !mobile.includes('1234567'), mobile);
+    check('087 replaced', mobile.includes('[redacted]'), mobile);
+  }
+
+  // --- Case 3: redactPII strips an Eircode ---
+  {
+    console.log('Case 3: redactPII strips an Eircode');
+    const out = redactPII('my Eircode is T12 ABCD thanks');
+    check('Eircode removed', !out.includes('T12 ABCD'), out);
+    check('Eircode replaced', out.includes('[redacted]'), out);
+  }
+
+  // --- Case 4: redactPII strips the user's name when provided ---
+  {
+    console.log("Case 4: redactPII strips the user's name when provided");
+    const out = redactPII('Hi, this is Sam Donworth speaking', 'Sam Donworth');
+    check('name removed', !out.includes('Sam Donworth'), out);
+    check('name replaced', out.includes('[redacted]'), out);
+    // Without the name arg, the name survives (proves it's the name arg doing it).
+    const noName = redactPII('Hi, this is Sam Donworth speaking');
+    check('name survives without the name arg', noName.includes('Sam Donworth'), noName);
+  }
+
+  // --- Case 4b: combined sentence (manual-verification case from the spec) ---
+  {
+    console.log('Case 4b: combined PII sentence is fully stripped');
+    const out = redactPII(
+      "Hi, I'm Sam Donworth, email sam@evolvai.ie, phone 087 1234567, Eircode T12 ABCD",
+      'Sam Donworth',
+    );
+    check('no name', !out.includes('Sam Donworth'), out);
+    check('no email', !out.includes('sam@evolvai.ie'), out);
+    check('no phone', !out.includes('087 1234567') && !out.includes('1234567'), out);
+    check('no eircode', !out.includes('T12 ABCD'), out);
+  }
+
+  // --- Case 5: logTurn inserts a row of the expected shape ---
+  {
+    console.log('Case 5: logTurn inserts a full row with the expected shape');
+    const { client, captured } = mockClient();
+    const input: LogInput = {
+      flagPath: 'openhouse_agent_v1',
+      promptVersion: 'openhouse-assistant-v1@test',
+      userRole: 'homeowner',
+      messageText: "I'm Sam Donworth, email sam@evolvai.ie, ring 087 1234567, Eircode T12 ABCD",
+      attachedMedia: [{ mime: 'image/jpeg', size: 120000, width: 1024, height: 768 }],
+      audioTranscript: null,
+      modelUsed: 'gpt-4o',
+      tokensIn: 1200,
+      tokensOut: 340,
+      costUsdMicro: 6400,
+      latencyMs: 2200,
+      responseText: 'That looks like an active leak; I will log it for the site team.',
+      actionReturned: 'create_issue_report',
+      issueCreated: true,
+      severityReturned: 'high',
+      categoryReturned: 'plumbing',
+      developmentId: 'dev-abc-123', // must NOT be stored
+      userName: 'Sam Donworth', // must NOT be stored; used only to redact
+      errored: false,
+      errorType: null,
+    };
+    await logTurn(input, { client });
+
+    const row = captured.row;
+    check('insert hit the analytics table', captured.table === 'assistant_analytics_anonymous', String(captured.table));
+    check('row was inserted', !!row);
+    if (row) {
+      check('flag_path', row.flag_path === 'openhouse_agent_v1', row.flag_path);
+      check('prompt_version', row.prompt_version === 'openhouse-assistant-v1@test', String(row.prompt_version));
+      check('user_role', row.user_role === 'homeowner', String(row.user_role));
+      check('message_had_image', row.message_had_image === true, String(row.message_had_image));
+      check('image_count', row.image_count === 1, String(row.image_count));
+      check('image_classification', row.image_classification === 'image', String(row.image_classification));
+      check('message_had_audio', row.message_had_audio === false, String(row.message_had_audio));
+      check('model_used', row.model_used === 'gpt-4o', String(row.model_used));
+      check('tokens_input', row.tokens_input === 1200, String(row.tokens_input));
+      check('tokens_output', row.tokens_output === 340, String(row.tokens_output));
+      check('cost_usd_micro', row.cost_usd_micro === 6400, String(row.cost_usd_micro));
+      check('latency_ms', row.latency_ms === 2200, String(row.latency_ms));
+      check('action_returned', row.action_returned === 'create_issue_report', String(row.action_returned));
+      check('issue_created', row.issue_created === true, String(row.issue_created));
+      check('severity_returned', row.severity_returned === 'high', String(row.severity_returned));
+      check('category_returned', row.category_returned === 'plumbing', String(row.category_returned));
+      check('development_type defaults to unknown', row.development_type === 'unknown', String(row.development_type));
+      check('errored', row.errored === false, String(row.errored));
+
+      const redacted = row.message_text_redacted ?? '';
+      check('message redacted: no name', !redacted.includes('Sam Donworth'), redacted);
+      check('message redacted: no email', !redacted.includes('sam@evolvai.ie'), redacted);
+      check('message redacted: no phone', !redacted.includes('1234567'), redacted);
+      check('message redacted: no eircode', !redacted.includes('T12 ABCD'), redacted);
+
+      // Privacy guarantee: no direct identifiers are present on the row.
+      const forbidden = [
+        'development_id',
+        'developmentId',
+        'user_id',
+        'userId',
+        'user_name',
+        'userName',
+        'conversation_id',
+        'unit_id',
+        'message_id',
+      ];
+      const leaked = forbidden.filter((k) => k in (row as Record<string, unknown>));
+      check('no identifier columns on the row', leaked.length === 0, `leaked: ${leaked.join(', ')}`);
+    }
+  }
+
+  // --- Case 6: logTurn with errored=true still inserts an errored row ---
+  {
+    console.log('Case 6: logTurn(errored=true) inserts an errored row');
+    const { client, captured } = mockClient();
+    const input: LogInput = {
+      flagPath: 'housing_reasoning_v1',
+      modelUsed: 'gpt-4o',
+      messageText: null,
+      errored: true,
+      errorType: 'model_call_failed: boom',
+    };
+    await logTurn(input, { client });
+
+    const row = captured.row;
+    check('errored row inserted', !!row);
+    if (row) {
+      check('flag_path', row.flag_path === 'housing_reasoning_v1', row.flag_path);
+      check('errored is true', row.errored === true, String(row.errored));
+      check('error_type populated', row.error_type === 'model_call_failed: boom', String(row.error_type));
+      check('no image on errored row', row.message_had_image === false, String(row.message_had_image));
+      check('message_text_redacted null when no message', row.message_text_redacted === null, String(row.message_text_redacted));
+    }
+  }
+
+  console.log('');
+  if (failures > 0) {
+    console.log(`SMOKE FAILED — ${failures} assertion(s) failed.`);
+    process.exit(1);
+  }
+  console.log('SMOKE PASSED — all cases green.');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error('SMOKE ERRORED:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
Logs every turn through /api/assistant/chat/multimodal to a new assistant_analytics_anonymous table for product improvement and aggregate insights. Covers all three flag paths (openhouse agent, housing-reasoning-v1, placeholder) symmetrically.

The privacy policy on the live site has been updated to disclose this logging under GDPR legitimate-interest basis. The "OpenHouse Assistant Conversations" section published on openhouseai.ie/privacy authorises this processing.

Schema (assistant_analytics_anonymous): no user_id, conversation_id, unit_id, development_id, message_id, or image hashes. Day-level timestamp only. Message text and response text are PII-redacted before insert (emails, Irish phone patterns, Eircodes, user name if available). RLS enabled with no policies — service role access only.

Files created:
- migrations/064_assistant_analytics_anonymous.sql (not yet applied to any environment — manual run per CLAUDE.md)
- lib/assistant-analytics/ module (redact, classify-image, dev-type, logger, types)
- scripts/smoke/assistant-analytics.smoke.ts (7 test cases)

Files modified:
- app/api/assistant/chat/multimodal/route.ts — six logging points (3 model-call errors, 2 analysis-insert errors, 1 success). All use waitUntil() so logging never adds latency or blocks the user response.
- lib/openhouse-agent/v1/{service,types}.ts and lib/housing-reasoning/v1/{service,types}.ts — surface OpenAI response.usage as { input_tokens, output_tokens }. Additive change, no existing call sites broken.

Cost calculation: hardcoded gpt-4o pricing ($2.50/$10.00 per 1M tokens) in the route, stored as an integer in micro-USD (millionths of a dollar; column `cost_usd_micro`) to avoid float precision issues. Revisit when OpenAI pricing changes.

Validation:
- New smoke (7 cases): green
- openhouse-agent-v1 regression smoke: green
- housing-reasoning-v1 regression smoke: green
- next build: green
- Touched files type-clean

Three intentional TODOs in code (separate follow-up ticket):
- classifyImage stub returns 'image'
- deriveDevelopmentType stub returns 'unknown'
- Route passes image placeholder mime, not real metadata

To apply the migration when ready:
Supabase Dashboard → SQL Editor → paste full contents of 064_assistant_analytics_anonymous.sql → Run.

To roll back: drop the assistant_analytics_anonymous table. No code path reads it, so the only impact is loss of analytics. Service-level usage capture remains harmless (it's just data the route can ignore).

---
_Generated by [Claude Code](https://claude.ai/code/session_011VdVBbFKo2zHcsDGmrjZDi)_