### PR TITLE
Sprint 4: House context wiring (real dimensions + scheme details to agent)

### DIFF
--- a/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
+++ b/apps/unified-portal/app/api/assistant/chat/multimodal/route.ts
@@ -57,10 +57,8 @@ import { HOUSING_REASONING_V1_PROMPT_VERSION } from '@/lib/housing-reasoning/v1/
 import type { HousingReasoningResult, IssueSeverity } from '@/lib/housing-reasoning/v1/types';
 import { callAgent } from '@/lib/openhouse-agent/v1/service';
 import { OPENHOUSE_AGENT_V1_PROMPT_VERSION } from '@/lib/openhouse-agent/v1/prompt';
-import type {
-  OpenhouseAgentResult,
-  OpenhouseAgentHouseContext,
-} from '@/lib/openhouse-agent/v1/types';
+import type { OpenhouseAgentResult } from '@/lib/openhouse-agent/v1/types';
+import { loadHouseContext } from '@/lib/house-context';
 import { logTurn } from '@/lib/assistant-analytics/logger';
 import type { AttachedMediaItem, LogInput } from '@/lib/assistant-analytics/types';
 
@@ -545,15 +543,19 @@ export async function POST(request: NextRequest) {
       imageUrls.push(signed.signedUrl);
     }
 
-    // Pass only the house context the route already loads. resolveMediaAuth
-    // returns ids only. FLAG (follow-up): the route does NOT currently load the
-    // development name, unit name/number, room dimensions, floor plan refs, or
-    // snag history that the prompt is designed to use. Wiring those in needs new
-    // queries and is intentionally out of scope here (no new data plumbing).
-    const houseContext: OpenhouseAgentHouseContext = {
-      developmentId: auth.developmentId,
-      unitId: auth.unitId,
-    };
+    // Load the structured briefing of this homeowner's actual home (development,
+    // unit, every room with dimensions, and scheme-level heating/broadband/waste/
+    // parking facts) so the agent answers from real data instead of deferring to
+    // the Documents tab. Service-role queries; any failure degrades to null/empty
+    // fields and never breaks the chat turn. developmentId is guaranteed by the
+    // early return near the top of this handler; unitId by requireUnit:true in
+    // resolveMediaAuth. See lib/house-context.
+    const houseContext = await loadHouseContext({
+      tenantId: auth.tenantId,
+      developmentId: auth.developmentId!,
+      unitId: auth.unitId!,
+      supabase,
+    });
 
     // Short-term conversation memory: replay the most recent turns (token-
     // bounded, oldest trimmed, image turns reduced to a placeholder) so the

--- a/apps/unified-portal/lib/house-context/index.ts
+++ b/apps/unified-portal/lib/house-context/index.ts
@@ -1,0 +1,10 @@
+export { loadHouseContext } from './loader';
+export type { LoadHouseContextParams } from './loader';
+export type {
+  HouseContext,
+  HouseContextDevelopment,
+  HouseContextScheme,
+  HouseContextUnit,
+  HouseContextRoom,
+  RoomDimensionSource,
+} from './types';

--- a/apps/unified-portal/lib/house-context/loader.ts
+++ b/apps/unified-portal/lib/house-context/loader.ts
@@ -1,0 +1,326 @@
+// loadHouseContext — assembles the structured HouseContext briefing for one home
+// from the live tables, using a service-role client. Pure data assembly: it does
+// not touch the request, storage, or any feature flag.
+//
+// Relationship notes (verified against the schema + data, not assumed):
+//   - scheme_profile has NO development_id. It is keyed by its own id, which
+//     equals projects.id, which equals units.project_id. So the scheme for a unit
+//     is scheme_profile.id = unit.project_id. This mirrors how the homeowner chat
+//     route resolves it (app/api/chat/route.ts) — developer_org_id is a tenant
+//     marker used by the developer-portal write paths, not the read key here.
+//   - unit_types joins via the real FK units.unit_type_id -> unit_types.id.
+//   - unit_room_dimensions.house_type_id references unit_types.id.
+//
+// Every query swallows its own errors (console.warn, return null/empty) so a
+// context-load failure can never break the homeowner's chat turn.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  HouseContext,
+  HouseContextDevelopment,
+  HouseContextRoom,
+  HouseContextScheme,
+  HouseContextUnit,
+  RoomDimensionSource,
+} from './types';
+
+export interface LoadHouseContextParams {
+  tenantId: string;
+  developmentId: string;
+  unitId: string;
+  supabase: SupabaseClient;
+}
+
+// Rough token cap on the serialized context (~4 chars/token). Over budget we trim
+// rooms first, then drop the verbose scheme notes.
+const TOKEN_BUDGET = 800;
+const MAX_ROOMS = 8;
+
+type Row = Record<string, unknown>;
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toStr(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+function emptyDevelopment(): HouseContextDevelopment {
+  return { name: '', address: null, project_type: null };
+}
+
+function emptyUnit(): HouseContextUnit {
+  return {
+    unit_number: null,
+    address: null,
+    eircode: null,
+    bedrooms: null,
+    bathrooms: null,
+    floor_area_m2: null,
+    property_type: null,
+    handover_date: null,
+    house_type_code: null,
+    unit_type_name: null,
+  };
+}
+
+function estimateTokens(context: HouseContext): number {
+  return Math.ceil(JSON.stringify(context).length / 4);
+}
+
+function mapRooms(rows: Row[] | null, source: RoomDimensionSource): HouseContextRoom[] {
+  return (rows ?? []).map((r) => ({
+    name: toStr(r.room_name) ?? '',
+    floor: toStr(r.floor),
+    length_m: toNum(r.length_m),
+    width_m: toNum(r.width_m),
+    area_sqm: toNum(r.area_sqm),
+    source,
+  }));
+}
+
+interface UnitLoad {
+  unit: HouseContextUnit;
+  projectId: string | null;
+  unitTypeId: string | null;
+  floorPlanUrl: string | null;
+}
+
+export async function loadHouseContext(params: LoadHouseContextParams): Promise<HouseContext> {
+  const { developmentId, unitId, supabase } = params;
+  // tenantId is accepted for symmetry and possible future RLS-scoped queries. The
+  // lookups here are by primary key / unit id; tenant isolation was already
+  // enforced upstream (resolveMediaAuth authorised this unit for the caller).
+
+  const loadDevelopment = async (): Promise<HouseContextDevelopment> => {
+    try {
+      const { data, error } = await supabase
+        .from('developments')
+        .select('name, address, project_type')
+        .eq('id', developmentId)
+        .maybeSingle();
+      if (error || !data) {
+        if (error) console.warn('[house-context] development_load_failed reason=%s', error.message);
+        return emptyDevelopment();
+      }
+      const row = data as Row;
+      return {
+        name: toStr(row.name) ?? '',
+        address: toStr(row.address),
+        project_type: toStr(row.project_type),
+      };
+    } catch (err) {
+      console.warn(
+        '[house-context] development_load_threw reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return emptyDevelopment();
+    }
+  };
+
+  const loadUnit = async (): Promise<UnitLoad> => {
+    const fallback: UnitLoad = {
+      unit: emptyUnit(),
+      projectId: null,
+      unitTypeId: null,
+      floorPlanUrl: null,
+    };
+    try {
+      const { data, error } = await supabase
+        .from('units')
+        .select(
+          'unit_number, address, eircode, bedrooms, bathrooms, floor_area_m2, property_type, handover_date, house_type_code, project_id, unit_type_id, unit_types(name, floor_plan_pdf_url)',
+        )
+        .eq('id', unitId)
+        .maybeSingle();
+      if (error || !data) {
+        if (error) console.warn('[house-context] unit_load_failed reason=%s', error.message);
+        return fallback;
+      }
+      const row = data as Row;
+      // unit_types is a to-one embed; supabase-js may surface it as an object or a
+      // single-element array depending on relationship detection. Handle both.
+      const utRaw = row.unit_types;
+      const ut = (Array.isArray(utRaw) ? utRaw[0] : utRaw) as Row | null | undefined;
+      return {
+        unit: {
+          unit_number: toStr(row.unit_number),
+          address: toStr(row.address),
+          eircode: toStr(row.eircode),
+          bedrooms: toNum(row.bedrooms),
+          bathrooms: toNum(row.bathrooms),
+          floor_area_m2: toNum(row.floor_area_m2),
+          property_type: toStr(row.property_type),
+          handover_date: toStr(row.handover_date),
+          house_type_code: toStr(row.house_type_code),
+          unit_type_name: ut ? toStr(ut.name) : null,
+        },
+        projectId: toStr(row.project_id),
+        unitTypeId: toStr(row.unit_type_id),
+        floorPlanUrl: ut ? toStr(ut.floor_plan_pdf_url) : null,
+      };
+    } catch (err) {
+      console.warn(
+        '[house-context] unit_load_threw reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return fallback;
+    }
+  };
+
+  // Rooms recorded against this specific unit.
+  const loadUnitRooms = async (): Promise<HouseContextRoom[]> => {
+    try {
+      const { data, error } = await supabase
+        .from('unit_room_dimensions')
+        .select('room_name, floor, length_m, width_m, area_sqm')
+        .eq('unit_id', unitId)
+        .eq('verified', true)
+        .order('floor', { ascending: true })
+        .order('room_name', { ascending: true });
+      if (error) {
+        console.warn('[house-context] unit_rooms_load_failed reason=%s', error.message);
+        return [];
+      }
+      return mapRooms(data as Row[] | null, 'unit');
+    } catch (err) {
+      console.warn(
+        '[house-context] unit_rooms_load_threw reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
+  };
+
+  // House-type template rooms (unit_id IS NULL), keyed by the unit's house type.
+  const loadHouseTypeRooms = async (unitTypeId: string): Promise<HouseContextRoom[]> => {
+    try {
+      const { data, error } = await supabase
+        .from('unit_room_dimensions')
+        .select('room_name, floor, length_m, width_m, area_sqm')
+        .eq('house_type_id', unitTypeId)
+        .eq('verified', true)
+        .is('unit_id', null)
+        .order('floor', { ascending: true })
+        .order('room_name', { ascending: true });
+      if (error) {
+        console.warn('[house-context] housetype_rooms_load_failed reason=%s', error.message);
+        return [];
+      }
+      return mapRooms(data as Row[] | null, 'house_type');
+    } catch (err) {
+      console.warn(
+        '[house-context] housetype_rooms_load_threw reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return [];
+    }
+  };
+
+  const loadScheme = async (projectId: string | null): Promise<HouseContextScheme | null> => {
+    if (!projectId) return null;
+    try {
+      const { data, error } = await supabase
+        .from('scheme_profile')
+        .select(
+          'heating_type, heating_controls, broadband_type, water_billing, waste_setup, waste_provider, parking_type, parking_notes, bin_storage_notes, emergency_contact_phone, emergency_contact_notes, managing_agent_name',
+        )
+        .eq('id', projectId)
+        .maybeSingle();
+      if (error || !data) {
+        if (error) console.warn('[house-context] scheme_load_failed reason=%s', error.message);
+        return null;
+      }
+      const row = data as Row;
+      return {
+        heating_type: toStr(row.heating_type),
+        heating_controls: toStr(row.heating_controls),
+        broadband_type: toStr(row.broadband_type),
+        water_billing: toStr(row.water_billing),
+        waste_setup: toStr(row.waste_setup),
+        waste_provider: toStr(row.waste_provider),
+        parking_type: toStr(row.parking_type),
+        parking_notes: toStr(row.parking_notes),
+        bin_storage_notes: toStr(row.bin_storage_notes),
+        emergency_contact_phone: toStr(row.emergency_contact_phone),
+        emergency_contact_notes: toStr(row.emergency_contact_notes),
+        managing_agent_name: toStr(row.managing_agent_name),
+      };
+    } catch (err) {
+      console.warn(
+        '[house-context] scheme_load_threw reason=%s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+  };
+
+  // Wave 1 — keyed entirely on the loader inputs, so run in parallel.
+  const [development, unitLoad, unitRooms] = await Promise.all([
+    loadDevelopment(),
+    loadUnit(),
+    loadUnitRooms(),
+  ]);
+
+  // Wave 2 — keyed on values the unit fetch returned (project_id for the scheme,
+  // unit_type_id for the room fallback), so they depend on loadUnit but run in
+  // parallel with each other. The house-type fallback only fires when the unit has
+  // no unit-keyed verified dimensions of its own.
+  const needsFallback = unitRooms.length === 0 && !!unitLoad.unitTypeId;
+  const [scheme, fallbackRooms] = await Promise.all([
+    loadScheme(unitLoad.projectId),
+    needsFallback
+      ? loadHouseTypeRooms(unitLoad.unitTypeId as string)
+      : Promise.resolve<HouseContextRoom[]>([]),
+  ]);
+
+  const rooms = unitRooms.length > 0 ? unitRooms : fallbackRooms;
+
+  let context: HouseContext = {
+    development,
+    scheme,
+    unit: unitLoad.unit,
+    rooms,
+    floor_plan_url: unitLoad.floorPlanUrl,
+  };
+
+  // Token budget guard. Over budget: trim rooms to the first MAX_ROOMS, then (if
+  // still over) drop the verbose scheme notes fields. Never throws; always returns
+  // something. Truncation is logged so analytics can show whether it is firing.
+  let estimated = estimateTokens(context);
+  if (estimated > TOKEN_BUDGET) {
+    if (context.rooms.length > MAX_ROOMS) {
+      const before = context.rooms.length;
+      context = { ...context, rooms: context.rooms.slice(0, MAX_ROOMS) };
+      console.warn(
+        '[house-context] truncated rooms %d->%d (est %d tokens > %d budget)',
+        before,
+        MAX_ROOMS,
+        estimated,
+        TOKEN_BUDGET,
+      );
+      estimated = estimateTokens(context);
+    }
+    if (estimated > TOKEN_BUDGET && context.scheme) {
+      context = {
+        ...context,
+        scheme: {
+          ...context.scheme,
+          parking_notes: null,
+          bin_storage_notes: null,
+          emergency_contact_notes: null,
+        },
+      };
+      console.warn(
+        '[house-context] dropped scheme notes fields (est %d tokens > %d budget)',
+        estimated,
+        TOKEN_BUDGET,
+      );
+    }
+  }
+
+  return context;
+}

--- a/apps/unified-portal/lib/house-context/types.ts
+++ b/apps/unified-portal/lib/house-context/types.ts
@@ -1,0 +1,68 @@
+// House context types — the structured briefing of a homeowner's actual home
+// that the OpenHouse Assistant reasons against.
+//
+// Loaded by ./loader.ts from the live tables (developments, units, unit_types,
+// unit_room_dimensions, scheme_profile) and serialized verbatim into the agent's
+// HOUSE CONTEXT system message. The prompt (docs/prompts/openhouse-assistant-v1.md,
+// v1.2) describes this shape field-for-field, so keep the two in step.
+
+/**
+ * Where a room's dimensions came from. 'unit' = recorded for this specific home;
+ * 'house_type' = a template for the unit type, which may vary slightly in this
+ * particular home. The prompt is told to phrase 'house_type' rooms as typical
+ * rather than exact.
+ */
+export type RoomDimensionSource = 'unit' | 'house_type';
+
+export interface HouseContextRoom {
+  name: string;
+  floor: string | null;
+  length_m: number | null;
+  width_m: number | null;
+  area_sqm: number | null;
+  source: RoomDimensionSource;
+}
+
+export interface HouseContextDevelopment {
+  name: string;
+  address: string | null;
+  project_type: string | null;
+}
+
+export interface HouseContextScheme {
+  heating_type: string | null;
+  heating_controls: string | null;
+  broadband_type: string | null;
+  water_billing: string | null;
+  waste_setup: string | null;
+  waste_provider: string | null;
+  parking_type: string | null;
+  parking_notes: string | null;
+  bin_storage_notes: string | null;
+  emergency_contact_phone: string | null;
+  emergency_contact_notes: string | null;
+  managing_agent_name: string | null;
+}
+
+export interface HouseContextUnit {
+  unit_number: string | null;
+  address: string | null;
+  eircode: string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  floor_area_m2: number | null;
+  property_type: string | null;
+  /** ISO date (YYYY-MM-DD) or null. */
+  handover_date: string | null;
+  house_type_code: string | null;
+  unit_type_name: string | null;
+}
+
+export interface HouseContext {
+  development: HouseContextDevelopment;
+  scheme: HouseContextScheme | null;
+  unit: HouseContextUnit;
+  rooms: HouseContextRoom[];
+  /** From unit_types.floor_plan_pdf_url for this unit's type. */
+  floor_plan_url: string | null;
+}

--- a/apps/unified-portal/lib/openhouse-agent/v1/prompt.ts
+++ b/apps/unified-portal/lib/openhouse-agent/v1/prompt.ts
@@ -1,13 +1,13 @@
 // Source of truth: docs/prompts/openhouse-assistant-v1.md
 // Do not edit here without updating the docs file and vice versa.
 //
-// This is the v1.1 prompt body verbatim, the block between the triple
-// backticks under "## The prompt (v1.1)" in the docs file. It is the locked
+// This is the v1.2 prompt body verbatim, the block between the triple
+// backticks under "## The prompt (v1.2)" in the docs file. It is the locked
 // behavioural contract for the OpenHouse Assistant general home agent and is
 // used as-is as the OpenAI system prompt. The lock is the behaviour, not the
 // model.
 
-export const OPENHOUSE_AGENT_V1_PROMPT_VERSION = 'openhouse-assistant-v1.1';
+export const OPENHOUSE_AGENT_V1_PROMPT_VERSION = 'openhouse-assistant-v1.2';
 
 export const OPENHOUSE_AGENT_V1_PROMPT = `You are the OpenHouse Assistant, the homeowner's helpful and
 knowledgeable companion for everything to do with their home.
@@ -22,13 +22,28 @@ fridge, lawn care, pest queries, weather impact on the property,
 how to fix small things, how to maintain larger things, and
 anything else a homeowner might wonder while living in their home.
 
-You have access to context about this homeowner's specific
-house, which development they live in, which unit, and the
-structured data we hold about it. When you have specific
-information, use it. When you don't, say so honestly rather
-than guessing. Detailed floor plans, dimensions, and appliance
-models will become available to you over time as we expand
-what the system surfaces.
+You have access to detailed structured information about
+this homeowner's specific home. The HOUSE CONTEXT system
+message contains: development name and address, unit details
+(number, eircode, bedrooms, bathrooms, floor area, handover
+date, house type), every room with its dimensions in metres
+(length, width, floor area), and scheme-level details about
+heating, broadband, water, waste collection, parking, and
+emergency contacts. Use this whenever it makes the answer
+better. If they ask the size of their living room, find
+Living Room in the rooms array and answer in metres. If they
+ask how their heating works, use the heating_type and
+heating_controls fields. Never make up details about the
+home - if a field is null or missing, say so honestly. The
+information may be partial; some fields may not be populated.
+
+Each room carries a source tag. A room tagged 'unit' has
+dimensions recorded for this specific home, so you can state
+them directly. A room tagged 'house_type' is typical for
+this unit type and may vary slightly in this particular
+home, so phrase those as typical rather than exact, for
+example "this house type typically has a living room around
+4.1m by 3.8m".
 
 You can see images they send. Voice notes will become
 available to you soon. Use everything they give you.

--- a/apps/unified-portal/lib/openhouse-agent/v1/types.ts
+++ b/apps/unified-portal/lib/openhouse-agent/v1/types.ts
@@ -20,6 +20,7 @@ import type {
   IssueCategory,
   IssueStatus,
 } from '../../housing-reasoning/v1/types';
+import type { HouseContext } from '../../house-context/types';
 
 export type { IssueSeverity, IssueCategory, IssueStatus };
 
@@ -102,6 +103,11 @@ export interface CallAgentInput {
    * single-turn call (the original behaviour).
    */
   priorMessages?: { role: 'user' | 'assistant'; content: string }[];
-  /** What the route knows about this specific home. Optional. */
-  houseContext?: OpenhouseAgentHouseContext | null;
+  /**
+   * What the route knows about this specific home. Optional. Accepts either the
+   * legacy flat OpenhouseAgentHouseContext or the structured HouseContext now
+   * loaded by lib/house-context; the service JSON-serializes whichever it gets
+   * into the HOUSE CONTEXT system message.
+   */
+  houseContext?: OpenhouseAgentHouseContext | HouseContext | null;
 }

--- a/apps/unified-portal/scripts/smoke/house-context.smoke.ts
+++ b/apps/unified-portal/scripts/smoke/house-context.smoke.ts
@@ -1,0 +1,333 @@
+/**
+ * House context loader — smoke test (Sprint 4).
+ *
+ * Plain TypeScript, no test runner. Mocks the Supabase service-role client (no
+ * network, no DB) and exercises loadHouseContext() against five cases:
+ *   1. Full data — structure matches the HouseContext type; numerics coerced.
+ *   2. House-type fallback — empty unit-keyed rooms fall back to house_type rows,
+ *      tagged source 'house_type', and the fallback query is shaped correctly.
+ *   3. Token budget — many rooms trip the guard and the rooms array is trimmed.
+ *   4. Token budget stage 2 — verbose scheme notes are dropped after room trim.
+ *   5. Partial data — scheme_profile missing yields scheme: null, rest intact.
+ *
+ * Run:
+ *   npx tsx apps/unified-portal/scripts/smoke/house-context.smoke.ts
+ *
+ * Exit 0 = all cases pass. Exit 1 = a case failed.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { loadHouseContext, type HouseContext } from '../../lib/house-context';
+
+let failures = 0;
+
+function check(name: string, condition: boolean, detail?: string): void {
+  if (condition) {
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+type Row = Record<string, unknown>;
+
+interface Fixtures {
+  developments?: Row | null;
+  units?: Row | null;
+  scheme_profile?: Row | null;
+  rooms_by_unit?: Row[];
+  rooms_by_housetype?: Row[];
+}
+
+interface RecordedCall {
+  table: string;
+  filters: Record<string, unknown>;
+  isNull: string[];
+}
+
+// A mock Supabase client: a chainable, awaitable query builder that records the
+// table + filters it was given and returns canned data on resolution. Supports
+// the exact chain the loader uses: select / eq / is / order / maybeSingle, plus
+// awaiting the builder directly (for the multi-row room queries).
+function makeSupabase(fixtures: Fixtures): { client: SupabaseClient; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const from = (table: string) => {
+    const state: RecordedCall = { table, filters: {}, isNull: [] };
+    const resolve = () => {
+      calls.push({ table, filters: { ...state.filters }, isNull: [...state.isNull] });
+      let data: unknown = null;
+      if (table === 'developments') data = fixtures.developments ?? null;
+      else if (table === 'units') data = fixtures.units ?? null;
+      else if (table === 'scheme_profile') data = fixtures.scheme_profile ?? null;
+      else if (table === 'unit_room_dimensions') {
+        const isHouseType = state.isNull.includes('unit_id') || 'house_type_id' in state.filters;
+        data = (isHouseType ? fixtures.rooms_by_housetype : fixtures.rooms_by_unit) ?? [];
+      }
+      return Promise.resolve({ data, error: null });
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const builder: any = {
+      select: () => builder,
+      eq: (col: string, val: unknown) => {
+        state.filters[col] = val;
+        return builder;
+      },
+      is: (col: string, val: unknown) => {
+        if (val === null) state.isNull.push(col);
+        return builder;
+      },
+      order: () => builder,
+      maybeSingle: () => resolve(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      then: (onF: any, onR: any) => resolve().then(onF, onR),
+    };
+    return builder;
+  };
+  return { client: { from } as unknown as SupabaseClient, calls };
+}
+
+const BASE_PARAMS = { tenantId: 'tenant-1', developmentId: 'dev-1', unitId: 'unit-1' };
+
+async function run(): Promise<void> {
+  // --- Case 1: full data ---
+  {
+    console.log('Case 1: full data — structure + numeric coercion');
+    const { client } = makeSupabase({
+      developments: { name: 'Longview Park', address: '1 Longview Rd, Cork', project_type: 'residential' },
+      units: {
+        unit_number: '12',
+        address: '12 Longview Park',
+        eircode: 'T12 AB34',
+        bedrooms: 3,
+        bathrooms: 2,
+        floor_area_m2: '110.5', // string in, number out
+        property_type: 'semi-detached',
+        handover_date: '2025-03-01',
+        house_type_code: 'TYPE-B',
+        project_id: 'proj-1',
+        unit_type_id: 'ut-1',
+        unit_types: { name: 'The Birch', floor_plan_pdf_url: 'https://x/plan.pdf' },
+      },
+      scheme_profile: {
+        heating_type: 'Air-to-water heat pump',
+        heating_controls: 'Honeywell room stat',
+        broadband_type: 'FTTH',
+        water_billing: 'Uisce Eireann',
+        waste_setup: 'three-bin kerbside',
+        waste_provider: 'Panda',
+        parking_type: 'driveway',
+        parking_notes: 'two spaces',
+        bin_storage_notes: 'side passage',
+        emergency_contact_phone: '021 000 0000',
+        emergency_contact_notes: 'out of hours via managing agent',
+        managing_agent_name: 'ABC Property Management',
+      },
+      rooms_by_unit: [
+        { room_name: 'Living Room', floor: 'Ground', length_m: '4.1', width_m: '3.8', area_sqm: '15.58' },
+        { room_name: 'Kitchen', floor: 'Ground', length_m: 3.0, width_m: 3.5, area_sqm: 10.5 },
+      ],
+    });
+    const ctx: HouseContext = await loadHouseContext({ ...BASE_PARAMS, supabase: client });
+
+    check(
+      'top-level keys match HouseContext',
+      JSON.stringify(Object.keys(ctx).sort()) ===
+        JSON.stringify(['development', 'floor_plan_url', 'rooms', 'scheme', 'unit']),
+      Object.keys(ctx).join(','),
+    );
+    check('development.name', ctx.development.name === 'Longview Park', ctx.development.name);
+    check('development.project_type', ctx.development.project_type === 'residential');
+    check('unit.unit_number', ctx.unit.unit_number === '12', String(ctx.unit.unit_number));
+    check('unit.bedrooms is number 3', ctx.unit.bedrooms === 3, String(ctx.unit.bedrooms));
+    check(
+      'unit.floor_area_m2 coerced string->number',
+      ctx.unit.floor_area_m2 === 110.5 && typeof ctx.unit.floor_area_m2 === 'number',
+      String(ctx.unit.floor_area_m2),
+    );
+    check('unit.handover_date ISO', ctx.unit.handover_date === '2025-03-01', String(ctx.unit.handover_date));
+    check('unit.unit_type_name from embed', ctx.unit.unit_type_name === 'The Birch', String(ctx.unit.unit_type_name));
+    check('floor_plan_url from unit_types', ctx.floor_plan_url === 'https://x/plan.pdf', String(ctx.floor_plan_url));
+    check('scheme present', ctx.scheme !== null);
+    check('scheme.heating_type', ctx.scheme?.heating_type === 'Air-to-water heat pump', String(ctx.scheme?.heating_type));
+    check('scheme.managing_agent_name', ctx.scheme?.managing_agent_name === 'ABC Property Management');
+    check('rooms length 2', ctx.rooms.length === 2, String(ctx.rooms.length));
+    check('room[0] name', ctx.rooms[0]?.name === 'Living Room', ctx.rooms[0]?.name);
+    check(
+      'room[0] length coerced string->number',
+      ctx.rooms[0]?.length_m === 4.1 && typeof ctx.rooms[0]?.length_m === 'number',
+      String(ctx.rooms[0]?.length_m),
+    );
+    check('room[0] source is unit', ctx.rooms[0]?.source === 'unit', ctx.rooms[0]?.source);
+  }
+
+  // --- Case 2: house-type fallback ---
+  {
+    console.log("Case 2: house-type fallback when unit has no unit-keyed rooms");
+    const { client, calls } = makeSupabase({
+      developments: { name: 'Longview Park', address: null, project_type: null },
+      units: {
+        unit_number: '7',
+        address: '7 Longview Park',
+        eircode: null,
+        bedrooms: 2,
+        bathrooms: 1,
+        floor_area_m2: 85,
+        property_type: 'apartment',
+        handover_date: null,
+        house_type_code: 'TYPE-A',
+        project_id: 'proj-1',
+        unit_type_id: 'ut-9',
+        unit_types: { name: 'The Ash', floor_plan_pdf_url: null },
+      },
+      scheme_profile: null,
+      rooms_by_unit: [], // none recorded for this specific unit
+      rooms_by_housetype: [
+        { room_name: 'Living Room', floor: 'Ground', length_m: 4.0, width_m: 3.7, area_sqm: 14.8 },
+        { room_name: 'Bedroom 1', floor: 'First', length_m: 3.2, width_m: 3.0, area_sqm: 9.6 },
+      ],
+    });
+    const ctx = await loadHouseContext({ ...BASE_PARAMS, supabase: client });
+
+    check('rooms from fallback (length 2)', ctx.rooms.length === 2, String(ctx.rooms.length));
+    check('fallback room source is house_type', ctx.rooms[0]?.source === 'house_type', ctx.rooms[0]?.source);
+    check('fallback room name', ctx.rooms[0]?.name === 'Living Room', ctx.rooms[0]?.name);
+
+    const urdCalls = calls.filter((c) => c.table === 'unit_room_dimensions');
+    check('tried unit-keyed query first', urdCalls.some((c) => c.filters.unit_id === 'unit-1' && c.isNull.length === 0));
+    check(
+      'fallback query keyed by house_type_id = unit.unit_type_id and unit_id IS NULL',
+      urdCalls.some((c) => c.filters.house_type_id === 'ut-9' && c.filters.verified === true && c.isNull.includes('unit_id')),
+      JSON.stringify(urdCalls),
+    );
+  }
+
+  // --- Case 3: token budget — many rooms trimmed to 8 ---
+  {
+    console.log('Case 3: token budget guard trims a long rooms array to 8');
+    const manyRooms: Row[] = [];
+    for (let i = 1; i <= 40; i++) {
+      manyRooms.push({
+        room_name: `Bedroom number ${i} with a deliberately long descriptive name`,
+        floor: i % 2 === 0 ? 'Ground floor' : 'First floor',
+        length_m: 4.12,
+        width_m: 3.87,
+        area_sqm: 15.94,
+      });
+    }
+    const { client } = makeSupabase({
+      developments: { name: 'Big Scheme', address: 'somewhere', project_type: 'residential' },
+      units: {
+        unit_number: '1',
+        address: 'a',
+        eircode: null,
+        bedrooms: 40,
+        bathrooms: 10,
+        floor_area_m2: 500,
+        property_type: 'house',
+        handover_date: null,
+        house_type_code: 'X',
+        project_id: 'proj-1',
+        unit_type_id: 'ut-1',
+        unit_types: { name: 'Mansion', floor_plan_pdf_url: null },
+      },
+      scheme_profile: null, // isolate the room-truncation branch
+      rooms_by_unit: manyRooms,
+    });
+    const ctx = await loadHouseContext({ ...BASE_PARAMS, supabase: client });
+    check('rooms truncated to 8', ctx.rooms.length === 8, String(ctx.rooms.length));
+    check('kept rooms keep unit source', ctx.rooms.every((r) => r.source === 'unit'));
+  }
+
+  // --- Case 4: token budget stage 2 — drop verbose scheme notes ---
+  {
+    console.log('Case 4: token budget guard drops verbose scheme notes (stage 2)');
+    const bulky = 'x'.repeat(1500);
+    const { client } = makeSupabase({
+      developments: { name: 'Scheme', address: null, project_type: null },
+      units: {
+        unit_number: '2',
+        address: 'b',
+        eircode: null,
+        bedrooms: 2,
+        bathrooms: 1,
+        floor_area_m2: 80,
+        property_type: 'house',
+        handover_date: null,
+        house_type_code: 'Y',
+        project_id: 'proj-1',
+        unit_type_id: 'ut-1',
+        unit_types: { name: 'Type', floor_plan_pdf_url: null },
+      },
+      scheme_profile: {
+        heating_type: 'Gas boiler',
+        heating_controls: 'wall thermostat',
+        broadband_type: 'FTTH',
+        water_billing: 'Uisce Eireann',
+        waste_setup: 'three-bin',
+        waste_provider: 'Greenstar',
+        parking_type: 'on-street',
+        parking_notes: bulky,
+        bin_storage_notes: bulky,
+        emergency_contact_phone: '999',
+        emergency_contact_notes: bulky,
+        managing_agent_name: 'Agent',
+      },
+      rooms_by_unit: [
+        { room_name: 'Living Room', floor: 'Ground', length_m: 4.0, width_m: 3.5, area_sqm: 14 },
+        { room_name: 'Kitchen', floor: 'Ground', length_m: 3, width_m: 3, area_sqm: 9 },
+      ],
+    });
+    const ctx = await loadHouseContext({ ...BASE_PARAMS, supabase: client });
+    check('rooms untouched (2, below the 8 cap)', ctx.rooms.length === 2, String(ctx.rooms.length));
+    check('scheme still present', ctx.scheme !== null);
+    check('parking_notes dropped', ctx.scheme?.parking_notes === null);
+    check('bin_storage_notes dropped', ctx.scheme?.bin_storage_notes === null);
+    check('emergency_contact_notes dropped', ctx.scheme?.emergency_contact_notes === null);
+    check('non-notes scheme fields kept', ctx.scheme?.heating_type === 'Gas boiler', String(ctx.scheme?.heating_type));
+    check('emergency_contact_phone kept', ctx.scheme?.emergency_contact_phone === '999', String(ctx.scheme?.emergency_contact_phone));
+  }
+
+  // --- Case 5: partial data — scheme_profile missing ---
+  {
+    console.log('Case 5: partial data — scheme_profile missing returns scheme: null');
+    const { client } = makeSupabase({
+      developments: { name: 'Longview Park', address: '1 Longview Rd', project_type: 'residential' },
+      units: {
+        unit_number: '5',
+        address: '5 Longview Park',
+        eircode: 'T12 ZZ99',
+        bedrooms: 3,
+        bathrooms: 2,
+        floor_area_m2: 100,
+        property_type: 'house',
+        handover_date: '2024-12-10',
+        house_type_code: 'TYPE-C',
+        project_id: 'proj-1',
+        unit_type_id: 'ut-1',
+        unit_types: { name: 'The Oak', floor_plan_pdf_url: 'https://x/oak.pdf' },
+      },
+      scheme_profile: null, // no scheme row for this project
+      rooms_by_unit: [{ room_name: 'Hall', floor: 'Ground', length_m: 2, width_m: 1.5, area_sqm: 3 }],
+    });
+    const ctx = await loadHouseContext({ ...BASE_PARAMS, supabase: client });
+    check('scheme is null', ctx.scheme === null, JSON.stringify(ctx.scheme));
+    check('development still loaded', ctx.development.name === 'Longview Park');
+    check('unit still loaded', ctx.unit.unit_number === '5', String(ctx.unit.unit_number));
+    check('rooms still loaded', ctx.rooms.length === 1 && ctx.rooms[0]?.source === 'unit');
+    check('floor_plan_url still loaded', ctx.floor_plan_url === 'https://x/oak.pdf');
+  }
+
+  console.log('');
+  if (failures > 0) {
+    console.log(`SMOKE FAILED — ${failures} assertion(s) failed.`);
+    process.exit(1);
+  }
+  console.log('SMOKE PASSED — all cases green.');
+  process.exit(0);
+}
+
+run().catch((err) => {
+  console.error('SMOKE ERRORED:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/docs/prompts/openhouse-assistant-v1.md
+++ b/docs/prompts/openhouse-assistant-v1.md
@@ -1,10 +1,15 @@
-# OpenHouse Assistant Prompt v1.1
+# OpenHouse Assistant Prompt v1.2
 
 **Status:** Production prompt for the OpenHouse Assistant, a general home agent that helps homeowners with anything to do with their home, inside or outside, including what goes into it.
 
 **Distinct from:** `housing-reasoning-v1.md`, which is a narrower snag-triage prompt. This is the broader replacement.
 
 **Source of truth:** This file. Mirrored verbatim into `apps/unified-portal/lib/openhouse-agent/v1/prompt.ts`.
+
+## Changes from v1.1
+
+- **House context wired in.** The multimodal route now loads a structured HOUSE CONTEXT briefing — development name and address, unit details (number, eircode, bedrooms, bathrooms, floor area, handover date, house type), every room with its dimensions in metres, and scheme-level heating/broadband/water/waste/parking/emergency facts — from the live tables (`developments`, `units`, `unit_types`, `unit_room_dimensions`, `scheme_profile`) and passes it to the model. The house-context paragraph is rewritten to describe exactly what is now available and how to use it. Loader: `apps/unified-portal/lib/house-context`.
+- **Room dimension source tags.** Each room is tagged `unit` (recorded for this specific home) or `house_type` (a template for the unit type, surfaced as a fallback when the unit has no unit-specific dimensions). The prompt instructs the model to phrase `house_type` dimensions as typical rather than exact.
 
 ## Changes from v1.0
 
@@ -15,7 +20,7 @@
 
 ---
 
-## The prompt (v1.1)
+## The prompt (v1.2)
 
 ```
 You are the OpenHouse Assistant, the homeowner's helpful and
@@ -31,13 +36,28 @@ fridge, lawn care, pest queries, weather impact on the property,
 how to fix small things, how to maintain larger things, and
 anything else a homeowner might wonder while living in their home.
 
-You have access to context about this homeowner's specific
-house, which development they live in, which unit, and the
-structured data we hold about it. When you have specific
-information, use it. When you don't, say so honestly rather
-than guessing. Detailed floor plans, dimensions, and appliance
-models will become available to you over time as we expand
-what the system surfaces.
+You have access to detailed structured information about
+this homeowner's specific home. The HOUSE CONTEXT system
+message contains: development name and address, unit details
+(number, eircode, bedrooms, bathrooms, floor area, handover
+date, house type), every room with its dimensions in metres
+(length, width, floor area), and scheme-level details about
+heating, broadband, water, waste collection, parking, and
+emergency contacts. Use this whenever it makes the answer
+better. If they ask the size of their living room, find
+Living Room in the rooms array and answer in metres. If they
+ask how their heating works, use the heating_type and
+heating_controls fields. Never make up details about the
+home - if a field is null or missing, say so honestly. The
+information may be partial; some fields may not be populated.
+
+Each room carries a source tag. A room tagged 'unit' has
+dimensions recorded for this specific home, so you can state
+them directly. A room tagged 'house_type' is typical for
+this unit type and may vary slightly in this particular
+home, so phrase those as typical rather than exact, for
+example "this house type typically has a living room around
+4.1m by 3.8m".
 
 You can see images they send. Voice notes will become
 available to you soon. Use everything they give you.


### PR DESCRIPTION
Wires real house context into the OpenHouse Assistant agent path. Replaces the previous placeholder {developmentId, unitId} with a structured briefing of the homeowner's actual home: room dimensions, heating system, broadband, waste collection, parking, emergency contacts.

The agent can now answer "what size is my dinette" with real numbers from unit_room_dimensions and "how does my heating work" with the specific Daikin Altherma details from scheme_profile, instead of deferring to the Documents tab.

Schema discovery: scheme_profile links via scheme_profile.id = units.project_id (not via developer_org_id, which doesn't match any developments column). Same resolution pattern as the existing /api/chat route. Confirmed against data: 187 units resolve a scheme this way.

Files created:
- lib/house-context/ module (types, loader, index)
  Parallel queries (Promise.all) for development, unit with unit_types embed, and unit-keyed room dimensions.
  Sequential fallback: scheme_profile by unit.project_id, house-type-keyed room dimensions if unit-keyed query returned zero rows.
  All errors degrade to null/empty fields, never throw.

- scripts/smoke/house-context.smoke.ts
  5 cases: structure, house-type fallback, room truncation, scheme notes drop, scheme missing/partial data.

Files modified:
- app/api/assistant/chat/multimodal/route.ts
  Replaced placeholder houseContext (lines 553-556) with loadHouseContext call on agent path only. Housing-reasoning and placeholder paths unchanged.

- lib/openhouse-agent/v1/types.ts
  Widened callAgent houseContext param to union with the new HouseContext shape. Existing OpenhouseAgentHouseContext preserved.

- docs/prompts/openhouse-assistant-v1.md + lib/openhouse-agent/v1/prompt.ts
  v1.2: new house-context section describing fields available (rooms, heating, broadband, waste, parking, emergency contacts). house_type-tagged dimensions noted as typical rather than exact. Bodies byte-identical (11,145 chars).

Token budget: ~800 tokens. Trims rooms to 8 first if over, then drops verbose scheme notes. Logs on truncation fire.

Validation:
- New smoke 5/5 green
- Existing 3 smokes still green (regression)
- next build green
- Touched files type-clean

No env var changes, no migration. Code-only deploy.

Rollback: revert the squash merge. The OpenhouseAgentHouseContext type is still in place, so the prior placeholder shape works if the new loader is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCUBy4JHS6EPGAMQwBZFng)_