### PR TITLE
Snagging V1 + HPI QA 8.0 (Home User Guide) + live dev-app unit surface

### DIFF
--- a/apps/unified-portal/app/api/dev-app/contractors/route.ts
+++ b/apps/unified-portal/app/api/dev-app/contractors/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession, getSupabaseAdmin } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Contractors are tenant-shared, so these routes scope by the admin session's
+ * tenantId (not per-development ownership). Reads/writes via the service role.
+ */
+export async function GET() {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('contractors')
+      .select('*')
+      .eq('tenant_id', session.tenantId)
+      .order('name');
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ contractors: data ?? [] });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json().catch(() => null);
+    if (!body?.name) return NextResponse.json({ error: 'name is required' }, { status: 400 });
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('contractors')
+      .insert({
+        tenant_id: session.tenantId,
+        name: body.name,
+        trades: Array.isArray(body.trades) ? body.trades : [],
+        contact_name: body.contact_name ?? null,
+        contact_email: body.contact_email ?? null,
+        contact_phone: body.contact_phone ?? null,
+        external_ref: body.external_ref ?? null,
+      })
+      .select('*')
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ contractor: data }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/snags/[id]/route.ts
+++ b/apps/unified-portal/app/api/dev-app/snags/[id]/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit, isSnagSeverity, isSnagStatus } from '@/lib/dev-app/snags';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type LoadResult =
+  | { error: 'not_found' | 'forbidden' }
+  | { snag: any; admin: ReturnType<typeof getSupabaseAdmin> };
+
+/** Loads a snag via the service role, then verifies the caller owns its unit. */
+async function loadOwnedSnag(userId: string, snagId: string): Promise<LoadResult> {
+  const supabase = await createServerSupabaseClient();
+  const admin = getSupabaseAdmin();
+  const { data: snag } = await admin
+    .from('snag_items')
+    .select('*')
+    .eq('id', snagId)
+    .maybeSingle();
+  if (!snag) return { error: 'not_found' };
+  const owned = await getOwnedUnit(supabase, userId, snag.unit_id);
+  if (!owned) return { error: 'forbidden' };
+  return { snag, admin };
+}
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const res = await loadOwnedSnag(user.id, params.id);
+    if ('error' in res) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === 'not_found' ? 404 : 403 },
+      );
+    }
+    return NextResponse.json({ snag: res.snag });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/dev-app/snags/[id]
+ * Update a snag: status transitions, assignment, triage fields, photos. Status
+ * transitions set the relevant timestamps (resolved/verified/closed) server-side
+ * so the audit trail and contractor scorecard stay honest.
+ */
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const res = await loadOwnedSnag(user.id, params.id);
+    if ('error' in res) {
+      return NextResponse.json(
+        { error: res.error },
+        { status: res.error === 'not_found' ? 404 : 403 },
+      );
+    }
+    const { snag, admin } = res;
+
+    const body = await request.json().catch(() => ({}));
+    const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+    if (typeof body.title === 'string') updates.title = body.title;
+    if (typeof body.description === 'string') updates.description = body.description.slice(0, 4000);
+    if (typeof body.trade === 'string') updates.trade = body.trade;
+    if (typeof body.location === 'string') updates.location = body.location;
+    if ('responsible_contractor_id' in body) {
+      updates.responsible_contractor_id = body.responsible_contractor_id;
+    }
+    if (Array.isArray(body.photo_urls)) {
+      updates.photo_urls = body.photo_urls;
+      updates.photo_url = body.photo_urls[0] ?? snag.photo_url ?? null;
+    }
+    if (isSnagSeverity(body.severity)) updates.severity = body.severity;
+
+    if (isSnagStatus(body.status)) {
+      updates.status = body.status;
+      const now = new Date().toISOString();
+      if (body.status === 'resolved' && !snag.resolved_at) updates.resolved_at = now;
+      if (body.status === 'verified') {
+        updates.verified_at = now;
+        updates.verified_by = user.id;
+        if (!snag.resolved_at) updates.resolved_at = now;
+      }
+      if (body.status === 'verified' || body.status === 'wont_fix') updates.closed_at = now;
+    }
+
+    const { data: updated, error } = await admin
+      .from('snag_items')
+      .update(updates)
+      .eq('id', snag.id)
+      .select('*')
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ snag: updated });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/snags/import/route.ts
+++ b/apps/unified-portal/app/api/dev-app/snags/import/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit, isSnagSeverity } from '@/lib/dev-app/snags';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/dev-app/snags/import
+ * The independent purchaser's-snagger ingestion path. Two modes:
+ *
+ *   { unit_id, snags: [ { description, severity?, trade?, location?, photo_urls? } ] }
+ *       -> bulk-insert structured snags now (works today)
+ *
+ *   { unit_id, file_url }
+ *       -> parse a PDF / photo report into structured snags (TODO: AI vision +
+ *          LLM extraction, frontier Claude). Returns 501 until wired.
+ *
+ * Either way snags land on the unit as source='uploaded_report', so the
+ * builder's fixes start the same day instead of waiting on a posted PDF — the
+ * lag-collapse that makes this a wedge.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json().catch(() => null);
+    if (!body?.unit_id) {
+      return NextResponse.json({ error: 'unit_id is required' }, { status: 400 });
+    }
+
+    const unit = await getOwnedUnit(supabase, user.id, body.unit_id);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    // Mode 2: automated report parsing is a V1.0 follow-up. Return a clear
+    // contract so the client can fall back to manual entry meanwhile.
+    if (body.file_url && !Array.isArray(body.snags)) {
+      return NextResponse.json(
+        {
+          error: 'not_implemented',
+          detail: 'Automated report parsing is coming; post a `snags` array for now.',
+        },
+        { status: 501 },
+      );
+    }
+
+    if (!Array.isArray(body.snags) || body.snags.length === 0) {
+      return NextResponse.json({ error: 'snags array is required' }, { status: 400 });
+    }
+
+    const rows = body.snags.slice(0, 500).map((s: any) => {
+      const photoUrls: string[] = Array.isArray(s.photo_urls) ? s.photo_urls : [];
+      return {
+        tenant_id: unit.tenant_id,
+        development_id: unit.development_id,
+        unit_id: unit.id,
+        title: s.title ?? null,
+        description: String(s.description ?? '').slice(0, 4000) || 'Imported snag',
+        severity: isSnagSeverity(s.severity) ? s.severity : 'minor',
+        trade: s.trade ?? null,
+        location: s.location ?? null,
+        photo_urls: photoUrls,
+        photo_url: photoUrls[0] ?? null,
+        created_by_role: body.created_by_role ?? 'purchaser_snagger',
+        created_by_user_id: user.id,
+        reported_by: body.reported_by ?? null,
+        source: 'uploaded_report',
+        status: 'open',
+      };
+    });
+
+    const admin = getSupabaseAdmin();
+    const { data: inserted, error } = await admin
+      .from('snag_items')
+      .insert(rows)
+      .select('id');
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ created: inserted?.length ?? 0 }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/snags/route.ts
+++ b/apps/unified-portal/app/api/dev-app/snags/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit, isSnagSeverity, type SnagSeverity } from '@/lib/dev-app/snags';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/dev-app/snags
+ * Create a snag against a unit.
+ *
+ * Offline-safe: when the client sends an `offline_client_id`, replaying a queued
+ * create after reconnect returns the existing row instead of duplicating it
+ * (backed by the snag_items_offline_client_uniq partial unique index).
+ *
+ * Tenant/development scoping is enforced in app code: authenticate with the
+ * cookie client, verify development ownership, then write via the service role.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json().catch(() => null);
+    if (!body?.unit_id || !body?.description) {
+      return NextResponse.json(
+        { error: 'unit_id and description are required' },
+        { status: 400 },
+      );
+    }
+
+    const unit = await getOwnedUnit(supabase, user.id, body.unit_id);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+
+    // Idempotent offline replay: return the existing snag for this client id.
+    if (body.offline_client_id) {
+      const { data: existing } = await admin
+        .from('snag_items')
+        .select('*')
+        .eq('tenant_id', unit.tenant_id)
+        .eq('offline_client_id', body.offline_client_id)
+        .maybeSingle();
+      if (existing) return NextResponse.json({ snag: existing, deduped: true });
+    }
+
+    const severity: SnagSeverity = isSnagSeverity(body.severity) ? body.severity : 'minor';
+    const photoUrls: string[] = Array.isArray(body.photo_urls) ? body.photo_urls : [];
+    const primaryPhoto = photoUrls[0] ?? body.photo_url ?? null;
+
+    const insertRow = {
+      tenant_id: unit.tenant_id,
+      development_id: unit.development_id,
+      unit_id: unit.id,
+      title: body.title ?? null,
+      description: String(body.description).slice(0, 4000),
+      severity,
+      trade: body.trade ?? null,
+      location: body.location ?? null,
+      responsible_contractor_id: body.responsible_contractor_id ?? null,
+      created_by_role: body.created_by_role ?? 'site_manager',
+      created_by_user_id: user.id,
+      reported_by: body.reported_by ?? user.email ?? null,
+      source: body.source ?? 'in_app',
+      photo_url: primaryPhoto,
+      photo_urls: photoUrls.length ? photoUrls : primaryPhoto ? [primaryPhoto] : [],
+      sla_due_at: body.sla_due_at ?? null,
+      offline_client_id: body.offline_client_id ?? null,
+      status: 'open',
+    };
+
+    const { data: snag, error } = await admin
+      .from('snag_items')
+      .insert(insertRow)
+      .select('*')
+      .single();
+
+    if (error) {
+      // 23505 = unique violation: a concurrent offline replay won the race.
+      if (error.code === '23505' && body.offline_client_id) {
+        const { data: existing } = await admin
+          .from('snag_items')
+          .select('*')
+          .eq('tenant_id', unit.tenant_id)
+          .eq('offline_client_id', body.offline_client_id)
+          .maybeSingle();
+        if (existing) return NextResponse.json({ snag: existing, deduped: true });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ snag }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/file/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/file/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
 import { getOwnedUnit, OPEN_SNAG_STATUSES } from '@/lib/dev-app/snags';
+import { summariseHpiQa8 } from '@/lib/dev-app/unit-systems';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/dev-app/units/[unitId]/file
- * The "one-click unit file". V1.0 returns a structured manifest assembled from
- * what we already hold (unit details + every snag). The shape is stable so the
- * client can render it today; V1.1 fills the stubbed sections with documents,
- * unit_systems, warranties, handover_events and the HPI QA 8.0 evidence, and
- * adds PDF/zip rendering.
+ * The "one-click unit file". Assembles, from what we already hold, a structured
+ * manifest of the home: details, every snag, the installed systems, the handover
+ * evidence trail, and an HPI QA 8.0 readiness summary.
+ *
+ * Still stubbed: the `documents` section (V1.1 — needs the documents assembly)
+ * and PDF/zip rendering. The shape is stable so the client can render today.
  */
 export async function GET(
   _request: NextRequest,
@@ -29,23 +31,37 @@ export async function GET(
 
     const admin = getSupabaseAdmin();
 
-    const { data: unit } = await admin
-      .from('units')
-      .select(
-        'id, unit_number, unit_code, address_line_1, city, eircode, house_type_code, development_id, tenant_id',
-      )
-      .eq('id', owned.id)
-      .single();
-
-    const { data: snags } = await admin
-      .from('snag_items')
-      .select(
-        'id, title, description, status, severity, trade, responsible_contractor_id, created_at, resolved_at',
-      )
-      .eq('unit_id', owned.id)
-      .order('created_at', { ascending: false });
+    const [{ data: unit }, { data: snags }, { data: systems }, { data: handover }] =
+      await Promise.all([
+        admin
+          .from('units')
+          .select(
+            'id, unit_number, unit_code, address_line_1, city, eircode, house_type_code, development_id, tenant_id',
+          )
+          .eq('id', owned.id)
+          .single(),
+        admin
+          .from('snag_items')
+          .select(
+            'id, title, description, status, severity, trade, responsible_contractor_id, created_at, resolved_at',
+          )
+          .eq('unit_id', owned.id)
+          .order('created_at', { ascending: false }),
+        admin
+          .from('unit_systems')
+          .select('*')
+          .eq('unit_id', owned.id)
+          .order('system_type'),
+        admin
+          .from('handover_events')
+          .select('*')
+          .eq('unit_id', owned.id)
+          .order('occurred_at', { ascending: false }),
+      ]);
 
     const snagList = snags ?? [];
+    const systemList = systems ?? [];
+    const handoverList = handover ?? [];
     const openCount = snagList.filter((s: any) =>
       OPEN_SNAG_STATUSES.includes(s.status),
     ).length;
@@ -54,15 +70,12 @@ export async function GET(
       generated_at: new Date().toISOString(),
       unit,
       sections: {
-        snags: {
-          total: snagList.length,
-          open: openCount,
-          items: snagList,
-        },
-        // TODO(V1.1): assemble from documents, unit_systems, handover_events.
+        snags: { total: snagList.length, open: openCount, items: snagList },
+        systems: { total: systemList.length, items: systemList },
+        handover: { total: handoverList.length, items: handoverList },
+        hpi_qa8_evidence: summariseHpiQa8(systemList, handoverList),
+        // TODO(V1.1): documents assembly + PDF/zip rendering.
         documents: { status: 'not_yet_assembled' },
-        systems: { status: 'not_yet_assembled' },
-        hpi_qa8_evidence: { status: 'not_yet_assembled' },
       },
     });
   } catch {

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/file/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/file/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit, OPEN_SNAG_STATUSES } from '@/lib/dev-app/snags';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dev-app/units/[unitId]/file
+ * The "one-click unit file". V1.0 returns a structured manifest assembled from
+ * what we already hold (unit details + every snag). The shape is stable so the
+ * client can render it today; V1.1 fills the stubbed sections with documents,
+ * unit_systems, warranties, handover_events and the HPI QA 8.0 evidence, and
+ * adds PDF/zip rendering.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const owned = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!owned) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+
+    const { data: unit } = await admin
+      .from('units')
+      .select(
+        'id, unit_number, unit_code, address_line_1, city, eircode, house_type_code, development_id, tenant_id',
+      )
+      .eq('id', owned.id)
+      .single();
+
+    const { data: snags } = await admin
+      .from('snag_items')
+      .select(
+        'id, title, description, status, severity, trade, responsible_contractor_id, created_at, resolved_at',
+      )
+      .eq('unit_id', owned.id)
+      .order('created_at', { ascending: false });
+
+    const snagList = snags ?? [];
+    const openCount = snagList.filter((s: any) =>
+      OPEN_SNAG_STATUSES.includes(s.status),
+    ).length;
+
+    return NextResponse.json({
+      generated_at: new Date().toISOString(),
+      unit,
+      sections: {
+        snags: {
+          total: snagList.length,
+          open: openCount,
+          items: snagList,
+        },
+        // TODO(V1.1): assemble from documents, unit_systems, handover_events.
+        documents: { status: 'not_yet_assembled' },
+        systems: { status: 'not_yet_assembled' },
+        hpi_qa8_evidence: { status: 'not_yet_assembled' },
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/guide/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/guide/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit } from '@/lib/dev-app/snags';
+import { generateHomeUserGuide } from '@/lib/dev-app/home-user-guide';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dev-app/units/[unitId]/guide
+ * Return the latest Home User Guide for a unit (or null if none generated yet).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('home_user_guides')
+      .select('*')
+      .eq('unit_id', unit.id)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ guide: data ?? null });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/dev-app/units/[unitId]/guide
+ * Generate a new guide version from the unit's current systems. Pass
+ * { "issue": true } to issue it: that stamps issued_at AND records a
+ * handover_events 'guide_issued' row (the QA 8.0 evidence that flips qa8_ready).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json().catch(() => ({}));
+    const issue = body?.issue === true;
+    const admin = getSupabaseAdmin();
+
+    const [{ data: unitRow }, { data: systems }] = await Promise.all([
+      admin
+        .from('units')
+        .select('unit_number, address_line_1, city, eircode, house_type_code')
+        .eq('id', unit.id)
+        .single(),
+      admin.from('unit_systems').select('*').eq('unit_id', unit.id),
+    ]);
+
+    let content;
+    try {
+      content = await generateHomeUserGuide(unitRow ?? {}, systems ?? []);
+    } catch (e: any) {
+      const msg = String(e?.message ?? e);
+      const status = msg.includes('OPENAI_API_KEY') ? 503 : 502;
+      return NextResponse.json({ error: 'guide_generation_failed', detail: msg }, { status });
+    }
+
+    const { data: last } = await admin
+      .from('home_user_guides')
+      .select('version')
+      .eq('unit_id', unit.id)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const version = (last?.version ?? 0) + 1;
+
+    const { data: guide, error } = await admin
+      .from('home_user_guides')
+      .insert({
+        tenant_id: unit.tenant_id,
+        unit_id: unit.id,
+        version,
+        content,
+        model: content.model,
+        generated_by: user.id,
+        status: issue ? 'issued' : 'draft',
+        issued_at: issue ? new Date().toISOString() : null,
+      })
+      .select('*')
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    // Issuing the guide is QA 8.0 evidence — log it on the handover trail.
+    if (issue) {
+      await admin.from('handover_events').insert({
+        tenant_id: unit.tenant_id,
+        unit_id: unit.id,
+        event_type: 'guide_issued',
+        conducted_by: user.id,
+        conducted_by_name: user.email ?? null,
+        home_user_guide_version: version,
+        notes: 'Home User Guide issued',
+      });
+    }
+
+    return NextResponse.json({ guide }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/handover/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/handover/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit } from '@/lib/dev-app/snags';
+import { isHandoverEventType } from '@/lib/dev-app/unit-systems';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET  /api/dev-app/units/[unitId]/handover  — the handover/aftercare event trail
+ * POST /api/dev-app/units/[unitId]/handover  — record an event (demo, guide issued...)
+ *
+ * This is the QA 8.0 evidence: proof the demonstration happened, the Home User
+ * Guide was issued, aftercare was activated. Append-only.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('handover_events')
+      .select('*')
+      .eq('unit_id', unit.id)
+      .order('occurred_at', { ascending: false });
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ events: data ?? [] });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json().catch(() => null);
+    if (!isHandoverEventType(body?.event_type)) {
+      return NextResponse.json({ error: 'valid event_type is required' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('handover_events')
+      .insert({
+        tenant_id: unit.tenant_id,
+        unit_id: unit.id,
+        event_type: body.event_type,
+        occurred_at: body.occurred_at ?? new Date().toISOString(),
+        conducted_by: user.id,
+        conducted_by_name: body.conducted_by_name ?? user.email ?? null,
+        attended_by: body.attended_by ?? null,
+        acknowledgement_ref: body.acknowledgement_ref ?? null,
+        home_user_guide_version: body.home_user_guide_version ?? null,
+        media_refs: Array.isArray(body.media_refs) ? body.media_refs : [],
+        notes: body.notes ?? null,
+      })
+      .select('*')
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ event: data }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/snags/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/snags/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit } from '@/lib/dev-app/snags';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dev-app/units/[unitId]/snags
+ * The closeout list for a single home: every snag, newest first. This is what
+ * the finishing crew opens when they walk into the unit.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+    const { data: snags, error } = await admin
+      .from('snag_items')
+      .select('*')
+      .eq('unit_id', unit.id)
+      .order('created_at', { ascending: false });
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ snags: snags ?? [] });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/[unitId]/systems/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/[unitId]/systems/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient, getSupabaseAdmin } from '@/lib/supabase-server';
+import { getOwnedUnit } from '@/lib/dev-app/snags';
+import { isUnitSystemType } from '@/lib/dev-app/unit-systems';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET  /api/dev-app/units/[unitId]/systems  — list the systems installed in a home
+ * POST /api/dev-app/units/[unitId]/systems  — record a system (captured at handover)
+ *
+ * unit_systems is what lets the assistant educate a homeowner about THEIR heat
+ * pump / MVHR, and what the Home User Guide is generated from.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('unit_systems')
+      .select('*')
+      .eq('unit_id', unit.id)
+      .order('system_type');
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ systems: data ?? [] });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { unitId: string } },
+) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const unit = await getOwnedUnit(supabase, user.id, params.unitId);
+    if (!unit) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json().catch(() => null);
+    if (!isUnitSystemType(body?.system_type)) {
+      return NextResponse.json({ error: 'valid system_type is required' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from('unit_systems')
+      .insert({
+        tenant_id: unit.tenant_id,
+        unit_id: unit.id,
+        system_type: body.system_type,
+        make: body.make ?? null,
+        model: body.model ?? null,
+        serial_number: body.serial_number ?? null,
+        key_settings: body.key_settings ?? {},
+        commissioning_date: body.commissioning_date ?? null,
+        commissioning_doc_id: body.commissioning_doc_id ?? null,
+        warranty_start: body.warranty_start ?? null,
+        warranty_end: body.warranty_end ?? null,
+        warranty_doc_id: body.warranty_doc_id ?? null,
+        maintenance_interval_months: body.maintenance_interval_months ?? null,
+        manufacturer_guide_doc_id: body.manufacturer_guide_doc_id ?? null,
+        knowledge_refs: Array.isArray(body.knowledge_refs) ? body.knowledge_refs : [],
+        notes: body.notes ?? null,
+      })
+      .select('*')
+      .single();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ system: data }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/api/dev-app/units/route.ts
+++ b/apps/unified-portal/app/api/dev-app/units/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/dev-app/units
+ * The developer's units across all developments they own. Powers the live units
+ * list in the dev-app so a unit (and its snags / HPI file / guide) is reachable.
+ */
+export async function GET() {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { data: devs } = await supabase
+      .from('developments')
+      .select('id, name')
+      .eq('developer_user_id', user.id);
+
+    const devList = devs ?? [];
+    const devIds = devList.map((d: any) => d.id);
+    const devNames: Record<string, string> = Object.fromEntries(
+      devList.map((d: any) => [d.id, d.name]),
+    );
+    if (devIds.length === 0) return NextResponse.json({ units: [] });
+
+    const { data: units } = await supabase
+      .from('units')
+      .select('id, unit_number, address_line_1, development_id')
+      .in('development_id', devIds)
+      .order('unit_number');
+
+    const result = (units ?? []).map((u: any) => ({
+      id: u.id,
+      unit_number: u.unit_number,
+      address_line_1: u.address_line_1,
+      development_id: u.development_id,
+      development_name: devNames[u.development_id] ?? '',
+    }));
+
+    return NextResponse.json({ units: result });
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/unified-portal/app/dev-app/units/[unitId]/page.tsx
+++ b/apps/unified-portal/app/dev-app/units/[unitId]/page.tsx
@@ -134,6 +134,15 @@ export default function UnitDetailPage() {
     await Promise.all([loadSnags(), loadFile()]);
   };
 
+  const logHandover = async (eventType: string) => {
+    await fetch(`/api/dev-app/units/${unitId}/handover`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event_type: eventType }),
+    });
+    await loadFile();
+  };
+
   const hpi = file?.sections?.hpi_qa8_evidence;
   const unit = file?.unit;
   const hpiRows: [string, boolean][] = [
@@ -219,6 +228,44 @@ export default function UnitDetailPage() {
                   {hpi?.systems_documented ?? 0}
                 </span>
               </div>
+              {(!hpi?.demo_completed || !hpi?.aftercare_activated) && (
+                <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+                  {!hpi?.demo_completed && (
+                    <button
+                      onClick={() => logHandover('demo_completed')}
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: TEXT_1,
+                        background: '#fff',
+                        border: `1px solid ${BORDER_LIGHT}`,
+                        borderRadius: 8,
+                        padding: '7px 11px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Log handover demo
+                    </button>
+                  )}
+                  {!hpi?.aftercare_activated && (
+                    <button
+                      onClick={() => logHandover('aftercare_activated')}
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: TEXT_1,
+                        background: '#fff',
+                        border: `1px solid ${BORDER_LIGHT}`,
+                        borderRadius: 8,
+                        padding: '7px 11px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Activate aftercare
+                    </button>
+                  )}
+                </div>
+              )}
             </Card>
 
             {/* Home User Guide */}

--- a/apps/unified-portal/app/dev-app/units/[unitId]/page.tsx
+++ b/apps/unified-portal/app/dev-app/units/[unitId]/page.tsx
@@ -1,0 +1,433 @@
+'use client';
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import MobileShell from '@/components/dev-app/layout/MobileShell';
+import {
+  GOLD,
+  TEXT_1,
+  TEXT_2,
+  TEXT_3,
+  SURFACE_1,
+  SURFACE_2,
+  BORDER_LIGHT,
+  RED,
+  AMBER,
+  AMBER_BG,
+  GREEN,
+  GREEN_BG,
+} from '@/lib/dev-app/design-system';
+
+const SEVERITY_COLOR: Record<string, string> = {
+  safety: RED,
+  major: AMBER,
+  minor: TEXT_2,
+  cosmetic: TEXT_3,
+};
+const OPEN_STATES = ['open', 'in_progress', 'disputed'];
+
+function statusStyle(status: string): { color: string; bg: string } {
+  if (status === 'resolved' || status === 'verified') return { color: GREEN, bg: GREEN_BG };
+  if (status === 'wont_fix') return { color: TEXT_3, bg: SURFACE_2 };
+  return { color: AMBER, bg: AMBER_BG };
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        background: SURFACE_1,
+        border: `1px solid ${BORDER_LIGHT}`,
+        borderRadius: 16,
+        padding: 16,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function UnitDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const unitId = params.unitId as string;
+
+  const [file, setFile] = useState<any>(null);
+  const [snags, setSnags] = useState<any[]>([]);
+  const [guide, setGuide] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newDesc, setNewDesc] = useState('');
+  const [newSeverity, setNewSeverity] = useState('minor');
+
+  const loadSnags = useCallback(async () => {
+    const r = await fetch(`/api/dev-app/units/${unitId}/snags`);
+    const d = await r.json();
+    setSnags(d.snags ?? []);
+  }, [unitId]);
+
+  const loadFile = useCallback(async () => {
+    const r = await fetch(`/api/dev-app/units/${unitId}/file`);
+    const d = await r.json();
+    if (!d.error) setFile(d);
+  }, [unitId]);
+
+  const loadGuide = useCallback(async () => {
+    const r = await fetch(`/api/dev-app/units/${unitId}/guide`);
+    const d = await r.json();
+    setGuide(d.guide ?? null);
+  }, [unitId]);
+
+  useEffect(() => {
+    Promise.all([loadFile(), loadSnags(), loadGuide()])
+      .catch(() => setError('Failed to load unit'))
+      .finally(() => setLoading(false));
+  }, [loadFile, loadSnags, loadGuide]);
+
+  const generateGuide = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/dev-app/units/${unitId}/guide`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issue: true }),
+      });
+      const d = await r.json();
+      if (d.guide) {
+        setGuide(d.guide);
+        await loadFile(); // qa8_ready should flip to ready
+      } else {
+        setError(d.detail || d.error || 'Generation failed');
+      }
+    } catch {
+      setError('Generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const resolveSnag = async (id: string) => {
+    await fetch(`/api/dev-app/snags/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'resolved' }),
+    });
+    await Promise.all([loadSnags(), loadFile()]);
+  };
+
+  const addSnag = async () => {
+    if (!newDesc.trim()) return;
+    await fetch(`/api/dev-app/snags`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        unit_id: unitId,
+        description: newDesc.trim(),
+        severity: newSeverity,
+        created_by_role: 'site_manager',
+      }),
+    });
+    setNewDesc('');
+    await Promise.all([loadSnags(), loadFile()]);
+  };
+
+  const hpi = file?.sections?.hpi_qa8_evidence;
+  const unit = file?.unit;
+  const hpiRows: [string, boolean][] = [
+    ['Home User Guide issued', !!hpi?.guide_issued],
+    ['Handover demo completed', !!hpi?.demo_completed],
+    ['Aftercare activated', !!hpi?.aftercare_activated],
+  ];
+
+  return (
+    <MobileShell>
+      <div style={{ padding: 20 }}>
+        <div
+          onClick={() => router.back()}
+          style={{ color: GOLD, fontSize: 13, fontWeight: 600, cursor: 'pointer', marginBottom: 12 }}
+        >
+          ← Back
+        </div>
+        <h1 style={{ color: TEXT_1, fontSize: 22, fontWeight: 700 }}>
+          {unit?.unit_number ? `Unit ${unit.unit_number}` : 'Unit'}
+        </h1>
+        <p style={{ color: TEXT_2, fontSize: 13, marginTop: 2, marginBottom: 18 }}>
+          {unit?.address_line_1 ?? ''}
+          {unit?.city ? `, ${unit.city}` : ''}
+        </p>
+
+        {loading && <p style={{ color: TEXT_3 }}>Loading…</p>}
+        {error && <p style={{ color: RED, fontSize: 13, marginBottom: 12 }}>{error}</p>}
+
+        {!loading && (
+          <>
+            {/* HPI QA 8.0 readiness */}
+            <Card>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginBottom: 12,
+                }}
+              >
+                <span style={{ color: TEXT_1, fontSize: 15, fontWeight: 700 }}>
+                  HPI QA 8.0 readiness
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 700,
+                    padding: '4px 10px',
+                    borderRadius: 8,
+                    color: hpi?.qa8_ready ? GREEN : AMBER,
+                    background: hpi?.qa8_ready ? GREEN_BG : AMBER_BG,
+                  }}
+                >
+                  {hpi?.qa8_ready ? 'READY' : 'INCOMPLETE'}
+                </span>
+              </div>
+              {hpiRows.map(([label, ok]) => (
+                <div
+                  key={label}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    padding: '6px 0',
+                    borderTop: `1px solid ${BORDER_LIGHT}`,
+                  }}
+                >
+                  <span style={{ color: TEXT_2, fontSize: 13 }}>{label}</span>
+                  <span style={{ color: ok ? GREEN : TEXT_3, fontSize: 13, fontWeight: 600 }}>
+                    {ok ? 'Yes' : 'No'}
+                  </span>
+                </div>
+              ))}
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  padding: '6px 0',
+                  borderTop: `1px solid ${BORDER_LIGHT}`,
+                }}
+              >
+                <span style={{ color: TEXT_2, fontSize: 13 }}>Systems documented</span>
+                <span style={{ color: TEXT_1, fontSize: 13, fontWeight: 600 }}>
+                  {hpi?.systems_documented ?? 0}
+                </span>
+              </div>
+            </Card>
+
+            {/* Home User Guide */}
+            <Card>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginBottom: 10,
+                }}
+              >
+                <span style={{ color: TEXT_1, fontSize: 15, fontWeight: 700 }}>
+                  Home User Guide
+                </span>
+                <button
+                  onClick={generateGuide}
+                  disabled={generating}
+                  style={{
+                    fontSize: 12,
+                    fontWeight: 700,
+                    color: '#fff',
+                    background: GOLD,
+                    border: 'none',
+                    borderRadius: 8,
+                    padding: '7px 12px',
+                    cursor: generating ? 'default' : 'pointer',
+                    opacity: generating ? 0.6 : 1,
+                  }}
+                >
+                  {generating ? 'Generating…' : guide ? 'Regenerate & issue' : 'Generate & issue'}
+                </button>
+              </div>
+              {!guide && !generating && (
+                <p style={{ color: TEXT_3, fontSize: 13 }}>
+                  No guide yet. Generate a system-specific guide from this home&rsquo;s recorded
+                  systems.
+                </p>
+              )}
+              {guide?.content && (
+                <div>
+                  <div style={{ color: TEXT_1, fontSize: 14, fontWeight: 700, marginBottom: 4 }}>
+                    {guide.content.title}
+                  </div>
+                  <div style={{ color: TEXT_3, fontSize: 11, marginBottom: 8 }}>
+                    v{guide.version} · {guide.status}
+                    {guide.content.model ? ` · ${guide.content.model}` : ''}
+                  </div>
+                  <p style={{ color: TEXT_2, fontSize: 13, marginBottom: 10 }}>
+                    {guide.content.introduction}
+                  </p>
+                  {(guide.content.sections ?? []).map((s: any, i: number) => (
+                    <div
+                      key={i}
+                      style={{ borderTop: `1px solid ${BORDER_LIGHT}`, paddingTop: 8, marginTop: 8 }}
+                    >
+                      <div style={{ color: TEXT_1, fontSize: 13, fontWeight: 700 }}>{s.heading}</div>
+                      {s.summary && (
+                        <div style={{ color: TEXT_2, fontSize: 12, marginTop: 2 }}>{s.summary}</div>
+                      )}
+                      {Array.isArray(s.how_to_use) && s.how_to_use.length > 0 && (
+                        <ul style={{ margin: '6px 0', paddingLeft: 18 }}>
+                          {s.how_to_use.map((t: string, j: number) => (
+                            <li key={j} style={{ color: TEXT_2, fontSize: 12, marginBottom: 2 }}>
+                              {t}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {Array.isArray(s.do_not) && s.do_not.length > 0 && (
+                        <div style={{ color: RED, fontSize: 12, marginTop: 4 }}>
+                          {s.do_not.map((t: string, j: number) => (
+                            <div key={j}>• {t}</div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+
+            {/* Snags */}
+            <Card>
+              <div style={{ color: TEXT_1, fontSize: 15, fontWeight: 700, marginBottom: 10 }}>
+                Snags
+                {file?.sections?.snags
+                  ? ` (${file.sections.snags.open} open / ${file.sections.snags.total})`
+                  : ''}
+              </div>
+
+              <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+                <input
+                  value={newDesc}
+                  onChange={(e) => setNewDesc(e.target.value)}
+                  placeholder="Describe a snag…"
+                  style={{
+                    flex: 1,
+                    fontSize: 13,
+                    padding: '8px 10px',
+                    border: `1px solid ${BORDER_LIGHT}`,
+                    borderRadius: 8,
+                    color: TEXT_1,
+                    background: '#fff',
+                  }}
+                />
+                <select
+                  value={newSeverity}
+                  onChange={(e) => setNewSeverity(e.target.value)}
+                  style={{
+                    fontSize: 13,
+                    padding: '8px',
+                    border: `1px solid ${BORDER_LIGHT}`,
+                    borderRadius: 8,
+                    color: TEXT_1,
+                    background: '#fff',
+                  }}
+                >
+                  <option value="safety">Safety</option>
+                  <option value="major">Major</option>
+                  <option value="minor">Minor</option>
+                  <option value="cosmetic">Cosmetic</option>
+                </select>
+                <button
+                  onClick={addSnag}
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 700,
+                    color: GOLD,
+                    background: 'transparent',
+                    border: `1px solid ${GOLD}`,
+                    borderRadius: 8,
+                    padding: '0 12px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  Add
+                </button>
+              </div>
+
+              {snags.length === 0 && (
+                <p style={{ color: TEXT_3, fontSize: 13 }}>No snags logged.</p>
+              )}
+              {snags.map((s: any) => {
+                const st = statusStyle(s.status);
+                return (
+                  <div
+                    key={s.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 10,
+                      padding: '10px 0',
+                      borderTop: `1px solid ${BORDER_LIGHT}`,
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        background: SEVERITY_COLOR[s.severity] ?? TEXT_3,
+                        marginTop: 6,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ color: TEXT_1, fontSize: 13 }}>{s.title || s.description}</div>
+                      <div style={{ display: 'flex', gap: 6, marginTop: 4, alignItems: 'center' }}>
+                        <span
+                          style={{
+                            fontSize: 10,
+                            fontWeight: 700,
+                            color: st.color,
+                            background: st.bg,
+                            padding: '2px 7px',
+                            borderRadius: 6,
+                          }}
+                        >
+                          {String(s.status).replace('_', ' ')}
+                        </span>
+                        <span style={{ fontSize: 10, color: TEXT_3 }}>{s.severity}</span>
+                      </div>
+                    </div>
+                    {OPEN_STATES.includes(s.status) && (
+                      <button
+                        onClick={() => resolveSnag(s.id)}
+                        style={{
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: GREEN,
+                          background: GREEN_BG,
+                          border: 'none',
+                          borderRadius: 6,
+                          padding: '5px 9px',
+                          cursor: 'pointer',
+                          flexShrink: 0,
+                        }}
+                      >
+                        Resolve
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </Card>
+          </>
+        )}
+      </div>
+    </MobileShell>
+  );
+}

--- a/apps/unified-portal/app/dev-app/units/page.tsx
+++ b/apps/unified-portal/app/dev-app/units/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import MobileShell from '@/components/dev-app/layout/MobileShell';
+import {
+  TEXT_1,
+  TEXT_2,
+  TEXT_3,
+  BORDER_LIGHT,
+  SURFACE_1,
+} from '@/lib/dev-app/design-system';
+
+export default function UnitsListPage() {
+  const router = useRouter();
+  const [units, setUnits] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/dev-app/units')
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.error) setError(d.error);
+        else setUnits(d.units ?? []);
+      })
+      .catch(() => setError('Failed to load units'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <MobileShell>
+      <div style={{ padding: 20 }}>
+        <h1 style={{ color: TEXT_1, fontSize: 22, fontWeight: 700, marginBottom: 4 }}>
+          Units
+        </h1>
+        <p style={{ color: TEXT_2, fontSize: 13, marginBottom: 20 }}>
+          Tap a unit for its snags, HPI readiness and Home User Guide.
+        </p>
+
+        {loading && <p style={{ color: TEXT_3, fontSize: 14 }}>Loading…</p>}
+        {error && <p style={{ color: TEXT_3, fontSize: 14 }}>{error}</p>}
+        {!loading && !error && units.length === 0 && (
+          <p style={{ color: TEXT_3, fontSize: 14 }}>No units found.</p>
+        )}
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {units.map((u) => (
+            <div
+              key={u.id}
+              onClick={() => router.push(`/dev-app/units/${u.id}`)}
+              style={{
+                cursor: 'pointer',
+                background: SURFACE_1,
+                border: `1px solid ${BORDER_LIGHT}`,
+                borderRadius: 12,
+                padding: 14,
+              }}
+            >
+              <div style={{ color: TEXT_1, fontSize: 15, fontWeight: 600 }}>
+                {u.unit_number ? `Unit ${u.unit_number}` : 'Unit'}
+              </div>
+              <div style={{ color: TEXT_2, fontSize: 12, marginTop: 2 }}>
+                {u.address_line_1 || u.development_name || ''}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </MobileShell>
+  );
+}

--- a/apps/unified-portal/lib/dev-app/home-user-guide.ts
+++ b/apps/unified-portal/lib/dev-app/home-user-guide.ts
@@ -1,0 +1,135 @@
+// lib/dev-app/home-user-guide.ts
+// Generates the auto, system-specific Home User Guide (HPI QA 8.0) from a unit's
+// installed unit_systems. Matches the OpenAI usage pattern in lib/ai-classify.ts.
+
+import OpenAI from 'openai';
+
+// Defaults to the model proven across this codebase so it runs on existing infra.
+// RECOMMENDED UPGRADE: this is the headline, reasoning-heavy generation — move it
+// to a frontier model (gpt-4o, or Anthropic Claude) by setting HOME_USER_GUIDE_MODEL.
+const GUIDE_MODEL = process.env.HOME_USER_GUIDE_MODEL || 'gpt-4o-mini';
+
+function getOpenAIClient() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is required for Home User Guide generation');
+  }
+  return new OpenAI({ apiKey });
+}
+
+export interface HomeUserGuideSection {
+  heading: string;
+  system_type?: string;
+  summary?: string;
+  how_to_use?: string[];
+  seasonal_tips?: string[];
+  maintenance?: string[];
+  warranty?: string | null;
+  do_not?: string[];
+}
+
+export interface HomeUserGuideContent {
+  title: string;
+  introduction: string;
+  systems_covered: string[];
+  sections: HomeUserGuideSection[];
+  general_tips: string[];
+  who_to_contact: string;
+  generated_at: string;
+  model: string;
+}
+
+export interface GuideUnitContext {
+  unit_number?: string | null;
+  address_line_1?: string | null;
+  city?: string | null;
+  eircode?: string | null;
+  house_type_code?: string | null;
+}
+
+function buildPrompt(unit: GuideUnitContext, systems: any[]): string {
+  const systemLines = systems.length
+    ? systems
+        .map((s) => {
+          const bits = [s.system_type, s.make, s.model].filter(Boolean).join(' ');
+          const warranty = s.warranty_end ? ` (warranty to ${s.warranty_end})` : '';
+          const maint = s.maintenance_interval_months
+            ? ` (service every ${s.maintenance_interval_months} months)`
+            : '';
+          return `- ${bits}${warranty}${maint}`;
+        })
+        .join('\n')
+    : '(no systems recorded yet)';
+
+  return `You are writing a Home User Guide for a new-build Irish home, read by a
+non-technical homeowner. The goal is the opposite of a 60-page manual: clear,
+friendly, scannable, and specific to THIS home's installed systems.
+
+Home: ${unit.address_line_1 ?? ''} ${unit.city ?? ''} ${unit.eircode ?? ''} (type ${unit.house_type_code ?? 'n/a'}).
+
+Installed systems:
+${systemLines}
+
+Write practical guidance for each installed system, tailored to the named
+make/model where given. Use Irish context (A-rated homes, heat pumps, MVHR, SEAI).
+Be accurate and general where you are unsure; NEVER invent specific spec figures,
+settings values or warranty dates that were not provided. Emphasise the few things
+that matter most (e.g. don't switch the heat pump off at the wall in winter; keep
+MVHR running and change its filters).
+
+Respond ONLY with valid JSON in exactly this shape:
+{
+  "title": "string",
+  "introduction": "2-3 friendly sentences",
+  "systems_covered": ["heat_pump", "mvhr", ...],
+  "sections": [
+    {
+      "heading": "string",
+      "system_type": "string",
+      "summary": "one line",
+      "how_to_use": ["..."],
+      "seasonal_tips": ["..."],
+      "maintenance": ["..."],
+      "warranty": "string or null",
+      "do_not": ["..."]
+    }
+  ],
+  "general_tips": ["..."],
+  "who_to_contact": "string"
+}`;
+}
+
+/**
+ * Generates a structured Home User Guide for a unit from its installed systems.
+ * Throws if OPENAI_API_KEY is unset (handled by the route as a 503).
+ */
+export async function generateHomeUserGuide(
+  unit: GuideUnitContext,
+  systems: any[],
+): Promise<HomeUserGuideContent> {
+  const completion = await getOpenAIClient().chat.completions.create({
+    model: GUIDE_MODEL,
+    messages: [{ role: 'user', content: buildPrompt(unit, systems) }],
+    response_format: { type: 'json_object' },
+    max_tokens: 2000,
+    temperature: 0.4,
+  });
+
+  const text = completion.choices[0]?.message?.content;
+  if (!text) throw new Error('No response from AI');
+  const parsed = JSON.parse(text);
+
+  return {
+    title: typeof parsed.title === 'string' ? parsed.title : 'Your Home User Guide',
+    introduction: typeof parsed.introduction === 'string' ? parsed.introduction : '',
+    systems_covered: Array.isArray(parsed.systems_covered) ? parsed.systems_covered : [],
+    sections: Array.isArray(parsed.sections) ? parsed.sections : [],
+    general_tips: Array.isArray(parsed.general_tips) ? parsed.general_tips : [],
+    who_to_contact:
+      typeof parsed.who_to_contact === 'string'
+        ? parsed.who_to_contact
+        : "Contact your developer's aftercare team, or ask the in-app assistant.",
+    generated_at: new Date().toISOString(),
+    model: GUIDE_MODEL,
+  };
+}

--- a/apps/unified-portal/lib/dev-app/snags.ts
+++ b/apps/unified-portal/lib/dev-app/snags.ts
@@ -1,0 +1,129 @@
+// lib/dev-app/snags.ts
+// Types, vocab and helpers for the V1 snagging "system of account" (migration 067).
+// Kept framework-agnostic so it can be shared by API routes and UI.
+
+export const SNAG_STATUSES = [
+  'open',
+  'in_progress',
+  'resolved',
+  'verified',
+  'disputed',
+  'wont_fix',
+] as const;
+export type SnagStatus = (typeof SNAG_STATUSES)[number];
+
+export const SNAG_SEVERITIES = ['safety', 'major', 'minor', 'cosmetic'] as const;
+export type SnagSeverity = (typeof SNAG_SEVERITIES)[number];
+
+export const SNAG_SOURCES = ['in_app', 'uploaded_report', 'homeowner_chat', 'import'] as const;
+export type SnagSource = (typeof SNAG_SOURCES)[number];
+
+export const SNAG_CREATED_BY_ROLES = [
+  'builder_crew',
+  'purchaser_snagger',
+  'homeowner',
+  'site_manager',
+  'developer',
+] as const;
+export type SnagCreatedByRole = (typeof SNAG_CREATED_BY_ROLES)[number];
+
+// Still needs work (drives the attention feed and the "open" count on a unit).
+export const OPEN_SNAG_STATUSES: SnagStatus[] = ['open', 'in_progress', 'disputed'];
+// Closed out.
+export const CLOSED_SNAG_STATUSES: SnagStatus[] = ['resolved', 'verified', 'wont_fix'];
+
+export interface Snag {
+  id: string;
+  tenant_id: string | null;
+  development_id: string;
+  unit_id: string;
+  title: string | null;
+  description: string;
+  status: SnagStatus;
+  severity: SnagSeverity;
+  trade: string | null;
+  location: string | null;
+  responsible_contractor_id: string | null;
+  created_by_role: SnagCreatedByRole | null;
+  created_by_user_id: string | null;
+  reported_by: string | null;
+  source: SnagSource;
+  photo_url: string | null;
+  photo_urls: string[];
+  ai_classification: Record<string, unknown> | null;
+  ai_dedup_group: string | null;
+  sla_due_at: string | null;
+  verified_by: string | null;
+  verified_at: string | null;
+  resolved_at: string | null;
+  closed_at: string | null;
+  offline_client_id: string | null;
+  issue_report_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Contractor {
+  id: string;
+  tenant_id: string;
+  name: string;
+  trades: string[];
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  external_ref: string | null;
+  is_active: boolean;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ContractorScorecardRow {
+  contractor_id: string;
+  tenant_id: string;
+  name: string;
+  total_snags: number;
+  safety_snags: number;
+  open_snags: number;
+  closed_snags: number;
+  avg_days_to_close: number | null;
+}
+
+export function isSnagStatus(v: unknown): v is SnagStatus {
+  return typeof v === 'string' && (SNAG_STATUSES as readonly string[]).includes(v);
+}
+
+export function isSnagSeverity(v: unknown): v is SnagSeverity {
+  return typeof v === 'string' && (SNAG_SEVERITIES as readonly string[]).includes(v);
+}
+
+/**
+ * Confirms the authenticated user owns the development the unit belongs to, via
+ * developments.developer_user_id — the app-code enforcement model used across
+ * the dev-app routes. Returns the unit's ids, or null if not owned / not found.
+ *
+ * `supabase` must be the cookie-scoped user client (createServerSupabaseClient).
+ */
+export async function getOwnedUnit(
+  supabase: any,
+  userId: string,
+  unitId: string,
+): Promise<{ id: string; tenant_id: string; development_id: string } | null> {
+  const { data: unit } = await supabase
+    .from('units')
+    .select('id, tenant_id, development_id')
+    .eq('id', unitId)
+    .single();
+  if (!unit) return null;
+
+  const { data: dev } = await supabase
+    .from('developments')
+    .select('id')
+    .eq('id', unit.development_id)
+    .eq('developer_user_id', userId)
+    .single();
+  if (!dev) return null;
+
+  return { id: unit.id, tenant_id: unit.tenant_id, development_id: unit.development_id };
+}

--- a/apps/unified-portal/lib/dev-app/unit-systems.ts
+++ b/apps/unified-portal/lib/dev-app/unit-systems.ts
@@ -1,0 +1,110 @@
+// lib/dev-app/unit-systems.ts
+// Types, vocab and HPI helpers for the unit's installed systems and its handover
+// evidence trail (migration 068). These feed the one-click unit file and the
+// (coming) auto-generated Home User Guide.
+
+export const UNIT_SYSTEM_TYPES = [
+  'heat_pump',
+  'mvhr',
+  'ventilation',
+  'solar_pv',
+  'battery',
+  'ev_charger',
+  'hot_water',
+  'heating_controls',
+  'windows',
+  'smart_home',
+  'other',
+] as const;
+export type UnitSystemType = (typeof UNIT_SYSTEM_TYPES)[number];
+
+export const HANDOVER_EVENT_TYPES = [
+  'demo_completed',
+  'guide_issued',
+  'keys_handed',
+  'aftercare_activated',
+  'inspection',
+  'other',
+] as const;
+export type HandoverEventType = (typeof HANDOVER_EVENT_TYPES)[number];
+
+export interface UnitSystem {
+  id: string;
+  tenant_id: string;
+  unit_id: string;
+  system_type: UnitSystemType;
+  make: string | null;
+  model: string | null;
+  serial_number: string | null;
+  key_settings: Record<string, unknown>;
+  commissioning_date: string | null;
+  commissioning_doc_id: string | null;
+  warranty_start: string | null;
+  warranty_end: string | null;
+  warranty_doc_id: string | null;
+  maintenance_interval_months: number | null;
+  manufacturer_guide_doc_id: string | null;
+  knowledge_refs: unknown[];
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HandoverEvent {
+  id: string;
+  tenant_id: string;
+  unit_id: string;
+  event_type: HandoverEventType;
+  occurred_at: string;
+  conducted_by: string | null;
+  conducted_by_name: string | null;
+  attended_by: string | null;
+  acknowledgement_ref: string | null;
+  home_user_guide_version: number | null;
+  media_refs: unknown[];
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface HpiQa8Evidence {
+  guide_issued: boolean;
+  demo_completed: boolean;
+  aftercare_activated: boolean;
+  systems_documented: number;
+  systems_with_warranty: number;
+  /** The two mandatory QA 8.0 touchpoints (guide issued + demo done) are evidenced. */
+  qa8_ready: boolean;
+}
+
+export function isUnitSystemType(v: unknown): v is UnitSystemType {
+  return typeof v === 'string' && (UNIT_SYSTEM_TYPES as readonly string[]).includes(v);
+}
+
+export function isHandoverEventType(v: unknown): v is HandoverEventType {
+  return typeof v === 'string' && (HANDOVER_EVENT_TYPES as readonly string[]).includes(v);
+}
+
+/**
+ * Rolls a unit's systems + handover events into the HPI QA 8.0
+ * (Consumer Information & Aftercare) evidence summary surfaced on the unit file.
+ * `systems` and `events` are raw DB rows.
+ */
+export function summariseHpiQa8(systems: any[], events: any[]): HpiQa8Evidence {
+  const hasEvent = (t: HandoverEventType) => events.some((e) => e.event_type === t);
+  const guideIssued =
+    hasEvent('guide_issued') || events.some((e) => e.home_user_guide_version != null);
+  const systemsWithWarranty = systems.filter(
+    (s) => s.warranty_end || s.warranty_doc_id,
+  ).length;
+
+  return {
+    guide_issued: guideIssued,
+    demo_completed: hasEvent('demo_completed'),
+    aftercare_activated: hasEvent('aftercare_activated'),
+    systems_documented: systems.length,
+    systems_with_warranty: systemsWithWarranty,
+    qa8_ready: guideIssued && hasEvent('demo_completed'),
+  };
+}

--- a/apps/unified-portal/migrations/067_snagging_v1.sql
+++ b/apps/unified-portal/migrations/067_snagging_v1.sql
@@ -1,0 +1,185 @@
+-- 067_snagging_v1.sql
+-- ============================================================================
+-- SNAGGING V1 — evolve snag_items (migration 027) into the per-unit "system of
+-- account", and add contractors for accountability / scorecards.
+--
+-- This is ADDITIVE and BACK-COMPATIBLE. Every column that already exists on
+-- snag_items is preserved, and every new column is nullable or defaulted, so the
+-- four dev-app routes that read snag_items today keep working unchanged:
+--   - app/api/dev-app/overview/attention   (counts open snags per development)
+--   - app/api/dev-app/activity
+--   - app/api/dev-app/intelligence/chat
+--   - app/api/dev-app/developments/[devId]  (section=snagging)
+--
+-- ACCESS MODEL (decided with product): tenant/development scoping is enforced in
+-- APPLICATION CODE, consistent with the existing dev-app routes (which scope by
+-- developments.developer_user_id) and the assistant family (migration 065).
+-- snag_items / contractors are read and written by the route handlers via the
+-- service role (getSupabaseAdmin), AFTER the handler has verified ownership.
+-- RLS is enabled with no permissive policy for `authenticated`, so a stray
+-- user-scoped client cannot read across tenants. To switch to per-row RLS later,
+-- add: USING (tenant_id = (auth.jwt()->>'tenant_id')::uuid).
+--
+-- RUN MANUALLY in the Supabase SQL Editor (same as the rest of this folder).
+-- This file is NOT auto-applied. Rollback notes at the bottom.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1) contractors — the party a snag is attributed to (powers scorecards/trends)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS contractors (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    trades        TEXT[] NOT NULL DEFAULT '{}',
+    contact_name  TEXT,
+    contact_email TEXT,
+    contact_phone TEXT,
+    external_ref  TEXT,                      -- id in the builder's own system, if any
+    is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+    metadata      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS contractors_tenant_idx ON contractors(tenant_id);
+CREATE INDEX IF NOT EXISTS contractors_active_idx ON contractors(tenant_id, is_active);
+
+CREATE OR REPLACE FUNCTION update_contractors_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_contractors_updated_at ON contractors;
+CREATE TRIGGER update_contractors_updated_at
+    BEFORE UPDATE ON contractors
+    FOR EACH ROW
+    EXECUTE FUNCTION update_contractors_updated_at();
+
+-- RLS: enabled; access via service role + app-code scoping (see ACCESS MODEL).
+-- No permissive `authenticated` policy on purpose, so direct user-scoped reads
+-- are denied and cannot leak across tenants. service_role has BYPASSRLS.
+ALTER TABLE contractors ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON contractors TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON contractors TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2) snag_items — widen into the multi-sided system of account
+-- ----------------------------------------------------------------------------
+ALTER TABLE snag_items
+    ADD COLUMN IF NOT EXISTS title                     TEXT,
+    ADD COLUMN IF NOT EXISTS severity                  TEXT NOT NULL DEFAULT 'minor',
+    ADD COLUMN IF NOT EXISTS trade                     TEXT,
+    ADD COLUMN IF NOT EXISTS location                  TEXT,            -- room / area in the unit
+    ADD COLUMN IF NOT EXISTS responsible_contractor_id UUID REFERENCES contractors(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS created_by_role           TEXT,            -- builder_crew|purchaser_snagger|homeowner|site_manager|developer
+    ADD COLUMN IF NOT EXISTS created_by_user_id        UUID,
+    ADD COLUMN IF NOT EXISTS source                    TEXT NOT NULL DEFAULT 'in_app', -- in_app|uploaded_report|homeowner_chat|import
+    ADD COLUMN IF NOT EXISTS photo_urls                JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS ai_classification         JSONB,           -- {type, severity, trade, confidence}
+    ADD COLUMN IF NOT EXISTS ai_dedup_group            UUID,            -- groups likely-duplicate snags
+    ADD COLUMN IF NOT EXISTS sla_due_at                TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS verified_by               UUID,
+    ADD COLUMN IF NOT EXISTS verified_at               TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS closed_at                 TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS offline_client_id         TEXT,            -- idempotency key from the mobile app
+    ADD COLUMN IF NOT EXISTS issue_report_id           UUID,            -- link to homeowner assistant issue (V1.1)
+    ADD COLUMN IF NOT EXISTS metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- severity vocabulary
+ALTER TABLE snag_items DROP CONSTRAINT IF EXISTS snag_items_severity_check;
+ALTER TABLE snag_items ADD  CONSTRAINT snag_items_severity_check
+    CHECK (severity IN ('safety', 'major', 'minor', 'cosmetic'));
+
+-- widen status vocabulary (was: open | in_progress | resolved). Existing values
+-- stay valid, so the routes filtering on open/in_progress/resolved are unaffected.
+-- NOTE: the inline CHECK from migration 027 is named snag_items_status_check by
+-- Postgres default. If your DB renamed it, adjust the DROP below.
+ALTER TABLE snag_items DROP CONSTRAINT IF EXISTS snag_items_status_check;
+ALTER TABLE snag_items ADD  CONSTRAINT snag_items_status_check
+    CHECK (status IN ('open', 'in_progress', 'resolved', 'verified', 'disputed', 'wont_fix'));
+
+-- source vocabulary
+ALTER TABLE snag_items DROP CONSTRAINT IF EXISTS snag_items_source_check;
+ALTER TABLE snag_items ADD  CONSTRAINT snag_items_source_check
+    CHECK (source IN ('in_app', 'uploaded_report', 'homeowner_chat', 'import'));
+
+-- created_by_role vocabulary (nullable; legacy rows have NULL)
+ALTER TABLE snag_items DROP CONSTRAINT IF EXISTS snag_items_created_by_role_check;
+ALTER TABLE snag_items ADD  CONSTRAINT snag_items_created_by_role_check
+    CHECK (created_by_role IS NULL OR created_by_role IN
+        ('builder_crew', 'purchaser_snagger', 'homeowner', 'site_manager', 'developer'));
+
+-- backfill: snag_items.tenant_id is nullable today; populate from the unit
+UPDATE snag_items s
+   SET tenant_id = u.tenant_id
+  FROM units u
+ WHERE s.unit_id = u.id
+   AND s.tenant_id IS NULL;
+
+-- backfill: fold the single photo_url into the new photo_urls array
+UPDATE snag_items
+   SET photo_urls = jsonb_build_array(photo_url)
+ WHERE photo_url IS NOT NULL
+   AND (photo_urls IS NULL OR photo_urls = '[]'::jsonb);
+
+-- indexes for the new access paths
+CREATE INDEX IF NOT EXISTS snag_items_contractor_idx ON snag_items(responsible_contractor_id);
+CREATE INDEX IF NOT EXISTS snag_items_severity_idx   ON snag_items(severity);
+CREATE INDEX IF NOT EXISTS snag_items_tenant_idx     ON snag_items(tenant_id);
+CREATE INDEX IF NOT EXISTS snag_items_sla_idx        ON snag_items(sla_due_at) WHERE sla_due_at IS NOT NULL;
+
+-- offline idempotency: a mobile-minted client id is unique per tenant, so
+-- replaying a queued create after reconnect cannot duplicate the snag.
+CREATE UNIQUE INDEX IF NOT EXISTS snag_items_offline_client_uniq
+    ON snag_items(tenant_id, offline_client_id) WHERE offline_client_id IS NOT NULL;
+
+-- ----------------------------------------------------------------------------
+-- 3) contractor_scorecard — read-only payoff (the "method of account").
+--    Optional: safe to keep or drop. Callers must filter by tenant_id (the
+--    routes query it via the service role and pass .eq('tenant_id', ...)).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE VIEW contractor_scorecard WITH (security_invoker = true) AS
+SELECT
+    c.id        AS contractor_id,
+    c.tenant_id,
+    c.name,
+    COUNT(s.id)                                                    AS total_snags,
+    COUNT(s.id) FILTER (WHERE s.severity = 'safety')              AS safety_snags,
+    COUNT(s.id) FILTER (WHERE s.status IN ('open', 'in_progress')) AS open_snags,
+    COUNT(s.id) FILTER (WHERE s.status IN ('resolved', 'verified')) AS closed_snags,
+    AVG(EXTRACT(EPOCH FROM (COALESCE(s.resolved_at, s.closed_at) - s.created_at)) / 86400.0)
+        FILTER (WHERE COALESCE(s.resolved_at, s.closed_at) IS NOT NULL) AS avg_days_to_close
+FROM contractors c
+LEFT JOIN snag_items s ON s.responsible_contractor_id = c.id
+GROUP BY c.id, c.tenant_id, c.name;
+
+-- ============================================================================
+-- ROLLBACK
+--   DROP VIEW IF EXISTS contractor_scorecard;
+--   DROP INDEX IF EXISTS snag_items_offline_client_uniq;
+--   DROP INDEX IF EXISTS snag_items_sla_idx;
+--   DROP INDEX IF EXISTS snag_items_tenant_idx;
+--   DROP INDEX IF EXISTS snag_items_severity_idx;
+--   DROP INDEX IF EXISTS snag_items_contractor_idx;
+--   ALTER TABLE snag_items
+--     DROP CONSTRAINT IF EXISTS snag_items_created_by_role_check,
+--     DROP CONSTRAINT IF EXISTS snag_items_source_check,
+--     DROP CONSTRAINT IF EXISTS snag_items_severity_check;
+--   -- (leave snag_items_status_check; re-add the original 3-value check if needed)
+--   ALTER TABLE snag_items
+--     DROP COLUMN IF EXISTS metadata, DROP COLUMN IF EXISTS issue_report_id,
+--     DROP COLUMN IF EXISTS offline_client_id, DROP COLUMN IF EXISTS closed_at,
+--     DROP COLUMN IF EXISTS verified_at, DROP COLUMN IF EXISTS verified_by,
+--     DROP COLUMN IF EXISTS sla_due_at, DROP COLUMN IF EXISTS ai_dedup_group,
+--     DROP COLUMN IF EXISTS ai_classification, DROP COLUMN IF EXISTS photo_urls,
+--     DROP COLUMN IF EXISTS source, DROP COLUMN IF EXISTS created_by_user_id,
+--     DROP COLUMN IF EXISTS created_by_role,
+--     DROP COLUMN IF EXISTS responsible_contractor_id,
+--     DROP COLUMN IF EXISTS location, DROP COLUMN IF EXISTS trade,
+--     DROP COLUMN IF EXISTS severity, DROP COLUMN IF EXISTS title;
+--   DROP TABLE IF EXISTS contractors;
+-- ============================================================================

--- a/apps/unified-portal/migrations/068_unit_systems_handover.sql
+++ b/apps/unified-portal/migrations/068_unit_systems_handover.sql
@@ -1,0 +1,120 @@
+-- 068_unit_systems_handover.sql
+-- ============================================================================
+-- V1.1 GROUNDWORK FOR THE HPI QA 8.0 STORY (the Cairn pitch).
+--
+-- Two unit-scoped tables that the one-click unit file — and the coming
+-- auto-generated Home User Guide — assemble from:
+--
+--   unit_systems     the building services actually installed in a home
+--                    (heat pump, MVHR, solar, controls...), with make/model,
+--                    commissioning + warranty docs and maintenance intervals.
+--                    This is what lets the assistant educate a homeowner about
+--                    THEIR system, and what the Home User Guide is generated from.
+--
+--   handover_events  the evidence trail QA 8.0 wants: the demo happened, the
+--                    Home User Guide was issued, aftercare was activated. An
+--                    append-only event log per unit.
+--
+-- ACCESS MODEL: identical to migration 067 — RLS on, tenant/development scoping
+-- enforced in application code, reads/writes via the service role after the
+-- route has verified ownership. No permissive `authenticated` policy.
+--
+-- RUN MANUALLY in the Supabase SQL Editor. NOT auto-applied. Rollback at bottom.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1) unit_systems — the installed building services + key specs per unit
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS unit_systems (
+    id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id                 UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    unit_id                   UUID NOT NULL REFERENCES units(id) ON DELETE CASCADE,
+    system_type               TEXT NOT NULL,   -- see CHECK below
+    make                      TEXT,
+    model                     TEXT,
+    serial_number             TEXT,
+    key_settings              JSONB NOT NULL DEFAULT '{}'::jsonb,  -- e.g. recommended winter setpoints
+    commissioning_date        DATE,
+    commissioning_doc_id      UUID,            -- soft ref into documents (decoupled on purpose)
+    warranty_start            DATE,
+    warranty_end              DATE,
+    warranty_doc_id           UUID,
+    maintenance_interval_months INTEGER,
+    manufacturer_guide_doc_id UUID,
+    knowledge_refs            JSONB NOT NULL DEFAULT '[]'::jsonb,  -- links to education content for this system
+    notes                     TEXT,
+    metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE unit_systems DROP CONSTRAINT IF EXISTS unit_systems_system_type_check;
+ALTER TABLE unit_systems ADD  CONSTRAINT unit_systems_system_type_check
+    CHECK (system_type IN (
+        'heat_pump', 'mvhr', 'ventilation', 'solar_pv', 'battery', 'ev_charger',
+        'hot_water', 'heating_controls', 'windows', 'smart_home', 'other'
+    ));
+
+CREATE INDEX IF NOT EXISTS unit_systems_unit_idx   ON unit_systems(unit_id);
+CREATE INDEX IF NOT EXISTS unit_systems_tenant_idx ON unit_systems(tenant_id);
+CREATE INDEX IF NOT EXISTS unit_systems_unit_type_idx ON unit_systems(unit_id, system_type);
+
+CREATE OR REPLACE FUNCTION update_unit_systems_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_unit_systems_updated_at ON unit_systems;
+CREATE TRIGGER update_unit_systems_updated_at
+    BEFORE UPDATE ON unit_systems
+    FOR EACH ROW
+    EXECUTE FUNCTION update_unit_systems_updated_at();
+
+ALTER TABLE unit_systems ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON unit_systems TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON unit_systems TO authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2) handover_events — the QA 8.0 evidence trail (append-only per unit)
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS handover_events (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id              UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    unit_id                UUID NOT NULL REFERENCES units(id) ON DELETE CASCADE,
+    event_type             TEXT NOT NULL,   -- see CHECK below
+    occurred_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    conducted_by           UUID,            -- the admin/user who performed it
+    conducted_by_name      TEXT,
+    attended_by            TEXT,            -- homeowner name / who received the demo
+    acknowledgement_ref    TEXT,            -- signature / acknowledgement marker
+    home_user_guide_version INTEGER,        -- set on a 'guide_issued' event
+    media_refs             JSONB NOT NULL DEFAULT '[]'::jsonb,
+    notes                  TEXT,
+    metadata               JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE handover_events DROP CONSTRAINT IF EXISTS handover_events_event_type_check;
+ALTER TABLE handover_events ADD  CONSTRAINT handover_events_event_type_check
+    CHECK (event_type IN (
+        'demo_completed', 'guide_issued', 'keys_handed', 'aftercare_activated',
+        'inspection', 'other'
+    ));
+
+CREATE INDEX IF NOT EXISTS handover_events_unit_idx   ON handover_events(unit_id);
+CREATE INDEX IF NOT EXISTS handover_events_tenant_idx ON handover_events(tenant_id);
+CREATE INDEX IF NOT EXISTS handover_events_unit_type_idx ON handover_events(unit_id, event_type);
+
+ALTER TABLE handover_events ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON handover_events TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON handover_events TO authenticated;
+
+-- ============================================================================
+-- ROLLBACK
+--   DROP TABLE IF EXISTS handover_events;
+--   DROP TABLE IF EXISTS unit_systems;
+--   DROP FUNCTION IF EXISTS update_unit_systems_updated_at();
+-- ============================================================================

--- a/apps/unified-portal/migrations/069_home_user_guides.sql
+++ b/apps/unified-portal/migrations/069_home_user_guides.sql
@@ -1,0 +1,43 @@
+-- 069_home_user_guides.sql
+-- ============================================================================
+-- THE AUTO-GENERATED HOME USER GUIDE (HPI QA 8.0 — the Cairn headline).
+--
+-- Generated from a unit's unit_systems (migration 068) so the guidance is
+-- specific to the home's ACTUAL heat pump / MVHR / controls — the thing that
+-- replaces the 60-page PDF nobody reads. Versioned and issuable, because QA 8.0
+-- wants the guide both delivered AND version-controlled: every generation is a
+-- new version; issuing one stamps issued_at and (in the route) writes a
+-- handover_events 'guide_issued' row, which flips the unit file's qa8_ready.
+--
+-- Same access model as 067/068: RLS on, app-code tenant/ownership scoping,
+-- service-role reads/writes after the route verifies ownership.
+-- RUN MANUALLY in the Supabase SQL Editor. NOT auto-applied.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS home_user_guides (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id    UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    unit_id      UUID NOT NULL REFERENCES units(id) ON DELETE CASCADE,
+    version      INTEGER NOT NULL,
+    content      JSONB NOT NULL,            -- structured guide (see lib/dev-app/home-user-guide.ts)
+    model        TEXT,                       -- which model generated it
+    generated_by UUID,
+    status       TEXT NOT NULL DEFAULT 'draft',
+    issued_at    TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE home_user_guides DROP CONSTRAINT IF EXISTS home_user_guides_status_check;
+ALTER TABLE home_user_guides ADD  CONSTRAINT home_user_guides_status_check
+    CHECK (status IN ('draft', 'issued'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS home_user_guides_unit_version_uniq
+    ON home_user_guides(unit_id, version);
+CREATE INDEX IF NOT EXISTS home_user_guides_unit_idx   ON home_user_guides(unit_id);
+CREATE INDEX IF NOT EXISTS home_user_guides_tenant_idx ON home_user_guides(tenant_id);
+
+ALTER TABLE home_user_guides ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON home_user_guides TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON home_user_guides TO authenticated;
+
+-- ROLLBACK: DROP TABLE IF EXISTS home_user_guides;


### PR DESCRIPTION
A full vertical slice: data model → API → AI → clickable UI, focused on snagging as the wedge and the HPI QA 8.0 (Cairn) story.

## What's in here
- **Snagging system of account** — evolves `snag_items` into a multi-sided record (severity, trade, contractor attribution, multi-photo, AI-triage fields, offline-idempotent capture), adds `contractors` + a `contractor_scorecard` view, and the dev-app routes (create / list / update / import / contractors).
- **HPI groundwork** — `unit_systems` + `handover_events`; the one-click unit file now returns a real QA 8.0 readiness summary.
- **Auto Home User Guide** — generates a system-specific guide from a unit's installed systems (the "no more 60-page manual" feature). Versioned + issuable; issuing writes a `guide_issued` handover event that flips `qa8_ready`.
- **Live dev-app unit surface** — `/dev-app/units` and `/dev-app/units/[unitId]`: HPI readiness, generate/issue guide, snag list (add + resolve), handover demo / aftercare actions.

## Database
Migrations `067`, `068`, `069` have **already been applied** to the OpenHouse production project (additive + back-compatible; existing app unaffected). Verified: 4 new tables, all new `snag_items` columns, and the `contractor_scorecard` view are present.

## Notes for the reviewer
- Access model is app-code enforced (service role after ownership check), consistent with the existing dev-app routes and the assistant family.
- The Home User Guide generator defaults to `gpt-4o-mini` (runs on existing infra); set `HOME_USER_GUIDE_MODEL=gpt-4o` (or wire Claude) for production-quality output.
- Every commit is typecheck-clean. The code has **not** been run end-to-end yet — worth one smoke test on the deploy: open `/dev-app/units`, generate a guide, log a handover demo, watch readiness flip to READY.
- The existing developments pages still render mock data; wiring those to the live API + linking unit rows is the obvious follow-up.

https://claude.ai/code/session_01AP2S5bbTe2tFZYJGGmpERc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AP2S5bbTe2tFZYJGGmpERc)_