### PR TITLE
fix(assistant): render markdown in homeowner and care chat replies

### DIFF
--- a/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
+++ b/apps/unified-portal/app/care/[installationId]/screens/AssistantScreen.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Home, Mic, Send, Info, ChevronDown, ChevronUp, FileText, Clock, X } from 'lucide-react';
 import Image from 'next/image';
-import { cleanForDisplay } from '@/lib/assistant/formatting';
+import { cleanForDisplay, renderChatMarkdown } from '@/lib/assistant/formatting';
 import { useCareApp } from '../care-app-provider';
 
 /* ── Animation Styles — VERBATIM from PurchaserChatTab + UX Enhancements ──── */
@@ -69,12 +69,12 @@ function getWordDelay(word: string, isAfterParagraph: boolean): number {
 
 /* ── Format assistant response text ───────────────────────────────────────── */
 function formatContent(text: string): string {
-  let html = cleanForDisplay(text);
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong class="font-semibold text-gray-900">$1</strong>');
-  html = html.replace(/^(\d+)\.\s+/gm, '<span class="text-[#D4AF37] font-semibold mr-1">$1.</span> ');
-  html = html.replace(/^[-•]\s+/gm, '<span class="text-[#D4AF37] mr-1">•</span> ');
-  html = html.replace(/\n/g, '<br/>');
-  return html;
+  // Same markdown rendering as the homeowner bubble (bold, italic, inline code,
+  // h3/h4, lists) so replies look consistent across the product. The sanitiser
+  // runs first, then the shared renderer escapes and styles the result.
+  return renderChatMarkdown(cleanForDisplay(text), {
+    codeClassName: 'bg-black/[0.06] text-gray-800',
+  });
 }
 
 /* ── Typing Indicator — matches Property portal ───────────────────────────── */

--- a/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
+++ b/apps/unified-portal/components/purchaser/PurchaserChatTab.tsx
@@ -6,7 +6,7 @@ import { Home, Mic, Send, FileText, Download, Eye, Info, ChevronDown, ChevronUp,
 import { useSuggestedPills } from '@/hooks/useSuggestedPills';
 import { useHomeNotes } from '@/hooks/useHomeNotes';
 import { PillDefinition } from '@/lib/assistant/suggested-pills';
-import { cleanForDisplay } from '@/lib/assistant/formatting';
+import { cleanForDisplay, renderChatMarkdown } from '@/lib/assistant/formatting';
 import { isAssistantImageUploadEnabled, isOpenhouseAgentV1Enabled } from '@/lib/feature-flags';
 import {
   ASSISTANT_MEDIA_MAX_FILES,
@@ -149,47 +149,30 @@ function getWordDelay(word: string, isAfterParagraph: boolean): number {
   return Math.max(10, delay);
 }
 
-// Format assistant content with selective styling for professionalism
-// Converts clean text into styled HTML with bold headings and proper list formatting
-function formatAssistantContent(content: string, isDarkMode: boolean): string {
-  if (!content) return '';
+// Prose rules layered onto paragraph text in the homeowner bubble: section
+// headers, clickable contacts, smart typography and highlighted figures. These
+// run on plain paragraph text only, so the structural markdown the shared
+// renderer produces (lists, headings) is left untouched.
+function applyAssistantProseRules(text: string): string {
+  let html = text;
 
-  // Escape HTML to prevent XSS
-  let html = content
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-
-  // Style lines that end with a colon as bold headings (e.g., "Walls:" or "Important:")
-  // These are section headers in the assistant's responses
+  // Style a short line that ends in a colon as a section header.
   html = html.replace(/^([A-Z][^:\n]{0,50}:)\s*$/gm, (match, heading) => {
     return `<strong class="block mt-3 mb-1 text-[15px] font-semibold">${heading}</strong>`;
   });
 
-  // Also style inline headings that start a paragraph (e.g., "Walls: The walls are...")
+  // Style an inline "Label:" that starts a line.
   html = html.replace(/^([A-Z][^:\n]{0,50}:)(\s+\S)/gm, (match, heading, rest) => {
     return `<strong class="font-semibold">${heading}</strong>${rest}`;
   });
 
-  // Style list items with proper indentation and bullet styling
-  // Using flex with items-start ensures multi-line text aligns properly (not under the bullet)
-  html = html.replace(/^- (.+)$/gm, (match, item) => {
-    return `<div class="flex items-start gap-2 ml-1 my-1"><span class="text-gold-500 select-none shrink-0 mt-[2px]">•</span><span class="flex-1">${item}</span></div>`;
-  });
-
-  // Style numbered lists with proper alignment for multi-line items
-  html = html.replace(/^(\d+)\.\s+(.+)$/gm, (match, num, item) => {
-    return `<div class="flex items-start gap-2 ml-1 my-1"><span class="text-gold-500 font-medium select-none shrink-0 min-w-[1.25rem] mt-[1px]">${num}.</span><span class="flex-1">${item}</span></div>`;
-  });
-
-  // Make URLs clickable (but keep them clean-looking)
+  // Make URLs clickable.
   html = html.replace(
     /(https?:\/\/[^\s<]+)/g,
     '<a href="$1" target="_blank" rel="noopener noreferrer" class="text-gold-500 hover:text-gold-400 underline underline-offset-2">$1</a>'
   );
 
-  // Make phone numbers clickable (Irish and international formats)
-  // Matches: +353..., 01234..., 083..., 0800..., etc.
+  // Make phone numbers clickable (Irish and international formats).
   html = html.replace(
     /(\+\d{1,3}[\s-]?\d{2,4}[\s-]?\d{3,4}[\s-]?\d{3,4}|\b0\d{2,4}[\s-]?\d{3,4}[\s-]?\d{3,4}\b)/g,
     (match) => {
@@ -198,54 +181,47 @@ function formatAssistantContent(content: string, isDarkMode: boolean): string {
     }
   );
 
-  // Make email addresses clickable
+  // Make email addresses clickable.
   html = html.replace(
     /([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g,
     '<a href="mailto:$1" class="text-gold-500 hover:text-gold-400 underline underline-offset-2">$1</a>'
   );
 
-  // Smart typography - convert straight quotes to curly quotes
-  // Using Unicode escape sequences to avoid parsing issues with curly quotes
-  html = html.replace(/(\s|^)"([^"]+)"(\s|$|[.,!?])/g, '$1\u201C$2\u201D$3'); // Double quotes " "
-  html = html.replace(/(\s|^)'([^']+)'(\s|$|[.,!?])/g, '$1\u2018$2\u2019$3'); // Single quotes ' '
-  html = html.replace(/(\w)'(\w)/g, '$1\u2019$2'); // Apostrophes (e.g., "don't") '
-  html = html.replace(/--/g, '–'); // En-dash
-  html = html.replace(/\.\.\./g, '…'); // Ellipsis
+  // Smart typography. Unicode escapes avoid encoding ambiguity in the source.
+  html = html.replace(/(\s|^)"([^"]+)"(\s|$|[.,!?])/g, '$1“$2”$3');
+  html = html.replace(/(\s|^)'([^']+)'(\s|$|[.,!?])/g, '$1‘$2’$3');
+  html = html.replace(/(\w)'(\w)/g, '$1’$2');
+  html = html.replace(/--/g, '–');
+  html = html.replace(/\.\.\./g, '…');
 
-  // Highlight important numbers - prices, measurements, percentages
-  // Prices (€, £, $)
+  // Highlight prices, measurements, percentages and dates.
   html = html.replace(
     /([€£$]\d{1,3}(?:,\d{3})*(?:\.\d{2})?|\d{1,3}(?:,\d{3})*(?:\.\d{2})?\s*(?:euro|EUR|pounds?|GBP))/gi,
     '<span class="font-semibold text-gold-600">$1</span>'
   );
-  // Measurements (m², sq ft, sqm, etc.)
   html = html.replace(
     /(\d+(?:\.\d+)?\s*(?:m²|sq\.?\s*(?:ft|m|metres?|meters?)|sqm|square\s+(?:feet|metres?|meters?)|hectares?|ha|acres?))/gi,
     '<span class="font-medium">$1</span>'
   );
-  // Percentages
-  html = html.replace(
-    /(\d+(?:\.\d+)?%)/g,
-    '<span class="font-medium">$1</span>'
-  );
-  // Dates (common formats)
+  html = html.replace(/(\d+(?:\.\d+)?%)/g, '<span class="font-medium">$1</span>');
   html = html.replace(
     /(\d{1,2}(?:st|nd|rd|th)?\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{4})/gi,
     '<span class="font-medium">$1</span>'
   );
 
-  // Convert newlines to proper breaks (preserve paragraph structure)
-  html = html.replace(/\n\n/g, '</p><p class="mt-3">');
-  html = html.replace(/\n/g, '<br/>');
-
-  // Wrap in paragraph
-  html = `<p>${html}</p>`;
-
-  // Clean up empty paragraphs
-  html = html.replace(/<p class="mt-3"><\/p>/g, '');
-  html = html.replace(/<p><\/p>/g, '');
-
   return html;
+}
+
+// Render an assistant reply: the shared markdown core plus the homeowner prose
+// rules. Bold, italic, inline code, h3/h4 and lists are styled to match the
+// bubble. The reveal animation re-renders this each frame; partial markdown
+// stays plain text until its closing marker arrives.
+function formatAssistantContent(content: string, isDarkMode: boolean): string {
+  const codeClassName = isDarkMode ? 'bg-white/10 text-gray-100' : 'bg-black/[0.06] text-gray-800';
+  return renderChatMarkdown(content, {
+    codeClassName,
+    transformParagraph: applyAssistantProseRules,
+  });
 }
 
 const TypingIndicator = ({ isDarkMode }: { isDarkMode: boolean }) => (

--- a/apps/unified-portal/lib/assistant/formatting.ts
+++ b/apps/unified-portal/lib/assistant/formatting.ts
@@ -1,45 +1,51 @@
 /**
- * Formatting utilities for assistant responses
- * 
- * Sanitizes markdown and ensures clean output for chat display.
+ * Formatting utilities for assistant responses.
+ *
+ * `sanitizeForChat` neutralises unsupported or unsafe markdown (code blocks,
+ * images, links, blockquotes, horizontal rules) and caps heading levels, while
+ * preserving the inline and list markers the chat renderer styles: bold,
+ * italic, inline code, h3/h4 headings, and ordered/unordered lists.
+ *
+ * `renderChatMarkdown` turns that preserved markdown into safe HTML for the
+ * chat bubbles. It HTML-escapes first, so model output can never inject markup,
+ * then maps the supported markers to styled elements. Both the homeowner
+ * (PurchaserChatTab) and care (AssistantScreen) bubbles render through it so the
+ * markdown looks the same across the product.
  */
 
 export function sanitizeForChat(text: string): string {
   let result = text;
-  
+
+  // Flatten fenced code blocks to their inner text (code blocks are not rendered).
   result = result.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, (_, content) => content.trim());
-  
-  result = result.replace(/`([^`\n]+)`/g, '$1');
-  
-  result = result.replace(/\*\*\*([^*]+)\*\*\*/g, '$1');
-  result = result.replace(/___([^_]+)___/g, '$1');
-  
-  result = result.replace(/\*\*([^*]+)\*\*/g, '$1');
-  result = result.replace(/__([^_]+)__/g, '$1');
-  
-  result = result.replace(/(?<!\*)\*(?!\*)([^*\n]+)(?<!\*)\*(?!\*)/g, '$1');
-  result = result.replace(/(?<!_)_(?!_)([^_\n]+)(?<!_)_(?!_)/g, '$1');
-  
-  result = result.replace(/^#{1,6}\s+(.+)$/gm, '$1');
-  
+
+  // Images are not supported: drop them (must run before the link rule, since
+  // an image is a link with a leading "!").
+  result = result.replace(/!\[([^\]]*)\]\([^)]+\)/g, '');
+
+  // Links are not supported as links: keep the visible text, drop the URL.
+  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+  // Cap heading levels: h3 and h4 are the only sizes the bubble renders, so
+  // fold h1/h2/h5/h6 down. Markers are kept for the renderer to style.
+  result = result.replace(/^(#{1,6})[ \t]+(.+?)[ \t]*$/gm, (_, hashes: string, rest: string) => {
+    const level = hashes.length === 4 ? 4 : 3;
+    return `${'#'.repeat(level)} ${rest}`;
+  });
+
+  // Horizontal rules are not supported: remove the line.
   result = result.replace(/^---+$/gm, '');
   result = result.replace(/^\*\*\*+$/gm, '');
   result = result.replace(/^___+$/gm, '');
-  
-  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
-  
-  result = result.replace(/!\[([^\]]*)\]\([^)]+\)/g, '');
-  
+
+  // Blockquotes are not supported: keep the text, drop the leading "> " marker.
   result = result.replace(/^>\s+(.+)$/gm, '$1');
-  
-  result = result.replace(/^\d+\.\s+/gm, '- ');
-  
+
+  // Collapse runs of blank lines and trim trailing whitespace per line.
   result = result.replace(/\n{3,}/g, '\n\n');
-  
-  result = result.split('\n').map(line => line.trimEnd()).join('\n');
-  
+  result = result.split('\n').map((line) => line.trimEnd()).join('\n');
   result = result.trim();
-  
+
   return result;
 }
 
@@ -62,6 +68,143 @@ export function cleanForDisplay(text: string): string {
   return result;
 }
 
+// A control char that never appears in chat text or in the markup we generate,
+// used to fence stashed inline-code contents while the other passes run.
+const CODE_SENTINEL = String.fromCharCode(0);
+
+/**
+ * Render the supported markdown subset to HTML for a chat bubble.
+ *
+ * Supports: bold, italic, inline code, h3/h4 headings, and ordered/unordered
+ * lists. Everything else is treated as plain text. Callers pass the inline-code
+ * background via `codeClassName` (light/dark differs by surface) and may pass a
+ * `transformParagraph` hook to layer extra prose rules (auto-linking, smart
+ * typography, etc.) onto paragraph text only.
+ *
+ * Safe to call on partial input during a word-by-word reveal: incomplete markers
+ * (e.g. a "**" with no closing pair yet) are left as literal text until the
+ * closing marker arrives, so nothing flashes or throws.
+ */
+export function renderChatMarkdown(
+  content: string,
+  options: { codeClassName: string; transformParagraph?: (text: string) => string },
+): string {
+  if (!content) return '';
+
+  // 1. Escape HTML. From here on, only the tags we generate are real markup.
+  let html = content
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  // 2. Defence in depth: strip unsupported markdown that may have slipped past
+  //    the sanitiser (flatten code fences, drop images, links to plain text).
+  html = html.replace(/```(?:\w+)?\n?([\s\S]*?)```/g, (_, code) => code.trim());
+  html = html.replace(/!\[([^\]]*)\]\([^)]+\)/g, '');
+  html = html.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+  // 3. Inline code first: stash contents behind the sentinel so later passes
+  //    cannot reparse them.
+  const codeSpans: string[] = [];
+  html = html.replace(/`([^`\n]+)`/g, (_, code) => {
+    codeSpans.push(code);
+    return `${CODE_SENTINEL}${codeSpans.length - 1}${CODE_SENTINEL}`;
+  });
+
+  // 4. Bold and italic. Markers never span a line break.
+  html = html.replace(/\*\*\*([^*\n]+?)\*\*\*/g, '<strong class="font-semibold"><em>$1</em></strong>');
+  html = html.replace(/___([^_\n]+?)___/g, '<strong class="font-semibold"><em>$1</em></strong>');
+  html = html.replace(/\*\*([^*\n]+?)\*\*/g, '<strong class="font-semibold">$1</strong>');
+  html = html.replace(/__([^_\n]+?)__/g, '<strong class="font-semibold">$1</strong>');
+  // Italic on the residue. Require a non-space after the marker so "* item"
+  // bullets and snake_case identifiers are left alone.
+  html = html.replace(/(^|[^*\w])\*(?!\s)([^*\n]+?)\*(?!\*)/g, '$1<em>$2</em>');
+  html = html.replace(/(^|[^_\w])_(?!\s)([^_\n]+?)_(?![_\w])/g, '$1<em>$2</em>');
+
+  // 5. Block pass: headings and lists, line by line. Consecutive list lines of
+  //    the same kind collapse into one <ul>/<ol>; a blank line or a different
+  //    block ends the run.
+  const lines = html.split('\n');
+  const blocks: { kind: 'block' | 'text'; value: string }[] = [];
+  const bulletRe = /^[-*•]\s+(.+)$/;
+  const numberedRe = /^\d+\.\s+(.+)$/;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const h4 = /^####\s+(.+?)\s*$/.exec(line);
+    const h3 = /^###\s+(.+?)\s*$/.exec(line);
+    if (h4) {
+      blocks.push({ kind: 'block', value: `<h4 class="text-[15px] font-semibold mt-2 mb-1">${h4[1]}</h4>` });
+      i++;
+    } else if (h3) {
+      blocks.push({ kind: 'block', value: `<h3 class="text-base font-semibold mt-3 mb-1">${h3[1]}</h3>` });
+      i++;
+    } else if (bulletRe.test(line) || numberedRe.test(line)) {
+      const ordered = numberedRe.test(line);
+      const items: string[] = [];
+      while (i < lines.length) {
+        const bullet = bulletRe.exec(lines[i]);
+        const numbered = numberedRe.exec(lines[i]);
+        if (ordered && numbered) {
+          items.push(numbered[1]);
+          i++;
+        } else if (!ordered && bullet) {
+          items.push(bullet[1]);
+          i++;
+        } else {
+          break;
+        }
+      }
+      const tag = ordered ? 'ol' : 'ul';
+      const listClass = ordered ? 'list-decimal' : 'list-disc';
+      const lis = items.map((item) => `<li>${item}</li>`).join('');
+      blocks.push({
+        kind: 'block',
+        value: `<${tag} class="${listClass} list-outside ml-5 space-y-1 my-2 marker:text-gold-500">${lis}</${tag}>`,
+      });
+    } else {
+      blocks.push({ kind: 'text', value: line });
+      i++;
+    }
+  }
+
+  // 6. Group runs of text lines into paragraphs (blank line or block ends one).
+  //    Prose rules apply to paragraph text only, then newlines become <br/>.
+  const parts: string[] = [];
+  let paragraph: string[] = [];
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    let text = paragraph.join('\n');
+    if (options.transformParagraph) {
+      text = options.transformParagraph(text);
+    }
+    text = text.replace(/\n/g, '<br/>');
+    parts.push(`<p>${text}</p>`);
+    paragraph = [];
+  };
+  for (const block of blocks) {
+    if (block.kind === 'block') {
+      flushParagraph();
+      parts.push(block.value);
+    } else if (block.value.trim() === '') {
+      flushParagraph();
+    } else {
+      paragraph.push(block.value);
+    }
+  }
+  flushParagraph();
+
+  let result = parts.length > 1 ? `<div class="space-y-2">${parts.join('')}</div>` : parts.join('');
+
+  // 7. Restore inline code, kept verbatim and never reparsed.
+  const sentinel = new RegExp(`${CODE_SENTINEL}(\\d+)${CODE_SENTINEL}`, 'g');
+  result = result.replace(sentinel, (_match, idx) =>
+    `<code class="px-1.5 py-0.5 rounded ${options.codeClassName} font-mono text-[13px]">${codeSpans[Number(idx)]}</code>`,
+  );
+
+  return result;
+}
+
 export function hasMarkdownTokens(text: string): boolean {
   const markdownPatterns = [
     /\*\*[^*]+\*\*/,
@@ -74,6 +217,6 @@ export function hasMarkdownTokens(text: string): boolean {
     /^---+$/m,
     /\[([^\]]+)\]\([^)]+\)/,
   ];
-  
+
   return markdownPatterns.some(pattern => pattern.test(text));
 }


### PR DESCRIPTION
## Summary

Assistant replies (gpt-4o agent and the RAG path) come back as markdown, but the chat pipeline was **stripping the markers before render**, so homeowners saw raw `**asterisks**` and numbered lists flattened to dashes. The root cause was upstream, not the bubble: `sanitizeForChat` (shared by both surfaces) deleted bold/italic/code/headings and downgraded `1.` to `- ` before the renderer ever saw them.

This change makes the sanitiser **preserve** the renderable markdown subset and adds one shared renderer used by both the homeowner and care bubbles, so replies look the same across the product.

## What changed (3 files, no new dependencies)

- **`lib/assistant/formatting.ts`**
  - `sanitizeForChat` now preserves bold, italic, inline code, `###`/`####` headings, and ordered/unordered lists. It still neutralises unsupported or unsafe markup: code fences (flattened to text), images (dropped), links (reduced to their text, URL dropped), blockquote markers, horizontal rules. Heading levels are capped (`h1/h2/h5/h6` fold to `###`, `h4` stays `####`). It no longer downgrades numbered lists to bullets.
  - New `renderChatMarkdown(content, { codeClassName, transformParagraph? })`: HTML-escapes first, then maps the supported subset to styled elements. Inline code is stashed behind a sentinel so later passes never reparse it.
- **`components/purchaser/PurchaserChatTab.tsx`**
  - `formatAssistantContent` is now a thin wrapper over `renderChatMarkdown`, passing the homeowner prose rules (section headers, tap-to-call / tap-to-email auto-linking, smart typography, price/measurement highlighting) as `transformParagraph` so none of that existing behaviour is lost.
- **`app/care/[installationId]/screens/AssistantScreen.tsx`**
  - `formatContent` now delegates to `renderChatMarkdown` for the same markdown look. As a side benefit it now HTML-escapes before `dangerouslySetInnerHTML` (it did not before).

## Typography

- bold -> `font-semibold` (not `font-bold`)
- ordered list -> real `<ol class="list-decimal ...">`, gold markers via `marker:text-gold-500`
- unordered list -> real `<ul class="list-disc ...">`, same indent and gold markers
- list items -> `space-y-1` (tighter than browser defaults)
- `###` -> `<h3 class="text-base font-semibold mt-3 mb-1">`, `####` -> `<h4 class="text-[15px] font-semibold mt-2 mb-1">`
- inline code -> subtle background + `font-mono text-[13px]` (light/dark chosen via `isDarkMode`, since the app's dark mode is JS-driven and Tailwind `darkMode` defaults to `media` here)
- paragraphs -> `space-y-2`

## Both paths covered

Both the agent path (`displayTextWithDelay`) and the RAG SSE path write into the same `content` field rendered by the same formatter, so fixing the shared sanitiser + renderer covers both consistently.

## Reveal behaviour

The renderer is regex-based and no-ops on incomplete syntax. During the word-by-word reveal, `**Clear the Are` (no closing pair yet) renders as literal text and snaps to bold when the closing `**` lands. Verified, no flashing or errors.

## Verification

- `npm run typecheck`: passes (0 errors)
- `npm run build`: passes
- A 31-case functional harness (run against the real module, then removed) covering the gardening reply, XSS escaping, partial-reveal frames, care parity, and sanitiser preserve/strip: all green. Example output for `**Clear the Area:** ...`:
  ```html
  <p><strong class="font-semibold">Clear the Area:</strong> Remove all weeds.</p>
  <ol class="list-decimal list-outside ml-5 space-y-1 my-2 marker:text-gold-500"><li>Mark the bed</li><li>Dig deep</li></ol>
  <code class="... font-mono text-[13px]">spade</code>
  <h3 class="text-base font-semibold mt-3 mb-1">Soil prep</h3>
  ```

## Caller impact (`sanitizeForChat` / `cleanForDisplay`)

- Homeowner `PurchaserChatTab` (4 call sites) and care `AssistantScreen` (1): now keep markdown for rendering. Intended.
- `lib/assistant/escalation.ts`: escalation text is plain prose plus a code fence (still flattened); `containsForbiddenPlaceholders` runs on the raw text before sanitising, so no behaviour change.
- `app/api/chat/route.ts` (server RAG): `cleanForDisplay(fullAnswer)` now preserves the subset too. Consistent.

## Known limitation / suggested follow-up (intentionally out of scope)

The RAG fallback (`/api/chat`) has a **separate** server-side stripper, `cleanMarkdownFormatting` (route.ts), applied per streamed chunk and on the non-streaming completion, which still removes bold/italic on that path. The **primary path today is the agent path** (gated by `isOpenhouseAgentV1Enabled`), which has no server-side stripping and is fully fixed here. Making the RAG fallback fully consistent is a small follow-up in `route.ts`, kept out of this PR to honour the agreed file scope. Happy to do it as a one-line follow-up if wanted.

## Scope notes

Homeowner + care only. Agent-side / installer chat components untouched. No raw HTML, images, links, tables, code blocks, or blockquotes are rendered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3T4f84taa5DHkHEQQVoxq)_