### PR TITLE
fix: group homeowner photo above text bubble (iMessage style)

### DIFF
--- a/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
@@ -1977,26 +1977,51 @@ export default function PurchaserChatTab({
           <div className="mx-auto max-w-3xl flex flex-col gap-4">
               {messages.map((msg, idx) => {
                 if (msg.role === 'user') {
-                  const hasMedia = !!(msg.media && msg.media.length > 0);
+                  // iMessage grouping: photo(s) render in their own rounded
+                  // element above the text bubble, both right-aligned and sharing
+                  // one max-width so a caption no longer wraps short inside a
+                  // photo-constrained bubble. A single photo renders larger than
+                  // the multi-photo grid; two or more reuse MediaThumbnailGrid.
+                  const mediaItems = msg.media ?? [];
+                  const singleImage = mediaItems.length === 1;
                   return (
                     <div key={`msg-${idx}`} className="flex justify-end">
-                      {/* User bubble - iMessage inspired, asymmetric rounded */}
-                      <div className={`message-bubble max-w-[75%] rounded-[20px] rounded-br-[6px] px-4 py-3 shadow-sm ${
-                        isDarkMode
-                          ? 'bg-gradient-to-br from-gold-500 to-gold-600 text-white shadow-gold-500/10'
-                          : 'bg-gradient-to-br from-gold-400 to-gold-500 text-white shadow-gold-500/20'
-                      }`}>
-                        <div className="space-y-2">
-                          {hasMedia && (
+                      <div className="flex max-w-[75%] flex-col items-end gap-1.5">
+                        {mediaItems.length > 0 && (
+                          singleImage ? (
+                            <button
+                              type="button"
+                              onClick={() => openLightbox(mediaItems[0].id)}
+                              className={`block overflow-hidden rounded-2xl shadow-sm transition-all duration-150 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ${
+                                isDarkMode
+                                  ? 'border border-white/10 focus-visible:ring-gold-400'
+                                  : 'border border-black/5 focus-visible:ring-gold-500'
+                              }`}
+                              aria-label="Open photo"
+                            >
+                              <img
+                                src={mediaItems[0].thumbnail_url}
+                                alt=""
+                                className="max-h-[320px] w-auto max-w-[240px] object-cover"
+                              />
+                            </button>
+                          ) : (
                             <MediaThumbnailGrid
-                              media={msg.media!}
+                              media={mediaItems}
                               onOpenLightbox={openLightbox}
                             />
-                          )}
-                          {msg.content && (
+                          )
+                        )}
+                        {msg.content && (
+                          // Text bubble - iMessage inspired, asymmetric rounded
+                          <div className={`message-bubble rounded-[20px] rounded-br-[6px] px-4 py-3 shadow-sm ${
+                            isDarkMode
+                              ? 'bg-gradient-to-br from-gold-500 to-gold-600 text-white shadow-gold-500/10'
+                              : 'bg-gradient-to-br from-gold-400 to-gold-500 text-white shadow-gold-500/20'
+                          }`}>
                             <p className="text-[15px] leading-[1.5] whitespace-pre-wrap break-words">{msg.content}</p>
-                          )}
-                        </div>
+                          </div>
+                        )}
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Issue

In the homeowner assistant chat (QR entry, `PurchaserChatTab`), a photo attached to a message rendered **inside** the gold text bubble. The bubble width got constrained by the photo, so the caption text wrapped short underneath. Reference behaviour is iMessage: photo flush above the text, both right-aligned and grouped as one message.

## Change

Scope is the `msg.role === 'user'` branch only, in `apps/unified-portal/components/purchaser/PurchaserChatTab.tsx`. The assistant branch, the composer, `MediaThumbnailGrid`, and all types are untouched.

- The user message is now a right-aligned vertical column at a shared `max-w-[75%]`.
- Photo(s) render in their own rounded element **above** the text bubble (no gold background, no bubble padding around the image).
- The gold text bubble sits **below**, sized to its own content up to the shared width, keeping the existing asymmetric tail.
- A single photo renders larger (own `rounded-2xl` container) than the multi-photo grid; two or more reuse `MediaThumbnailGrid`.
- Photo-only messages show just the photo (no empty gold bubble). Text-only messages are visually unchanged.
- Tapping a photo still opens the lightbox.

## Test plan

- [ ] Photo + caption: photo above, caption below at full width, grouped
- [ ] Photo, no caption: just the photo, no empty bubble
- [ ] Long caption, no photo: unchanged from today
- [ ] Short caption + photo: caption no longer wraps short
- [ ] Two or more photos: grid renders as before, above the caption
- [ ] Tapping a photo opens the lightbox
- [ ] Holds at narrow widths (Capacitor iOS/Android webview) and in dark mode

## Verification

`tsc --noEmit` reports zero errors in the edited file. Live QA on the QR + agent flow needs a real environment (Supabase + seeded unit), which is not available in the build container.

https://claude.ai/code/session_01AsM6QLFmikNMC9R1MTQm65

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsM6QLFmikNMC9R1MTQm65)_