### PR TITLE
fix(purchaser): resolve unit_uid to units.id in purchaser validators

### DIFF
--- a/apps/unified-portal/app/api/purchaser/docs-list/route.ts
+++ b/apps/unified-portal/app/api/purchaser/docs-list/route.ts
@@ -123,8 +123,8 @@ export async function GET(request: NextRequest) {
 
     // SECURITY: Validate token matches claimed unit - cross-unit access forbidden
     const tokenResult = await validatePurchaserToken(token || unitUid, unitUid);
-    
-    if (!tokenResult.valid) {
+
+    if (!tokenResult.valid || !tokenResult.unitId) {
       logSecurityViolation({
         request_id: requestId,
         unit_uid: unitUid,
@@ -135,14 +135,19 @@ export async function GET(request: NextRequest) {
         { status: 401 }
       );
     }
-    
+
+    // The homeowner app addresses the unit by its human unit_uid; the validator
+    // resolves it to the canonical units.id. The lookup below keys on units.id
+    // (a UUID), so use the resolved id rather than the raw unit_uid.
+    const resolvedUnitId = tokenResult.unitId;
+
     // STEP 1: Resolve unit's project_id and house_type_code from Supabase
     // Select house_type_code directly — it is a first-class column on units.
     // The unit_types(name) join is kept as a fallback only.
     const { data: supabaseUnit, error: unitError } = await supabase
       .from('units')
       .select('id, project_id, house_type_code, unit_type_id, unit_types(name)')
-      .eq('id', unitUid)
+      .eq('id', resolvedUnitId)
       .single();
 
     if (unitError || !supabaseUnit) {

--- a/apps/unified-portal/lib/assistant/media-auth.ts
+++ b/apps/unified-portal/lib/assistant/media-auth.ts
@@ -131,6 +131,25 @@ function extractPurchaserCandidate(token: string): string | null {
 }
 
 /**
+ * Resolve a unit reference to its canonical units.id. The homeowner app passes
+ * the human unit_uid (e.g. AV-015-7CCB), not the UUID; a non-UUID reference is
+ * looked up by unit_uid. A UUID is returned unchanged with no round trip, so
+ * the admin and snag paths are unaffected. Mirrors getUnitInfo's either-form
+ * resolution. Returns null if unknown.
+ */
+async function resolveUnitUidToId(ref: string): Promise<string | null> {
+  if (UUID_RE.test(ref)) return ref;
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from('units')
+    .select('id')
+    .eq('unit_uid', ref)
+    .maybeSingle();
+  if (error || !data) return null;
+  return (data as { id: string }).id;
+}
+
+/**
  * Resolve and verify the caller. If a unit_id is provided, the returned
  * context's tenant_id and development_id are taken from the unit (cross
  * checked against the caller's verified tenant). If no unit_id is given,
@@ -145,10 +164,19 @@ export async function resolveMediaAuth(
   request: NextRequest,
   opts: { unitId?: string | null; requireUnit?: boolean } = {},
 ): Promise<MediaAuthContext> {
-  const { unitId: requestedUnitId = null, requireUnit = false } = opts;
+  const { unitId: rawRequestedUnitId = null, requireUnit = false } = opts;
 
-  if (requestedUnitId && !UUID_RE.test(requestedUnitId)) {
-    throw new MediaAuthError('invalid_unit');
+  // The homeowner app addresses units by their human unit_uid (e.g. AV-015-7CCB),
+  // not the units.id UUID. Resolve any non-UUID reference to the canonical id up
+  // front so the UUID and ownership checks below run against it. A UUID resolves
+  // to itself with no round trip, so the admin and snag paths are unchanged. A
+  // reference we cannot resolve is an invalid unit, same as the old check.
+  let requestedUnitId: string | null = rawRequestedUnitId;
+  if (rawRequestedUnitId && !UUID_RE.test(rawRequestedUnitId)) {
+    requestedUnitId = await resolveUnitUidToId(rawRequestedUnitId);
+    if (!requestedUnitId) {
+      throw new MediaAuthError('invalid_unit');
+    }
   }
 
   const qrToken = request.headers.get('x-qr-token');
@@ -171,15 +199,21 @@ export async function resolveMediaAuth(
       // whose token has not been refreshed and who only supply
       // media_id.
       if (requestedUnitId) {
+        // The homeowner presents the unit_uid as the token, so accept either the
+        // raw value they hold or its resolved units.id; carry the canonical id.
         const tokenMatchesUnit =
+          qrToken === rawRequestedUnitId ||
           qrToken === requestedUnitId ||
-          (qrToken.includes(':') && qrToken.split(':')[0] === requestedUnitId);
+          (qrToken.includes(':') &&
+            (qrToken.split(':')[0] === rawRequestedUnitId ||
+              qrToken.split(':')[0] === requestedUnitId));
         if (!tokenMatchesUnit) {
           throw new MediaAuthError('unauthenticated');
         }
         candidateUnitId = requestedUnitId;
       } else {
-        candidateUnitId = extractPurchaserCandidate(qrToken);
+        candidateUnitId =
+          extractPurchaserCandidate(qrToken) ?? (await resolveUnitUidToId(qrToken));
         if (!candidateUnitId) {
           throw new MediaAuthError('unauthenticated');
         }

--- a/packages/api/src/qr-tokens.ts
+++ b/packages/api/src/qr-tokens.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { nanoid } from 'nanoid';
 import { db } from '@openhouse/db/client';
-import { qr_tokens } from '@openhouse/db/schema';
+import { qr_tokens, units } from '@openhouse/db/schema';
 import { eq, and, or, lt, isNull, isNotNull } from 'drizzle-orm';
 
 function getSecret(): string {
@@ -230,12 +230,34 @@ export interface TokenValidationResult {
 }
 
 /**
+ * Resolve a unit reference to its canonical units.id. The homeowner app
+ * addresses a unit by its human unit_uid (e.g. AV-015-7CCB), not the UUID the
+ * purchaser routes expect, so a non-UUID reference is looked up by unit_uid.
+ * A UUID is returned unchanged with no database round trip. Mirrors the
+ * either-form resolution getUnitInfo already does. Returns null if unknown.
+ */
+async function resolveUnitUidToId(ref: string): Promise<string | null> {
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (uuidPattern.test(ref)) return ref;
+  try {
+    const rows = await db
+      .select({ id: units.id })
+      .from(units)
+      .where(eq(units.unit_uid, ref))
+      .limit(1);
+    return rows[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Standardized token validation for purchaser API endpoints
  * Validates either:
  * 1. A proper signed QR token matching the claimed unitUid
  * 2. Showhouse mode (demo access) - when token equals unitUid OR when signed QR token fails
  *    but the token was originally issued for this unitUid
- * 
+ *
  * Security: Access is granted if either:
  * - Valid cryptographic signature matches unitUid
  * - Token format contains unitUid (even if expired/used - allows continued session access)
@@ -246,42 +268,47 @@ export async function validatePurchaserToken(
   unitUid: string,
   checkShowhouseEnabled?: () => Promise<boolean>
 ): Promise<TokenValidationResult> {
-  // Validate unitUid format (must be a valid UUID)
-  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  if (!uuidPattern.test(unitUid)) {
+  // The homeowner app passes the unit's human unit_uid, not its units.id UUID.
+  // Resolve it up front so every check below runs against the canonical id and
+  // the result carries that id back to the caller. UUID input resolves to
+  // itself, so existing behaviour is unchanged. A reference we cannot resolve
+  // is rejected, same as the old strict-format check.
+  const resolvedUnitId = await resolveUnitUidToId(unitUid);
+  if (!resolvedUnitId) {
     return { valid: false, unitId: null, isShowhouse: false, error: 'Invalid unit ID format' };
   }
-  
+
   // Try validating as a proper QR token first
   const payload = await validateQRToken(token);
-  if (payload && payload.supabaseUnitId === unitUid) {
-    return { valid: true, unitId: unitUid, isShowhouse: false };
+  if (payload && payload.supabaseUnitId === resolvedUnitId) {
+    return { valid: true, unitId: resolvedUnitId, isShowhouse: false };
   }
-  
-  // Check if this might be showhouse mode (token === unitUid)
-  if (token === unitUid) {
+
+  // Showhouse / continued-session capability: the caller presented the unit's
+  // own identifier, either the unit_uid they were issued or the resolved UUID.
+  if (token === unitUid || token === resolvedUnitId) {
     if (checkShowhouseEnabled) {
       const isShowhouse = await checkShowhouseEnabled();
       if (isShowhouse) {
-        return { valid: true, unitId: unitUid, isShowhouse: true };
+        return { valid: true, unitId: resolvedUnitId, isShowhouse: true };
       }
     }
     // Fallback: Allow showhouse if no checker provided (backward compatibility)
-    return { valid: true, unitId: unitUid, isShowhouse: true };
+    return { valid: true, unitId: resolvedUnitId, isShowhouse: true };
   }
-  
+
   // Check if this is a signed QR token that was originally for this unit
   // This allows continued access even if token is marked as used in DB
   // The token format is: {supabaseUnitId}:{projectId}:{timestamp}:{nonce}:{signature}
   if (token.includes(':')) {
     const parts = token.split(':');
-    if (parts.length >= 2 && parts[0] === unitUid) {
+    if (parts.length >= 2 && (parts[0] === unitUid || parts[0] === resolvedUnitId)) {
       // Token was issued for this unit - allow continued session access
       // This handles the case where a user scanned a QR code, the token was marked as used,
       // but they should still have access to their session
-      return { valid: true, unitId: unitUid, isShowhouse: true };
+      return { valid: true, unitId: resolvedUnitId, isShowhouse: true };
     }
   }
-  
+
   return { valid: false, unitId: null, isShowhouse: false, error: 'Invalid or expired token' };
 }


### PR DESCRIPTION
Homeowners address their unit by its human unit_uid (e.g. AV-015-7CCB), but the purchaser and assistant validators required a units.id UUID and rejected anything else up front, so every homeowner was turned away. This resolves a non-UUID reference to its canonical units.id before the existing checks run, mirroring getUnitInfo.

Three touches:
- packages/api/src/qr-tokens.ts: validatePurchaserToken resolves a unit_uid to its units.id and returns that id.
- apps/unified-portal/lib/assistant/media-auth.ts: resolveMediaAuth applies the same normalisation.
- apps/unified-portal/app/api/purchaser/docs-list/route.ts: the unit lookup keys on the resolved id rather than the raw unit_uid.

UUID input resolves to itself with no extra query, so admin, QR-scan and showhouse behaviour is unchanged. This unblocks the homeowner Documents and Noticeboard tabs, which were showing the Session Expired / Scan QR Code modal, and the assistant write path to assistant_conversation_turns.

https://claude.ai/code/session_01NJaaYCcgxXPjpeALpR9ptv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJaaYCcgxXPjpeALpR9ptv)_