### PR TITLE
fix(purchaser): resolve unit_uid in @openhouse/api getUnitInfo so noticeboard and notes load

### DIFF
--- a/apps/unified-portal/app/api/purchaser/notes/[noteId]/route.ts
+++ b/apps/unified-portal/app/api/purchaser/notes/[noteId]/route.ts
@@ -33,7 +33,7 @@ export async function DELETE(
     }
 
     const tokenResult = await validatePurchaserToken(token, unitUid);
-    if (!tokenResult.valid) {
+    if (!tokenResult.valid || !tokenResult.unitId) {
       return NextResponse.json(
         { error: tokenResult.error || 'Invalid or expired token' },
         { status: 401 }
@@ -43,7 +43,7 @@ export async function DELETE(
     // Delete note only if it belongs to this unit (scoped by unit_id)
     const [deleted] = await db
       .delete(homeNotes)
-      .where(and(eq(homeNotes.id, noteId), eq(homeNotes.unit_id, unitUid)))
+      .where(and(eq(homeNotes.id, noteId), eq(homeNotes.unit_id, tokenResult.unitId)))
       .returning({ id: homeNotes.id });
 
     if (!deleted) {

--- a/apps/unified-portal/app/api/purchaser/notes/route.ts
+++ b/apps/unified-portal/app/api/purchaser/notes/route.ts
@@ -57,7 +57,7 @@ export async function GET(request: NextRequest) {
         updated_at: homeNotes.updated_at,
       })
       .from(homeNotes)
-      .where(eq(homeNotes.unit_id, unitUid))
+      .where(eq(homeNotes.unit_id, unit.id))
       .orderBy(desc(homeNotes.pinned), desc(homeNotes.created_at));
 
     return NextResponse.json({ notes });
@@ -123,7 +123,7 @@ export async function POST(request: NextRequest) {
     const existing = await db
       .select({ id: homeNotes.id })
       .from(homeNotes)
-      .where(eq(homeNotes.unit_id, unitUid));
+      .where(eq(homeNotes.unit_id, unit.id));
 
     if (existing.length >= NOTES_PER_UNIT_LIMIT) {
       return NextResponse.json(
@@ -143,7 +143,7 @@ export async function POST(request: NextRequest) {
     const [note] = await db
       .insert(homeNotes)
       .values({
-        unit_id: unitUid,
+        unit_id: unit.id,
         content: content.trim(),
         source_query: source_query?.trim() || null,
         title,
@@ -192,7 +192,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     const tokenResult = await validatePurchaserToken(token, unitUid);
-    if (!tokenResult.valid) {
+    if (!tokenResult.valid || !tokenResult.unitId) {
       return NextResponse.json(
         { error: tokenResult.error || 'Invalid or expired token' },
         { status: 401 }
@@ -202,7 +202,7 @@ export async function PATCH(request: NextRequest) {
     const [updated] = await db
       .update(homeNotes)
       .set({ pinned })
-      .where(and(eq(homeNotes.id, noteId), eq(homeNotes.unit_id, unitUid)))
+      .where(and(eq(homeNotes.id, noteId), eq(homeNotes.unit_id, tokenResult.unitId)))
       .returning({
         id: homeNotes.id,
         content: homeNotes.content,

--- a/packages/api/src/unit-resolver.ts
+++ b/packages/api/src/unit-resolver.ts
@@ -16,15 +16,39 @@ function getSupabaseClient() {
   );
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function getUnitInfo(unitUid: string): Promise<ResolvedUnit | null> {
   const supabase = getSupabaseClient();
+
+  // The homeowner app addresses a unit by its human unit_uid (e.g. AV-015-7CCB),
+  // while the developer portal passes the units.id UUID. Match the shape-appropriate
+  // column so a non-UUID is never compared against the uuid id column, which errors
+  // with 22P02 and was being swallowed into a null (a 404). The two forms are
+  // disjoint, so there is no cross-match risk.
+  const column = UUID_RE.test(unitUid) ? 'id' : 'unit_uid';
 
   // Include tenant_id and development_id directly from units table
   const { data: supabaseUnit, error } = await supabase
     .from('units')
     .select('id, address, development_id, unit_type_id, tenant_id')
-    .eq('id', unitUid)
-    .single();
+    .eq(column, unitUid)
+    .maybeSingle();
+
+  if (error) {
+    // Surface the REST error rather than swallowing it silently, then fall through
+    // to null. A genuine not-found is error-free with maybeSingle, so it returns
+    // null below without logging. We never throw: callers 404 on null today, and
+    // throwing would turn those graceful 404s into 500s.
+    console.error('[unit-resolver] getUnitInfo lookup failed', JSON.stringify({
+      unitUid,
+      column,
+      code: (error as { code?: string }).code ?? null,
+      message: error.message ?? null,
+      details: (error as { details?: string }).details ?? null,
+      hint: (error as { hint?: string }).hint ?? null,
+    }));
+  }
 
   if (error || !supabaseUnit) {
     return null;


### PR DESCRIPTION
This PR fixes the shared `@openhouse/api` `getUnitInfo` resolver and the notes route, so the homeowner Noticeboard and Notes load for units addressed by their `unit_uid`.

**getUnitInfo (`packages/api/src/unit-resolver.ts`).** It looked a unit up only by `.eq('id', unitUid)`. The homeowner routes pass the human `unit_uid` (e.g. AV-015-7CCB), so it compared a non-UUID against the `uuid` `id` column, errored with `22P02 invalid input syntax for type uuid`, and that error was swallowed by `if (error || !supabaseUnit) return null`, surfacing as a 404 on the noticeboard and notes. A schema reload cannot fix a type-cast error, which matched the symptom. It now matches the shape-appropriate column (non-UUID matches `unit_uid`, UUID matches `id`, unchanged), uses `maybeSingle`, and logs a genuine REST error instead of swallowing it, while still returning null and never throwing so callers keep their graceful 404 rather than a 500.

**Notes route (`app/api/purchaser/notes/route.ts` and `notes/[noteId]/route.ts`).** With getUnitInfo resolving, the notes route then hit its own copy of the same fault: it filtered and inserted `home_notes.unit_id` (a `uuid` column, FK to `units.id`) using the raw `unit_uid`, which 500'd on the same `22P02`. All five spots now key on the resolved `units.id`: GET and POST use `unit.id` from getUnitInfo (already null-checked there), PATCH and the `[noteId]` DELETE use `tokenResult.unitId` (the same canonical id from `validatePurchaserToken`, since they do not call getUnitInfo), with the token guard narrowed to ensure it is non-null. Covers list, create, pin-toggle, and delete.

**Complete set of `@openhouse/api` getUnitInfo callers (on record):**
- `app/api/purchaser/noticeboard/route.ts` (GET and POST)
- `app/api/purchaser/noticeboard/[noticeId]/comments/route.ts`
- `app/api/purchaser/notes/route.ts`

The RAG chat and `document-link-resolver` use the separate `@/lib/unit-lookup` resolver and are unaffected; docs-list keys on the resolved UUID from #198.

**Preview verification (commit d36972c, unit AV-015-7CCB):**
- Noticeboard GET: 200 with the development's 1 post.
- Notes GET: 200 (empty list, this homeowner has saved none yet).
- docs-list: 200 with 59 docs, unchanged.
- Health: 200, version d36972c.

Noticeboard POST and comments share the getUnitInfo call and `noticeboard_posts.unit_id` is text, so they follow, though they were not exercised directly.

Out of scope: the second tolerant resolver, the user_id=null item, and the #198 files.

https://claude.ai/code/session_01NJaaYCcgxXPjpeALpR9ptv