### PR TITLE
fix(assistant): route text-only turns to the agent route when flag on…

### DIFF
--- a/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
@@ -7,7 +7,7 @@ import { useSuggestedPills } from '@/hooks/useSuggestedPills';
 import { useHomeNotes } from '@/hooks/useHomeNotes';
 import { PillDefinition } from '@/lib/assistant/suggested-pills';
 import { cleanForDisplay } from '@/lib/assistant/formatting';
-import { isAssistantImageUploadEnabled } from '@/lib/feature-flags';
+import { isAssistantImageUploadEnabled, isOpenhouseAgentV1Enabled } from '@/lib/feature-flags';
 import {
   ASSISTANT_MEDIA_MAX_FILES,
   normalizeFiles,
@@ -1466,6 +1466,33 @@ export default function PurchaserChatTab({
 
     if (intentMetadata) {
       setLastIntentKey(intentMetadata.intentKey);
+    }
+
+    // Bug 1 fix: when the OpenHouse agent is enabled (client flag
+    // NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1), route text-only turns through the
+    // agent route via sendMultimodal with no attachments, so they get
+    // conversation memory and are logged to assistant_conversation_turns the
+    // same way photo turns are. Flag off => unchanged RAG /api/chat behaviour.
+    if (isOpenhouseAgentV1Enabled()) {
+      try {
+        const result = await sendMultimodal({
+          conversationId: getOrCreateConversationId(),
+          unitId: unitUid,
+          qrToken: token,
+          messageText: textToSend,
+          selections: [],
+        });
+        setMessages((prev) => [...prev, { role: 'assistant', content: result.assistantMessage }]);
+      } catch (err) {
+        const message =
+          err instanceof SendMultimodalError
+            ? err.residentMessage
+            : "Couldn't send the message. Try again or come back to it later.";
+        setMessages((prev) => [...prev, { role: 'assistant', content: message }]);
+      } finally {
+        setSending(false);
+      }
+      return;
     }
 
     try {

--- a/apps/unified-portal/lib/assistant/multimodal-client.ts
+++ b/apps/unified-portal/lib/assistant/multimodal-client.ts
@@ -72,52 +72,66 @@ const CHAT_FAILED_MESSAGE =
 export async function sendMultimodal(input: SendMultimodalInput): Promise<SendMultimodalResult> {
   const { conversationId, unitId, qrToken, messageText, selections, onStatus } = input;
 
-  onStatus?.('compressing');
-  // compressSelectionsForUpload is a no-op for files already under the
-  // threshold and for browsers that cannot decode the source format
-  // (HEIC on Chrome and Firefox), so this is always safe to call.
-  const compressed = await compressSelectionsForUpload(selections);
+  // Text-only turns (no attachments) skip the compress + upload steps entirely
+  // and post straight to the chat route with empty media_ids. This is the path
+  // PurchaserChatTab uses when the OpenHouse agent flag is on, so a text-only
+  // message goes through the agent route (which has conversation memory) rather
+  // than the RAG /api/chat endpoint. The multimodal route accepts empty
+  // media_ids on the agent path.
+  const textOnly = selections.length === 0;
 
-  onStatus?.('uploading');
+  let media: UploadedMedia[] = [];
+  let uploadedMessageId: string | undefined;
 
-  const form = new FormData();
-  form.set('conversation_id', conversationId);
-  form.set('unit_id', unitId);
-  for (const sel of compressed) {
-    form.append('files', sel.file, sel.file.name);
-  }
+  if (!textOnly) {
+    onStatus?.('compressing');
+    // compressSelectionsForUpload is a no-op for files already under the
+    // threshold and for browsers that cannot decode the source format
+    // (HEIC on Chrome and Firefox), so this is always safe to call.
+    const compressed = await compressSelectionsForUpload(selections);
 
-  let uploadJson: {
-    message_id?: string;
-    media?: UploadedMedia[];
-  };
-  try {
-    const uploadRes = await fetch('/api/assistant/media/upload', {
-      method: 'POST',
-      headers: { 'x-qr-token': qrToken },
-      body: form,
-    });
-    if (!uploadRes.ok) {
-      let serverMessage = UPLOAD_FAILED_MESSAGE;
-      try {
-        const errJson = await uploadRes.json();
-        if (typeof errJson?.error === 'string' && errJson.error.length > 0 && errJson.error.length < 200) {
-          serverMessage = errJson.error;
-        }
-      } catch {
-        // ignore json parse failure
-      }
-      throw new SendMultimodalError(serverMessage, 'upload');
+    onStatus?.('uploading');
+
+    const form = new FormData();
+    form.set('conversation_id', conversationId);
+    form.set('unit_id', unitId);
+    for (const sel of compressed) {
+      form.append('files', sel.file, sel.file.name);
     }
-    uploadJson = await uploadRes.json();
-  } catch (err) {
-    if (err instanceof SendMultimodalError) throw err;
-    throw new SendMultimodalError(UPLOAD_FAILED_MESSAGE, 'upload');
-  }
 
-  const media = Array.isArray(uploadJson.media) ? uploadJson.media : [];
-  if (media.length === 0) {
-    throw new SendMultimodalError(UPLOAD_FAILED_MESSAGE, 'upload');
+    let uploadJson: {
+      message_id?: string;
+      media?: UploadedMedia[];
+    };
+    try {
+      const uploadRes = await fetch('/api/assistant/media/upload', {
+        method: 'POST',
+        headers: { 'x-qr-token': qrToken },
+        body: form,
+      });
+      if (!uploadRes.ok) {
+        let serverMessage = UPLOAD_FAILED_MESSAGE;
+        try {
+          const errJson = await uploadRes.json();
+          if (typeof errJson?.error === 'string' && errJson.error.length > 0 && errJson.error.length < 200) {
+            serverMessage = errJson.error;
+          }
+        } catch {
+          // ignore json parse failure
+        }
+        throw new SendMultimodalError(serverMessage, 'upload');
+      }
+      uploadJson = await uploadRes.json();
+    } catch (err) {
+      if (err instanceof SendMultimodalError) throw err;
+      throw new SendMultimodalError(UPLOAD_FAILED_MESSAGE, 'upload');
+    }
+
+    media = Array.isArray(uploadJson.media) ? uploadJson.media : [];
+    if (media.length === 0) {
+      throw new SendMultimodalError(UPLOAD_FAILED_MESSAGE, 'upload');
+    }
+    uploadedMessageId = uploadJson.message_id;
   }
 
   onStatus?.('reviewing');
@@ -142,7 +156,7 @@ export async function sendMultimodal(input: SendMultimodalInput): Promise<SendMu
         unit_id: unitId,
         message_text: messageText,
         media_ids: media.map((m) => m.media_id),
-        message_id: uploadJson.message_id,
+        message_id: uploadedMessageId,
       }),
     });
     if (!chatRes.ok) {
@@ -164,7 +178,7 @@ export async function sendMultimodal(input: SendMultimodalInput): Promise<SendMu
   }
 
   return {
-    messageId: chatJson.message_id ?? uploadJson.message_id ?? '',
+    messageId: chatJson.message_id ?? uploadedMessageId ?? '',
     conversationId: chatJson.conversation_id ?? conversationId,
     media,
     assistantMessage: typeof chatJson.message === 'string' ? chatJson.message : '',

--- a/apps/unified-portal/lib/feature-flags.ts
+++ b/apps/unified-portal/lib/feature-flags.ts
@@ -162,12 +162,21 @@ export function isHousingReasoningV1Enabled(): boolean {
  * snag-triage path. Takes priority over FEATURE_HOUSING_REASONING_V1 when both
  * are set; the housing-reasoning path remains the fallback.
  *
- * Server-only: the gating happens entirely in the route handler, so there is
- * no client-side check and no NEXT_PUBLIC_ variant. Reads
- * FEATURE_OPENHOUSE_AGENT_V1.
+ * Dual server/client (same pattern as isAssistantImageUploadEnabled): the
+ * client needs to know whether the agent is on so PurchaserChatTab can route
+ * text-only turns to the agent route instead of the RAG /api/chat endpoint.
+ * Server reads FEATURE_OPENHOUSE_AGENT_V1. Client reads
+ * NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1 (must be set separately for the
+ * bundler to inline the value).
  */
 export function isOpenhouseAgentV1Enabled(): boolean {
-  return process.env.FEATURE_OPENHOUSE_AGENT_V1 === 'true';
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1 === 'true';
+  }
+  return (
+    process.env.FEATURE_OPENHOUSE_AGENT_V1 === 'true' ||
+    process.env.NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1 === 'true'
+  );
 }
 
 export function getFeatureFlags() {

--- a/apps/unified-portal/scripts/smoke/openhouse-agent-v1.smoke.ts
+++ b/apps/unified-portal/scripts/smoke/openhouse-agent-v1.smoke.ts
@@ -22,6 +22,7 @@ import type {
   OpenhouseAgentResult,
   OpenhouseAgentHouseContext,
 } from '../../lib/openhouse-agent/v1/types';
+import { sendMultimodal } from '../../lib/assistant/multimodal-client';
 
 let failures = 0;
 
@@ -365,6 +366,73 @@ async function run(): Promise<void> {
       result.issue_report?.category,
     );
     assertWiring(calls, 'HOMEOWNER', false);
+  }
+
+  // --- Case 9: text-only routing (bug 1) ---
+  // Unit test of the routing logic: with no attachments, sendMultimodal must
+  // skip the media-upload step and POST to /api/assistant/chat/multimodal with
+  // empty media_ids — i.e. a text-only turn reaches the agent route, not the RAG
+  // /api/chat endpoint. PurchaserChatTab takes this path when the agent flag is
+  // on (isOpenhouseAgentV1Enabled); the React component's flag branch itself is
+  // not unit-testable here, so this validates the routing target + the empty-
+  // media contract that the relaxed route guard depends on.
+  {
+    console.log('Case 9: text-only routing — sendMultimodal skips upload, posts to the multimodal route');
+    const calls: Array<{ url: string; body: any }> = [];
+    const originalFetch = (globalThis as any).fetch;
+    (globalThis as any).fetch = async (url: any, init: any) => {
+      let body: any = null;
+      try {
+        body = init?.body ? JSON.parse(init.body) : null;
+      } catch {
+        body = init?.body ?? null;
+      }
+      calls.push({ url: String(url), body });
+      return {
+        ok: true,
+        json: async () => ({
+          message: 'Your main stopcock is usually under the kitchen sink.',
+          analysis_id: null,
+          action: 'answer_only',
+          message_id: 'mid-1',
+          conversation_id: 'conv-1',
+        }),
+      };
+    };
+    try {
+      const result = await sendMultimodal({
+        conversationId: 'conv-1',
+        unitId: 'unit-1',
+        qrToken: 'qr-token',
+        messageText: 'How do I shut off the water?',
+        selections: [],
+      });
+      check('exactly one fetch call (upload step skipped)', calls.length === 1, `got ${calls.length}`);
+      check(
+        'posts to the multimodal agent route',
+        calls.some((c) => c.url.includes('/api/assistant/chat/multimodal')),
+        calls.map((c) => c.url).join(', '),
+      );
+      check(
+        'never calls the media-upload endpoint',
+        !calls.some((c) => c.url.includes('/api/assistant/media/upload')),
+        'upload endpoint was hit',
+      );
+      check(
+        'never calls the RAG /api/chat endpoint',
+        !calls.some((c) => c.url.endsWith('/api/chat')),
+        '/api/chat was hit',
+      );
+      const body = calls[0]?.body;
+      check(
+        'media_ids sent as empty array',
+        Array.isArray(body?.media_ids) && body.media_ids.length === 0,
+        JSON.stringify(body?.media_ids),
+      );
+      check('assistant message returned', result.assistantMessage.length > 0, result.assistantMessage);
+    } finally {
+      (globalThis as any).fetch = originalFetch;
+    }
   }
 
   console.log('');


### PR DESCRIPTION
… (bug 1)

PurchaserChatTab sent text-only messages to /api/chat (RAG) unconditionally, bypassing the OpenHouse agent route, so the relaxed media_ids guard and the new conversation memory never applied to text-only turns.

- feature-flags: isOpenhouseAgentV1Enabled() now uses the dual server/client pattern (client reads NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1), matching isAssistantImageUploadEnabled, so the client can see the flag.
- PurchaserChatTab.sendMessage: when the agent flag is on, route the text-only turn through sendMultimodal (no attachments) using the shared conversation_id, instead of /api/chat. Flag off keeps /api/chat unchanged.
- multimodal-client.sendMultimodal: text-only path skips the compress+upload steps and posts to /api/assistant/chat/multimodal with empty media_ids (the route already accepts this on the agent path).
- smoke: new case asserting the text-only path skips upload, hits the multimodal route, and sends empty media_ids.

/api/chat itself is untouched and not deprecated.

DEPLOYMENT: NEXT_PUBLIC_FEATURE_OPENHOUSE_AGENT_V1 must be set to 'true' in Vercel Preview AND Production (alongside server FEATURE_OPENHOUSE_AGENT_V1) for the client to route text-only turns to the agent.

https://claude.ai/code/session_014V5q47yDvaXaqX3DChQK5s